### PR TITLE
CMM-801 create sync taxonomies calls in flux c

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.taxonomies
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -253,30 +252,6 @@ class TermsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun storeTerms(site: SiteModel, terms: List<AnyTermWithEditContext>) = withContext(ioDispatcher) {
-        val termsResponsePayload = FetchTermsResponsePayload(
-            TermsModel(
-                terms.map { term ->
-                    TermModel(
-                        term.id.toInt(),
-                        site.id,
-                        term.id,
-                        taxonomySlug,
-                        term.name,
-                        term.slug,
-                        term.description,
-                        term.parent ?: 0,
-                        term.parent != null,
-                        term.count.toInt()
-                    )
-                },
-            ),
-            site,
-            taxonomySlug
-        )
-        fluxCDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(termsResponsePayload))
-    }
-
     private fun sortByHierarchy(terms: List<AnyTermWithEditContext>): List<AnyTermWithEditContext> {
         val result = mutableListOf<AnyTermWithEditContext>()
         val termsById = terms.associateBy { it.id }
@@ -303,6 +278,30 @@ class TermsViewModel @Inject constructor(
             }
 
         return result
+    }
+
+    private suspend fun storeTerms(site: SiteModel, terms: List<AnyTermWithEditContext>) = withContext(ioDispatcher) {
+        val termsResponsePayload = FetchTermsResponsePayload(
+            TermsModel(
+                terms.map { term ->
+                    TermModel(
+                        term.id.toInt(),
+                        site.id,
+                        term.id,
+                        taxonomySlug,
+                        term.name,
+                        term.slug,
+                        term.description,
+                        term.parent ?: 0,
+                        term.parent != null,
+                        term.count.toInt()
+                    )
+                },
+            ),
+            site,
+            taxonomySlug
+        )
+        fluxCDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(termsResponsePayload))
     }
 
     fun saveTerm() {
@@ -508,12 +507,6 @@ class TermsViewModel @Inject constructor(
         DEFAULT_TAXONOMY_CATEGORY -> TermEndpointType.Categories
         DEFAULT_TAXONOMY_TAG -> TermEndpointType.Tags
         else -> TermEndpointType.Custom(taxonomySlug)
-    }
-
-    private fun TermEndpointType.toTaxonomyName(): String = when (this) {
-        TermEndpointType.Categories -> DEFAULT_TAXONOMY_CATEGORY
-        TermEndpointType.Tags -> DEFAULT_TAXONOMY_TAG
-        is TermEndpointType.Custom -> this.v1
     }
 
     fun consumeUIEvent() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.taxonomies
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -14,11 +15,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.TermModel
+import org.wordpress.android.fluxc.model.TermsModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
+import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -74,6 +81,8 @@ class TermsViewModel @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
     private val appLogWrapper: AppLogWrapper,
     private val selectedSiteRepository: SelectedSiteRepository,
+    private val taxonomyStore: TaxonomyStore,
+    private val fluxCDispatcher: Dispatcher, // Used to include FluxC in the flow (local terms store)
     accountStore: AccountStore,
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     sharedPrefs: SharedPreferences,
@@ -112,6 +121,7 @@ class TermsViewModel @Inject constructor(
     fun initialize(taxonomySlug: String, isHierarchical: Boolean) {
         this.taxonomySlug = taxonomySlug
         this.isHierarchical = isHierarchical
+        taxonomyStore.onRegister()
         initialize()
     }
 
@@ -232,11 +242,39 @@ class TermsViewModel @Inject constructor(
             allTerms
         }
 
+        if (sortedTerms.isNotEmpty()) {
+            storeTerms(selectedSite, sortedTerms)
+        }
+
         // Convert to DataViewItems and return
         sortedTerms.map { term ->
             // Do not use hierarchical indentation when the user is searching terms
             convertToDataViewItem(allTerms, term, isHierarchical && searchQuery.isEmpty())
         }
+    }
+
+    private suspend fun storeTerms(site: SiteModel, terms: List<AnyTermWithEditContext>) = withContext(ioDispatcher) {
+        val termsResponsePayload = FetchTermsResponsePayload(
+            TermsModel(
+                terms.map { term ->
+                    TermModel(
+                        term.id.toInt(),
+                        site.id,
+                        term.id,
+                        taxonomySlug,
+                        term.name,
+                        term.slug,
+                        term.description,
+                        term.parent ?: 0,
+                        term.parent != null,
+                        term.count.toInt()
+                    )
+                },
+            ),
+            site,
+            taxonomySlug
+        )
+        fluxCDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(termsResponsePayload))
     }
 
     private fun sortByHierarchy(terms: List<AnyTermWithEditContext>): List<AnyTermWithEditContext> {
@@ -470,6 +508,12 @@ class TermsViewModel @Inject constructor(
         DEFAULT_TAXONOMY_CATEGORY -> TermEndpointType.Categories
         DEFAULT_TAXONOMY_TAG -> TermEndpointType.Tags
         else -> TermEndpointType.Custom(taxonomySlug)
+    }
+
+    private fun TermEndpointType.toTaxonomyName(): String = when (this) {
+        TermEndpointType.Categories -> DEFAULT_TAXONOMY_CATEGORY
+        TermEndpointType.Tags -> DEFAULT_TAXONOMY_TAG
+        is TermEndpointType.Custom -> this.v1
     }
 
     fun consumeUIEvent() {


### PR DESCRIPTION
## Description
This PR is manually calling FluxC event every time the terms list is loaded. This helps to store the terms locally for quicker access.

Important note: Neither "Site settings" nor "DataView" support offline mode. So, even though the terms are stored locally, the flow when offline is not available.

## Testing instructions

1. Log into a self-hosted site using Application Password
2. Add categories or tags to the site
3. Go to "Site Settings" and load any taxonomy
4. Modify the terms of that taxonomy in your PC (add or delete some of them)
5. In your Andorid phone, go back and open the taxonomy again
- [ ] Verify the local taxonomy copy is available before the list is updated from the server.


https://github.com/user-attachments/assets/051b528a-c3e4-42b3-82c8-66a75f32a659



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->