### PR TITLE
Run all unit tests in a single Buildkite job

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -64,7 +64,7 @@ for module in "${MODULES[@]}"; do
         continue
     fi
 
-    results_file="${merge_dir}/../merged-test-results.xml"
+    results_file="${merge_dir}/merged-test-results.xml"
     # Merge JUnit results into a single file (for performance reasons with reporting)
     merge_junit_reports -d "$merge_dir" -o "$results_file"
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -42,8 +42,6 @@ if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
 fi
 
 echo "--- 🚦 Collecting Test Results"
-# Create temporary directory for collecting all test results
-temp_test_results_dir=$(mktemp -d)
 
 # Define test result directories for each module
 declare -A TEST_RESULT_DIRS=(
@@ -53,6 +51,9 @@ declare -A TEST_RESULT_DIRS=(
   ["fluxc"]="libs/fluxc/build/test-results/testDebugUnitTest"
   ["login"]="libs/login/build/test-results/testDebugUnitTest"
 )
+
+# Create temporary directory for collecting all test results
+temp_test_results_dir=$(mktemp -d)
 
 # Copy all XML test results to temporary directory
 for module in "${!TEST_RESULT_DIRS[@]}"; do

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -37,47 +37,50 @@ if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
   .buildkite/commands/upload-code-coverage.sh
 fi
 
-MODULES=(WordPress:jetpack WordPress:wordpress processors image-editor fluxc login)
-for module in "${MODULES[@]}"; do
-    echo "--- 🚦 Report Tests Status (Module: ${module})"
+echo "--- 🚦 Collecting Test Results"
+# Create temporary directory for collecting all test results
+temp_test_results_dir=$(mktemp -d)
 
-    # Define possible directories for merging JUnit reports
-    if [[ "$module" == "WordPress:jetpack" ]]; then
-        junit_test_results_dir="WordPress/build/test-results/testJetpackJalapenoDebugUnitTest"
-    elif [[ "$module" == "WordPress:wordpress" ]]; then
-        junit_test_results_dir="WordPress/build/test-results/testWordpressJalapenoDebugUnitTest"
-    elif [[ "$module" == "processors" ]]; then
-        junit_test_results_dir="libs/processors/build/test-results/test"
-    elif [[ "$module" == "image-editor" ]]; then
-        junit_test_results_dir="libs/image-editor/build/test-results/testDebugUnitTest"
-    elif [[ "$module" == "fluxc" ]]; then
-        junit_test_results_dir="libs/fluxc/build/test-results/testDebugUnitTest"
-    elif [[ "$module" == "login" ]]; then
-        junit_test_results_dir="libs/login/build/test-results/testDebugUnitTest"
-    fi
+# Define test result directories for each module
+declare -A TEST_RESULT_DIRS=(
+  ["WordPress:jetpack"]="WordPress/build/test-results/testJetpackJalapenoDebugUnitTest"
+  ["WordPress:wordpress"]="WordPress/build/test-results/testWordpressJalapenoDebugUnitTest"
+  ["processors"]="libs/processors/build/test-results/test"
+  ["image-editor"]="libs/image-editor/build/test-results/testDebugUnitTest"
+  ["fluxc"]="libs/fluxc/build/test-results/testDebugUnitTest"
+  ["login"]="libs/login/build/test-results/testDebugUnitTest"
+)
 
-    # Determine which directory exists
-    if [ -d "$junit_test_results_dir" ]; then
-        merge_dir="$junit_test_results_dir"
+# Copy all XML test results to temporary directory
+for module in "${!TEST_RESULT_DIRS[@]}"; do
+    test_results_dir="${TEST_RESULT_DIRS[$module]}"
+
+    if [ -d "$test_results_dir" ]; then
+        echo "Collecting test results from ${module}..."
+        cp "$test_results_dir"/*.xml "$temp_test_results_dir/" 2>/dev/null || true
     else
-        echo "$junit_test_results_dir does not exist for module $module. Skipping..."
-        continue
+        echo "Test results directory $test_results_dir does not exist for module $module. Skipping..."
     fi
-
-    results_file="${merge_dir}/merged-test-results.xml"
-    # Merge JUnit results into a single file (for performance reasons with reporting)
-    merge_junit_reports -d "$merge_dir" -o "$results_file"
-
-    if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
-        annotate_test_failures "$results_file" --module "$module" --slack "build-and-ship"
-    else
-        annotate_test_failures "$results_file" --module "$module"
-    fi
-
-    echo "--- 🧪 Copying Test Logs for Test Collector (Module: ${module})"
-    mkdir -p buildkite-test-analytics
-    cp "$results_file" "buildkite-test-analytics/${module}-merged-test-results.xml"
 done
+
+echo "--- 🚦 Report Tests Status"
+results_file="WordPress/build/test-results/merged-test-results.xml"
+# Merge JUnit results into a single file (for performance reasons with reporting)
+# See https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/103
+merge_junit_reports -d "$temp_test_results_dir" -o "$results_file"
+
+# Clean up temporary directory
+rm -rf "$temp_test_results_dir"
+
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
+    annotate_test_failures "$results_file" --slack "build-and-ship"
+else
+    annotate_test_failures "$results_file"
+fi
+
+echo "--- 🧪 Copying Test Logs for Test Collector"
+mkdir -p buildkite-test-analytics
+cp "$results_file" "buildkite-test-analytics/merged-test-results.xml"
 
 echo "--- 📊 Tests Status"
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -7,41 +7,24 @@ fi
 
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
-echo "--- 🧪 Testing"
+echo "+++ 🧪 Testing"
 set +e
-if [ "$1" == "wordpress" ]; then
-    test_suite="testWordpressVanillaRelease koverXmlReportWordpressVanillaRelease"
-    test_results_dir="WordPress/build/test-results"
-    test_log_dir="${test_results_dir}/*/*.xml"
-    code_coverage_report="WordPress/build/reports/kover/reportWordpressVanillaRelease.xml"
-elif [ "$1" == "processors" ]; then
-    test_suite=":libs:processors:test :libs:processors:koverXmlReport"
-    test_results_dir="libs/processors/build/test-results"
-    test_log_dir="${test_results_dir}/test/*.xml"
-    code_coverage_report="libs/processors/build/reports/kover/report.xml"
-elif [ "$1" == "image-editor" ]; then
-    test_suite=":libs:image-editor:testReleaseUnitTest :libs:image-editor:koverXmlReportRelease"
-    test_results_dir="libs/image-editor/build/test-results"
-    test_log_dir="${test_results_dir}/testReleaseUnitTest/*.xml"
-    code_coverage_report="libs/image-editor/build/reports/kover/reportRelease.xml"
-elif [ "$1" == "fluxc" ]; then
-    test_suite=":libs:fluxc:testReleaseUnitTest :libs:fluxc:koverXmlReportRelease"
-    test_results_dir="libs/fluxc/build/test-results"
-    test_log_dir="${test_results_dir}/testReleaseUnitTest/*.xml"
-    code_coverage_report="libs/fluxc/build/reports/kover/reportRelease.xml"
-elif [ "$1" == "login" ]; then
-    test_suite=":libs:login:testReleaseUnitTest :libs:login:koverXmlReportRelease"
-    test_results_dir="libs/login/build/test-results"
-    test_log_dir="${test_results_dir}/testReleaseUnitTest/*.xml"
-    code_coverage_report="libs/login/build/reports/kover/reportRelease.xml"
-else
-    echo "Invalid Test Suite! Expected 'wordpress', 'processors', or 'image-editor', received '$1' instead"
-    exit 1
-fi
-
-./gradlew $test_suite
+./gradlew \
+  testJetpackJalapenoDebugUnitTest \
+  testWordpressJalapenoDebugUnitTest \
+  :libs:processors:test \
+  :libs:image-editor:testDebugUnitTest \
+  :libs:fluxc:testDebugUnitTest \
+  :libs:login:testDebugUnitTest \
+  koverXmlReportJetpackJalapenoDebug \
+  koverXmlReportWordpressJalapenoDebug \
+  :libs:processors:koverXmlReportJvm \
+  :libs:image-editor:koverXmlReportDebug \
+  :libs:fluxc:koverXmlReportDebug \
+  :libs:login:koverXmlReportDebug
 TESTS_EXIT_STATUS=$?
 set -e
+echo ""
 
 if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
   # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
@@ -49,23 +32,52 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
   echo "Unit Tests failed!"
 fi
 
-echo "--- 🚦 Report Tests Status"
-results_file="$test_results_dir/merged-test-results.xml"
-
-# Merge JUnit results into a single file (for performance reasons with reporting)
-merge_junit_reports -d ${test_log_dir%/*} -o $results_file
-
-if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
-  annotate_test_failures "$results_file" --slack "build-and-ship"
-else
-  annotate_test_failures "$results_file"
+if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
+  echo "--- ⚒️ Uploading code coverage"
+  .buildkite/commands/upload-code-coverage.sh
 fi
 
-echo "--- 🧪 Copying test logs for test collector"
-mkdir buildkite-test-analytics
-cp $results_file buildkite-test-analytics
+MODULES=(WordPress:jetpack WordPress:wordpress processors image-editor fluxc login)
+for module in "${MODULES[@]}"; do
+    echo "--- 🚦 Report Tests Status (Module: ${module})"
 
-echo "--- ⚒️ Uploading code coverage"
-.buildkite/commands/upload-code-coverage.sh $code_coverage_report
+    # Define possible directories for merging JUnit reports
+    if [[ "$module" == "WordPress:jetpack" ]]; then
+        junit_test_results_dir="WordPress/build/test-results/testJetpackJalapenoDebugUnitTest"
+    elif [[ "$module" == "WordPress:wordpress" ]]; then
+        junit_test_results_dir="WordPress/build/test-results/testWordpressJalapenoDebugUnitTest"
+    elif [[ "$module" == "processors" ]]; then
+        junit_test_results_dir="libs/processors/build/test-results/test"
+    elif [[ "$module" == "image-editor" ]]; then
+        junit_test_results_dir="libs/image-editor/build/test-results/testDebugUnitTest"
+    elif [[ "$module" == "fluxc" ]]; then
+        junit_test_results_dir="libs/fluxc/build/test-results/testDebugUnitTest"
+    elif [[ "$module" == "login" ]]; then
+        junit_test_results_dir="libs/login/build/test-results/testDebugUnitTest"
+    fi
 
+    # Determine which directory exists
+    if [ -d "$junit_test_results_dir" ]; then
+        merge_dir="$junit_test_results_dir"
+    else
+        echo "$junit_test_results_dir does not exist for module $module. Skipping..."
+        continue
+    fi
+
+    results_file="${merge_dir}/../merged-test-results.xml"
+    # Merge JUnit results into a single file (for performance reasons with reporting)
+    merge_junit_reports -d "$merge_dir" -o "$results_file"
+
+    if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
+        annotate_test_failures "$results_file" --module "$module" --slack "build-and-ship"
+    else
+        annotate_test_failures "$results_file" --module "$module"
+    fi
+
+    echo "--- 🧪 Copying Test Logs for Test Collector (Module: ${module})"
+    mkdir -p buildkite-test-analytics
+    cp "$results_file" "buildkite-test-analytics/${module}-merged-test-results.xml"
+done
+
+echo "--- 📊 Tests Status"
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -10,14 +10,12 @@ fi
 echo "+++ 🧪 Testing"
 set +e
 ./gradlew \
-  testJetpackJalapenoDebugUnitTest \
-  testWordpressJalapenoDebugUnitTest \
+  testWordpressWasabiDebugUnitTest \
   :libs:processors:test \
   :libs:image-editor:testDebugUnitTest \
   :libs:fluxc:testDebugUnitTest \
   :libs:login:testDebugUnitTest \
-  koverXmlReportJetpackJalapenoDebug \
-  koverXmlReportWordpressJalapenoDebug \
+  koverXmlReportWordpressWasabiDebug \
   :libs:processors:koverXmlReportJvm \
   :libs:image-editor:koverXmlReportDebug \
   :libs:fluxc:koverXmlReportDebug \
@@ -43,8 +41,7 @@ temp_test_results_dir=$(mktemp -d)
 
 # Define test result directories for each module
 declare -A TEST_RESULT_DIRS=(
-  ["WordPress:jetpack"]="WordPress/build/test-results/testJetpackJalapenoDebugUnitTest"
-  ["WordPress:wordpress"]="WordPress/build/test-results/testWordpressJalapenoDebugUnitTest"
+  ["WordPress:wordpress"]="WordPress/build/test-results/testWordpressWasabiDebugUnitTest"
   ["processors"]="libs/processors/build/test-results/test"
   ["image-editor"]="libs/image-editor/build/test-results/testDebugUnitTest"
   ["fluxc"]="libs/fluxc/build/test-results/testDebugUnitTest"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -32,7 +32,13 @@ fi
 
 if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
   echo "--- ⚒️ Uploading code coverage"
-  .buildkite/commands/upload-code-coverage.sh
+  # Find all kover XML reports and upload them
+  coverage_files=$(find . -path "*/build/reports/kover/*.xml" -type f)
+  if [ -n "$coverage_files" ]; then
+    .buildkite/commands/upload-code-coverage.sh $coverage_files
+  else
+    echo "No coverage files found matching pattern */build/reports/kover/*.xml"
+  fi
 fi
 
 echo "--- 🚦 Collecting Test Results"

--- a/.buildkite/commands/upload-code-coverage.sh
+++ b/.buildkite/commands/upload-code-coverage.sh
@@ -7,4 +7,12 @@ curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
 gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
 sha256sum -c codecov.SHA256SUM
 chmod +x codecov
-./codecov -t "$CODECOV_TOKEN"
+
+# Build arguments with multiple -f flags for each coverage file
+coverage_args=()
+for coverage_file in "$@"; do
+  coverage_args+=("-f" "$coverage_file")
+done
+
+# Upload all coverage reports in a single execution
+./codecov -t "$CODECOV_TOKEN" "${coverage_args[@]}"

--- a/.buildkite/commands/upload-code-coverage.sh
+++ b/.buildkite/commands/upload-code-coverage.sh
@@ -7,4 +7,4 @@ curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
 gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
 sha256sum -c codecov.SHA256SUM
 chmod +x codecov
-./codecov -t "$CODECOV_TOKEN" -f "$1"
+./codecov -t "$CODECOV_TOKEN"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,7 +107,7 @@ steps:
       - $CI_TOOLKIT
       - $TEST_COLLECTOR :
           <<: *test_collector_common_params
-          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
+          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
     artifact_paths:
       - "**/build/test-results/merged-test-results.xml"
       - "**/build/reports/kover/*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,57 +101,16 @@ steps:
   #################
   # Unit Tests
   #################
-  - group: "🔬 Unit Tests"
-    steps:
-      - label: "🔬 Unit Test WordPress"
-        command: ".buildkite/commands/run-unit-tests.sh wordpress"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "🔬 Unit Test Processors"
-        command: ".buildkite/commands/run-unit-tests.sh processors"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "🔬 Unit Test Image Editor"
-        command: ".buildkite/commands/run-unit-tests.sh image-editor"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "🔬 Unit Test FluxC"
-        command: ".buildkite/commands/run-unit-tests.sh fluxc"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR:
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_FLUXC"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "🔬 Unit Test Login"
-        command: ".buildkite/commands/run-unit-tests.sh login"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR:
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_LOGIN"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
+  - label: "🔬 Unit Tests"
+    command: ".buildkite/commands/run-unit-tests.sh"
+    plugins:
+      - $CI_TOOLKIT
+      - $TEST_COLLECTOR :
+          <<: *test_collector_common_params
+          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
+    artifact_paths:
+      - "**/build/test-results/merged-test-results.xml"
+      - "**/build/reports/kover/*.xml"
 
   #################
   # Instrumented (aka UI) Tests


### PR DESCRIPTION
Closes: [AINFRA-1369: Merge unit tests into a single Buildkite job in WordPress/Jetpack Android](https://linear.app/a8c/issue/AINFRA-1369/merge-unit-tests-into-a-single-buildkite-job-in-wordpressjetpack)

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This PR merges 5 separate unit tests Buildkite jobs into one.

| Before | After | 
| --- | --- | 
| <img width="407" height="216" alt="Screenshot 2025-10-07 at 10 46 06" src="https://github.com/user-attachments/assets/4d855866-39f6-461b-ae45-67e57d18190b" /> | <img width="266" height="112" alt="Screenshot 2025-10-07 at 10 46 24" src="https://github.com/user-attachments/assets/c6d78332-0614-46a9-a855-7b82a3af1dc2" /> |

## Motivation

What motivated me to propose this change:
1. **Resources**: with 5 separate jobs, we allocate a BK runner that builds modules from the ground just to run a few seconds of unit tests. With 1 job, we build the app once. It's especially visible when running tests on `WordPress` module, which builds all submodules but runs only `WordPress` unit tests.
2. **No significant performance regression**: The signle unit tests step will still be shorter than the longest step of the pipeline (UI tests). So overall PR checks job won't be longer. It's true, that unit tests step on its own will be longer, but this is a very small (few seconds) difference.
3. **Single report**: With single Buildkite step, we also gain a single Buildkite Test Engine report ([example](https://buildkite.com/organizations/automattic/analytics/suites/wordpress-android-unit-test-wordpress/runs/1f8126ce-b03d-8a3b-8665-d266a5e2fd2f)). This is better, because if we look for flaky or long unit tests, there's no benefit to look for them in 5 different "test suites".
4. **Easier automation**: Lastly, this change was motivated by the work on integrating Buildkite Claude plugin. It's easier to design automations if there's one trigger, rather than 5 of them.


## Testing instructions

1. **Test reports**: On this PR checks, verify that you can see 6373 tests in Test Engine (button in top-right corner of logs)
2. **Code coverage reports**: See that code coverage wasn't changed meaningfully by this PR (a slight change comes from the fact it's outdated branch). To double check, see in Buildkite logs that 5 reports have been uploaded to Codecov
3. **Failed tests report**: Open PR #22263. Verify, that tests have been reported to Test Engine, even though one of them failed.

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->