### PR TITLE
feat: Editor mode names match the web and iOS

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1946,10 +1946,10 @@
     <string name="menu_publish_now" translatable="false">@string/publish_now</string>
     <string name="menu_preview">Preview</string>
     <string name="menu_history">History</string>
-    <string name="menu_html_mode">HTML Mode</string>
-    <string name="menu_html_mode_switched_notice">Switched to HTML mode</string>
-    <string name="menu_visual_mode">Visual Mode</string>
-    <string name="menu_visual_mode_switched_notice">Switched to Visual mode</string>
+    <string name="menu_html_mode">Code Editor</string>
+    <string name="menu_html_mode_switched_notice">Switched to Code Editor</string>
+    <string name="menu_visual_mode">Visual Editor</string>
+    <string name="menu_visual_mode_switched_notice">Switched to Visual Editor</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Improve product familiarity through consistent editor mode names across
the various platforms.

| Android | Web | iOS |
| - | - | - |
| ![android-modes](https://github.com/user-attachments/assets/175922cb-aae5-4944-a5e9-c2fa4ea88e1e) | <img width="546" height="284" alt="web-modes" src="https://github.com/user-attachments/assets/52f2f622-faaf-4286-9050-be307d6e65b8" /> | <img width="750" height="1334" alt="ios-modes" src="https://github.com/user-attachments/assets/9db451a2-0b45-489e-99ad-afb3ada58a31" /> |


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the Gutenberg editor.
1. Tap the more menu (three-dots icon).
1. Toggle the editor mode by tapping Code Editor/Visual Editor.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
