### PR TITLE
[Tooling] [AINFRA-1332] Annotate builds with Sentry mapping UUID

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,21 +22,6 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
-  - label: ":android: Build {{matrix}} Bundle"
-    command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
-
-      echo "--- :closed_lock_with_key: Installing Secrets"
-      bundle exec fastlane run configure_apply
-
-      echo "--- :hammer_and_wrench: Building"
-      bundle exec fastlane build_bundle app:"{{matrix}}" flavor:Vanilla buildType:Release skip_confirm:true skip_prechecks:true
-    plugins: [$CI_TOOLKIT]
-    matrix:
-      - wordpress
-      - jetpack
-
   #################
   # Linters
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,21 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: ":android: Build {{matrix}} Bundle"
+    command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
+
+      echo "--- :hammer_and_wrench: Building"
+      bundle exec fastlane build_bundle app:"{{matrix}}" flavor:Vanilla buildType:Release skip_confirm:true skip_prechecks:true
+    plugins: [$CI_TOOLKIT]
+    matrix:
+      - wordpress
+      - jetpack
+
   #################
   # Linters
   #################

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -258,8 +258,8 @@ platform :android do
   desc 'Builds an app bundle'
   lane :build_bundle do |options|
     # Create the file names
-    version_name = options[:version_name]
-    build_code = options[:build_code]
+    version_name = options[:version_name] || current_version_name
+    build_code = options[:build_code] || current_build_code
     app = get_app_name_option!(options)
 
     if version_name.nil?

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -258,8 +258,8 @@ platform :android do
   desc 'Builds an app bundle'
   lane :build_bundle do |options|
     # Create the file names
-    version_name = options[:version_name] || current_version_name
-    build_code = options[:build_code] || current_build_code
+    version_name = options[:version_name]
+    build_code = options[:build_code]
     app = get_app_name_option!(options)
 
     if version_name.nil?


### PR DESCRIPTION
Closes [AINFRA-1332](https://linear.app/a8c/issue/AINFRA-1332/update-releasesv2-instructions-for-checking-mappings)
See: p1759078113521129-slack-C06CKSPHYA1

### Why

Sentry has updated their web UI and no longer show the list of releases associated with each Proguard Mapping file.
This made [the instructions in the ReleasesV2 step (about checking that the mapping file was uploaded) inconsistent](https://mc.a8c.com/releases-v2/release.php?product=WPAndroid&version=26.3#task-dbd2e698-a7e4-4e77-a8ea-7b91cb8e275e-fragment), and means we no longer had a consistent way of validating if the mapping file was available in Sentry.

### How

This PR extracts the Sentry mapping UUID generated by the Sentry Gradle Plugin from the `assets/sentry-debug-meta.properties` file found within the produced `.aab` bundle, and exposes this information as a Buildkite annotation.

### What's Next

Once this is merged, we'll be able to update the wording of the ReleasesV2 scenario instructions to suggest to verify that the UUID in that annotation is present in Sentry.

### Testing Steps

See [annotations on this test build](https://buildkite.com/automattic/wordpress-android/builds/23478/annotations)
<img width="629" height="250" alt="image" src="https://github.com/user-attachments/assets/e5d1334e-c6a8-4b50-88d7-eac667aef7e7" />

Compare with Sentry's latests mapping files on their web UI for [wordpress](https://a8c.sentry.io/settings/projects/wordpress-android/proguard/) and [jetpack](https://a8c.sentry.io/settings/projects/jetpack-android/proguard/):
<img width="547" height="343" alt="image" src="https://github.com/user-attachments/assets/0b5a869b-bab8-4af1-8fbe-f3266ca4d507" />
<img width="521" height="340" alt="image" src="https://github.com/user-attachments/assets/637c3107-7b1e-4457-b344-6a5939c59823" />
