### PR TITLE
refactor: Simplify GutenbergKit app password requirement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -627,13 +627,9 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     }
 
     private fun shouldRequireApplicationPassword(): Boolean {
-        val isExperimentalEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
-                !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-
-        return isExperimentalEditorEnabled &&
+        return !siteModel.isUsingSelfHostedRestApi &&
                 !siteModel.isWPCom && // WPCOM Simple sites use bearer tokens
-                !siteModel.isPrivateWPComAtomic && // App passwords don't support private Atomic sites
-                site.apiRestPasswordPlain.isNullOrEmpty()
+                !siteModel.isPrivateWPComAtomic // App passwords don't support private Atomic sites
     }
 
     private fun refreshMobileEditorFromSiteSetting() {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Address https://github.com/wordpress-mobile/WordPress-Android/pull/22228#discussion_r2378816155.

Prefer existing helper utilities over raw value checks.

Remove unnecessary GutenbergKit feature check now that this logic
resides within a separate `GutenbergKitActivity` beneath the
`EditorLauncher`, which takes into consideration the feature status.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
Verify GutenbergKit requires an application password for all sites except:

- WPCOM Simple sites
- Private Atomic sites

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
