### PR TITLE
CMM-828 taxonomies data view second iteration  create, update, delete support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -15,19 +15,27 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
@@ -96,17 +104,24 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
     @Composable
     private fun NavigableContent(taxonomyName: String) {
         navController = rememberNavController()
-        val listTitle = taxonomyName
-        val titleState = remember { mutableStateOf(listTitle) }
+        val termDetailState by viewModel.termDetailState.collectAsState()
+        val title = termDetailState?.name ?: taxonomyName
+
+        LaunchedEffect(termDetailState) {
+            if (termDetailState == null && navController.currentDestination?.route == TermScreen.Detail.name) {
+                navController.navigateUp()
+            }
+        }
 
         AppThemeM3 {
             Scaffold(
                 topBar = {
                     TopAppBar(
-                        title = { Text(titleState.value) },
+                        title = { Text(title) },
                         navigationIcon = {
                             IconButton(onClick = {
                                 if (navController.previousBackStackEntry != null) {
+                                    viewModel.clearTermDetail()
                                     navController.navigateUp()
                                 } else {
                                     finish()
@@ -123,7 +138,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     startDestination = TermScreen.List.name
                 ) {
                     composable(route = TermScreen.List.name) {
-                        titleState.value = listTitle
                         ShowListScreen(
                             navController,
                             modifier = Modifier.padding(contentPadding)
@@ -131,18 +145,11 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     }
 
                     composable(route = TermScreen.Detail.name) {
-                        navController.previousBackStackEntry?.savedStateHandle?.let { handle ->
-                            val termId = handle.get<Long>(KEY_TERM_ID)
-                            if (termId != null) {
-                                viewModel.getTerm(termId)?.let { term ->
-                                    titleState.value = term.name
-                                    ShowTermDetailScreen(
-                                        allTerms = viewModel.getAllTerms(),
-                                        term = term,
-                                        modifier = Modifier.padding(contentPadding)
-                                    )
-                                }
-                            }
+                        termDetailState?.let { state ->
+                            ShowTermDetailScreen(
+                                state = state,
+                                modifier = Modifier.padding(contentPadding)
+                            )
                         }
                     }
                 }
@@ -171,10 +178,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
             onItemClick = { item ->
                 viewModel.onItemClick(item)
                 (item.data as? AnyTermWithEditContext)?.let { term ->
-                    navController.currentBackStackEntry?.savedStateHandle?.set(
-                        key = KEY_TERM_ID,
-                        value = term.id
-                    )
+                    viewModel.navigateToTermDetail(term.id)
                     navController.navigate(route = TermScreen.Detail.name)
                 }
             },
@@ -194,8 +198,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
 
     @Composable
     private fun ShowTermDetailScreen(
-        allTerms: List<AnyTermWithEditContext>,
-        term: AnyTermWithEditContext,
+        state: TermDetailUiState,
         modifier: Modifier
     ) {
         Column(
@@ -205,12 +208,19 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            TermDetailsCard(allTerms, term)
+            TermDetailsCard(state = state)
+
+            Button(
+                onClick = { viewModel.saveTerm() },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(R.string.save))
+            }
         }
     }
 
     @Composable
-    private fun TermDetailsCard(allTerms: List<AnyTermWithEditContext>, term: AnyTermWithEditContext) {
+    private fun TermDetailsCard(state: TermDetailUiState) {
         Card(
             modifier = Modifier.fillMaxWidth(),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
@@ -380,7 +390,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         private const val TAXONOMY_SLUG = "taxonomy_slug"
         private const val IS_HIERARCHICAL = "is_hierarchical"
         private const val TAXONOMY_NAME = "taxonomy_name"
-        private const val KEY_TERM_ID = "termId"
 
         fun getIntent(context: Context, taxonomySlug: String, taxonomyName: String, isHierarchical: Boolean): Intent =
             Intent(context, TermsDataViewActivity::class.java).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -113,6 +113,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                         ToastUtils.Duration.LONG
                     )
                 }
+                viewModel.consumeUIEvent()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -253,17 +253,14 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     singleLine = false
                 )
 
-                DetailRow(
-                    label = stringResource(R.string.term_count_label),
-                    value = state.count.toString()
-                )
-
-                ParentDropdownField(
-                    label = stringResource(R.string.term_parent_label),
-                    availableParents = state.availableParents,
-                    selectedParentId = state.parentId,
-                    onParentIdChange = { viewModel.updateTermParent(it) }
-                )
+                if (!state.availableParents.isNullOrEmpty() && state.parentId != null) {
+                    ParentDropdownField(
+                        label = stringResource(R.string.term_parent_label),
+                        availableParents = state.availableParents,
+                        selectedParentId = state.parentId,
+                        onParentIdChange = { viewModel.updateTermParent(it) }
+                    )
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -131,8 +131,11 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         val termDetailState by viewModel.termDetailState.collectAsState()
         val title = termDetailState?.name ?: taxonomyName
 
+        // Observe navigation changes to trigger recomposition
+        val currentBackStackEntry by navController.currentBackStackEntryFlow.collectAsState(initial = navController.currentBackStackEntry)
+        val currentRoute = currentBackStackEntry?.destination?.route
+
         LaunchedEffect(termDetailState) {
-            val currentRoute = navController.currentDestination?.route
             if (termDetailState == null && (currentRoute == TermScreen.Detail.name || currentRoute == TermScreen.Create.name)) {
                 navController.navigateUp()
             }
@@ -155,8 +158,8 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                             }
                         },
                         actions = {
-                            if (navController.currentDestination == null ||
-                                navController.currentDestination?.route == TermScreen.List.name) {
+                            // Show the add button only on the List screen
+                            if (currentRoute == TermScreen.List.name) {
                                 IconButton(onClick = {
                                     viewModel.navigateToCreateTerm()
                                 }) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -201,6 +202,8 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         state: TermDetailUiState,
         modifier: Modifier
     ) {
+        val isSaving by viewModel.isSaving.collectAsState()
+
         Column(
             modifier = modifier
                 .fillMaxSize()
@@ -212,9 +215,17 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
 
             Button(
                 onClick = { viewModel.saveTerm() },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isSaving
             ) {
-                Text(stringResource(R.string.save))
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.padding(end = 8.dp),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text(stringResource(R.string.save))
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -43,7 +42,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -132,11 +130,12 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         val title = termDetailState?.name ?: taxonomyName
 
         // Observe navigation changes to trigger recomposition
-        val currentBackStackEntry by navController.currentBackStackEntryFlow.collectAsState(initial = navController.currentBackStackEntry)
+        val currentBackStackEntry by navController.currentBackStackEntryFlow
+            .collectAsState(initial = navController.currentBackStackEntry)
         val currentRoute = currentBackStackEntry?.destination?.route
 
         LaunchedEffect(termDetailState) {
-            if (termDetailState == null && (currentRoute == TermScreen.Detail.name || currentRoute == TermScreen.Create.name)) {
+            if (termDetailState == null && currentRoute != TermScreen.List.name) {
                 navController.navigateUp()
             }
         }
@@ -466,32 +465,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = singleLine,
                 textStyle = MaterialTheme.typography.bodyMedium
-            )
-        }
-    }
-
-    @Composable
-    private fun DetailRow(
-        label: String,
-        value: String
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(0.3f)
-            )
-
-            Text(
-                text = value,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(0.7f)
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -224,36 +224,129 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                DetailRow(
+                EditableDetailField(
                     label = stringResource(R.string.term_name_label),
-                    value = term.name
+                    value = state.name,
+                    onValueChange = { viewModel.updateTermName(it) }
                 )
 
-                DetailRow(
+                EditableDetailField(
                     label = stringResource(R.string.term_slug_label),
-                    value = term.slug
+                    value = state.slug,
+                    onValueChange = { viewModel.updateTermSlug(it) }
                 )
 
-                DetailRow(
+                EditableDetailField(
                     label = stringResource(R.string.term_description_label),
-                    value = term.description
+                    value = state.description,
+                    onValueChange = { viewModel.updateTermDescription(it) },
+                    singleLine = false
                 )
 
                 DetailRow(
                     label = stringResource(R.string.term_count_label),
-                    value = term.count.toString()
+                    value = state.count.toString()
                 )
 
-                term.parent?.let { parentId ->
-                    val parentName = allTerms.firstOrNull {  it.id == parentId }?.name
-                    parentName?.let {
-                        DetailRow(
-                            label = stringResource(R.string.term_parent_label),
-                            value = parentName
+                ParentDropdownField(
+                    label = stringResource(R.string.term_parent_label),
+                    availableParents = state.availableParents,
+                    selectedParentId = state.parentId,
+                    onParentIdChange = { viewModel.updateTermParent(it) }
+                )
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun ParentDropdownField(
+        label: String,
+        availableParents: List<ParentOption>,
+        selectedParentId: Long,
+        onParentIdChange: (Long) -> Unit
+    ) {
+        var expanded by remember { mutableStateOf(false) }
+        val selectedParentName = availableParents.firstOrNull { it.id == selectedParentId }?.name
+            ?: stringResource(R.string.term_parent_none)
+
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it }
+            ) {
+                OutlinedTextField(
+                    value = selectedParentName,
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                    textStyle = MaterialTheme.typography.bodyMedium
+                )
+
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.term_parent_none)) },
+                        onClick = {
+                            onParentIdChange(0L)
+                            expanded = false
+                        }
+                    )
+
+                    availableParents.forEach { parent ->
+                        DropdownMenuItem(
+                            text = { Text(parent.name) },
+                            onClick = {
+                                onParentIdChange(parent.id)
+                                expanded = false
+                            }
                         )
                     }
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun EditableDetailField(
+        label: String,
+        value: String,
+        onValueChange: (String) -> Unit,
+        singleLine: Boolean = true
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+
+            OutlinedTextField(
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = singleLine,
+                textStyle = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -8,15 +8,20 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -49,6 +54,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -223,6 +229,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         modifier: Modifier
     ) {
         val isSaving by viewModel.isSaving.collectAsState()
+        val isDeleting by viewModel.isDeleting.collectAsState()
 
         Column(
             modifier = modifier
@@ -236,16 +243,60 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
             Button(
                 onClick = { viewModel.saveTerm() },
                 modifier = Modifier.fillMaxWidth(),
-                enabled = !isSaving
+                enabled = !isSaving && !isDeleting
             ) {
                 if (isSaving) {
                     CircularProgressIndicator(
-                        modifier = Modifier.padding(end = 8.dp),
                         color = MaterialTheme.colorScheme.onPrimary
                     )
                 } else {
                     Text(stringResource(R.string.save))
                 }
+            }
+
+            // Only show delete button if editing existing term (termId != 0)
+            if (state.termId != 0L) {
+                DeleteTermButton(
+                    isDeleting,
+                    onClick = {
+                        if (!isDeleting) {
+                            showDeleteTermConfirmation(state.termId, state.name)
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun DeleteTermButton(
+        isDeleting: Boolean,
+        onClick: () -> Unit,
+    ) {
+        Button(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = androidx.compose.ui.graphics.Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.error
+            ),
+            elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = stringResource(R.string.delete),
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            if (isDeleting) {
+                CircularProgressIndicator(
+                    color = MaterialTheme.colorScheme.error
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.delete),
+                    style = MaterialTheme.typography.bodyLarge
+                )
             }
         }
     }
@@ -357,6 +408,18 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     }
                 }
             }
+        }
+    }
+
+    private fun showDeleteTermConfirmation(termId: Long, termName: String) {
+        MaterialAlertDialogBuilder(this).also { builder ->
+            builder.setTitle(R.string.term_delete_confirmation_title)
+            builder.setMessage(getString(R.string.term_delete_confirmation_message, termName))
+            builder.setPositiveButton(R.string.delete) { _, _ ->
+                viewModel.deleteTerm(termId)
+            }
+            builder.setNegativeButton(R.string.cancel, null)
+            builder.show()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -89,8 +89,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
             return
         }
 
-        viewModel.initialize(taxonomySlug, isHierarchical)
-
         composeView = ComposeView(this)
         setContentView(
             composeView.apply {
@@ -104,6 +102,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
             }
         )
 
+        viewModel.initialize(taxonomySlug, isHierarchical)
         lifecycleScope.launch {
             viewModel.uiEvent.filterNotNull().collect { event ->
                 when (event) {
@@ -128,7 +127,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         }
 
         val termDetailState by viewModel.termDetailState.collectAsState()
-        val title = termDetailState?.name ?: taxonomyName
 
         // Observe navigation changes to trigger recomposition
         val currentBackStackEntry by navController.currentBackStackEntryFlow
@@ -145,7 +143,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
             Scaffold(
                 topBar = {
                     TopAppBar(
-                        title = { Text(title) },
+                        title = { Text(taxonomyName) },
                         navigationIcon = {
                             IconButton(onClick = {
                                 if (navController.previousBackStackEntry != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -50,18 +50,22 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.dataview.DataViewScreen
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.ToastUtils
 import uniffi.wp_api.AnyTermWithEditContext
 import javax.inject.Inject
 
@@ -101,6 +105,18 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                 }
             }
         )
+
+        lifecycleScope.launch {
+            viewModel.uiEvent.filterNotNull().collect { event ->
+                when (event) {
+                    is UiEvent.ShowError -> ToastUtils.showToast(
+                        this@TermsDataViewActivity,
+                        event.messageRes,
+                        ToastUtils.Duration.LONG
+                    )
+                }
+            }
+        }
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -56,7 +55,6 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.dataview.DataViewScreen
 import org.wordpress.android.ui.main.BaseAppCompatActivity
-import org.wordpress.android.ui.subscribers.SubscribersActivity.SubscriberScreen
 import org.wordpress.android.util.AppLog
 import uniffi.wp_api.AnyTermWithEditContext
 import javax.inject.Inject
@@ -99,16 +97,15 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         )
     }
 
-    private enum class TermScreen {
-        List,
-        Detail,
-        Create
-    }
-
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     private fun NavigableContent(taxonomyName: String) {
         navController = rememberNavController()
+
+        LaunchedEffect(navController) {
+            viewModel.setNavController(navController)
+        }
+
         val termDetailState by viewModel.termDetailState.collectAsState()
         val title = termDetailState?.name ?: taxonomyName
 
@@ -127,8 +124,7 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                         navigationIcon = {
                             IconButton(onClick = {
                                 if (navController.previousBackStackEntry != null) {
-                                    viewModel.clearTermDetail()
-                                    navController.navigateUp()
+                                    viewModel.navigateBack()
                                 } else {
                                     finish()
                                 }
@@ -137,12 +133,10 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                             }
                         },
                         actions = {
-                            Log.d("TAG_TAG", "NavigableContent: ${navController.currentDestination}")
                             if (navController.currentDestination == null ||
                                 navController.currentDestination?.route == TermScreen.List.name) {
                                 IconButton(onClick = {
                                     viewModel.navigateToCreateTerm()
-                                    navController.navigate(TermScreen.Create.name)
                                 }) {
                                     Icon(
                                         imageVector = Icons.Default.Add,
@@ -160,7 +154,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                 ) {
                     composable(route = TermScreen.List.name) {
                         ShowListScreen(
-                            navController,
                             modifier = Modifier.padding(contentPadding)
                         )
                     }
@@ -189,7 +182,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
 
     @Composable
     private fun ShowListScreen(
-        navController: NavHostController,
         modifier: Modifier
     ) {
         DataViewScreen(
@@ -209,7 +201,6 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                 viewModel.onItemClick(item)
                 (item.data as? AnyTermWithEditContext)?.let { term ->
                     viewModel.navigateToTermDetail(term.id)
-                    navController.navigate(route = TermScreen.Detail.name)
                 }
             },
             onFilterClick = { filter ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsDataViewActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -54,6 +56,7 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.dataview.DataViewScreen
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.subscribers.SubscribersActivity.SubscriberScreen
 import org.wordpress.android.util.AppLog
 import uniffi.wp_api.AnyTermWithEditContext
 import javax.inject.Inject
@@ -98,7 +101,8 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
 
     private enum class TermScreen {
         List,
-        Detail
+        Detail,
+        Create
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
@@ -109,7 +113,8 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
         val title = termDetailState?.name ?: taxonomyName
 
         LaunchedEffect(termDetailState) {
-            if (termDetailState == null && navController.currentDestination?.route == TermScreen.Detail.name) {
+            val currentRoute = navController.currentDestination?.route
+            if (termDetailState == null && (currentRoute == TermScreen.Detail.name || currentRoute == TermScreen.Create.name)) {
                 navController.navigateUp()
             }
         }
@@ -130,6 +135,21 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                             }) {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
                             }
+                        },
+                        actions = {
+                            Log.d("TAG_TAG", "NavigableContent: ${navController.currentDestination}")
+                            if (navController.currentDestination == null ||
+                                navController.currentDestination?.route == TermScreen.List.name) {
+                                IconButton(onClick = {
+                                    viewModel.navigateToCreateTerm()
+                                    navController.navigate(TermScreen.Create.name)
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Add,
+                                        contentDescription = stringResource(R.string.add_term)
+                                    )
+                                }
+                            }
                         }
                     )
                 },
@@ -146,6 +166,15 @@ class TermsDataViewActivity : BaseAppCompatActivity() {
                     }
 
                     composable(route = TermScreen.Detail.name) {
+                        termDetailState?.let { state ->
+                            ShowTermDetailScreen(
+                                state = state,
+                                modifier = Modifier.padding(contentPadding)
+                            )
+                        }
+                    }
+
+                    composable(route = TermScreen.Create.name) {
                         termDetailState?.let { state ->
                             ShowTermDetailScreen(
                                 state = state,

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -3,12 +3,14 @@ package org.wordpress.android.ui.taxonomies
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
@@ -31,6 +33,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 import uniffi.wp_api.AnyTermWithEditContext
+import uniffi.wp_api.TermUpdateParams
 import uniffi.wp_api.WpApiParamOrder
 import uniffi.wp_api.WpApiParamTermsOrderBy
 import javax.inject.Inject
@@ -213,16 +216,40 @@ class TermsViewModel @Inject constructor(
         return result
     }
 
-    fun saveTerm() {
-        val state = _termDetailState.value ?: return
+    fun saveTerm(termId: Long, termName: String, termDescription: String, termSlug: String, termParentId: Long?) {
+        viewModelScope.launch {
+            val selectedSite = selectedSiteRepository.getSelectedSite()
+            if (selectedSite == null) {
+                // TODO: error
+                return@launch
+            }
 
-        // TODO: Implement term update logic here
-        // This should:
-        // 1. Validate the input fields (state.name, state.slug, state.description, state.parentId)
-        // 2. Make an API call to update the term on the server using state.termId
-        // 3. Update the local cache/state if successful
-        // 4. Show success/error message to the user
-        // 5. Navigate back or show confirmation
+            val wpApiClient = wpApiClientProvider.getWpApiClient(selectedSite)
+
+            val termsResponse = wpApiClient.request { requestBuilder ->
+                requestBuilder.terms().update(
+                    termEndpointType = getTermEndpointType(),
+                    termId = termId,
+                    params = TermUpdateParams(
+                        name = termName,
+                        description = termDescription,
+                        slug = termSlug,
+                        parent = termParentId
+                    )
+                )
+            }
+
+            when (termsResponse) {
+                is WpRequestResult.Success -> {
+                    // TODO: navigate to list again
+                }
+
+                else -> {
+                    // TODO error
+                    appLogWrapper.e(AppLog.T.API, "Error saving term: $taxonomySlug")
+                }
+            }
+        }
     }
 
     private fun convertToDataViewItem(
@@ -284,15 +311,9 @@ class TermsViewModel @Inject constructor(
     ): List<AnyTermWithEditContext> {
         val wpApiClient = wpApiClientProvider.getWpApiClient(site)
 
-        val termEndpointType = when (taxonomySlug) {
-            DEFAULT_TAXONOMY_CATEGORY -> TermEndpointType.Categories
-            DEFAULT_TAXONOMY_TAG -> TermEndpointType.Tags
-            else -> TermEndpointType.Custom(taxonomySlug)
-        }
-
         val termsResponse = wpApiClient.request { requestBuilder ->
             requestBuilder.terms().listWithEditContext(
-                termEndpointType = termEndpointType,
+                termEndpointType = getTermEndpointType(),
                 params = TermListParams(
                     page = page.toUInt(),
                     search = searchQuery,
@@ -326,6 +347,12 @@ class TermsViewModel @Inject constructor(
                 emptyList()
             }
         }
+    }
+
+    private fun getTermEndpointType(): TermEndpointType = when (taxonomySlug) {
+        DEFAULT_TAXONOMY_CATEGORY -> TermEndpointType.Categories
+        DEFAULT_TAXONOMY_TAG -> TermEndpointType.Tags
+        else -> TermEndpointType.Custom(taxonomySlug)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -216,10 +216,11 @@ class TermsViewModel @Inject constructor(
         return result
     }
 
-    fun saveTerm(termId: Long, termName: String, termDescription: String, termSlug: String, termParentId: Long?) {
+    fun saveTerm() {
         viewModelScope.launch {
             val selectedSite = selectedSiteRepository.getSelectedSite()
-            if (selectedSite == null) {
+            val currentTerm = _termDetailState.value
+            if (selectedSite == null || currentTerm == null) {
                 // TODO: error
                 return@launch
             }
@@ -229,19 +230,20 @@ class TermsViewModel @Inject constructor(
             val termsResponse = wpApiClient.request { requestBuilder ->
                 requestBuilder.terms().update(
                     termEndpointType = getTermEndpointType(),
-                    termId = termId,
+                    termId = currentTerm.termId,
                     params = TermUpdateParams(
-                        name = termName,
-                        description = termDescription,
-                        slug = termSlug,
-                        parent = termParentId
+                        name = currentTerm.name,
+                        description = currentTerm.description,
+                        slug = currentTerm.slug,
+                        parent = currentTerm.parentId
                     )
                 )
             }
 
             when (termsResponse) {
                 is WpRequestResult.Success -> {
-                    // TODO: navigate to list again
+                    // Go back to the list and load the data again
+                    initialize()
                 }
 
                 else -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -83,6 +83,9 @@ class TermsViewModel @Inject constructor(
     private val _termDetailState = MutableStateFlow<TermDetailUiState?>(null)
     val termDetailState: StateFlow<TermDetailUiState?> = _termDetailState.asStateFlow()
 
+    private val _isSaving = MutableStateFlow(false)
+    val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
+
     fun initialize(taxonomySlug: String, isHierarchical: Boolean) {
         this.taxonomySlug = taxonomySlug
         this.isHierarchical = isHierarchical
@@ -225,6 +228,8 @@ class TermsViewModel @Inject constructor(
                 return@launch
             }
 
+            _isSaving.value = true
+
             val wpApiClient = wpApiClientProvider.getWpApiClient(selectedSite)
 
             val termsResponse = wpApiClient.request { requestBuilder ->
@@ -242,11 +247,15 @@ class TermsViewModel @Inject constructor(
 
             when (termsResponse) {
                 is WpRequestResult.Success -> {
-                    // Go back to the list and load the data again
+                    _isSaving.value = false
+                    // Clear term detail to navigate back
+                    clearTermDetail()
+                    // Reload the list
                     initialize()
                 }
 
                 else -> {
+                    _isSaving.value = false
                     // TODO error
                     appLogWrapper.e(AppLog.T.API, "Error saving term: $taxonomySlug")
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.unit.dp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
@@ -35,6 +38,22 @@ import javax.inject.Named
 
 private const val INDENTATION_IN_DP = 10
 
+data class TermDetailUiState(
+    val termId: Long = 0L,
+    val name: String = "",
+    val slug: String = "",
+    val description: String = "",
+    val count: Long = 0L,
+    val parentId: Long = 0L,
+    val availableParents: List<ParentOption> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+data class ParentOption(
+    val id: Long,
+    val name: String
+)
+
 @HiltViewModel
 class TermsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -59,10 +78,52 @@ class TermsViewModel @Inject constructor(
     private var isHierarchical: Boolean = false
     private var currentTerms = listOf<AnyTermWithEditContext>()
 
+    private val _termDetailState = MutableStateFlow<TermDetailUiState?>(null)
+    val termDetailState: StateFlow<TermDetailUiState?> = _termDetailState.asStateFlow()
+
     fun initialize(taxonomySlug: String, isHierarchical: Boolean) {
         this.taxonomySlug = taxonomySlug
         this.isHierarchical = isHierarchical
         initialize()
+    }
+
+    fun navigateToTermDetail(termId: Long) {
+        val term = currentTerms.firstOrNull { it.id == termId } ?: return
+
+        val availableParents = currentTerms
+            .filter { it.id != termId }
+            .map { ParentOption(id = it.id, name = it.name) }
+
+        _termDetailState.value = TermDetailUiState(
+            termId = term.id,
+            name = term.name,
+            slug = term.slug,
+            description = term.description,
+            count = term.count,
+            parentId = term.parent ?: 0L,
+            availableParents = availableParents,
+            isLoading = false
+        )
+    }
+
+    fun updateTermName(name: String) {
+        _termDetailState.value = _termDetailState.value?.copy(name = name)
+    }
+
+    fun updateTermSlug(slug: String) {
+        _termDetailState.value = _termDetailState.value?.copy(slug = slug)
+    }
+
+    fun updateTermDescription(description: String) {
+        _termDetailState.value = _termDetailState.value?.copy(description = description)
+    }
+
+    fun updateTermParent(parentId: Long) {
+        _termDetailState.value = _termDetailState.value?.copy(parentId = parentId)
+    }
+
+    fun clearTermDetail() {
+        _termDetailState.value = null
     }
 
     override fun getSupportedSorts(): List<DataViewDropdownItem> = if (isHierarchical) {
@@ -135,14 +196,17 @@ class TermsViewModel @Inject constructor(
         return result
     }
 
-    fun getTerm(termId: Long): AnyTermWithEditContext? {
-        val item = uiState.value.items.firstOrNull {
-            (it.data as? AnyTermWithEditContext)?.id == termId
-        }
-        return item?.data as? AnyTermWithEditContext
-    }
+    fun saveTerm() {
+        val state = _termDetailState.value ?: return
 
-    fun getAllTerms(): List<AnyTermWithEditContext> = currentTerms
+        // TODO: Implement term update logic here
+        // This should:
+        // 1. Validate the input fields (state.name, state.slug, state.description, state.parentId)
+        // 2. Make an API call to update the term on the server using state.termId
+        // 3. Update the local cache/state if successful
+        // 4. Show success/error message to the user
+        // 5. Navigate back or show confirmation
+    }
 
     private fun convertToDataViewItem(
         allTerms: List<AnyTermWithEditContext>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -103,7 +103,7 @@ class TermsViewModel @Inject constructor(
     val isDeleting: StateFlow<Boolean> = _isDeleting.asStateFlow()
 
     private val _uiEvent = MutableStateFlow<UiEvent?>(null)
-    val uiEvent = _uiEvent
+    val uiEvent = _uiEvent.asStateFlow()
 
     fun setNavController(navController: NavHostController) {
         this.navController = navController
@@ -289,7 +289,7 @@ class TermsViewModel @Inject constructor(
                             name = currentTerm.name,
                             description = currentTerm.description,
                             slug = currentTerm.slug,
-                            parent = if (currentTerm.parentId == 0L) null else currentTerm.parentId
+                            parent = if (isHierarchical) currentTerm.parentId else null
                         )
                     )
                 }
@@ -470,6 +470,10 @@ class TermsViewModel @Inject constructor(
         DEFAULT_TAXONOMY_CATEGORY -> TermEndpointType.Categories
         DEFAULT_TAXONOMY_TAG -> TermEndpointType.Tags
         else -> TermEndpointType.Custom(taxonomySlug)
+    }
+
+    fun consumeUIEvent() {
+        _uiEvent.value = null
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -43,6 +43,12 @@ import javax.inject.Named
 
 private const val INDENTATION_IN_DP = 10
 
+enum class TermScreen {
+    List,
+    Detail,
+    Create
+}
+
 data class TermDetailUiState(
     val termId: Long = 0L,
     val name: String = "",
@@ -81,12 +87,17 @@ class TermsViewModel @Inject constructor(
     private var taxonomySlug: String = ""
     private var isHierarchical: Boolean = false
     private var currentTerms = listOf<AnyTermWithEditContext>()
+    private var navController: NavHostController? = null
 
     private val _termDetailState = MutableStateFlow<TermDetailUiState?>(null)
     val termDetailState: StateFlow<TermDetailUiState?> = _termDetailState.asStateFlow()
 
     private val _isSaving = MutableStateFlow(false)
     val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
+
+    fun setNavController(navController: NavHostController) {
+        this.navController = navController
+    }
 
     fun initialize(taxonomySlug: String, isHierarchical: Boolean) {
         this.taxonomySlug = taxonomySlug
@@ -115,6 +126,7 @@ class TermsViewModel @Inject constructor(
             parentId = term.parent,
             availableParents = availableParents,
         )
+        navController?.navigate(TermScreen.Detail.name)
     }
 
     fun navigateToCreateTerm() {
@@ -133,6 +145,12 @@ class TermsViewModel @Inject constructor(
             parentId = 0L,
             availableParents = availableParents,
         )
+        navController?.navigate(TermScreen.Create.name)
+    }
+
+    fun navigateBack() {
+        clearTermDetail()
+        navController?.navigateUp()
     }
 
     private fun getDescendants(termId: Long): Set<Long> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.dataview.DataViewItem
 import org.wordpress.android.ui.dataview.DataViewItemField
 import org.wordpress.android.ui.dataview.DataViewViewModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.subscribers.SubscribersViewModel
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import rs.wordpress.api.kotlin.WpRequestResult

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.dataview.DataViewItem
 import org.wordpress.android.ui.dataview.DataViewItemField
 import org.wordpress.android.ui.dataview.DataViewViewModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.subscribers.SubscribersViewModel
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import rs.wordpress.api.kotlin.WpRequestResult
@@ -64,6 +65,10 @@ data class ParentOption(
     val name: String
 )
 
+sealed class UiEvent {
+    data class ShowError(val messageRes: Int) : UiEvent()
+}
+
 @HiltViewModel
 class TermsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -97,6 +102,9 @@ class TermsViewModel @Inject constructor(
 
     private val _isDeleting = MutableStateFlow(false)
     val isDeleting: StateFlow<Boolean> = _isDeleting.asStateFlow()
+
+    private val _uiEvent = MutableStateFlow<UiEvent?>(null)
+    val uiEvent = _uiEvent
 
     fun setNavController(navController: NavHostController) {
         this.navController = navController
@@ -265,7 +273,7 @@ class TermsViewModel @Inject constructor(
             val selectedSite = selectedSiteRepository.getSelectedSite()
             val currentTerm = _termDetailState.value
             if (selectedSite == null || currentTerm == null) {
-                // TODO: error
+                _uiEvent.value = UiEvent.ShowError(R.string.error_saving_term)
                 return@launch
             }
 
@@ -313,7 +321,7 @@ class TermsViewModel @Inject constructor(
 
                 else -> {
                     _isSaving.value = false
-                    // TODO error
+                    _uiEvent.value = UiEvent.ShowError(R.string.error_saving_term)
                     appLogWrapper.e(AppLog.T.API, "Error saving term: $taxonomySlug")
                 }
             }
@@ -324,7 +332,7 @@ class TermsViewModel @Inject constructor(
         viewModelScope.launch {
             val selectedSite = selectedSiteRepository.getSelectedSite()
             if (selectedSite == null) {
-                // TODO: error
+                _uiEvent.value = UiEvent.ShowError(R.string.error_deleting_term)
                 return@launch
             }
 
@@ -348,14 +356,14 @@ class TermsViewModel @Inject constructor(
                         // Reload the list
                         initialize()
                     } else {
-                        // TODO: error - term not deleted
+                        _uiEvent.value = UiEvent.ShowError(R.string.error_deleting_term)
                         appLogWrapper.e(AppLog.T.API, "Term was not deleted: $taxonomySlug")
                     }
                 }
 
                 else -> {
                     _isDeleting.value = false
-                    // TODO error
+                    _uiEvent.value = UiEvent.ShowError(R.string.error_deleting_term)
                     appLogWrapper.e(AppLog.T.API, "Error deleting term: $taxonomySlug")
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -44,9 +44,8 @@ data class TermDetailUiState(
     val slug: String = "",
     val description: String = "",
     val count: Long = 0L,
-    val parentId: Long = 0L,
-    val availableParents: List<ParentOption> = emptyList(),
-    val isLoading: Boolean = false
+    val parentId: Long? = null,
+    val availableParents: List<ParentOption>? = null,
 )
 
 data class ParentOption(
@@ -90,9 +89,13 @@ class TermsViewModel @Inject constructor(
     fun navigateToTermDetail(termId: Long) {
         val term = currentTerms.firstOrNull { it.id == termId } ?: return
 
-        val availableParents = currentTerms
-            .filter { it.id != termId }
-            .map { ParentOption(id = it.id, name = it.name) }
+        val availableParents = if (isHierarchical) {
+            currentTerms
+                .filter { it.id != termId }
+                .map { ParentOption(id = it.id, name = it.name) }
+        } else {
+            null
+        }
 
         _termDetailState.value = TermDetailUiState(
             termId = term.id,
@@ -100,9 +103,8 @@ class TermsViewModel @Inject constructor(
             slug = term.slug,
             description = term.description,
             count = term.count,
-            parentId = term.parent ?: 0L,
+            parentId = term.parent,
             availableParents = availableParents,
-            isLoading = false
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -95,6 +95,9 @@ class TermsViewModel @Inject constructor(
     private val _isSaving = MutableStateFlow(false)
     val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
 
+    private val _isDeleting = MutableStateFlow(false)
+    val isDeleting: StateFlow<Boolean> = _isDeleting.asStateFlow()
+
     fun setNavController(navController: NavHostController) {
         this.navController = navController
     }
@@ -312,6 +315,48 @@ class TermsViewModel @Inject constructor(
                     _isSaving.value = false
                     // TODO error
                     appLogWrapper.e(AppLog.T.API, "Error saving term: $taxonomySlug")
+                }
+            }
+        }
+    }
+
+    fun deleteTerm(termId: Long) {
+        viewModelScope.launch {
+            val selectedSite = selectedSiteRepository.getSelectedSite()
+            if (selectedSite == null) {
+                // TODO: error
+                return@launch
+            }
+
+            _isDeleting.value = true
+
+            val wpApiClient = wpApiClientProvider.getWpApiClient(selectedSite)
+
+            val deleteResponse = wpApiClient.request { requestBuilder ->
+                requestBuilder.terms().delete(
+                    termEndpointType = getTermEndpointType(),
+                    termId = termId
+                )
+            }
+
+            when (deleteResponse) {
+                is WpRequestResult.Success -> {
+                    _isDeleting.value = false
+                    if (deleteResponse.response.data.deleted) {
+                        // Clear term detail to navigate back
+                        clearTermDetail()
+                        // Reload the list
+                        initialize()
+                    } else {
+                        // TODO: error - term not deleted
+                        appLogWrapper.e(AppLog.T.API, "Term was not deleted: $taxonomySlug")
+                    }
+                }
+
+                else -> {
+                    _isDeleting.value = false
+                    // TODO error
+                    appLogWrapper.e(AppLog.T.API, "Error deleting term: $taxonomySlug")
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -90,8 +90,9 @@ class TermsViewModel @Inject constructor(
         val term = currentTerms.firstOrNull { it.id == termId } ?: return
 
         val availableParents = if (isHierarchical) {
+            val descendants = getDescendants(termId)
             currentTerms
-                .filter { it.id != termId }
+                .filter { it.id != termId && it.id !in descendants }
                 .map { ParentOption(id = it.id, name = it.name) }
         } else {
             null
@@ -106,6 +107,20 @@ class TermsViewModel @Inject constructor(
             parentId = term.parent,
             availableParents = availableParents,
         )
+    }
+
+    private fun getDescendants(termId: Long): Set<Long> {
+        val descendants = mutableSetOf<Long>()
+
+        fun addDescendantsRecursively(parentId: Long) {
+            currentTerms.filter { it.parent == parentId }.forEach { child ->
+                descendants.add(child.id)
+                addDescendantsRecursively(child.id)
+            }
+        }
+
+        addDescendantsRecursively(termId)
+        return descendants
     }
 
     fun updateTermName(name: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavHostController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -33,6 +34,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 import uniffi.wp_api.AnyTermWithEditContext
+import uniffi.wp_api.TermCreateParams
 import uniffi.wp_api.TermUpdateParams
 import uniffi.wp_api.WpApiParamOrder
 import uniffi.wp_api.WpApiParamTermsOrderBy
@@ -111,6 +113,24 @@ class TermsViewModel @Inject constructor(
             description = term.description,
             count = term.count,
             parentId = term.parent,
+            availableParents = availableParents,
+        )
+    }
+
+    fun navigateToCreateTerm() {
+        val availableParents = if (isHierarchical) {
+            currentTerms.map { ParentOption(id = it.id, name = it.name) }
+        } else {
+            null
+        }
+
+        _termDetailState.value = TermDetailUiState(
+            termId = 0L, // 0 indicates a new term
+            name = "",
+            slug = "",
+            description = "",
+            count = 0L,
+            parentId = 0L,
             availableParents = availableParents,
         )
     }
@@ -232,17 +252,33 @@ class TermsViewModel @Inject constructor(
 
             val wpApiClient = wpApiClientProvider.getWpApiClient(selectedSite)
 
-            val termsResponse = wpApiClient.request { requestBuilder ->
-                requestBuilder.terms().update(
-                    termEndpointType = getTermEndpointType(),
-                    termId = currentTerm.termId,
-                    params = TermUpdateParams(
-                        name = currentTerm.name,
-                        description = currentTerm.description,
-                        slug = currentTerm.slug,
-                        parent = currentTerm.parentId
+            val termsResponse = if (currentTerm.termId == 0L) {
+                // Create new term
+                wpApiClient.request { requestBuilder ->
+                    requestBuilder.terms().create(
+                        termEndpointType = getTermEndpointType(),
+                        params = TermCreateParams(
+                            name = currentTerm.name,
+                            description = currentTerm.description,
+                            slug = currentTerm.slug,
+                            parent = if (currentTerm.parentId == 0L) null else currentTerm.parentId
+                        )
                     )
-                )
+                }
+            } else {
+                // Update existing term
+                wpApiClient.request { requestBuilder ->
+                    requestBuilder.terms().update(
+                        termEndpointType = getTermEndpointType(),
+                        termId = currentTerm.termId,
+                        params = TermUpdateParams(
+                            name = currentTerm.name,
+                            description = currentTerm.description,
+                            slug = currentTerm.slug,
+                            parent = currentTerm.parentId
+                        )
+                    )
+                }
             }
 
             when (termsResponse) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5094,6 +5094,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="term_count_label">Count:</string>
     <string name="term_count">Count: %1$d</string>
     <string name="term_parent_label">Parent:</string>
+    <string name="term_parent_none">None</string>
     <string name="term_sort_by_name">Name</string>
     <string name="term_sort_by_count">Count</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5097,5 +5097,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="term_parent_none">None</string>
     <string name="term_sort_by_name">Name</string>
     <string name="term_sort_by_count">Count</string>
+    <string name="term_delete_confirmation_title">Delete term</string>
+    <string name="term_delete_confirmation_message">Are you sure you want to delete \"%1$s\"?</string>
     <string name="add_term">Add term</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5097,4 +5097,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="term_parent_none">None</string>
     <string name="term_sort_by_name">Name</string>
     <string name="term_sort_by_count">Count</string>
+    <string name="add_term">Add term</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5100,4 +5100,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="term_delete_confirmation_title">Delete term</string>
     <string name="term_delete_confirmation_message">Are you sure you want to delete \"%1$s\"?</string>
     <string name="add_term">Add term</string>
+    <string name="error_saving_term">There was an error saving the term</string>
+    <string name="error_deleting_term">There was an error deleting the term</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
@@ -2,14 +2,20 @@ package org.wordpress.android.ui.taxonomies
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.navigation.NavHostController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
@@ -43,7 +49,7 @@ class TermsViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        // Minimal setup - add more mocks in individual tests as needed
+        MockitoAnnotations.openMocks(this)
     }
 
     private fun createViewModel(): TermsViewModel {
@@ -92,5 +98,172 @@ class TermsViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.uiState.value.loadingState)
             .isEqualTo(org.wordpress.android.ui.dataview.LoadingState.OFFLINE)
+    }
+
+    @Test
+    fun `setNavController stores navigation controller`() {
+        val viewModel = createViewModel()
+        val navController = mock<NavHostController>()
+
+        viewModel.setNavController(navController)
+
+        // Should not throw - just verify it's stored
+        assertThat(viewModel).isNotNull
+    }
+
+    @Test
+    fun `navigateToCreateTerm sets empty term detail state`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+
+        viewModel.navigateToCreateTerm()
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state).isNotNull
+        assertThat(state?.termId).isEqualTo(0L)
+        assertThat(state?.name).isEmpty()
+        assertThat(state?.slug).isEmpty()
+        assertThat(state?.description).isEmpty()
+    }
+
+    @Test
+    fun `navigateToCreateTerm includes available parents for hierarchical taxonomy`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+
+        viewModel.navigateToCreateTerm()
+
+        val state = viewModel.termDetailState.first()
+        // availableParents should be non-null for hierarchical taxonomies
+        assertThat(state?.availableParents).isNotNull
+    }
+
+    @Test
+    fun `navigateToCreateTerm excludes available parents for non-hierarchical taxonomy`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+
+        viewModel.navigateToCreateTerm()
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state?.availableParents).isNull()
+    }
+
+    @Test
+    fun `navigateBack clears term detail state`() = test {
+        val viewModel = createViewModel()
+        val navController = mock<NavHostController>()
+        viewModel.setNavController(navController)
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.navigateBack()
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state).isNull()
+        verify(navController).navigateUp()
+    }
+
+    @Test
+    fun `updateTermName updates term detail state`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.updateTermName("New Term Name")
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state?.name).isEqualTo("New Term Name")
+    }
+
+    @Test
+    fun `updateTermSlug updates term detail state`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.updateTermSlug("new-slug")
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state?.slug).isEqualTo("new-slug")
+    }
+
+    @Test
+    fun `updateTermDescription updates term detail state`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.updateTermDescription("New description")
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state?.description).isEqualTo("New description")
+    }
+
+    @Test
+    fun `updateTermParent updates term detail state`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.updateTermParent(123L)
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state?.parentId).isEqualTo(123L)
+    }
+
+    @Test
+    fun `clearTermDetail sets state to null`() = test {
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.clearTermDetail()
+
+        val state = viewModel.termDetailState.first()
+        assertThat(state).isNull()
+    }
+
+    @Test
+    fun `saveTerm sets error when site is null`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        viewModel.navigateToCreateTerm()
+
+        viewModel.saveTerm()
+        advanceUntilIdle()
+
+        val event = viewModel.uiEvent.first()
+        assertThat(event).isInstanceOf(UiEvent.ShowError::class.java)
+        assertThat((event as UiEvent.ShowError).messageRes).isEqualTo(R.string.error_saving_term)
+    }
+
+    @Test
+    fun `saveTerm sets error when term detail is null`() = test {
+        val site = SiteModel()
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+
+        viewModel.saveTerm()
+        advanceUntilIdle()
+
+        val event = viewModel.uiEvent.first()
+        assertThat(event).isInstanceOf(UiEvent.ShowError::class.java)
+    }
+
+    @Test
+    fun `deleteTerm sets error when site is null`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+
+        viewModel.deleteTerm(123L)
+        advanceUntilIdle()
+
+        val event = viewModel.uiEvent.first()
+        assertThat(event).isInstanceOf(UiEvent.ShowError::class.java)
+        assertThat((event as UiEvent.ShowError).messageRes).isEqualTo(R.string.error_deleting_term)
     }
 }


### PR DESCRIPTION
## Description
Closes CMM-828 and CMM-829

This PR implements CRUD (Create, Read, Update, Delete) functionality for the taxonomies data view feature in WordPress Android. It allows users to create new terms, edit existing terms, and delete terms through the current Dataview.

Extra notes:
- The architecture has been moved to use a more MVVM approach
- Navigation has been completely moved inside the ViewModel as well.


## Testing instructions

1. Log into a self-hosted site with Application Password
2. Open Site Settings
- [ ] Open any of the current taxonomies and smoke test the CRUD features


https://github.com/user-attachments/assets/06ee0cbf-3fd7-4bb5-82f2-cb57d8e13481



NOTE: There's a UI glitch related to the top bar being displaced when opening the keyboard. But that glitch is also happening in `trunk`. So I'm better isolating it in a different branch.

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->