### PR TITLE
[Tooling] Use Release Version from ReleasesV2 in Code Freeze

### DIFF
--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -12,7 +12,7 @@ steps:
       install_gems
 
       echo '--- :snowflake: Start Code Freeze'
-      bundle exec fastlane code_freeze skip_confirm:true
+      bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     agents:
        queue: "tumblr-metal"
     retry:

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -3,6 +3,7 @@
 platform :android do
   # Creates a new release branch from the current trunk for code freeze.
   #
+  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
   # @param [Boolean] skip_confirm Whether to skip the confirmation prompt
   #
   lane :code_freeze do |version: nil, skip_confirm: false|

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -5,15 +5,22 @@ platform :android do
   #
   # @param [Boolean] skip_confirm Whether to skip the confirmation prompt
   #
-  lane :code_freeze do |skip_confirm: false|
+  lane :code_freeze do |version: nil, skip_confirm: false|
     ensure_git_status_clean
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
     ensure_git_branch(branch: DEFAULT_BRANCH)
 
+    # Validate provided version matches the calculated version
+    expected_version = next_release_version
+    if version && version != expected_version
+      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    end
+    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
+
     message = <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{next_release_version}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{expected_version}
       • Current release version and build code: #{current_release_version} (#{current_build_code}).
       • New release version and build code: #{code_freeze_beta_version} (#{next_build_code}).
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -10,17 +10,21 @@ platform :android do
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
     ensure_git_branch(branch: DEFAULT_BRANCH)
 
-    # Validate provided version matches the calculated version
-    expected_version = next_release_version
-    if version && version != expected_version
-      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    # Use provided version from release tool, or fall back to calculated version
+    calculated_version = next_release_version
+    release_version = version || calculated_version
+
+    # Warn if provided version differs from calculated version
+    if version && version != calculated_version
+      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+      UI.important(warning_message)
+      buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
     end
-    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
 
     message = <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{expected_version}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version}
       • Current release version and build code: #{current_release_version} (#{current_build_code}).
       • New release version and build code: #{code_freeze_beta_version} (#{next_build_code}).
 
@@ -32,7 +36,7 @@ platform :android do
 
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    release_branch_name = "release/#{next_release_version}"
+    release_branch_name = "release/#{release_version}"
     ensure_branch_does_not_exist!(release_branch_name)
 
     # Create the release branch

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -3,7 +3,8 @@
 platform :android do
   # Creates a new release branch from the current trunk for code freeze.
   #
-  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [String] version (optional) The version to use for the new release version to code freeze for.
+  #                 Typically auto-provided by ReleasesV2. If nil, computes the new version based on current one.
   # @param [Boolean] skip_confirm Whether to skip the confirmation prompt
   #
   lane :code_freeze do |version: nil, skip_confirm: false|
@@ -11,13 +12,17 @@ platform :android do
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
     ensure_git_branch(branch: DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to calculated version
-    calculated_version = next_release_version
-    release_version = version || calculated_version
+    # Use provided version from release tool, or fall back to computed version
+    computed_version = next_release_version
+    new_version = version || computed_version
 
-    # Warn if provided version differs from calculated version
-    if version && version != calculated_version
-      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+    # Warn if provided version differs from computed version
+    if version && version != computed_version
+      warning_message = <<~WARNING
+        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
+        If this is unexpected, you might want to investigate the discrepency.
+        Continuing with the explicitly-provided verison '#{version}'.
+      WARNING
       UI.important(warning_message)
       buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
     end
@@ -25,7 +30,7 @@ platform :android do
     message = <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version}
+      • New release branch from #{DEFAULT_BRANCH}: release/#{new_version}
       • Current release version and build code: #{current_release_version} (#{current_build_code}).
       • New release version and build code: #{code_freeze_beta_version} (#{next_build_code}).
 
@@ -37,7 +42,7 @@ platform :android do
 
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    release_branch_name = "release/#{release_version}"
+    release_branch_name = "release/#{new_version}"
     ensure_branch_does_not_exist!(release_branch_name)
 
     # Create the release branch
@@ -54,8 +59,6 @@ platform :android do
     )
     commit_version_bump
     UI.success "Done! New Beta Version: #{current_beta_version}. New Build Code: #{current_build_code}"
-
-    new_version = current_release_version
 
     extract_release_notes_for_version(
       version: new_version,


### PR DESCRIPTION
Closes [AINFRA-1379: WPAndroid: Validate that release version sent by ReleasesV2 matches the project](https://linear.app/a8c/issue/AINFRA-1379/wpandroid-validate-that-release-version-sent-by-releasesv2-matches-the)

## Description

This PR updates the code freeze process to use the release version provided by ReleasesV2 as the source of truth.

The code freeze Buildkite pipeline now passes the `RELEASE_VERSION` environment variable to the `code_freeze` Fastlane lane.
If there's a mismatch between the passed version and the project calculated version, a warning is displayed to help identify configuration discrepancies, but the ReleasesV2 version is always used.

## Testing

The code freeze lane has several side effects like potentially changing the version in the main branch, creating a release branch, updating release notes, etc, making it hard to easily test it. We can run a couple of tests locally commenting out parts of the lane, but they'll only test a minor part of the lane.
The changes will then be fully tested in the next release cycle during code freeze.