### PR TITLE
fix: Using showUi for taxonomies visibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/taxonomies/TaxonomiesNavMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/taxonomies/TaxonomiesNavMenuViewModel.kt
@@ -42,7 +42,7 @@ class TaxonomiesNavMenuViewModel @Inject constructor(
                     val taxonomies = mutableListOf<TaxonomyTypeDetailsWithEditContext>()
                     list.taxonomyTypes.forEach { type ->
                         appLogWrapper.d(AppLog.T.API, "Taxonomies - Taxonomy ${type.value.name}")
-                        if (type.value.visibility.showInNavMenus) {
+                        if (type.value.visibility.showUi) {
                             taxonomies.add(type.value)
                         }
                     }


### PR DESCRIPTION
## Description
The PR updates the condition for displaying taxonomies in navigation menus by changing from checking showInNavMenus to showUi property for determining taxonomy visibility.

More info: https://github.com/wordpress-mobile/WordPress-Android/pull/22255#issuecomment-3366249116

According to an internal conversation, _show_in_menu_ is not available in the current API, so we are using _show_ui_

## Testing instructions

Just check the code changes

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->