### PR TITLE
fix: fixing the edge-to-edge support UI glitch for new DataView activities

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import org.wordpress.android.support.SupportWebViewActivity
+import org.wordpress.android.ui.accounts.applicationpassword.ApplicationPasswordsListActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListActivity
 import org.wordpress.android.ui.comments.CommentsDetailActivity
@@ -35,6 +36,7 @@ import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 import org.wordpress.android.ui.subscribers.SubscribersActivity
+import org.wordpress.android.ui.taxonomies.TermsDataViewActivity
 
 /**
  * Base class for all activities - initially created to handle insets for Android 15's edge-to-edge support,
@@ -97,6 +99,8 @@ private val excludedActivities = listOf(
     SelfHostedUsersActivity::class.java.name,
     SiteMonitorParentActivity::class.java.name,
     SubscribersActivity::class.java.name,
+    TermsDataViewActivity::class.java.name,
+    ApplicationPasswordsListActivity::class.java.name,
     SupportWebViewActivity::class.java.name,
 
     // these are excluded because they explicitly enable edge-to-edge


### PR DESCRIPTION
## Description
This PR fixes edge-to-edge support UI glitches for new DataView activities by adding them to an exclusion list. The change prevents automatic edge-to-edge behavior from being applied to specific activities that likely need custom handling.

The bug, discovered [here](https://github.com/wordpress-mobile/WordPress-Android/pull/22268),  was causing an extra padding was added when the screen size was recalculated because of showing/hiding the keyboard.

Before:
<img width="622" height="514" alt="Screenshot 2025-10-08 at 17 53 26" src="https://github.com/user-attachments/assets/30579cc9-054a-499d-a04f-89042fd2f999" />


After:
<img width="614" height="516" alt="Screenshot 2025-10-08 at 17 56 20" src="https://github.com/user-attachments/assets/0d7a3cfe-6c7f-4828-8ac0-811bed5362ab" />


## Testing instructions

1. Login into a self-hosted site wioth Application Password
2. Go to "My Site" screen
3. Open "Application Passwords"
- [ ] Tap on the search bar and verify you don't see the glitch
4. Go back and open "Site Settings -> Tags"
- [ ] Tap on the search bar and verify you don't see the glitch

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->