### PR TITLE
CMM-784 self-hosted categories and tags management

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2033,7 +2033,16 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (group != null) {
             group.removeAll();
         }
-        if (!mSite.isUsingSelfHostedRestApi()) {
+        if (mSite.isUsingSelfHostedRestApi()) {
+            // Remove everything inside "Writing" preference but "Categories" and "Tags" which are now supported
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_category);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_format);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_date_format);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_time_format);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_week_start);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_posts_per_page);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_related_posts);
+        } else {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
         }
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2033,7 +2033,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (group != null) {
             group.removeAll();
         }
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
+        if (!mSite.isUsingSelfHostedRestApi()) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
+        }
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_quota);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -256,6 +256,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 val payload = RemoteTermPayload(term, site)
                 payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
                 notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                return@launch
             }
 
             val client = wpApiClientProvider.getWpApiClient(site)
@@ -310,6 +311,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 val payload = RemoteTermPayload(term, site)
                 payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
                 notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                return@launch
             }
 
             val client = wpApiClientProvider.getWpApiClient(site)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
+import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,15 +34,16 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
-    fun fetchTerms(site: SiteModel, taxonomyName: String) {
-        when (taxonomyName) {
-            DEFAULT_TAXONOMY_CATEGORY -> fetchPostCategories(site)
-            DEFAULT_TAXONOMY_TAG -> fetchPostTags(site)
+
+    fun createTerm(site: SiteModel, term: TermModel) {
+        when (term.taxonomy) {
+            DEFAULT_TAXONOMY_CATEGORY -> createCategory(site, term)
+            DEFAULT_TAXONOMY_TAG -> createTag(site, term)
             else -> {} // TODO
         }
     }
 
-    fun createPostCategory(site: SiteModel, term: TermModel) {
+    private fun createCategory(site: SiteModel, term: TermModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
@@ -87,7 +89,60 @@ class TaxonomyRsApiRestClient @Inject constructor(
         }
     }
 
-    private fun fetchPostCategories(site: SiteModel) {
+    private fun createTag(site: SiteModel, term: TermModel) {
+        scope.launch {
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val tagResponse = client.request { requestBuilder ->
+                requestBuilder.tags().create(
+                    TagCreateParams(
+                        name = term.name,
+                        description = term.description,
+                        slug = term.slug,
+                    )
+                )
+            }
+
+            when (tagResponse) {
+                is WpRequestResult.Success -> {
+                    val tag = tagResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Created tag: ${tag.name}")
+                    val payload = RemoteTermPayload(
+                        TermModel(
+                            tag.id.toInt(),
+                            site.id,
+                            tag.id,
+                            DEFAULT_TAXONOMY_TAG,
+                            tag.name,
+                            tag.slug,
+                            tag.description,
+                            0,
+                            tag.count.toInt()
+                        ),
+                        site
+                    )
+                    notifyTermCreated(payload)
+                }
+
+                else -> {
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating tag: $tagResponse")
+                    val payload = RemoteTermPayload(term, site)
+                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                    notifyTermCreated(payload)
+                }
+            }
+        }
+    }
+
+    fun fetchTerms(site: SiteModel, taxonomyName: String) {
+        when (taxonomyName) {
+            DEFAULT_TAXONOMY_CATEGORY -> fetchCategories(site)
+            DEFAULT_TAXONOMY_TAG -> fetchTags(site)
+            else -> {} // TODO
+        }
+    }
+
+    private fun fetchCategories(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
@@ -131,7 +186,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         }
     }
 
-    private fun fetchPostTags(site: SiteModel) {
+    private fun fetchTags(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -19,12 +19,14 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CategoriesRequestDeleteResponse
 import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
 import uniffi.wp_api.CategoryUpdateParams
 import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
 import uniffi.wp_api.TagUpdateParams
+import uniffi.wp_api.TagsRequestDeleteResponse
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -37,61 +39,53 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
     fun deleteTerm(site: SiteModel, term: TermModel) {
-        when (term.taxonomy) {
-            DEFAULT_TAXONOMY_CATEGORY -> deleteCategory(site, term)
-            DEFAULT_TAXONOMY_TAG -> deleteTag(site, term)
-            else -> {} // TODO We are not supporting any other taxonomy yet
-        }
-    }
-
-    private fun deleteCategory(site: SiteModel, term: TermModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
-            val categoriesResponse = client.request { requestBuilder ->
-                requestBuilder.categories().delete(categoryId = term.id.toLong())
-            }
-
-            when (categoriesResponse) {
-                is WpRequestResult.Success -> {
-                    val category = categoriesResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Deleted category: ${term.name} - ${category.deleted}")
-                    if (category.deleted) {
-                        val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
-                        notifyTermDeleted(RemoteTermPayload(termModel, site))
-                    } else {
-                        notifyFailedDeleting("category", site, term)
+            when (term.taxonomy) {
+                DEFAULT_TAXONOMY_CATEGORY -> {
+                    val categoriesResponse = client.request { requestBuilder ->
+                        requestBuilder.categories().delete(categoryId = term.id.toLong())
+                    }
+                    when (categoriesResponse) {
+                        is WpRequestResult.Success -> {
+                            val category = categoriesResponse.response.data
+                            appLogWrapper.d(AppLog.T.POSTS, "Deleted category: ${term.name} - ${category.deleted}")
+                            if (category.deleted) {
+                                val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
+                                notifyTermDeleted(RemoteTermPayload(termModel, site))
+                            } else {
+                                notifyFailedDeleting("category", site, term)
+                            }
+                        }
+                        else -> {
+                            notifyFailedDeleting("category", site, term)
+                        }
                     }
                 }
-                else -> {
-                    notifyFailedDeleting("category", site, term)
-                }
-            }
-        }
-    }
 
-    private fun deleteTag(site: SiteModel, term: TermModel) {
-        scope.launch {
-            val client = wpApiClientProvider.getWpApiClient(site)
-
-            val tagsResponse = client.request { requestBuilder ->
-                requestBuilder.tags().delete(tagId = term.id.toLong())
-            }
-
-            when (tagsResponse) {
-                is WpRequestResult.Success -> {
-                    val tag = tagsResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
-                    if (tag.deleted) {
-                        val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_TAG)
-                        notifyTermDeleted(RemoteTermPayload(termModel, site))
-                    } else {
-                        notifyFailedDeleting("tag", site, term)
+                DEFAULT_TAXONOMY_TAG -> {
+                    val tagsResponse = client.request { requestBuilder ->
+                        requestBuilder.tags().delete(tagId = term.id.toLong())
+                    }
+                    when (tagsResponse) {
+                        is WpRequestResult.Success -> {
+                            val tag = tagsResponse.response.data
+                            appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
+                            if (tag.deleted) {
+                                val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_TAG)
+                                notifyTermDeleted(RemoteTermPayload(termModel, site))
+                            } else {
+                                notifyFailedDeleting("tag", site, term)
+                            }
+                        }
+                        else -> {
+                            notifyFailedDeleting("tag", site, term)
+                        }
                     }
                 }
-                else -> {
-                    notifyFailedDeleting("tag", site, term)
-                }
+
+                else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
@@ -400,7 +394,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         }
                     )
                 }
-                
+
                 else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -9,7 +9,6 @@ import org.wordpress.android.fluxc.model.TermModel
 import org.wordpress.android.fluxc.model.TermsModel
 import org.wordpress.android.fluxc.module.FLUXC_SCOPE
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
-import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload
@@ -18,15 +17,16 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
-import uniffi.wp_api.CategoriesRequestDeleteResponse
 import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
 import uniffi.wp_api.CategoryUpdateParams
+import uniffi.wp_api.CategoryWithEditContext
 import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
 import uniffi.wp_api.TagUpdateParams
-import uniffi.wp_api.TagsRequestDeleteResponse
+import uniffi.wp_api.TagWithEditContext
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -50,9 +50,13 @@ class TaxonomyRsApiRestClient @Inject constructor(
                     when (categoriesResponse) {
                         is WpRequestResult.Success -> {
                             val category = categoriesResponse.response.data
-                            appLogWrapper.d(AppLog.T.POSTS, "Deleted category: ${term.name} - ${category.deleted}")
+                            appLogWrapper.d(
+                                AppLog.T.POSTS,
+                                "Deleted category: ${term.name} - ${category.deleted}"
+                            )
                             if (category.deleted) {
-                                val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
+                                val termModel =
+                                    createTermModelForDelete(term, site, DEFAULT_TAXONOMY_CATEGORY)
                                 notifyTermDeleted(RemoteTermPayload(termModel, site))
                             } else {
                                 notifyFailedDeleting("category", site, term)
@@ -73,7 +77,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             val tag = tagsResponse.response.data
                             appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
                             if (tag.deleted) {
-                                val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_TAG)
+                                val termModel = createTermModelForDelete(term, site, DEFAULT_TAXONOMY_TAG)
                                 notifyTermDeleted(RemoteTermPayload(termModel, site))
                             } else {
                                 notifyFailedDeleting("tag", site, term)
@@ -102,79 +106,90 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             when (term.taxonomy) {
-                DEFAULT_TAXONOMY_CATEGORY -> {
-                    val categoriesResponse = client.request { requestBuilder ->
-                        requestBuilder.categories().create(
-                            CategoryCreateParams(
-                                name = term.name,
-                                description = term.description,
-                                slug = term.slug,
-                                parent = term.parentRemoteId
-                            )
-                        )
-                    }
-
-                    handleCreateResponse(
-                        response = categoriesResponse,
-                        termType = "category",
-                        term = term,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModel = { data ->
-                            val category = data as uniffi.wp_api.CategoryWithEditContext
-                            TermModel(
-                                category.id.toInt(),
-                                site.id,
-                                category.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                                category.name,
-                                category.slug,
-                                category.description,
-                                category.parent,
-                                category.count.toInt()
-                            )
-                        }
-                    )
-                }
-
-                DEFAULT_TAXONOMY_TAG -> {
-                    val tagResponse = client.request { requestBuilder ->
-                        requestBuilder.tags().create(
-                            TagCreateParams(
-                                name = term.name,
-                                description = term.description,
-                                slug = term.slug,
-                            )
-                        )
-                    }
-                    handleCreateResponse(
-                        response = tagResponse,
-                        termType = "tag",
-                        term = term,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModel = { data ->
-                            val tag = data as uniffi.wp_api.TagWithEditContext
-                            TermModel(
-                                tag.id.toInt(),
-                                site.id,
-                                tag.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                                tag.name,
-                                tag.slug,
-                                tag.description,
-                                0,
-                                tag.count.toInt()
-                            )
-                        }
-                    )
-                }
-
+                DEFAULT_TAXONOMY_CATEGORY -> createCategory(client, term, site)
+                DEFAULT_TAXONOMY_TAG -> createTag(client, term, site)
                 else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
 
+    private suspend fun createCategory(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val categoriesResponse = client.request { requestBuilder ->
+            requestBuilder.categories().create(
+                CategoryCreateParams(
+                    name = term.name,
+                    description = term.description,
+                    slug = term.slug,
+                    parent = term.parentRemoteId
+                )
+            )
+        }
+
+        handleCreateResponse(
+            response = categoriesResponse,
+            termType = "category",
+            term = term,
+            site = site,
+            extractData = { it.response.data },
+            createTermModel = { data ->
+                val category = data as CategoryWithEditContext
+                TermModel(
+                    category.id.toInt(),
+                    site.id,
+                    category.id,
+                    DEFAULT_TAXONOMY_CATEGORY,
+                    category.name,
+                    category.slug,
+                    category.description,
+                    category.parent,
+                    category.count.toInt()
+                )
+            }
+        )
+    }
+
+    private suspend fun createTag(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val tagResponse = client.request { requestBuilder ->
+            requestBuilder.tags().create(
+                TagCreateParams(
+                    name = term.name,
+                    description = term.description,
+                    slug = term.slug,
+                )
+            )
+        }
+        handleCreateResponse(
+            response = tagResponse,
+            termType = "tag",
+            term = term,
+            site = site,
+            extractData = { it.response.data },
+            createTermModel = { data ->
+                val tag = data as TagWithEditContext
+                TermModel(
+                    tag.id.toInt(),
+                    site.id,
+                    tag.id,
+                    DEFAULT_TAXONOMY_TAG,
+                    tag.name,
+                    tag.slug,
+                    tag.description,
+                    0,
+                    tag.count.toInt()
+                )
+            }
+        )
+    }
+
+    @Suppress("LongParameterList")
     private inline fun <T> handleCreateResponse(
         response: WpRequestResult<T>,
         termType: String,
@@ -221,80 +236,91 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             when (term.taxonomy) {
-                DEFAULT_TAXONOMY_CATEGORY -> {
-                    val categoriesResponse = client.request { requestBuilder ->
-                        requestBuilder.categories().update(
-                            categoryId = term.remoteTermId,
-                            params = CategoryUpdateParams(
-                                name = term.name,
-                                description = term.description,
-                                slug = term.slug,
-                                parent = term.parentRemoteId
-                            )
-                        )
-                    }
-                    handleUpdateResponse(
-                        response = categoriesResponse,
-                        termType = "category",
-                        term = term,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModel = { data ->
-                            val category = data as uniffi.wp_api.CategoryWithEditContext
-                            TermModel(
-                                category.id.toInt(),
-                                site.id,
-                                category.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                                category.name,
-                                category.slug,
-                                category.description,
-                                category.parent,
-                                category.count.toInt()
-                            )
-                        }
-                    )
-                }
-
-                DEFAULT_TAXONOMY_TAG -> {
-                    val tagResponse = client.request { requestBuilder ->
-                        requestBuilder.tags().update(
-                            tagId = term.remoteTermId,
-                            params = TagUpdateParams(
-                                name = term.name,
-                                description = term.description,
-                                slug = term.slug,
-                            )
-                        )
-                    }
-                    handleUpdateResponse(
-                        response = tagResponse,
-                        termType = "tag",
-                        term = term,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModel = { data ->
-                            val tag = data as uniffi.wp_api.TagWithEditContext
-                            TermModel(
-                                tag.id.toInt(),
-                                site.id,
-                                tag.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                                tag.name,
-                                tag.slug,
-                                tag.description,
-                                0,
-                                tag.count.toInt()
-                            )
-                        }
-                    )
-                }
-
+                DEFAULT_TAXONOMY_CATEGORY -> updateCategory(client, term, site)
+                DEFAULT_TAXONOMY_TAG -> updateTag(client, term, site)
                 else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
 
+    private suspend fun updateCategory(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val categoriesResponse = client.request { requestBuilder ->
+            requestBuilder.categories().update(
+                categoryId = term.remoteTermId,
+                params = CategoryUpdateParams(
+                    name = term.name,
+                    description = term.description,
+                    slug = term.slug,
+                    parent = term.parentRemoteId
+                )
+            )
+        }
+        handleUpdateResponse(
+            response = categoriesResponse,
+            termType = "category",
+            term = term,
+            site = site,
+            extractData = { it.response.data },
+            createTermModel = { data ->
+                val category = data as CategoryWithEditContext
+                TermModel(
+                    category.id.toInt(),
+                    site.id,
+                    category.id,
+                    DEFAULT_TAXONOMY_CATEGORY,
+                    category.name,
+                    category.slug,
+                    category.description,
+                    category.parent,
+                    category.count.toInt()
+                )
+            }
+        )
+    }
+
+    private suspend fun updateTag(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val tagResponse = client.request { requestBuilder ->
+            requestBuilder.tags().update(
+                tagId = term.remoteTermId,
+                params = TagUpdateParams(
+                    name = term.name,
+                    description = term.description,
+                    slug = term.slug,
+                )
+            )
+        }
+        handleUpdateResponse(
+            response = tagResponse,
+            termType = "tag",
+            term = term,
+            site = site,
+            extractData = { it.response.data },
+            createTermModel = { data ->
+                val tag = data as TagWithEditContext
+                TermModel(
+                    tag.id.toInt(),
+                    site.id,
+                    tag.id,
+                    DEFAULT_TAXONOMY_TAG,
+                    tag.name,
+                    tag.slug,
+                    tag.description,
+                    0,
+                    tag.count.toInt()
+                )
+            }
+        )
+    }
+
+    @Suppress("LongParameterList")
     private inline fun <T> handleUpdateResponse(
         response: WpRequestResult<T>,
         termType: String,
@@ -307,8 +333,8 @@ class TaxonomyRsApiRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 val data = extractData(response)
                 val name = when (data) {
-                    is uniffi.wp_api.CategoryWithEditContext -> data.name
-                    is uniffi.wp_api.TagWithEditContext -> data.name
+                    is CategoryWithEditContext -> data.name
+                    is TagWithEditContext -> data.name
                     else -> "unknown"
                 }
                 appLogWrapper.d(AppLog.T.POSTS, "${termType.replaceFirstChar { it.uppercase() }} updated: $name")
@@ -333,73 +359,82 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             when (taxonomyName) {
-                DEFAULT_TAXONOMY_CATEGORY -> {
-                    val categoriesResponse = client.request { requestBuilder ->
-                        requestBuilder.categories().listWithEditContext(
-                            CategoryListParams()
-                        )
-                    }
-                    handleFetchResponse(
-                        response = categoriesResponse,
-                        termType = "categories",
-                        taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModels = { data ->
-                            (data as List<*>).map { category ->
-                                val cat = category as uniffi.wp_api.CategoryWithEditContext
-                                TermModel(
-                                    cat.id.toInt(),
-                                    site.id,
-                                    cat.id,
-                                    TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                                    cat.name,
-                                    cat.slug,
-                                    cat.description,
-                                    0,
-                                    cat.count.toInt()
-                                )
-                            }
-                        }
-                    )
-                }
-
-                DEFAULT_TAXONOMY_TAG -> {
-                    val tagsResponse = client.request { requestBuilder ->
-                        requestBuilder.tags().listWithEditContext(
-                            TagListParams()
-                        )
-                    }
-                    handleFetchResponse(
-                        response = tagsResponse,
-                        termType = "tags",
-                        taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                        site = site,
-                        extractData = { it.response.data },
-                        createTermModels = { data ->
-                            (data as List<*>).map { tag ->
-                                val t = tag as uniffi.wp_api.TagWithEditContext
-                                TermModel(
-                                    t.id.toInt(),
-                                    site.id,
-                                    t.id,
-                                    TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                                    t.name,
-                                    t.slug,
-                                    t.description,
-                                    0,
-                                    t.count.toInt()
-                                )
-                            }
-                        }
-                    )
-                }
-
+                DEFAULT_TAXONOMY_CATEGORY -> fetchCategories(client, site)
+                DEFAULT_TAXONOMY_TAG -> fetchTags(client, site)
                 else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
 
+    private suspend fun fetchCategories(
+        client: WpApiClient,
+        site: SiteModel
+    ) {
+        val categoriesResponse = client.request { requestBuilder ->
+            requestBuilder.categories().listWithEditContext(
+                CategoryListParams()
+            )
+        }
+        handleFetchResponse(
+            response = categoriesResponse,
+            termType = "categories",
+            taxonomy = DEFAULT_TAXONOMY_CATEGORY,
+            site = site,
+            extractData = { it.response.data },
+            createTermModels = { data ->
+                (data as List<*>).map { category ->
+                    val cat = category as CategoryWithEditContext
+                    TermModel(
+                        cat.id.toInt(),
+                        site.id,
+                        cat.id,
+                        DEFAULT_TAXONOMY_CATEGORY,
+                        cat.name,
+                        cat.slug,
+                        cat.description,
+                        0,
+                        cat.count.toInt()
+                    )
+                }
+            }
+        )
+    }
+
+    private suspend fun fetchTags(
+        client: WpApiClient,
+        site: SiteModel
+    ) {
+        val tagsResponse = client.request { requestBuilder ->
+            requestBuilder.tags().listWithEditContext(
+                TagListParams()
+            )
+        }
+        handleFetchResponse(
+            response = tagsResponse,
+            termType = "tags",
+            taxonomy = DEFAULT_TAXONOMY_TAG,
+            site = site,
+            extractData = { it.response.data },
+            createTermModels = { data ->
+                (data as List<*>).map { tag ->
+                    val t = tag as TagWithEditContext
+                    TermModel(
+                        t.id.toInt(),
+                        site.id,
+                        t.id,
+                        DEFAULT_TAXONOMY_TAG,
+                        t.name,
+                        t.slug,
+                        t.description,
+                        0,
+                        t.count.toInt()
+                    )
+                }
+            }
+        )
+    }
+
+    @Suppress("LongParameterList")
     private inline fun <T> handleFetchResponse(
         response: WpRequestResult<T>,
         termType: String,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.TermsModel
 import org.wordpress.android.fluxc.module.FLUXC_SCOPE
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.store.TaxonomyStore
+import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError
@@ -30,7 +31,15 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
-    fun fetchPostCategories(site: SiteModel) {
+    fun fetchTerms(site: SiteModel, taxonomyName: String) {
+        when (taxonomyName) {
+            DEFAULT_TAXONOMY_CATEGORY -> fetchPostCategories(site)
+            DEFAULT_TAXONOMY_TAG -> fetchPostTags(site)
+            else -> {} // TODO
+        }
+    }
+
+    private fun fetchPostCategories(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
@@ -74,7 +83,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         }
     }
 
-    fun fetchPostTags(site: SiteModel) {
+    private fun fetchPostTags(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -20,10 +20,12 @@ import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.CategoryCreateParams
+import uniffi.wp_api.CategoryDeleteResponse
 import uniffi.wp_api.CategoryListParams
 import uniffi.wp_api.CategoryUpdateParams
 import uniffi.wp_api.CategoryWithEditContext
 import uniffi.wp_api.TagCreateParams
+import uniffi.wp_api.TagDeleteResponse
 import uniffi.wp_api.TagListParams
 import uniffi.wp_api.TagUpdateParams
 import uniffi.wp_api.TagWithEditContext
@@ -58,26 +60,15 @@ class TaxonomyRsApiRestClient @Inject constructor(
         val categoriesResponse = client.request { requestBuilder ->
             requestBuilder.categories().delete(categoryId = term.id.toLong())
         }
-        when (categoriesResponse) {
-            is WpRequestResult.Success -> {
-                val category = categoriesResponse.response.data
-                appLogWrapper.d(
-                    AppLog.T.POSTS,
-                    "Deleted category: ${term.name} - ${category.deleted}"
-                )
-                if (category.deleted) {
-                    val termModel =
-                        createTermModelForDelete(term, site, DEFAULT_TAXONOMY_CATEGORY)
-                    notifyTermDeleted(RemoteTermPayload(termModel, site))
-                } else {
-                    notifyFailedDeleting("category", site, term)
-                }
-            }
-
-            else -> {
-                notifyFailedDeleting("category", site, term)
-            }
-        }
+        handleDeleteResponse(
+            response = categoriesResponse,
+            termType = "category",
+            term = term,
+            site = site,
+            taxonomy = DEFAULT_TAXONOMY_CATEGORY,
+            extractData = { it.response.data },
+            checkDeleted = { data -> (data as CategoryDeleteResponse).deleted }
+        )
     }
 
     private suspend fun deleteTag(
@@ -88,20 +79,40 @@ class TaxonomyRsApiRestClient @Inject constructor(
         val tagsResponse = client.request { requestBuilder ->
             requestBuilder.tags().delete(tagId = term.id.toLong())
         }
-        when (tagsResponse) {
+        handleDeleteResponse(
+            response = tagsResponse,
+            termType = "tag",
+            term = term,
+            site = site,
+            taxonomy = DEFAULT_TAXONOMY_TAG,
+            extractData = { it.response.data },
+            checkDeleted = { data -> (data as TagDeleteResponse).deleted }
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private inline fun <T> handleDeleteResponse(
+        response: WpRequestResult<T>,
+        termType: String,
+        term: TermModel,
+        site: SiteModel,
+        taxonomy: String,
+        extractData: (WpRequestResult.Success<T>) -> Any,
+        checkDeleted: (Any) -> Boolean
+    ) {
+        when (response) {
             is WpRequestResult.Success -> {
-                val tag = tagsResponse.response.data
-                appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
-                if (tag.deleted) {
-                    val termModel = createTermModelForDelete(term, site, DEFAULT_TAXONOMY_TAG)
+                val data = extractData(response)
+                appLogWrapper.d(AppLog.T.POSTS, "Deleted $termType: ${term.name} - ${checkDeleted(data)}")
+                if (checkDeleted(data)) {
+                    val termModel = createTermModelForDelete(term, site, taxonomy)
                     notifyTermDeleted(RemoteTermPayload(termModel, site))
                 } else {
-                    notifyFailedDeleting("tag", site, term)
+                    notifyFailedDeleting(termType, site, term)
                 }
             }
-
             else -> {
-                notifyFailedDeleting("tag", site, term)
+                notifyFailedDeleting(termType, site, term)
             }
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -104,108 +104,111 @@ class TaxonomyRsApiRestClient @Inject constructor(
     }
 
     fun createTerm(site: SiteModel, term: TermModel) {
-        when (term.taxonomy) {
-            DEFAULT_TAXONOMY_CATEGORY -> createCategory(site, term)
-            DEFAULT_TAXONOMY_TAG -> createTag(site, term)
-            else -> {} // TODO We are not supporting any other taxonomy yet
-        }
-    }
-
-    private fun createCategory(site: SiteModel, term: TermModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
-            val categoriesResponse = client.request { requestBuilder ->
-                requestBuilder.categories().create(
-                    CategoryCreateParams(
-                        name = term.name,
-                        description = term.description,
-                        slug = term.slug,
-                        parent = term.parentRemoteId
-                    )
-                )
-            }
+            when (term.taxonomy) {
+                DEFAULT_TAXONOMY_CATEGORY -> {
+                    val categoriesResponse = client.request { requestBuilder ->
+                        requestBuilder.categories().create(
+                            CategoryCreateParams(
+                                name = term.name,
+                                description = term.description,
+                                slug = term.slug,
+                                parent = term.parentRemoteId
+                            )
+                        )
+                    }
 
-            when (categoriesResponse) {
-                is WpRequestResult.Success -> {
-                    val category = categoriesResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Created category: ${category.name}")
-                    val payload = RemoteTermPayload(
-                        TermModel(
-                            category.id.toInt(),
-                            site.id,
-                            category.id,
-                            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                            category.name,
-                            category.slug,
-                            category.description,
-                            category.parent,
-                            category.count.toInt()
-                        ),
-                        site
-                    )
-                    notifyTermCreated(payload)
-                }
-
-                else -> {
-                    notifyFailedOperation(
-                        operation = "creating",
+                    handleCreateResponse(
+                        response = categoriesResponse,
                         termType = "category",
                         term = term,
                         site = site,
-                        errorDetails = categoriesResponse.toString(),
-                        notifier = ::notifyTermCreated
+                        extractData = { it.response.data },
+                        createTermModel = { data ->
+                            val category = data as uniffi.wp_api.CategoryWithEditContext
+                            TermModel(
+                                category.id.toInt(),
+                                site.id,
+                                category.id,
+                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                                category.name,
+                                category.slug,
+                                category.description,
+                                category.parent,
+                                category.count.toInt()
+                            )
+                        }
                     )
                 }
+                DEFAULT_TAXONOMY_TAG -> {
+                    val tagResponse = client.request { requestBuilder ->
+                        requestBuilder.tags().create(
+                            TagCreateParams(
+                                name = term.name,
+                                description = term.description,
+                                slug = term.slug,
+                            )
+                        )
+                    }
+
+                    handleCreateResponse(
+                        response = tagResponse,
+                        termType = "tag",
+                        term = term,
+                        site = site,
+                        extractData = { it.response.data },
+                        createTermModel = { data ->
+                            val tag = data as uniffi.wp_api.TagWithEditContext
+                            TermModel(
+                                tag.id.toInt(),
+                                site.id,
+                                tag.id,
+                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+                                tag.name,
+                                tag.slug,
+                                tag.description,
+                                0,
+                                tag.count.toInt()
+                            )
+                        }
+                    )
+                }
+                else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
 
-    private fun createTag(site: SiteModel, term: TermModel) {
-        scope.launch {
-            val client = wpApiClientProvider.getWpApiClient(site)
-
-            val tagResponse = client.request { requestBuilder ->
-                requestBuilder.tags().create(
-                    TagCreateParams(
-                        name = term.name,
-                        description = term.description,
-                        slug = term.slug,
-                    )
-                )
+    private inline fun <T> handleCreateResponse(
+        response: WpRequestResult<T>,
+        termType: String,
+        term: TermModel,
+        site: SiteModel,
+        extractData: (WpRequestResult.Success<T>) -> Any,
+        createTermModel: (Any) -> TermModel
+    ) {
+        when (response) {
+            is WpRequestResult.Success -> {
+                val data = extractData(response)
+                val name = when (data) {
+                    is uniffi.wp_api.CategoryWithEditContext -> data.name
+                    is uniffi.wp_api.TagWithEditContext -> data.name
+                    else -> "unknown"
+                }
+                appLogWrapper.d(AppLog.T.POSTS, "Created $termType: $name")
+                val payload = RemoteTermPayload(createTermModel(data), site)
+                notifyTermCreated(payload)
             }
-
-            when (tagResponse) {
-                is WpRequestResult.Success -> {
-                    val tag = tagResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Created tag: ${tag.name}")
-                    val payload = RemoteTermPayload(
-                        TermModel(
-                            tag.id.toInt(),
-                            site.id,
-                            tag.id,
-                            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                            tag.name,
-                            tag.slug,
-                            tag.description,
-                            0,
-                            tag.count.toInt()
-                        ),
-                        site
-                    )
-                    notifyTermCreated(payload)
-                }
-
-                else -> {
-                    notifyFailedOperation(
-                        operation = "creating",
-                        termType = "tag",
-                        term = term,
-                        site = site,
-                        errorDetails = tagResponse.toString(),
-                        notifier = ::notifyTermCreated
-                    )
-                }
+            else -> {
+                notifyFailedOperation(
+                    operation = "creating",
+                    termType = termType,
+                    term = term,
+                    site = site,
+                    errorDetails = response.toString(),
+                    notifier = ::notifyTermCreated
+                )
             }
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -134,7 +134,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
     }
 
     private fun notifyFailedDeletingTag(site: SiteModel, term: TermModel) {
-        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting category")
+        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting tag")
         val payload = RemoteTermPayload(term, site)
         payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
         notifyTermDeleted(payload)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -12,11 +12,13 @@ import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
 import uniffi.wp_api.TagListParams
 import javax.inject.Inject
@@ -30,6 +32,53 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
+    fun createPostCategory(site: SiteModel, term: TermModel) {
+        scope.launch {
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val categoriesResponse = client.request { requestBuilder ->
+                requestBuilder.categories().create(
+                    CategoryCreateParams(
+                        name = term.name,
+                        description = term.description,
+                        slug = term.slug,
+                        parent = term.parentRemoteId
+                    )
+                )
+            }
+
+            val termResponsePayload = when (categoriesResponse) {
+                is WpRequestResult.Success -> {
+                    val category = categoriesResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Created category: ${category.name}")
+                    RemoteTermPayload(
+                        TermModel(
+                            category.id.toInt(),
+                            site.id,
+                            category.id,
+                            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                            category.name,
+                            category.slug,
+                            category.description,
+                            0,
+                            category.count.toInt()
+                        ),
+                        site
+                    )
+                }
+
+                else -> {
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
+                    FetchTermsResponsePayload(
+                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
+                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
+                    )
+                }
+            }
+            notifyTermCreated(termResponsePayload)
+        }
+    }
+
     fun fetchPostCategories(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
@@ -122,6 +171,12 @@ class TaxonomyRsApiRestClient @Inject constructor(
         payload: FetchTermsResponsePayload,
     ) {
         dispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload))
+    }
+
+    private fun notifyTermCreated(
+        payload: RemoteTermPayload,
+    ) {
+        dispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload))
     }
 
     private fun createTermsResponsePayload(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -69,7 +69,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating category: $categoriesResponse")
                     val payload = RemoteTermPayload(term, site)
                     payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
                     notifyTermCreated(payload)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -21,8 +21,10 @@ import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
+import uniffi.wp_api.CategoryUpdateParams
 import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
+import uniffi.wp_api.TagUpdateParams
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -234,6 +236,121 @@ class TaxonomyRsApiRestClient @Inject constructor(
                     val payload = RemoteTermPayload(term, site)
                     payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
                     notifyTermCreated(payload)
+                }
+            }
+        }
+    }
+
+    fun updateTerm(site: SiteModel, term: TermModel) {
+        when (term.taxonomy) {
+            DEFAULT_TAXONOMY_CATEGORY -> updateCategory(site, term)
+            DEFAULT_TAXONOMY_TAG -> updateTag(site, term)
+            else -> {} // TODO We are not supporting any other taxonomy yet
+        }
+    }
+
+    private fun updateCategory(site: SiteModel, term: TermModel) {
+        scope.launch {
+            if (term.remoteTermId < 0) {
+                appLogWrapper.e(AppLog.T.POSTS, "Failed updating category: $term - id <= 0")
+                val payload = RemoteTermPayload(term, site)
+                payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+            }
+
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val categoriesResponse = client.request { requestBuilder ->
+                requestBuilder.categories().update(
+                    categoryId = term.remoteTermId,
+                    params = CategoryUpdateParams(
+                        name = term.name,
+                        description = term.description,
+                        slug = term.slug,
+                        parent = term.parentRemoteId
+                    )
+                )
+            }
+
+            when (categoriesResponse) {
+                is WpRequestResult.Success -> {
+                    val category = categoriesResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Category updated: ${category.name}")
+                    val payload = RemoteTermPayload(
+                        TermModel(
+                            category.id.toInt(),
+                            site.id,
+                            category.id,
+                            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                            category.name,
+                            category.slug,
+                            category.description,
+                            category.parent,
+                            category.count.toInt()
+                        ),
+                        site
+                    )
+                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                }
+
+                else -> {
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed updating category: $categoriesResponse")
+                    val payload = RemoteTermPayload(term, site)
+                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                }
+            }
+        }
+    }
+
+    private fun updateTag(site: SiteModel, term: TermModel) {
+        scope.launch {
+            if (term.remoteTermId < 0) {
+                appLogWrapper.e(AppLog.T.POSTS, "Failed updating tag: $term - id <= 0")
+                val payload = RemoteTermPayload(term, site)
+                payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+            }
+
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val tagResponse = client.request { requestBuilder ->
+                requestBuilder.tags().update(
+                    tagId = term.remoteTermId,
+                    params = TagUpdateParams(
+                        name = term.name,
+                        description = term.description,
+                        slug = term.slug,
+                    )
+                )
+            }
+
+            when (tagResponse) {
+                is WpRequestResult.Success -> {
+                    val tag = tagResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Tag updated: ${tag.name}")
+                    val payload = RemoteTermPayload(
+                        TermModel(
+                            tag.id.toInt(),
+                            site.id,
+                            tag.id,
+                            DEFAULT_TAXONOMY_TAG,
+                            tag.name,
+                            tag.slug,
+                            tag.description,
+                            0,
+                            tag.count.toInt()
+                        ),
+                        site
+                    )
+                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                }
+
+                else -> {
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed updating tag: $tagResponse")
+                    val payload = RemoteTermPayload(term, site)
+                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
                 }
             }
         }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -43,53 +43,65 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             when (term.taxonomy) {
-                DEFAULT_TAXONOMY_CATEGORY -> {
-                    val categoriesResponse = client.request { requestBuilder ->
-                        requestBuilder.categories().delete(categoryId = term.id.toLong())
-                    }
-                    when (categoriesResponse) {
-                        is WpRequestResult.Success -> {
-                            val category = categoriesResponse.response.data
-                            appLogWrapper.d(
-                                AppLog.T.POSTS,
-                                "Deleted category: ${term.name} - ${category.deleted}"
-                            )
-                            if (category.deleted) {
-                                val termModel =
-                                    createTermModelForDelete(term, site, DEFAULT_TAXONOMY_CATEGORY)
-                                notifyTermDeleted(RemoteTermPayload(termModel, site))
-                            } else {
-                                notifyFailedDeleting("category", site, term)
-                            }
-                        }
-                        else -> {
-                            notifyFailedDeleting("category", site, term)
-                        }
-                    }
-                }
-
-                DEFAULT_TAXONOMY_TAG -> {
-                    val tagsResponse = client.request { requestBuilder ->
-                        requestBuilder.tags().delete(tagId = term.id.toLong())
-                    }
-                    when (tagsResponse) {
-                        is WpRequestResult.Success -> {
-                            val tag = tagsResponse.response.data
-                            appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
-                            if (tag.deleted) {
-                                val termModel = createTermModelForDelete(term, site, DEFAULT_TAXONOMY_TAG)
-                                notifyTermDeleted(RemoteTermPayload(termModel, site))
-                            } else {
-                                notifyFailedDeleting("tag", site, term)
-                            }
-                        }
-                        else -> {
-                            notifyFailedDeleting("tag", site, term)
-                        }
-                    }
-                }
-
+                DEFAULT_TAXONOMY_CATEGORY -> deleteCategory(client, term, site)
+                DEFAULT_TAXONOMY_TAG -> deleteTag(client, term, site)
                 else -> {} // TODO We are not supporting any other taxonomy yet
+            }
+        }
+    }
+
+    private suspend fun deleteCategory(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val categoriesResponse = client.request { requestBuilder ->
+            requestBuilder.categories().delete(categoryId = term.id.toLong())
+        }
+        when (categoriesResponse) {
+            is WpRequestResult.Success -> {
+                val category = categoriesResponse.response.data
+                appLogWrapper.d(
+                    AppLog.T.POSTS,
+                    "Deleted category: ${term.name} - ${category.deleted}"
+                )
+                if (category.deleted) {
+                    val termModel =
+                        createTermModelForDelete(term, site, DEFAULT_TAXONOMY_CATEGORY)
+                    notifyTermDeleted(RemoteTermPayload(termModel, site))
+                } else {
+                    notifyFailedDeleting("category", site, term)
+                }
+            }
+
+            else -> {
+                notifyFailedDeleting("category", site, term)
+            }
+        }
+    }
+
+    private suspend fun deleteTag(
+        client: WpApiClient,
+        term: TermModel,
+        site: SiteModel
+    ) {
+        val tagsResponse = client.request { requestBuilder ->
+            requestBuilder.tags().delete(tagId = term.id.toLong())
+        }
+        when (tagsResponse) {
+            is WpRequestResult.Success -> {
+                val tag = tagsResponse.response.data
+                appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
+                if (tag.deleted) {
+                    val termModel = createTermModelForDelete(term, site, DEFAULT_TAXONOMY_TAG)
+                    notifyTermDeleted(RemoteTermPayload(termModel, site))
+                } else {
+                    notifyFailedDeleting("tag", site, term)
+                }
+            }
+
+            else -> {
+                notifyFailedDeleting("tag", site, term)
             }
         }
     }
@@ -202,8 +214,8 @@ class TaxonomyRsApiRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 val data = extractData(response)
                 val name = when (data) {
-                    is uniffi.wp_api.CategoryWithEditContext -> data.name
-                    is uniffi.wp_api.TagWithEditContext -> data.name
+                    is CategoryWithEditContext -> data.name
+                    is TagWithEditContext -> data.name
                     else -> "unknown"
                 }
                 appLogWrapper.d(AppLog.T.POSTS, "Created $termType: $name")

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -60,7 +60,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             category.name,
                             category.slug,
                             category.description,
-                            0,
+                            category.parent,
                             category.count.toInt()
                         ),
                         site

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -404,7 +404,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         cat.name,
                         cat.slug,
                         cat.description,
-                        0,
+                        cat.parent,
                         cat.count.toInt()
                     )
                 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -47,11 +47,11 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 )
             }
 
-            val termResponsePayload = when (categoriesResponse) {
+            when (categoriesResponse) {
                 is WpRequestResult.Success -> {
                     val category = categoriesResponse.response.data
                     appLogWrapper.d(AppLog.T.POSTS, "Created category: ${category.name}")
-                    RemoteTermPayload(
+                    val payload = RemoteTermPayload(
                         TermModel(
                             category.id.toInt(),
                             site.id,
@@ -65,17 +65,16 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         ),
                         site
                     )
+                    notifyTermCreated(payload)
                 }
 
                 else -> {
                     appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
-                    FetchTermsResponsePayload(
-                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
-                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
-                    )
+                    val payload = RemoteTermPayload(term, site)
+                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                    notifyTermCreated(payload)
                 }
             }
-            notifyTermCreated(termResponsePayload)
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -49,9 +49,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             val categoriesResponse = client.request { requestBuilder ->
-                requestBuilder.categories().delete(
-                    categoryId = term.id.toLong()
-                )
+                requestBuilder.categories().delete(categoryId = term.id.toLong())
             }
 
             when (categoriesResponse) {
@@ -59,26 +57,12 @@ class TaxonomyRsApiRestClient @Inject constructor(
                     val category = categoriesResponse.response.data
                     appLogWrapper.d(AppLog.T.POSTS, "Deleted category: ${term.name} - ${category.deleted}")
                     if (category.deleted) {
-                        val payload = RemoteTermPayload(
-                            TermModel(
-                                term.id,
-                                site.id,
-                                term.id.toLong(),
-                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                                term.name,
-                                term.slug,
-                                term.description,
-                                term.parentRemoteId,
-                                term.postCount
-                            ),
-                            site
-                        )
-                        notifyTermDeleted(payload)
+                        val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
+                        notifyTermDeleted(RemoteTermPayload(termModel, site))
                     } else {
                         notifyFailedDeleting("category", site, term)
                     }
                 }
-
                 else -> {
                     notifyFailedDeleting("category", site, term)
                 }
@@ -91,36 +75,20 @@ class TaxonomyRsApiRestClient @Inject constructor(
             val client = wpApiClientProvider.getWpApiClient(site)
 
             val tagsResponse = client.request { requestBuilder ->
-                requestBuilder.tags().delete(
-                    tagId = term.id.toLong()
-                )
+                requestBuilder.tags().delete(tagId = term.id.toLong())
             }
 
             when (tagsResponse) {
                 is WpRequestResult.Success -> {
-                    val category = tagsResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${category.deleted}")
-                    if (category.deleted) {
-                        val payload = RemoteTermPayload(
-                            TermModel(
-                                term.id,
-                                site.id,
-                                term.id.toLong(),
-                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                                term.name,
-                                term.slug,
-                                term.description,
-                                term.parentRemoteId,
-                                term.postCount
-                            ),
-                            site
-                        )
-                        notifyTermDeleted(payload)
+                    val tag = tagsResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${tag.deleted}")
+                    if (tag.deleted) {
+                        val termModel = createTermModelForDelete(term, site, TaxonomyStore.DEFAULT_TAXONOMY_TAG)
+                        notifyTermDeleted(RemoteTermPayload(termModel, site))
                     } else {
                         notifyFailedDeleting("tag", site, term)
                     }
                 }
-
                 else -> {
                     notifyFailedDeleting("tag", site, term)
                 }
@@ -488,6 +456,49 @@ class TaxonomyRsApiRestClient @Inject constructor(
             TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
             taxonomyName
         )
+
+
+    private fun createTermModelForDelete(term: TermModel, site: SiteModel, taxonomy: String): TermModel {
+        return TermModel(
+            term.id,
+            site.id,
+            term.id.toLong(),
+            taxonomy,
+            term.name,
+            term.slug,
+            term.description,
+            term.parentRemoteId,
+            term.postCount
+        )
+    }
+
+    private fun createCategoryTermModel(category: uniffi.wp_api.CategoryWithEditContext, site: SiteModel): TermModel {
+        return TermModel(
+            category.id.toInt(),
+            site.id,
+            category.id,
+            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+            category.name,
+            category.slug,
+            category.description,
+            category.parent,
+            category.count.toInt()
+        )
+    }
+
+    private fun createTagTermModel(tag: uniffi.wp_api.TagWithEditContext, site: SiteModel): TermModel {
+        return TermModel(
+            tag.id.toInt(),
+            site.id,
+            tag.id,
+            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+            tag.name,
+            tag.slug,
+            tag.description,
+            0,
+            tag.count.toInt()
+        )
+    }
 
     private fun createTermsResponsePayload(
         terms: List<TermModel>,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -37,8 +37,8 @@ class TaxonomyRsApiRestClient @Inject constructor(
     fun deleteTerm(site: SiteModel, term: TermModel) {
         when (term.taxonomy) {
             DEFAULT_TAXONOMY_CATEGORY -> deleteCategory(site, term)
-            DEFAULT_TAXONOMY_TAG -> createTag(site, term)
-            else -> {} // TODO
+            DEFAULT_TAXONOMY_TAG -> deleteTag(site, term)
+            else -> {} // TODO We are not supporting any other taxonomy yet
         }
     }
 
@@ -144,7 +144,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         when (term.taxonomy) {
             DEFAULT_TAXONOMY_CATEGORY -> createCategory(site, term)
             DEFAULT_TAXONOMY_TAG -> createTag(site, term)
-            else -> {} // TODO
+            else -> {} // TODO We are not supporting any other taxonomy yet
         }
     }
 
@@ -243,7 +243,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         when (taxonomyName) {
             DEFAULT_TAXONOMY_CATEGORY -> fetchCategories(site)
             DEFAULT_TAXONOMY_TAG -> fetchTags(site)
-            else -> {} // TODO
+            else -> {} // TODO We are not supporting any other taxonomy yet
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -142,6 +142,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         }
                     )
                 }
+
                 DEFAULT_TAXONOMY_TAG -> {
                     val tagResponse = client.request { requestBuilder ->
                         requestBuilder.tags().create(
@@ -152,7 +153,6 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             )
                         )
                     }
-
                     handleCreateResponse(
                         response = tagResponse,
                         termType = "tag",
@@ -175,6 +175,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         }
                     )
                 }
+
                 else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
@@ -214,107 +215,121 @@ class TaxonomyRsApiRestClient @Inject constructor(
     }
 
     fun updateTerm(site: SiteModel, term: TermModel) {
-        when (term.taxonomy) {
-            DEFAULT_TAXONOMY_CATEGORY -> updateCategory(site, term)
-            DEFAULT_TAXONOMY_TAG -> updateTag(site, term)
-            else -> {} // TODO We are not supporting any other taxonomy yet
-        }
-    }
-
-    private fun updateCategory(site: SiteModel, term: TermModel) {
         scope.launch {
-            if (!validateTermId(term, site, "category")) return@launch
+            if (term.remoteTermId < 0) {
+                appLogWrapper.e(AppLog.T.POSTS, "Failed updating term: $term - id <= 0")
+                val payload = RemoteTermPayload(term, site)
+                payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                return@launch
+            }
 
             val client = wpApiClientProvider.getWpApiClient(site)
 
-            val categoriesResponse = client.request { requestBuilder ->
-                requestBuilder.categories().update(
-                    categoryId = term.remoteTermId,
-                    params = CategoryUpdateParams(
-                        name = term.name,
-                        description = term.description,
-                        slug = term.slug,
-                        parent = term.parentRemoteId
-                    )
-                )
-            }
-
-            when (categoriesResponse) {
-                is WpRequestResult.Success -> {
-                    val category = categoriesResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Category updated: ${category.name}")
-                    val payload = RemoteTermPayload(
-                        TermModel(
-                            category.id.toInt(),
-                            site.id,
-                            category.id,
-                            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                            category.name,
-                            category.slug,
-                            category.description,
-                            category.parent,
-                            category.count.toInt()
-                        ),
-                        site
-                    )
-                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
-                }
-
-                else -> {
-                    notifyFailedOperation(
-                        operation = "updating",
-                        termType ="category",
+            when (term.taxonomy) {
+                DEFAULT_TAXONOMY_CATEGORY -> {
+                    val categoriesResponse = client.request { requestBuilder ->
+                        requestBuilder.categories().update(
+                            categoryId = term.remoteTermId,
+                            params = CategoryUpdateParams(
+                                name = term.name,
+                                description = term.description,
+                                slug = term.slug,
+                                parent = term.parentRemoteId
+                            )
+                        )
+                    }
+                    handleUpdateResponse(
+                        response = categoriesResponse,
+                        termType = "category",
                         term = term,
                         site = site,
-                        errorDetails = categoriesResponse.toString(),
-                        notifier = ::notifyTermCreated
+                        extractData = { it.response.data },
+                        createTermModel = { data ->
+                            val category = data as uniffi.wp_api.CategoryWithEditContext
+                            TermModel(
+                                category.id.toInt(),
+                                site.id,
+                                category.id,
+                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                                category.name,
+                                category.slug,
+                                category.description,
+                                category.parent,
+                                category.count.toInt()
+                            )
+                        }
                     )
                 }
+
+                DEFAULT_TAXONOMY_TAG -> {
+                    val tagResponse = client.request { requestBuilder ->
+                        requestBuilder.tags().update(
+                            tagId = term.remoteTermId,
+                            params = TagUpdateParams(
+                                name = term.name,
+                                description = term.description,
+                                slug = term.slug,
+                            )
+                        )
+                    }
+                    handleUpdateResponse(
+                        response = tagResponse,
+                        termType = "tag",
+                        term = term,
+                        site = site,
+                        extractData = { it.response.data },
+                        createTermModel = { data ->
+                            val tag = data as uniffi.wp_api.TagWithEditContext
+                            TermModel(
+                                tag.id.toInt(),
+                                site.id,
+                                tag.id,
+                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+                                tag.name,
+                                tag.slug,
+                                tag.description,
+                                0,
+                                tag.count.toInt()
+                            )
+                        }
+                    )
+                }
+
+                else -> {} // TODO We are not supporting any other taxonomy yet
             }
         }
     }
 
-    private fun updateTag(site: SiteModel, term: TermModel) {
-        scope.launch {
-            if (!validateTermId(term, site, "tag")) return@launch
-
-            val client = wpApiClientProvider.getWpApiClient(site)
-
-            val tagResponse = client.request { requestBuilder ->
-                requestBuilder.tags().update(
-                    tagId = term.remoteTermId,
-                    params = TagUpdateParams(
-                        name = term.name,
-                        description = term.description,
-                        slug = term.slug,
-                    )
-                )
+    private inline fun <T> handleUpdateResponse(
+        response: WpRequestResult<T>,
+        termType: String,
+        term: TermModel,
+        site: SiteModel,
+        extractData: (WpRequestResult.Success<T>) -> Any,
+        createTermModel: (Any) -> TermModel
+    ) {
+        when (response) {
+            is WpRequestResult.Success -> {
+                val data = extractData(response)
+                val name = when (data) {
+                    is uniffi.wp_api.CategoryWithEditContext -> data.name
+                    is uniffi.wp_api.TagWithEditContext -> data.name
+                    else -> "unknown"
+                }
+                appLogWrapper.d(AppLog.T.POSTS, "${termType.replaceFirstChar { it.uppercase() }} updated: $name")
+                val payload = RemoteTermPayload(createTermModel(data), site)
+                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
             }
-
-            when (tagResponse) {
-                is WpRequestResult.Success -> {
-                    val tag = tagResponse.response.data
-                    appLogWrapper.d(AppLog.T.POSTS, "Tag updated: ${tag.name}")
-                    val payload = RemoteTermPayload(
-                        TermModel(
-                            tag.id.toInt(),
-                            site.id,
-                            tag.id,
-                            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                            tag.name,
-                            tag.slug,
-                            tag.description,
-                            0,
-                            tag.count.toInt()
-                        ),
-                        site
-                    )
-                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
-                }
-
-                else -> {
-                    notifyFailedOperation("updating", "tag", term, site, tagResponse.toString(), ::notifyTermCreated)
-                }
+            else -> {
+                notifyFailedOperation(
+                    operation = "updating",
+                    termType = termType,
+                    term = term,
+                    site = site,
+                    errorDetails = response.toString(),
+                    notifier = ::notifyTermCreated
+                )
             }
         }
     }
@@ -427,18 +442,6 @@ class TaxonomyRsApiRestClient @Inject constructor(
         dispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload))
     }
 
-    private fun validateTermId(term: TermModel, site: SiteModel, termType: String): Boolean {
-        return if (term.remoteTermId < 0) {
-            appLogWrapper.e(AppLog.T.POSTS, "Failed updating $termType: $term - id <= 0")
-            val payload = RemoteTermPayload(term, site)
-            payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-            notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
-            false
-        } else {
-            true
-        }
-    }
-
     @Suppress("LongParameterList")
     private fun notifyFailedOperation(
         operation: String,
@@ -472,34 +475,6 @@ class TaxonomyRsApiRestClient @Inject constructor(
             term.description,
             term.parentRemoteId,
             term.postCount
-        )
-    }
-
-    private fun createCategoryTermModel(category: uniffi.wp_api.CategoryWithEditContext, site: SiteModel): TermModel {
-        return TermModel(
-            category.id.toInt(),
-            site.id,
-            category.id,
-            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-            category.name,
-            category.slug,
-            category.description,
-            category.parent,
-            category.count.toInt()
-        )
-    }
-
-    private fun createTagTermModel(tag: uniffi.wp_api.TagWithEditContext, site: SiteModel): TermModel {
-        return TermModel(
-            tag.id.toInt(),
-            site.id,
-            tag.id,
-            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-            tag.name,
-            tag.slug,
-            tag.description,
-            0,
-            tag.count.toInt()
         )
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -34,6 +34,111 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
+    fun deleteTerm(site: SiteModel, term: TermModel) {
+        when (term.taxonomy) {
+            DEFAULT_TAXONOMY_CATEGORY -> deleteCategory(site, term)
+            DEFAULT_TAXONOMY_TAG -> createTag(site, term)
+            else -> {} // TODO
+        }
+    }
+
+    private fun deleteCategory(site: SiteModel, term: TermModel) {
+        scope.launch {
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val categoriesResponse = client.request { requestBuilder ->
+                requestBuilder.categories().delete(
+                    categoryId = term.id.toLong()
+                )
+            }
+
+            when (categoriesResponse) {
+                is WpRequestResult.Success -> {
+                    val category = categoriesResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Deleted category: ${term.name} - ${category.deleted}")
+                    if (category.deleted) {
+                        val payload = RemoteTermPayload(
+                            TermModel(
+                                term.id,
+                                site.id,
+                                term.id.toLong(),
+                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                                term.name,
+                                term.slug,
+                                term.description,
+                                term.parentRemoteId,
+                                term.postCount
+                            ),
+                            site
+                        )
+                        notifyTermDeleted(payload)
+                    } else {
+                        notifyFailedDeletingCategory(site, term)
+                    }
+                }
+
+                else -> {
+                    notifyFailedDeletingCategory(site, term)
+                }
+            }
+        }
+    }
+
+    private fun notifyFailedDeletingCategory(site: SiteModel, term: TermModel) {
+        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting category")
+        val payload = RemoteTermPayload(term, site)
+        payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+        notifyTermDeleted(payload)
+    }
+
+    private fun deleteTag(site: SiteModel, term: TermModel) {
+        scope.launch {
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val tagsResponse = client.request { requestBuilder ->
+                requestBuilder.tags().delete(
+                    tagId = term.id.toLong()
+                )
+            }
+
+            when (tagsResponse) {
+                is WpRequestResult.Success -> {
+                    val category = tagsResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Deleted tag: ${term.name} - ${category.deleted}")
+                    if (category.deleted) {
+                        val payload = RemoteTermPayload(
+                            TermModel(
+                                term.id,
+                                site.id,
+                                term.id.toLong(),
+                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+                                term.name,
+                                term.slug,
+                                term.description,
+                                term.parentRemoteId,
+                                term.postCount
+                            ),
+                            site
+                        )
+                        notifyTermDeleted(payload)
+                    } else {
+                        notifyFailedDeletingTag(site, term)
+                    }
+                }
+
+                else -> {
+                    notifyFailedDeletingTag(site, term)
+                }
+            }
+        }
+    }
+
+    private fun notifyFailedDeletingTag(site: SiteModel, term: TermModel) {
+        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting category")
+        val payload = RemoteTermPayload(term, site)
+        payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+        notifyTermDeleted(payload)
+    }
 
     fun createTerm(site: SiteModel, term: TermModel) {
         when (term.taxonomy) {
@@ -240,6 +345,12 @@ class TaxonomyRsApiRestClient @Inject constructor(
         payload: RemoteTermPayload,
     ) {
         dispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload))
+    }
+
+    private fun notifyTermDeleted(
+        payload: RemoteTermPayload,
+    ) {
+        dispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload))
     }
 
     private fun createTermsResponsePayload(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -335,93 +335,102 @@ class TaxonomyRsApiRestClient @Inject constructor(
     }
 
     fun fetchTerms(site: SiteModel, taxonomyName: String) {
-        when (taxonomyName) {
-            DEFAULT_TAXONOMY_CATEGORY -> fetchCategories(site)
-            DEFAULT_TAXONOMY_TAG -> fetchTags(site)
-            else -> {} // TODO We are not supporting any other taxonomy yet
-        }
-    }
-
-    private fun fetchCategories(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
 
-            val categoriesResponse = client.request { requestBuilder ->
-                requestBuilder.categories().listWithEditContext(
-                    CategoryListParams()
-                )
-            }
-
-            val termsResponsePayload = when (categoriesResponse) {
-                is WpRequestResult.Success -> {
-                    appLogWrapper.d(AppLog.T.POSTS, "Fetched categories list: ${categoriesResponse.response.data.size}")
-                    createTermsResponsePayload(
-                        categoriesResponse.response.data.map { category ->
-                            TermModel(
-                                category.id.toInt(),
-                                site.id,
-                                category.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
-                                category.name,
-                                category.slug,
-                                category.description,
-                                0,
-                                category.count.toInt()
-                            )
-                        },
-                        site,
-                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
+            when (taxonomyName) {
+                DEFAULT_TAXONOMY_CATEGORY -> {
+                    val categoriesResponse = client.request { requestBuilder ->
+                        requestBuilder.categories().listWithEditContext(
+                            CategoryListParams()
+                        )
+                    }
+                    handleFetchResponse(
+                        response = categoriesResponse,
+                        termType = "categories",
+                        taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                        site = site,
+                        extractData = { it.response.data },
+                        createTermModels = { data ->
+                            (data as List<*>).map { category ->
+                                val cat = category as uniffi.wp_api.CategoryWithEditContext
+                                TermModel(
+                                    cat.id.toInt(),
+                                    site.id,
+                                    cat.id,
+                                    TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                                    cat.name,
+                                    cat.slug,
+                                    cat.description,
+                                    0,
+                                    cat.count.toInt()
+                                )
+                            }
+                        }
                     )
                 }
 
-                else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Fetch categories list failed: $categoriesResponse")
-                    createErrorResponsePayload(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
+                DEFAULT_TAXONOMY_TAG -> {
+                    val tagsResponse = client.request { requestBuilder ->
+                        requestBuilder.tags().listWithEditContext(
+                            TagListParams()
+                        )
+                    }
+                    handleFetchResponse(
+                        response = tagsResponse,
+                        termType = "tags",
+                        taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+                        site = site,
+                        extractData = { it.response.data },
+                        createTermModels = { data ->
+                            (data as List<*>).map { tag ->
+                                val t = tag as uniffi.wp_api.TagWithEditContext
+                                TermModel(
+                                    t.id.toInt(),
+                                    site.id,
+                                    t.id,
+                                    TaxonomyStore.DEFAULT_TAXONOMY_TAG,
+                                    t.name,
+                                    t.slug,
+                                    t.description,
+                                    0,
+                                    t.count.toInt()
+                                )
+                            }
+                        }
+                    )
                 }
+                
+                else -> {} // TODO We are not supporting any other taxonomy yet
             }
-            notifyTermsFetched(termsResponsePayload)
         }
     }
 
-    private fun fetchTags(site: SiteModel) {
-        scope.launch {
-            val client = wpApiClientProvider.getWpApiClient(site)
-
-            val tagsResponse = client.request { requestBuilder ->
-                requestBuilder.tags().listWithEditContext(
-                    TagListParams()
+    private inline fun <T> handleFetchResponse(
+        response: WpRequestResult<T>,
+        termType: String,
+        taxonomy: String,
+        site: SiteModel,
+        extractData: (WpRequestResult.Success<T>) -> Any,
+        createTermModels: (Any) -> List<TermModel>
+    ) {
+        val termsResponsePayload = when (response) {
+            is WpRequestResult.Success -> {
+                val data = extractData(response)
+                val dataList = data as List<*>
+                appLogWrapper.d(AppLog.T.POSTS, "Fetched $termType list: ${dataList.size}")
+                createTermsResponsePayload(
+                    createTermModels(data),
+                    site,
+                    taxonomy
                 )
             }
-
-            val termsResponsePayload = when (tagsResponse) {
-                is WpRequestResult.Success -> {
-                    appLogWrapper.d(AppLog.T.POSTS, "Fetched tags list: ${tagsResponse.response.data.size}")
-                    createTermsResponsePayload(
-                        tagsResponse.response.data.map { tag ->
-                            TermModel(
-                                tag.id.toInt(),
-                                site.id,
-                                tag.id,
-                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
-                                tag.name,
-                                tag.slug,
-                                tag.description,
-                                0,
-                                tag.count.toInt()
-                            )
-                        },
-                        site,
-                        TaxonomyStore.DEFAULT_TAXONOMY_TAG
-                    )
-                }
-
-                else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Fetch tags list failed: $tagsResponse")
-                    createErrorResponsePayload(TaxonomyStore.DEFAULT_TAXONOMY_TAG)
-                }
+            else -> {
+                appLogWrapper.e(AppLog.T.POSTS, "Fetch $termType list failed: $response")
+                createErrorResponsePayload(taxonomy)
             }
-            notifyTermsFetched(termsResponsePayload)
         }
+        notifyTermsFetched(termsResponsePayload)
     }
 
     private fun notifyTermsFetched(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -75,22 +75,15 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         )
                         notifyTermDeleted(payload)
                     } else {
-                        notifyFailedDeletingCategory(site, term)
+                        notifyFailedDeleting("category", site, term)
                     }
                 }
 
                 else -> {
-                    notifyFailedDeletingCategory(site, term)
+                    notifyFailedDeleting("category", site, term)
                 }
             }
         }
-    }
-
-    private fun notifyFailedDeletingCategory(site: SiteModel, term: TermModel) {
-        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting category")
-        val payload = RemoteTermPayload(term, site)
-        payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-        notifyTermDeleted(payload)
     }
 
     private fun deleteTag(site: SiteModel, term: TermModel) {
@@ -124,19 +117,19 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         )
                         notifyTermDeleted(payload)
                     } else {
-                        notifyFailedDeletingTag(site, term)
+                        notifyFailedDeleting("tag", site, term)
                     }
                 }
 
                 else -> {
-                    notifyFailedDeletingTag(site, term)
+                    notifyFailedDeleting("tag", site, term)
                 }
             }
         }
     }
 
-    private fun notifyFailedDeletingTag(site: SiteModel, term: TermModel) {
-        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting tag")
+    private fun notifyFailedDeleting(termType: String, site: SiteModel, term: TermModel) {
+        appLogWrapper.e(AppLog.T.POSTS, "Failed deleting $termType")
         val payload = RemoteTermPayload(term, site)
         payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
         notifyTermDeleted(payload)
@@ -187,10 +180,14 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating category: $categoriesResponse")
-                    val payload = RemoteTermPayload(term, site)
-                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                    notifyTermCreated(payload)
+                    notifyFailedOperation(
+                        operation = "creating",
+                        termType = "category",
+                        term = term,
+                        site = site,
+                        errorDetails = categoriesResponse.toString(),
+                        notifier = ::notifyTermCreated
+                    )
                 }
             }
         }
@@ -219,7 +216,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             tag.id.toInt(),
                             site.id,
                             tag.id,
-                            DEFAULT_TAXONOMY_TAG,
+                            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
                             tag.name,
                             tag.slug,
                             tag.description,
@@ -232,10 +229,14 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating tag: $tagResponse")
-                    val payload = RemoteTermPayload(term, site)
-                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                    notifyTermCreated(payload)
+                    notifyFailedOperation(
+                        operation = "creating",
+                        termType = "tag",
+                        term = term,
+                        site = site,
+                        errorDetails = tagResponse.toString(),
+                        notifier = ::notifyTermCreated
+                    )
                 }
             }
         }
@@ -251,13 +252,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
 
     private fun updateCategory(site: SiteModel, term: TermModel) {
         scope.launch {
-            if (term.remoteTermId < 0) {
-                appLogWrapper.e(AppLog.T.POSTS, "Failed updating category: $term - id <= 0")
-                val payload = RemoteTermPayload(term, site)
-                payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
-                return@launch
-            }
+            if (!validateTermId(term, site, "category")) return@launch
 
             val client = wpApiClientProvider.getWpApiClient(site)
 
@@ -295,10 +290,14 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed updating category: $categoriesResponse")
-                    val payload = RemoteTermPayload(term, site)
-                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                    notifyFailedOperation(
+                        operation = "updating",
+                        termType ="category",
+                        term = term,
+                        site = site,
+                        errorDetails = categoriesResponse.toString(),
+                        notifier = ::notifyTermCreated
+                    )
                 }
             }
         }
@@ -306,13 +305,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
 
     private fun updateTag(site: SiteModel, term: TermModel) {
         scope.launch {
-            if (term.remoteTermId < 0) {
-                appLogWrapper.e(AppLog.T.POSTS, "Failed updating tag: $term - id <= 0")
-                val payload = RemoteTermPayload(term, site)
-                payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
-                return@launch
-            }
+            if (!validateTermId(term, site, "tag")) return@launch
 
             val client = wpApiClientProvider.getWpApiClient(site)
 
@@ -336,7 +329,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             tag.id.toInt(),
                             site.id,
                             tag.id,
-                            DEFAULT_TAXONOMY_TAG,
+                            TaxonomyStore.DEFAULT_TAXONOMY_TAG,
                             tag.name,
                             tag.slug,
                             tag.description,
@@ -349,10 +342,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed updating tag: $tagResponse")
-                    val payload = RemoteTermPayload(term, site)
-                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
-                    notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+                    notifyFailedOperation("updating", "tag", term, site, tagResponse.toString(), ::notifyTermCreated)
                 }
             }
         }
@@ -400,10 +390,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
 
                 else -> {
                     appLogWrapper.e(AppLog.T.POSTS, "Fetch categories list failed: $categoriesResponse")
-                    FetchTermsResponsePayload(
-                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
-                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
-                    )
+                    createErrorResponsePayload(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY)
                 }
             }
             notifyTermsFetched(termsResponsePayload)
@@ -429,7 +416,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                                 tag.id.toInt(),
                                 site.id,
                                 tag.id,
-                                DEFAULT_TAXONOMY_TAG,
+                                TaxonomyStore.DEFAULT_TAXONOMY_TAG,
                                 tag.name,
                                 tag.slug,
                                 tag.description,
@@ -438,16 +425,13 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             )
                         },
                         site,
-                        DEFAULT_TAXONOMY_TAG
+                        TaxonomyStore.DEFAULT_TAXONOMY_TAG
                     )
                 }
 
                 else -> {
                     appLogWrapper.e(AppLog.T.POSTS, "Fetch tags list failed: $tagsResponse")
-                    FetchTermsResponsePayload(
-                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
-                        DEFAULT_TAXONOMY_TAG
-                    )
+                    createErrorResponsePayload(TaxonomyStore.DEFAULT_TAXONOMY_TAG)
                 }
             }
             notifyTermsFetched(termsResponsePayload)
@@ -471,6 +455,39 @@ class TaxonomyRsApiRestClient @Inject constructor(
     ) {
         dispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload))
     }
+
+    private fun validateTermId(term: TermModel, site: SiteModel, termType: String): Boolean {
+        return if (term.remoteTermId < 0) {
+            appLogWrapper.e(AppLog.T.POSTS, "Failed updating $termType: $term - id <= 0")
+            val payload = RemoteTermPayload(term, site)
+            payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+            notifyTermCreated(payload) // FluxC uses notifyTermCreated for updates
+            false
+        } else {
+            true
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun notifyFailedOperation(
+        operation: String,
+        termType: String,
+        term: TermModel,
+        site: SiteModel,
+        errorDetails: String,
+        notifier: (RemoteTermPayload) -> Unit
+    ) {
+        appLogWrapper.e(AppLog.T.POSTS, "Failed $operation $termType: $errorDetails")
+        val payload = RemoteTermPayload(term, site)
+        payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+        notifier(payload)
+    }
+
+    private fun createErrorResponsePayload(taxonomyName: String): FetchTermsResponsePayload =
+        FetchTermsResponsePayload(
+            TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
+            taxonomyName
+        )
 
     private fun createTermsResponsePayload(
         terms: List<TermModel>,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -278,6 +280,8 @@ public class TaxonomyStore extends Store {
             return;
         }
 
+        Log.d("TAX_TAG", "Action: " + actionType);
+
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:
                 fetchTerms(((SiteModel) action.getPayload()), DEFAULT_TAXONOMY_CATEGORY);
@@ -328,11 +332,8 @@ public class TaxonomyStore extends Store {
     }
 
     private void fetchTerms(@NonNull SiteModel site, @NonNull String taxonomyName) {
-        boolean isUsingApplicationPassword = site.isUsingSelfHostedRestApi();
-        if (isUsingApplicationPassword && DEFAULT_TAXONOMY_CATEGORY.equals(taxonomyName)) {
-            mTaxonomyRsApiRestClient.fetchPostCategories(site);
-        } else if (isUsingApplicationPassword && DEFAULT_TAXONOMY_TAG.equals(taxonomyName)) {
-            mTaxonomyRsApiRestClient.fetchPostTags(site);
+        if (site.isUsingSelfHostedRestApi()) {
+            mTaxonomyRsApiRestClient.fetchTerms(site, taxonomyName);
         } else if (site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.fetchTerms(site, taxonomyName);
         } else {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.store;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -279,8 +277,6 @@ public class TaxonomyStore extends Store {
         if (!(actionType instanceof TaxonomyAction)) {
             return;
         }
-
-        Log.d("TAX_TAG", "New action: " + actionType);
 
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -424,7 +424,7 @@ public class TaxonomyStore extends Store {
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
         if (payload.site.isUsingSelfHostedRestApi()) {
-            // FluxC pushTerm to update terms, so we need to mae the distinction here
+            // FluxC pushTerm to update terms, so we need to make the distinction here
             if (payload.term.getRemoteTermId() > 0) {
                 mTaxonomyRsApiRestClient.updateTerm(payload.site, payload.term);
             } else {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -430,7 +430,7 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
-        if (payload.site.isUsingWpComRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
+        if (payload.site.isUsingSelfHostedRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
             mTaxonomyRsApiRestClient.createPostCategory(payload.site, payload.term);
         } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.store;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -279,8 +277,6 @@ public class TaxonomyStore extends Store {
         if (!(actionType instanceof TaxonomyAction)) {
             return;
         }
-
-        Log.d("TAX_TAG", "Action: " + actionType);
 
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -427,8 +427,8 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
-        if (payload.site.isUsingSelfHostedRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
-            mTaxonomyRsApiRestClient.createPostCategory(payload.site, payload.term);
+        if (payload.site.isUsingSelfHostedRestApi()) {
+            mTaxonomyRsApiRestClient.createTerm(payload.site, payload.term);
         } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -428,7 +428,12 @@ public class TaxonomyStore extends Store {
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
         if (payload.site.isUsingSelfHostedRestApi()) {
-            mTaxonomyRsApiRestClient.createTerm(payload.site, payload.term);
+            // FluxC pushTerm to update terms, so we need to mae the distinction here
+            if (payload.term.getRemoteTermId() > 0) {
+                mTaxonomyRsApiRestClient.updateTerm(payload.site, payload.term);
+            } else {
+                mTaxonomyRsApiRestClient.createTerm(payload.site, payload.term);
+            }
         } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -278,6 +280,8 @@ public class TaxonomyStore extends Store {
             return;
         }
 
+        Log.d("TAX_TAG", "New action: " + actionType);
+
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:
                 fetchTerms(((SiteModel) action.getPayload()), DEFAULT_TAXONOMY_CATEGORY);
@@ -426,10 +430,11 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
-        if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
+            mTaxonomyRsApiRestClient.createPostCategory(payload.site, payload.term);
+        } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {
-            // TODO: check for WP-REST-API plugin and use it here
             mTaxonomyXMLRPCClient.pushTerm(payload.term, payload.site);
         }
     }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -35,6 +35,7 @@ import uniffi.wp_api.CategoryWithEditContext
 import uniffi.wp_api.CategoriesRequestCreateResponse
 import uniffi.wp_api.CategoriesRequestListWithEditContextResponse
 import uniffi.wp_api.TagWithEditContext
+import uniffi.wp_api.TagsRequestCreateResponse
 import uniffi.wp_api.TagsRequestListWithEditContextResponse
 import uniffi.wp_api.TaxonomyType
 import uniffi.wp_api.WpNetworkHeaderMap
@@ -71,6 +72,18 @@ class TaxonomyRsApiRestClientTest {
         0 // postCount
     )
 
+    private val testTagTermModel = TermModel(
+        2, // id
+        123, // localSiteId
+        3L, // remoteTermId
+        "post_tag", // taxonomy
+        "Test Tag", // name
+        "test-tag", // slug
+        "Test tag description", // description
+        0L, // parentRemoteId
+        0 // postCount
+    )
+
     private val testTagTaxonomyName = "post_tag"
     private val testCategoryTaxonomyName = "category"
 
@@ -93,7 +106,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `fetchPostTags with error response dispatches error action`() = runTest {
+    fun `fetchTerms tags with error response dispatches error action`() = runTest {
         // Use a concrete error type that we can create - UnknownError requires statusCode and response
         val errorResponse = WpRequestResult.UnknownError<Any>(
             statusCode = 500u,
@@ -102,7 +115,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
 
-        taxonomyClient.fetchPostTags(testSite)
+        taxonomyClient.fetchTerms(testSite, testTagTaxonomyName)
 
         // Verify dispatcher was called with error action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -117,7 +130,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `fetchPostTags with success response dispatches success action`() = runTest {
+    fun `fetchTerms tags with success response dispatches success action`() = runTest {
         val tagWithEditContext = listOf(
             createTestTagWithEditContext(),
             createTestTagWithEditContext()
@@ -137,7 +150,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<TagsRequestListWithEditContextResponse>(any())).thenReturn(successResponse)
 
-        taxonomyClient.fetchPostTags(testSite)
+        taxonomyClient.fetchTerms(testSite, testTagTaxonomyName)
 
         // Verify dispatcher was called with success action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -154,7 +167,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `fetchPostCategories with error response dispatches error action`() = runTest {
+    fun `fetchTerms categories with error response dispatches error action`() = runTest {
         // Use a concrete error type that we can create - UnknownError requires statusCode and response
         val errorResponse = WpRequestResult.UnknownError<Any>(
             statusCode = 500u,
@@ -163,7 +176,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
 
-        taxonomyClient.fetchPostCategories(testSite)
+        taxonomyClient.fetchTerms(testSite, testCategoryTaxonomyName)
 
         // Verify dispatcher was called with error action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -178,7 +191,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `fetchPostCategories with success response dispatches success action`() = runTest {
+    fun `fetchTerms categories with success response dispatches success action`() = runTest {
         val categoryWithEditContext = listOf(
             createTestCategoryWithEditContext(),
             createTestCategoryWithEditContext()
@@ -198,7 +211,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<CategoriesRequestListWithEditContextResponse>(any())).thenReturn(successResponse)
 
-        taxonomyClient.fetchPostCategories(testSite)
+        taxonomyClient.fetchTerms(testSite, testCategoryTaxonomyName)
 
         // Verify dispatcher was called with success action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -215,7 +228,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `createPostCategory with error response dispatches error action`() = runTest {
+    fun `createTerm category with error response dispatches error action`() = runTest {
         // Use a concrete error type that we can create - UnknownError requires statusCode and response
         val errorResponse = WpRequestResult.UnknownError<Any>(
             statusCode = 500u,
@@ -224,7 +237,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
 
-        taxonomyClient.createPostCategory(testSite, testTermModel)
+        taxonomyClient.createTerm(testSite, testTermModel)
 
         // Verify dispatcher was called with error action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -240,7 +253,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `createPostCategory with success response dispatches success action`() = runTest {
+    fun `createTerm category with success response dispatches success action`() = runTest {
         val categoryWithEditContext = createTestCategoryWithEditContext()
 
         // Create the correct response structure following the MediaRSApiRestClientTest pattern
@@ -255,7 +268,7 @@ class TaxonomyRsApiRestClientTest {
 
         whenever(wpApiClient.request<CategoriesRequestCreateResponse>(any())).thenReturn(successResponse)
 
-        taxonomyClient.createPostCategory(testSite, testTermModel)
+        taxonomyClient.createTerm(testSite, testTermModel)
 
         // Verify dispatcher was called with success action
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
@@ -275,6 +288,70 @@ class TaxonomyRsApiRestClientTest {
         assertEquals(categoryWithEditContext.slug, payload.term.slug)
         assertEquals(categoryWithEditContext.description, payload.term.description)
         assertEquals(categoryWithEditContext.count.toInt(), payload.term.postCount)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `createTerm tag with error response dispatches error action`() = runTest {
+        // Use a concrete error type that we can create - UnknownError requires statusCode and response
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.createTerm(testSite, testTagTermModel)
+
+        // Verify dispatcher was called with error action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTagTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `createTerm tag with success response dispatches success action`() = runTest {
+        val tagWithEditContext = createTestTagWithEditContext()
+
+        // Create the correct response structure following the MediaRSApiRestClientTest pattern
+        val tagResponse = TagsRequestCreateResponse(
+            tagWithEditContext,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<TagsRequestCreateResponse> = WpRequestResult.Success(
+            response = tagResponse
+        )
+
+        whenever(wpApiClient.request<TagsRequestCreateResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.createTerm(testSite, testTagTermModel)
+
+        // Verify dispatcher was called with success action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertNotNull(payload.term)
+        // Verify the created term has the correct properties
+        assertEquals(tagWithEditContext.id.toInt(), payload.term.id)
+        assertEquals(testSite.id, payload.term.localSiteId)
+        assertEquals(tagWithEditContext.id, payload.term.remoteTermId)
+        assertEquals(testTagTaxonomyName, payload.term.taxonomy)
+        assertEquals(tagWithEditContext.name, payload.term.name)
+        assertEquals(tagWithEditContext.slug, payload.term.slug)
+        assertEquals(tagWithEditContext.description, payload.term.description)
+        assertEquals(tagWithEditContext.count.toInt(), payload.term.postCount)
         assertNull(payload.error)
     }
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -31,11 +31,15 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CategoryDeleteResponse
 import uniffi.wp_api.CategoryWithEditContext
 import uniffi.wp_api.CategoriesRequestCreateResponse
+import uniffi.wp_api.CategoriesRequestDeleteResponse
 import uniffi.wp_api.CategoriesRequestListWithEditContextResponse
+import uniffi.wp_api.TagDeleteResponse
 import uniffi.wp_api.TagWithEditContext
 import uniffi.wp_api.TagsRequestCreateResponse
+import uniffi.wp_api.TagsRequestDeleteResponse
 import uniffi.wp_api.TagsRequestListWithEditContextResponse
 import uniffi.wp_api.TaxonomyType
 import uniffi.wp_api.WpNetworkHeaderMap
@@ -353,6 +357,204 @@ class TaxonomyRsApiRestClientTest {
         assertEquals(tagWithEditContext.description, payload.term.description)
         assertEquals(tagWithEditContext.count.toInt(), payload.term.postCount)
         assertNull(payload.error)
+    }
+
+    @Test
+    fun `deleteTerm category with error response dispatches error action`() = runTest {
+        // Use a concrete error type that we can create - UnknownError requires statusCode and response
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTermModel)
+
+        // Verify dispatcher was called with error action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `deleteTerm category with success response dispatches success action`() = runTest {
+        val categoryDeleteData = createTestCategoryDeleteData(deleted = true)
+
+        // Create the correct response structure following the MediaRsApiRestClientTest pattern
+        val categoryResponse = CategoriesRequestDeleteResponse(
+            categoryDeleteData,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<CategoriesRequestDeleteResponse> = WpRequestResult.Success(
+            response = categoryResponse
+        )
+
+        whenever(wpApiClient.request<CategoriesRequestDeleteResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTermModel)
+
+        // Verify dispatcher was called with success action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertNotNull(payload.term)
+        // Verify the deleted term has the correct properties
+        assertEquals(testTermModel.id, payload.term.id)
+        assertEquals(testSite.id, payload.term.localSiteId)
+        assertEquals(testTermModel.id.toLong(), payload.term.remoteTermId)
+        assertEquals(testCategoryTaxonomyName, payload.term.taxonomy)
+        assertEquals(testTermModel.name, payload.term.name)
+        assertEquals(testTermModel.slug, payload.term.slug)
+        assertEquals(testTermModel.description, payload.term.description)
+        assertEquals(testTermModel.postCount, payload.term.postCount)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `deleteTerm category with failed deletion response dispatches error action`() = runTest {
+        val categoryDeleteData = createTestCategoryDeleteData(deleted = false)
+
+        // Create the correct response structure with deleted = false
+        val categoryResponse = CategoriesRequestDeleteResponse(
+            categoryDeleteData,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<CategoriesRequestDeleteResponse> = WpRequestResult.Success(
+            response = categoryResponse
+        )
+
+        whenever(wpApiClient.request<CategoriesRequestDeleteResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTermModel)
+
+        // Verify dispatcher was called with error action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `deleteTerm tag with error response dispatches error action`() = runTest {
+        // Use a concrete error type that we can create - UnknownError requires statusCode and response
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTagTermModel)
+
+        // Verify dispatcher was called with error action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTagTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `deleteTerm tag with success response dispatches success action`() = runTest {
+        val tagDeleteData = createTestTagDeleteData(deleted = true)
+
+        // Create the correct response structure following the MediaRsApiRestClientTest pattern
+        val tagResponse = TagsRequestDeleteResponse(
+            tagDeleteData,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<TagsRequestDeleteResponse> = WpRequestResult.Success(
+            response = tagResponse
+        )
+
+        whenever(wpApiClient.request<TagsRequestDeleteResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTagTermModel)
+
+        // Verify dispatcher was called with success action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertNotNull(payload.term)
+        // Verify the deleted term has the correct properties
+        assertEquals(testTagTermModel.id, payload.term.id)
+        assertEquals(testSite.id, payload.term.localSiteId)
+        assertEquals(testTagTermModel.id.toLong(), payload.term.remoteTermId)
+        assertEquals(testTagTaxonomyName, payload.term.taxonomy)
+        assertEquals(testTagTermModel.name, payload.term.name)
+        assertEquals(testTagTermModel.slug, payload.term.slug)
+        assertEquals(testTagTermModel.description, payload.term.description)
+        assertEquals(testTagTermModel.postCount, payload.term.postCount)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `deleteTerm tag with failed deletion response dispatches error action`() = runTest {
+        val tagDeleteData = createTestTagDeleteData(deleted = false)
+
+        // Create the correct response structure with deleted = false
+        val tagResponse = TagsRequestDeleteResponse(
+            tagDeleteData,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<TagsRequestDeleteResponse> = WpRequestResult.Success(
+            response = tagResponse
+        )
+
+        whenever(wpApiClient.request<TagsRequestDeleteResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.deleteTerm(testSite, testTagTermModel)
+
+        // Verify dispatcher was called with error action
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.DELETED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTagTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    private fun createTestCategoryDeleteData(deleted: Boolean): CategoryDeleteResponse {
+        return CategoryDeleteResponse(deleted, createTestCategoryWithEditContext())
+    }
+
+    private fun createTestTagDeleteData(deleted: Boolean): TagDeleteResponse {
+        return TagDeleteResponse(deleted, createTestTagWithEditContext())
     }
 
     private fun createTestCategoryWithEditContext(): CategoryWithEditContext {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -624,27 +624,18 @@ class TaxonomyRsApiRestClientTest {
             testTermModel.postCount
         )
 
-        val errorResponse = WpRequestResult.UnknownError<Any>(
-            statusCode = 500u,
-            response = "Internal Server Error"
-        )
-
-        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
-
         taxonomyClient.updateTerm(testSite, invalidTermModel)
 
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, org.mockito.kotlin.times(2)).dispatch(actionCaptor.capture())
+        verify(dispatcher).dispatch(actionCaptor.capture())
 
-        val capturedActions = actionCaptor.allValues
-        assertEquals(2, capturedActions.size)
-        capturedActions.forEach { action ->
-            val payload = action.payload as RemoteTermPayload
-            assertEquals(action.type, TaxonomyAction.PUSHED_TERM)
-            assertEquals(testSite, payload.site)
-            assertNotNull(payload.error)
-            assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
-        }
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(invalidTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
     }
 
     @Test
@@ -720,27 +711,18 @@ class TaxonomyRsApiRestClientTest {
             testTagTermModel.postCount
         )
 
-        val errorResponse = WpRequestResult.UnknownError<Any>(
-            statusCode = 500u,
-            response = "Internal Server Error"
-        )
-
-        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
-
         taxonomyClient.updateTerm(testSite, invalidTagTermModel)
 
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, org.mockito.kotlin.times(2)).dispatch(actionCaptor.capture())
+        verify(dispatcher).dispatch(actionCaptor.capture())
 
-        val capturedActions = actionCaptor.allValues
-        assertEquals(2, capturedActions.size)
-        capturedActions.forEach { action ->
-            val payload = action.payload as RemoteTermPayload
-            assertEquals(action.type, TaxonomyAction.PUSHED_TERM)
-            assertEquals(testSite, payload.site)
-            assertNotNull(payload.error)
-            assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
-        }
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(invalidTagTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
     }
 
     private fun createTestCategoryDeleteData(deleted: Boolean): CategoryDeleteResponse {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -36,11 +36,13 @@ import uniffi.wp_api.CategoryWithEditContext
 import uniffi.wp_api.CategoriesRequestCreateResponse
 import uniffi.wp_api.CategoriesRequestDeleteResponse
 import uniffi.wp_api.CategoriesRequestListWithEditContextResponse
+import uniffi.wp_api.CategoriesRequestUpdateResponse
 import uniffi.wp_api.TagDeleteResponse
 import uniffi.wp_api.TagWithEditContext
 import uniffi.wp_api.TagsRequestCreateResponse
 import uniffi.wp_api.TagsRequestDeleteResponse
 import uniffi.wp_api.TagsRequestListWithEditContextResponse
+import uniffi.wp_api.TagsRequestUpdateResponse
 import uniffi.wp_api.TaxonomyType
 import uniffi.wp_api.WpNetworkHeaderMap
 
@@ -547,6 +549,198 @@ class TaxonomyRsApiRestClientTest {
         assertEquals(testTagTermModel, payload.term)
         assertNotNull(payload.error)
         assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `updateTerm category with error response dispatches error action`() = runTest {
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.updateTerm(testSite, testTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `updateTerm category with success response dispatches success action`() = runTest {
+        val categoryWithEditContext = createTestCategoryWithEditContext()
+
+        val categoryResponse = CategoriesRequestUpdateResponse(
+            categoryWithEditContext,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<CategoriesRequestUpdateResponse> = WpRequestResult.Success(
+            response = categoryResponse
+        )
+
+        whenever(wpApiClient.request<CategoriesRequestUpdateResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.updateTerm(testSite, testTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertNotNull(payload.term)
+        assertEquals(categoryWithEditContext.id.toInt(), payload.term.id)
+        assertEquals(testSite.id, payload.term.localSiteId)
+        assertEquals(categoryWithEditContext.id, payload.term.remoteTermId)
+        assertEquals(testCategoryTaxonomyName, payload.term.taxonomy)
+        assertEquals(categoryWithEditContext.name, payload.term.name)
+        assertEquals(categoryWithEditContext.slug, payload.term.slug)
+        assertEquals(categoryWithEditContext.description, payload.term.description)
+        assertEquals(categoryWithEditContext.count.toInt(), payload.term.postCount)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `updateTerm category with invalid id dispatches error action`() = runTest {
+        val invalidTermModel = TermModel(
+            testTermModel.id,
+            testTermModel.localSiteId,
+            -1L, // invalid remoteTermId
+            testTermModel.taxonomy,
+            testTermModel.name,
+            testTermModel.slug,
+            testTermModel.description,
+            testTermModel.parentRemoteId,
+            testTermModel.postCount
+        )
+
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.updateTerm(testSite, invalidTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher, org.mockito.kotlin.times(2)).dispatch(actionCaptor.capture())
+
+        val capturedActions = actionCaptor.allValues
+        assertEquals(2, capturedActions.size)
+        capturedActions.forEach { action ->
+            val payload = action.payload as RemoteTermPayload
+            assertEquals(action.type, TaxonomyAction.PUSHED_TERM)
+            assertEquals(testSite, payload.site)
+            assertNotNull(payload.error)
+            assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+        }
+    }
+
+    @Test
+    fun `updateTerm tag with error response dispatches error action`() = runTest {
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.updateTerm(testSite, testTagTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertEquals(testTagTermModel, payload.term)
+        assertNotNull(payload.error)
+        assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+    }
+
+    @Test
+    fun `updateTerm tag with success response dispatches success action`() = runTest {
+        val tagWithEditContext = createTestTagWithEditContext()
+
+        val tagResponse = TagsRequestUpdateResponse(
+            tagWithEditContext,
+            mock<WpNetworkHeaderMap>()
+        )
+
+        val successResponse: WpRequestResult<TagsRequestUpdateResponse> = WpRequestResult.Success(
+            response = tagResponse
+        )
+
+        whenever(wpApiClient.request<TagsRequestUpdateResponse>(any())).thenReturn(successResponse)
+
+        taxonomyClient.updateTerm(testSite, testTagTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as RemoteTermPayload
+        assertEquals(capturedAction.type, TaxonomyAction.PUSHED_TERM)
+        assertEquals(testSite, payload.site)
+        assertNotNull(payload.term)
+        assertEquals(tagWithEditContext.id.toInt(), payload.term.id)
+        assertEquals(testSite.id, payload.term.localSiteId)
+        assertEquals(tagWithEditContext.id, payload.term.remoteTermId)
+        assertEquals(testTagTaxonomyName, payload.term.taxonomy)
+        assertEquals(tagWithEditContext.name, payload.term.name)
+        assertEquals(tagWithEditContext.slug, payload.term.slug)
+        assertEquals(tagWithEditContext.description, payload.term.description)
+        assertEquals(tagWithEditContext.count.toInt(), payload.term.postCount)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `updateTerm tag with invalid id dispatches error action`() = runTest {
+        val invalidTagTermModel = TermModel(
+            testTagTermModel.id,
+            testTagTermModel.localSiteId,
+            -1L, // invalid remoteTermId
+            testTagTermModel.taxonomy,
+            testTagTermModel.name,
+            testTagTermModel.slug,
+            testTagTermModel.description,
+            testTagTermModel.parentRemoteId,
+            testTagTermModel.postCount
+        )
+
+        val errorResponse = WpRequestResult.UnknownError<Any>(
+            statusCode = 500u,
+            response = "Internal Server Error"
+        )
+
+        whenever(wpApiClient.request<Any>(any())).thenReturn(errorResponse)
+
+        taxonomyClient.updateTerm(testSite, invalidTagTermModel)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher, org.mockito.kotlin.times(2)).dispatch(actionCaptor.capture())
+
+        val capturedActions = actionCaptor.allValues
+        assertEquals(2, capturedActions.size)
+        capturedActions.forEach { action ->
+            val payload = action.payload as RemoteTermPayload
+            assertEquals(action.type, TaxonomyAction.PUSHED_TERM)
+            assertEquals(testSite, payload.site)
+            assertNotNull(payload.error)
+            assertEquals(TaxonomyErrorType.GENERIC_ERROR, payload.error?.type)
+        }
     }
 
     private fun createTestCategoryDeleteData(deleted: Boolean): CategoryDeleteResponse {


### PR DESCRIPTION
## Description

This PR implements full support for categories and tags on self-hosted WordPress sites via the REST API. It consolidates taxonomy management by unifying separate category/tag methods into streamlined term operations


## Testing instructions

1. Log into a WP.com site
2. Go to the site settings
3. Test categories and tags (create, delete, modify)
- [ ] Verify it works as expected

1. Log into a self-hosted site (NO Application Password)
2. Go to the site settings
- [ ] Verify you do NOT see tags nor category to manage

1. Log into a self-hosted site with Application Password
2. Go to the site settings
3. Test categories and tags (create, delete, modify)
- [ ] Verify it works as expected


https://github.com/user-attachments/assets/f3d224ed-faf6-462e-a1e2-2c102b560c46


https://github.com/user-attachments/assets/e3e0abbe-467a-473c-bb0e-b27a7a4f8dea



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->