### PR TITLE
refactor: Consolidate GutenbergKit logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -402,8 +402,6 @@ class MySiteViewModel @Inject constructor(
         dashboardItemsViewModelSlice.clearValue()
         dashboardCardsViewModelSlice.clearValue()
         dashboardCardsViewModelSlice.resetShownTracker()
-        // Trigger GutenbergView warmup for the newly selected site
-        gutenbergKitWarmupHelper.warmupIfNeeded(site, viewModelScope)
         dashboardItemsViewModelSlice.resetShownTracker()
         if (shouldShowDashboard(site)) {
             dashboardCardsViewModelSlice.buildCards(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
 import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,7 +23,6 @@ class SelectedSiteRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory,
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val experimentalFeatures: ExperimentalFeatures,
     private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -12,10 +12,9 @@ import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettings
 import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
-import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -26,6 +25,7 @@ class SelectedSiteRepository @Inject constructor(
     private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val experimentalFeatures: ExperimentalFeatures,
+    private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null
 
@@ -36,8 +36,6 @@ class SelectedSiteRepository @Inject constructor(
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
 
     val siteSelected = _selectedSiteChange.mapSafe { it?.id }.distinctUntilChanged()
-
-    @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
 
     fun refresh() {
         updateSiteSettingsIfNecessary()
@@ -138,8 +136,7 @@ class SelectedSiteRepository @Inject constructor(
         }
 
         // Fetch the site's editor theme and settings
-        if (experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-            gutenbergKitFeature.isEnabled()) {
+        if (gutenbergKitFeatureChecker.isGutenbergKitEnabled()) {
             fetchEditorSettings(selectedSite)
         } else {
             fetchEditorTheme(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -6,8 +6,6 @@ import org.wordpress.android.WordPress.Companion.getContext
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
-import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -28,7 +26,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class EditorLauncher @Inject constructor(
-    private val gutenbergKitFeature: GutenbergKitFeature,
+    private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker,
     private val experimentalFeatures: ExperimentalFeatures,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val siteStore: SiteStore,
@@ -93,15 +91,12 @@ class EditorLauncher @Inject constructor(
      * Determines if GutenbergKit editor should be used based on feature flags and post content.
      */
     private fun shouldUseGutenbergKitEditor(params: EditorLauncherParams): Boolean {
-        val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-                gutenbergKitFeature.isEnabled()
-        val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
+        val isGutenbergFeatureEnabled = gutenbergKitFeatureChecker.isGutenbergKitEnabled()
 
         val site = params.siteSource.getSite(siteStore)
         return when {
             !isGutenbergFeatureEnabled -> {
-                logFeatureDisabledReason(isGutenbergDisabled, isGutenbergEnabled)
+                logFeatureDisabledReason()
                 false
             }
 
@@ -126,14 +121,8 @@ class EditorLauncher @Inject constructor(
         return shouldUseGutenberg
     }
 
-    private fun logFeatureDisabledReason(isGutenbergDisabled: Boolean, isGutenbergEnabled: Boolean) {
-        val reason = when {
-            isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
-            !isGutenbergEnabled -> "neither the experimental block editor feature nor " +
-                    "GutenbergKit feature is enabled"
-
-            else -> "GutenbergKit feature checks failed"
-        }
+    private fun logFeatureDisabledReason() {
+        val reason = "the GutenbergKit feature is disabled"
         val featureFlags = getFeatureFlagsString()
         AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
     }
@@ -147,12 +136,8 @@ class EditorLauncher @Inject constructor(
     }
 
     private fun getFeatureFlagsString(): String {
-        val experimentalBlockEditor = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)
-        val gutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled()
-        val disableExperimentalBlockEditor = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        return "(experimental_block_editor: $experimentalBlockEditor, " +
-                "gutenberg_kit_feature: $gutenbergKitFeatureEnabled, " +
-                "disable_experimental_block_editor: $disableExperimentalBlockEditor)"
+        val gutenbergKitEnabled = gutenbergKitFeatureChecker.isGutenbergKitEnabled()
+        return "(gutenberg_kit_enabled: $gutenbergKitEnabled)"
     }
 
     private fun logEditorDecision(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import org.wordpress.android.WordPress.Companion.getContext
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SiteUtils
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -27,7 +26,6 @@ import javax.inject.Singleton
 @Singleton
 class EditorLauncher @Inject constructor(
     private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker,
-    private val experimentalFeatures: ExperimentalFeatures,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val siteStore: SiteStore,
     private val postStore: PostStore
@@ -124,7 +122,8 @@ class EditorLauncher @Inject constructor(
 
     private fun logFeatureDisabledReason(featureState: GutenbergKitFeatureChecker.FeatureState) {
         val reason = when {
-            featureState.isDisableExperimentalBlockEditorEnabled -> "the experimental block editor is explicitly disabled"
+            featureState.isDisableExperimentalBlockEditorEnabled ->
+                "the experimental block editor is explicitly disabled"
             !featureState.isExperimentalBlockEditorEnabled && !featureState.isGutenbergKitFeatureEnabled ->
                 "neither the experimental block editor feature nor GutenbergKit feature is enabled"
             else -> "GutenbergKit feature checks failed"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -91,12 +91,13 @@ class EditorLauncher @Inject constructor(
      * Determines if GutenbergKit editor should be used based on feature flags and post content.
      */
     private fun shouldUseGutenbergKitEditor(params: EditorLauncherParams): Boolean {
-        val isGutenbergFeatureEnabled = gutenbergKitFeatureChecker.isGutenbergKitEnabled()
+        val featureState = gutenbergKitFeatureChecker.getFeatureState()
+        val isGutenbergFeatureEnabled = featureState.isGutenbergKitEnabled
 
         val site = params.siteSource.getSite(siteStore)
         return when {
             !isGutenbergFeatureEnabled -> {
-                logFeatureDisabledReason()
+                logFeatureDisabledReason(featureState)
                 false
             }
 
@@ -121,9 +122,14 @@ class EditorLauncher @Inject constructor(
         return shouldUseGutenberg
     }
 
-    private fun logFeatureDisabledReason() {
-        val reason = "the GutenbergKit feature is disabled"
-        val featureFlags = getFeatureFlagsString()
+    private fun logFeatureDisabledReason(featureState: GutenbergKitFeatureChecker.FeatureState) {
+        val reason = when {
+            featureState.isDisableExperimentalBlockEditorEnabled -> "the experimental block editor is explicitly disabled"
+            !featureState.isExperimentalBlockEditorEnabled && !featureState.isGutenbergKitFeatureEnabled ->
+                "neither the experimental block editor feature nor GutenbergKit feature is enabled"
+            else -> "GutenbergKit feature checks failed"
+        }
+        val featureFlags = getFeatureFlagsString(featureState)
         AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
     }
 
@@ -135,9 +141,14 @@ class EditorLauncher @Inject constructor(
         )
     }
 
+    private fun getFeatureFlagsString(featureState: GutenbergKitFeatureChecker.FeatureState): String {
+        return "(experimental_block_editor: ${featureState.isExperimentalBlockEditorEnabled}, " +
+                "gutenberg_kit_feature: ${featureState.isGutenbergKitFeatureEnabled}, " +
+                "disable_experimental_block_editor: ${featureState.isDisableExperimentalBlockEditorEnabled})"
+    }
+
     private fun getFeatureFlagsString(): String {
-        val gutenbergKitEnabled = gutenbergKitFeatureChecker.isGutenbergKitEnabled()
-        return "(gutenberg_kit_enabled: $gutenbergKitEnabled)"
+        return getFeatureFlagsString(gutenbergKitFeatureChecker.getFeatureState())
     }
 
     private fun logEditorDecision(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
@@ -40,7 +40,9 @@ class GutenbergKitFeatureChecker @Inject constructor(
         return FeatureState(
             isExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR),
             isGutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled(),
-            isDisableExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+            isDisableExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(
+                Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+            )
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
+import org.wordpress.android.util.config.GutenbergKitFeature
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Centralized utility for checking if GutenbergKit feature is enabled.
+ * This consolidates the logic that was previously duplicated across multiple classes.
+ */
+@Singleton
+class GutenbergKitFeatureChecker @Inject constructor(
+    private val experimentalFeatures: ExperimentalFeatures,
+    private val gutenbergKitFeature: GutenbergKitFeature
+) {
+    /**
+     * Determines if GutenbergKit is enabled based on feature flags.
+     *
+     * The feature is enabled if:
+     * - Either the experimental block editor is enabled OR the GutenbergKit feature flag is on
+     * - AND the disable experimental block editor flag is NOT enabled
+     *
+     * @return true if GutenbergKit should be enabled, false otherwise
+     */
+    fun isGutenbergKitEnabled(): Boolean {
+        val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
+                gutenbergKitFeature.isEnabled()
+        val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        return isGutenbergEnabled && !isGutenbergDisabled
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
@@ -16,6 +16,35 @@ class GutenbergKitFeatureChecker @Inject constructor(
     private val gutenbergKitFeature: GutenbergKitFeature
 ) {
     /**
+     * Data class containing the state of all GutenbergKit-related feature flags.
+     */
+    data class FeatureState(
+        val isExperimentalBlockEditorEnabled: Boolean,
+        val isGutenbergKitFeatureEnabled: Boolean,
+        val isDisableExperimentalBlockEditorEnabled: Boolean
+    ) {
+        /**
+         * Determines if GutenbergKit should be enabled based on the feature states.
+         */
+        val isGutenbergKitEnabled: Boolean
+            get() = (isExperimentalBlockEditorEnabled || isGutenbergKitFeatureEnabled) &&
+                    !isDisableExperimentalBlockEditorEnabled
+    }
+
+    /**
+     * Gets the current state of all GutenbergKit-related feature flags.
+     *
+     * @return FeatureState containing all flag states and the computed enabled state
+     */
+    fun getFeatureState(): FeatureState {
+        return FeatureState(
+            isExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR),
+            isGutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled(),
+            isDisableExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        )
+    }
+
+    /**
      * Determines if GutenbergKit is enabled based on feature flags.
      *
      * The feature is enabled if:
@@ -25,9 +54,6 @@ class GutenbergKitFeatureChecker @Inject constructor(
      * @return true if GutenbergKit should be enabled, false otherwise
      */
     fun isGutenbergKitEnabled(): Boolean {
-        val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-                gutenbergKitFeature.isEnabled()
-        val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        return isGutenbergEnabled && !isGutenbergDisabled
+        return getFeatureState().isGutenbergKitEnabled
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitWarmupHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitWarmupHelper.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.PerAppLocaleManager
 import org.wordpress.android.util.SiteUtils
-import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.config.GutenbergKitPluginsFeature
 import org.wordpress.gutenberg.EditorConfiguration
 import org.wordpress.gutenberg.GutenbergView
@@ -32,7 +31,7 @@ class GutenbergKitWarmupHelper @Inject constructor(
     private val accountStore: AccountStore,
     private val userAgent: UserAgent,
     private val perAppLocaleManager: PerAppLocaleManager,
-    private val gutenbergKitFeature: GutenbergKitFeature,
+    private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker,
     private val gutenbergKitPluginsFeature: GutenbergKitPluginsFeature,
     private val experimentalFeatures: ExperimentalFeatures,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
@@ -78,12 +77,7 @@ class GutenbergKitWarmupHelper @Inject constructor(
     }
 
     private fun shouldWarmupForSite(site: SiteModel): Boolean {
-        val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-                gutenbergKitFeature.isEnabled()
-        val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
-
-        if (!isGutenbergFeatureEnabled) {
+        if (!gutenbergKitFeatureChecker.isGutenbergKitEnabled()) {
             AppLog.d(T.EDITOR, "GutenbergKitWarmupHelper: Skipping warmup - GutenbergKit features disabled")
             return false
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.AppInitializer
 import org.wordpress.android.fluxc.action.EditorSettingsAction
 import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 
 @ExperimentalCoroutinesApi
 class SelectedSiteRepositoryTest : BaseUnitTest() {
@@ -80,7 +79,6 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
             dispatcher,
             siteSettingsInterfaceFactory,
             appPrefsWrapper,
-            experimentalFeatures,
             gutenbergKitFeatureChecker
         )
         selectedSiteRepository.showSiteIconProgressBar.observeForever { siteIconProgressBarVisible = it == true }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
 import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.AppInitializer
 import org.wordpress.android.fluxc.action.EditorSettingsAction
+import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 
@@ -47,6 +48,9 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Mock
     lateinit var experimentalFeatures: ExperimentalFeatures
+
+    @Mock
+    lateinit var gutenbergKitFeatureChecker: GutenbergKitFeatureChecker
 
     @Mock
     lateinit var context: Context
@@ -72,16 +76,13 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
         // Mock AppPrefsWrapper
         whenever(appPrefsWrapper.setSelectedSite(any())).then { }
 
-        // Mock GutenbergKitFeature
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
-
         selectedSiteRepository = SelectedSiteRepository(
             dispatcher,
             siteSettingsInterfaceFactory,
             appPrefsWrapper,
             experimentalFeatures,
+            gutenbergKitFeatureChecker
         )
-        selectedSiteRepository.gutenbergKitFeature = gutenbergKitFeature
         selectedSiteRepository.showSiteIconProgressBar.observeForever { siteIconProgressBarVisible = it == true }
         selectedSiteRepository.selectedSiteChange.observeForever { selectedSite = it }
         siteModel = SiteModel()
@@ -254,7 +255,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `Should fetch EditorTheme when GutenbergKit and ExperimentalBlockEditor are disabled`() {
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
         initializeSiteAndSiteSettings()
 
         selectedSiteRepository.updateSiteSettingsIfNecessary()
@@ -264,7 +265,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `Should fetch EditorSettings when GutenbergKit is enabled`() {
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(true)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
         initializeSiteAndSiteSettings()
 
         selectedSiteRepository.updateSiteSettingsIfNecessary()
@@ -274,9 +275,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `Should fetch EditorSettings when ExperimentalBlockEditor is enabled`() {
-        whenever(
-            experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)
-        ).thenReturn(true)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
         initializeSiteAndSiteSettings()
 
         selectedSiteRepository.updateSiteSettingsIfNecessary()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -262,7 +262,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should fetch EditorSettings when GutenbergKit is enabled`() {
+    fun `Should fetch EditorSettings when GutenbergKit feature is enabled`() {
         whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
         initializeSiteAndSiteSettings()
 
@@ -271,15 +271,6 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
         assertThat(actions.last().type).isEqualTo(EditorSettingsAction.FETCH_EDITOR_SETTINGS)
     }
 
-    @Test
-    fun `Should fetch EditorSettings when ExperimentalBlockEditor is enabled`() {
-        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
-        initializeSiteAndSiteSettings()
-
-        selectedSiteRepository.updateSiteSettingsIfNecessary()
-
-        assertThat(actions.last().type).isEqualTo(EditorSettingsAction.FETCH_EDITOR_SETTINGS)
-    }
 
     private fun initializeSiteAndSiteSettings() {
         selectedSiteRepository.updateSite(siteModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
@@ -1,0 +1,248 @@
+package org.wordpress.android.ui.posts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
+import org.wordpress.android.util.config.GutenbergKitFeature
+
+@RunWith(MockitoJUnitRunner::class)
+class GutenbergKitFeatureCheckerTest {
+    @Mock
+    private lateinit var experimentalFeatures: ExperimentalFeatures
+
+    @Mock
+    private lateinit var gutenbergKitFeature: GutenbergKitFeature
+
+    private lateinit var featureChecker: GutenbergKitFeatureChecker
+
+    @Before
+    fun setUp() {
+        featureChecker = GutenbergKitFeatureChecker(experimentalFeatures, gutenbergKitFeature)
+    }
+
+    // Helper method to setup mock behavior
+    private fun setupFeatureFlags(
+        experimentalBlockEditor: Boolean = false,
+        gutenbergKitEnabled: Boolean = false,
+        disableExperimentalBlockEditor: Boolean = false
+    ) {
+        whenever(experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)).thenReturn(experimentalBlockEditor)
+        whenever(gutenbergKitFeature.isEnabled()).thenReturn(gutenbergKitEnabled)
+        whenever(experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)).thenReturn(disableExperimentalBlockEditor)
+    }
+
+    // ===== Feature State Tests =====
+
+    @Test
+    fun `getFeatureState returns correct individual flag values when all flags are false`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+
+        val featureState = featureChecker.getFeatureState()
+
+        assertThat(featureState.isExperimentalBlockEditorEnabled).isFalse()
+        assertThat(featureState.isGutenbergKitFeatureEnabled).isFalse()
+        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isFalse()
+        assertThat(featureState.isGutenbergKitEnabled).isFalse()
+    }
+
+    @Test
+    fun `getFeatureState returns correct individual flag values when all flags are true`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = true
+        )
+
+        val featureState = featureChecker.getFeatureState()
+
+        assertThat(featureState.isExperimentalBlockEditorEnabled).isTrue()
+        assertThat(featureState.isGutenbergKitFeatureEnabled).isTrue()
+        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isTrue()
+        // Should be false because disable flag overrides
+        assertThat(featureState.isGutenbergKitEnabled).isFalse()
+    }
+
+    @Test
+    fun `getFeatureState returns correct values for mixed flag states`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+
+        val featureState = featureChecker.getFeatureState()
+
+        assertThat(featureState.isExperimentalBlockEditorEnabled).isTrue()
+        assertThat(featureState.isGutenbergKitFeatureEnabled).isFalse()
+        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isFalse()
+        assertThat(featureState.isGutenbergKitEnabled).isTrue()
+    }
+
+    // ===== GutenbergKit Enabled Logic Tests =====
+
+    @Test
+    fun `isGutenbergKitEnabled returns true when experimental block editor is enabled`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isGutenbergKitEnabled returns true when GutenbergKit feature is enabled`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = false
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isGutenbergKitEnabled returns true when both experimental and GutenbergKit features are enabled`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = false
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isGutenbergKitEnabled returns false when all flags are disabled`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isGutenbergKitEnabled returns false when disable flag is enabled regardless of other flags`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = true
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isGutenbergKitEnabled returns false when only disable flag is enabled`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = true
+        )
+
+        val result = featureChecker.isGutenbergKitEnabled()
+
+        assertThat(result).isFalse()
+    }
+
+    // ===== Edge Cases and Consistency Tests =====
+
+    @Test
+    fun `isGutenbergKitEnabled matches getFeatureState isGutenbergKitEnabled for all combinations`() {
+        val testCases = listOf(
+            Triple(false, false, false),
+            Triple(false, false, true),
+            Triple(false, true, false),
+            Triple(false, true, true),
+            Triple(true, false, false),
+            Triple(true, false, true),
+            Triple(true, true, false),
+            Triple(true, true, true)
+        )
+
+        testCases.forEach { (experimental, gutenbergKit, disable) ->
+            setupFeatureFlags(
+                experimentalBlockEditor = experimental,
+                gutenbergKitEnabled = gutenbergKit,
+                disableExperimentalBlockEditor = disable
+            )
+
+            val directResult = featureChecker.isGutenbergKitEnabled()
+            val stateResult = featureChecker.getFeatureState().isGutenbergKitEnabled
+
+            assertThat(directResult)
+                .withFailMessage("Results should match for flags: experimental=$experimental, gutenbergKit=$gutenbergKit, disable=$disable")
+                .isEqualTo(stateResult)
+        }
+    }
+
+    @Test
+    fun `disable flag always overrides other settings`() {
+        val testCases = listOf(
+            Triple(false, false, true),  // Only disable flag
+            Triple(false, true, true),   // GutenbergKit + disable
+            Triple(true, false, true),   // Experimental + disable
+            Triple(true, true, true)     // All flags on
+        )
+
+        testCases.forEach { (experimental, gutenbergKit, disable) ->
+            setupFeatureFlags(
+                experimentalBlockEditor = experimental,
+                gutenbergKitEnabled = gutenbergKit,
+                disableExperimentalBlockEditor = disable
+            )
+
+            val result = featureChecker.isGutenbergKitEnabled()
+
+            assertThat(result)
+                .withFailMessage("Should be false when disable flag is true (experimental=$experimental, gutenbergKit=$gutenbergKit)")
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `feature is enabled when at least one enabling flag is true and disable flag is false`() {
+        val enabledTestCases = listOf(
+            Triple(true, false, false),   // Only experimental
+            Triple(false, true, false),   // Only GutenbergKit
+            Triple(true, true, false)     // Both enabled
+        )
+
+        enabledTestCases.forEach { (experimental, gutenbergKit, disable) ->
+            setupFeatureFlags(
+                experimentalBlockEditor = experimental,
+                gutenbergKitEnabled = gutenbergKit,
+                disableExperimentalBlockEditor = disable
+            )
+
+            val result = featureChecker.isGutenbergKitEnabled()
+
+            assertThat(result)
+                .withFailMessage("Should be true when at least one enabling flag is true (experimental=$experimental, gutenbergKit=$gutenbergKit)")
+                .isTrue()
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
@@ -32,9 +32,11 @@ class GutenbergKitFeatureCheckerTest {
         gutenbergKitEnabled: Boolean = false,
         disableExperimentalBlockEditor: Boolean = false
     ) {
-        whenever(experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)).thenReturn(experimentalBlockEditor)
+        whenever(experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR))
+            .thenReturn(experimentalBlockEditor)
         whenever(gutenbergKitFeature.isEnabled()).thenReturn(gutenbergKitEnabled)
-        whenever(experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)).thenReturn(disableExperimentalBlockEditor)
+        whenever(experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR))
+            .thenReturn(disableExperimentalBlockEditor)
     }
 
     // ===== Feature State Tests =====
@@ -194,7 +196,10 @@ class GutenbergKitFeatureCheckerTest {
             val stateResult = featureChecker.getFeatureState().isGutenbergKitEnabled
 
             assertThat(directResult)
-                .withFailMessage("Results should match for flags: experimental=$experimental, gutenbergKit=$gutenbergKit, disable=$disable")
+                .withFailMessage(
+                    "Results should match for flags: experimental=$experimental, " +
+                            "gutenbergKit=$gutenbergKit, disable=$disable"
+                )
                 .isEqualTo(stateResult)
         }
     }
@@ -218,7 +223,10 @@ class GutenbergKitFeatureCheckerTest {
             val result = featureChecker.isGutenbergKitEnabled()
 
             assertThat(result)
-                .withFailMessage("Should be false when disable flag is true (experimental=$experimental, gutenbergKit=$gutenbergKit)")
+                .withFailMessage(
+                    "Should be false when disable flag is true " +
+                            "(experimental=$experimental, gutenbergKit=$gutenbergKit)"
+                )
                 .isFalse()
         }
     }
@@ -241,7 +249,10 @@ class GutenbergKitFeatureCheckerTest {
             val result = featureChecker.isGutenbergKitEnabled()
 
             assertThat(result)
-                .withFailMessage("Should be true when at least one enabling flag is true (experimental=$experimental, gutenbergKit=$gutenbergKit)")
+                .withFailMessage(
+                    "Should be true when at least one enabling flag is true " +
+                            "(experimental=$experimental, gutenbergKit=$gutenbergKit)"
+                )
                 .isTrue()
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Consolidate GutenbergKit feature status check logic to mitigate bugs from
incomplete checks. Remove duplicative GutenbergKit warming.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
### 1. GutenbergKit launches when the feature is enabled
1. Toggle the experimental block editor on or off.
1. Verify the correct editor is opened for new/existing posts.

### 2. GutenbergKit is warmed, only on app launch or site change
1. Monitor network activity, Logcat, or use debuggers.
1. Launch the app.
1. Verify the editor is warmed.
1. Change sites.
1. Verify the editor is warmed.
1. Navigate away from and return to the _My Site_ tab.
1. Verify the editor is not re-warmed for an already warmed site.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
