### PR TITLE
CMM-841 create the new support main screen

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -442,7 +442,7 @@
 
         <activity android:name="org.wordpress.android.support.main.ui.SupportActivity"
             android:theme="@style/WordPress.NoActionBar"
-            android:label="@string/support"/>
+            android:label="@string/support_screen_title"/>
 
         <!-- Deep Linking Activity -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -440,6 +440,10 @@
             android:theme="@style/WordPress.NoActionBar"
             android:label="@string/ai_bot_conversations_title"/>
 
+        <activity android:name="org.wordpress.android.support.main.ui.SupportActivity"
+            android:theme="@style/WordPress.NoActionBar"
+            android:label="@string/support"/>
+
         <!-- Deep Linking Activity -->
         <activity
             android:name="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity"

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.support.main.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+
+@AndroidEntryPoint
+class SupportActivity : AppCompatActivity() {
+    private val viewModel by viewModels<SupportViewModel>()
+
+    private lateinit var composeView: ComposeView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.init()
+        composeView = ComposeView(this)
+        setContentView(
+            composeView.apply {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    this.isForceDarkAllowed = false
+                }
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent {
+                    val userInfo by viewModel.userInfo.collectAsState()
+                    AppThemeM3 {
+                        SupportScreen(
+                            userName = userInfo.userName,
+                            userEmail = userInfo.userEmail,
+                            userAvatarUrl = userInfo.avatarUrl,
+                            onBackClick = { finish() },
+                            onHelpCenterClick = { viewModel.onHelpCenterClick() },
+                            onAskTheBotsClick = { viewModel.onAskTheBotsClick() },
+                            onAskHappinessEngineersClick = { viewModel.onAskHappinessEngineersClick() },
+                            onApplicationLogsClick = { viewModel.onApplicationLogsClick() }
+                        )
+                    }
+                }
+            }
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun createIntent(context: Context): Intent = Intent(context, SupportActivity::class.java)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -15,15 +15,13 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.support.aibot.ui.AIBotSupportActivity
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
-import org.wordpress.android.ui.main.utils.MeGravatarLoader
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SupportActivity : AppCompatActivity() {
-    @Inject
-    lateinit var meGravatarLoader: MeGravatarLoader
     private val viewModel by viewModels<SupportViewModel>()
 
     private lateinit var composeView: ComposeView
@@ -42,14 +40,17 @@ class SupportActivity : AppCompatActivity() {
                 setContent {
                     val userInfo by viewModel.userInfo.collectAsState()
                     val optionsVisibility by viewModel.optionsVisibility.collectAsState()
+                    val hasAccessToken by viewModel.hasAccessToken.collectAsState()
                     AppThemeM3 {
                         SupportScreen(
                             userName = userInfo.userName,
                             userEmail = userInfo.userEmail,
                             userAvatarUrl = userInfo.avatarUrl,
+                            hasAccessToken = hasAccessToken,
                             showAskTheBots = optionsVisibility.showAskTheBots,
                             showAskHappinessEngineers = optionsVisibility.showAskHappinessEngineers,
                             onBackClick = { finish() },
+                            onLoginClick = { viewModel.onLoginClick() },
                             onHelpCenterClick = { viewModel.onHelpCenterClick() },
                             onAskTheBotsClick = { viewModel.onAskTheBotsClick() },
                             onAskHappinessEngineersClick = { viewModel.onAskHappinessEngineersClick() },
@@ -69,6 +70,9 @@ class SupportActivity : AppCompatActivity() {
                         is SupportViewModel.NavigationEvent.NavigateToAskTheBots -> {
                             navigateToAskTheBots(event.accessToken, event.userName)
                         }
+                        is SupportViewModel.NavigationEvent.NavigateToLogin -> {
+                            navigateToLogin()
+                        }
                     }
                 }
             }
@@ -79,6 +83,14 @@ class SupportActivity : AppCompatActivity() {
         startActivity(
             AIBotSupportActivity.Companion.createIntent(this, accessToken, userName)
         )
+    }
+
+    private fun navigateToLogin() {
+        if (BuildConfig.IS_JETPACK_APP) {
+            ActivityLauncher.showSignInForResultJetpackOnly(this)
+        } else {
+            ActivityLauncher.showSignInForResultWpComOnly(this)
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -40,13 +40,13 @@ class SupportActivity : AppCompatActivity() {
                 setContent {
                     val userInfo by viewModel.userInfo.collectAsState()
                     val optionsVisibility by viewModel.optionsVisibility.collectAsState()
-                    val hasAccessToken by viewModel.hasAccessToken.collectAsState()
+                    val isLoggedIn by viewModel.isLoggedIn.collectAsState()
                     AppThemeM3 {
                         SupportScreen(
                             userName = userInfo.userName,
                             userEmail = userInfo.userEmail,
                             userAvatarUrl = userInfo.avatarUrl,
-                            hasAccessToken = hasAccessToken,
+                            isLoggedIn = isLoggedIn,
                             showAskTheBots = optionsVisibility.showAskTheBots,
                             showAskHappinessEngineers = optionsVisibility.showAskHappinessEngineers,
                             onBackClick = { finish() },

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -37,11 +37,14 @@ class SupportActivity : AppCompatActivity() {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     val userInfo by viewModel.userInfo.collectAsState()
+                    val optionsVisibility by viewModel.optionsVisibility.collectAsState()
                     AppThemeM3 {
                         SupportScreen(
                             userName = userInfo.userName,
                             userEmail = userInfo.userEmail,
                             userAvatarUrl = userInfo.avatarUrl,
+                            showAskTheBots = optionsVisibility.showAskTheBots,
+                            showAskHappinessEngineers = optionsVisibility.showAskHappinessEngineers,
                             onBackClick = { finish() },
                             onHelpCenterClick = { viewModel.onHelpCenterClick() },
                             onAskTheBotsClick = { viewModel.onAskTheBotsClick() },

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -10,7 +10,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import org.wordpress.android.support.aibot.ui.AIBotSupportActivity
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @AndroidEntryPoint
@@ -22,6 +27,7 @@ class SupportActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.init()
+        observeNavigationEvents()
         composeView = ComposeView(this)
         setContentView(
             composeView.apply {
@@ -45,6 +51,26 @@ class SupportActivity : AppCompatActivity() {
                     }
                 }
             }
+        )
+    }
+
+    private fun observeNavigationEvents() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.navigationEvents.collect { event ->
+                    when (event) {
+                        is SupportViewModel.NavigationEvent.NavigateToAskTheBots -> {
+                            navigateToAskTheBots(event.accessToken, event.userName)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun navigateToAskTheBots(accessToken: String, userName: String) {
+        startActivity(
+            AIBotSupportActivity.Companion.createIntent(this, accessToken, userName)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -17,9 +17,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.support.aibot.ui.AIBotSupportActivity
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.main.utils.MeGravatarLoader
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SupportActivity : AppCompatActivity() {
+    @Inject
+    lateinit var meGravatarLoader: MeGravatarLoader
     private val viewModel by viewModels<SupportViewModel>()
 
     private lateinit var composeView: ComposeView

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -169,7 +169,6 @@ fun SupportScreen(
                         title = "Ask the Happiness Engineers",
                         description = "For your tough questions. We'll reply via email",
                         onClick = onAskHappinessEngineersClick,
-                        showDivider = false
                     )
                 }
             }
@@ -198,7 +197,6 @@ fun SupportScreen(
                     title = "Application Logs",
                     description = "Advanced tool to debug issues",
                     onClick = onApplicationLogsClick,
-                    showDivider = false
                 )
             }
 
@@ -212,35 +210,23 @@ private fun SupportOptionItem(
     title: String,
     description: String,
     onClick: () -> Unit,
-    showDivider: Boolean = true
 ) {
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(
-            modifier = Modifier.weight(1f)
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-            contentDescription = "Navigate",
-            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,7 +58,7 @@ fun SupportScreen(
     Scaffold(
         topBar = {
             MainTopAppBar(
-                title = "Support",
+                title = stringResource(R.string.support_screen_title),
                 navigationIcon = NavigationIcons.BackIcon,
                 onNavigationIconClick = onBackClick
             )
@@ -74,7 +75,7 @@ fun SupportScreen(
 
             // Support Profile Section
             Text(
-                text = "Support Profile",
+                text = stringResource(R.string.support_screen_profile_section_title),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Normal
@@ -99,7 +100,9 @@ fun SupportScreen(
                         if (userAvatarUrl.isNullOrEmpty()) {
                             Icon(
                                 painter = painterResource(R.drawable.ic_user_white_24dp),
-                                contentDescription = "User avatar",
+                                contentDescription = stringResource(
+                                    R.string.support_screen_user_avatar_content_description
+                                ),
                                 modifier = Modifier.size(64.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -133,7 +136,7 @@ fun SupportScreen(
                     onClick = onLoginClick,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(text = "Log into WordPress.com")
+                    Text(text = stringResource(R.string.support_screen_login_button))
                 }
             }
 
@@ -141,7 +144,7 @@ fun SupportScreen(
 
             // How can we help? Section
             Text(
-                text = "How can we help?",
+                text = stringResource(R.string.support_screen_how_can_we_help_title),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Normal
@@ -159,8 +162,8 @@ fun SupportScreen(
             ) {
                 Column {
                     SupportOptionItem(
-                        title = "Help Center",
-                        description = "Documentation and Tutorials to help you get started",
+                        title = stringResource(R.string.support_screen_help_center_title),
+                        description = stringResource(R.string.support_screen_help_center_description),
                         onClick = onHelpCenterClick
                     )
 
@@ -171,8 +174,8 @@ fun SupportScreen(
                         )
 
                         SupportOptionItem(
-                            title = "Ask the bots",
-                            description = "Get quick answers to common questions",
+                            title = stringResource(R.string.support_screen_ask_bots_title),
+                            description = stringResource(R.string.support_screen_ask_bots_description),
                             onClick = onAskTheBotsClick
                         )
                     }
@@ -184,8 +187,8 @@ fun SupportScreen(
                         )
 
                         SupportOptionItem(
-                            title = "Ask the Happiness Engineers",
-                            description = "For your tough questions. We'll reply via email",
+                            title = stringResource(R.string.support_screen_ask_happiness_engineers_title),
+                            description = stringResource(R.string.support_screen_ask_happiness_engineers_description),
                             onClick = onAskHappinessEngineersClick,
                         )
                     }
@@ -196,7 +199,7 @@ fun SupportScreen(
 
             // Diagnostics Section
             Text(
-                text = "Diagnostics",
+                text = stringResource(R.string.support_screen_diagnostics_section_title),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Normal
@@ -213,8 +216,8 @@ fun SupportScreen(
                 elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
             ) {
                 SupportOptionItem(
-                    title = "Application Logs",
-                    description = "Advanced tool to debug issues",
+                    title = stringResource(R.string.support_screen_application_logs_title),
+                    description = stringResource(R.string.support_screen_application_logs_description),
                     onClick = onApplicationLogsClick,
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.dataview.compose.RemoteImage
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -99,13 +100,21 @@ fun SupportScreen(
                         .background(MaterialTheme.colorScheme.surfaceVariant),
                     contentAlignment = Alignment.Center
                 ) {
-                    // TODO: Load actual avatar from userAvatarUrl
-                    Icon(
-                        painter = painterResource(R.drawable.ic_user_white_24dp),
-                        contentDescription = "User avatar",
-                        modifier = Modifier.size(32.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    if (userAvatarUrl.isNullOrEmpty()) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_user_white_24dp),
+                            contentDescription = "User avatar",
+                            modifier = Modifier.size(64.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        RemoteImage(
+                            imageUrl = userAvatarUrl,
+                            fallbackImageRes = R.drawable.ic_user_white_24dp,
+                            modifier = Modifier.size(64.dp)
+                                .clip(CircleShape),
+                        )
+                    }
                 }
 
                 Column(

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,9 +44,11 @@ fun SupportScreen(
     userName: String,
     userEmail: String,
     userAvatarUrl: String?,
+    hasAccessToken: Boolean,
     showAskTheBots: Boolean,
     showAskHappinessEngineers: Boolean,
     onBackClick: () -> Unit,
+    onLoginClick: () -> Unit,
     onHelpCenterClick: () -> Unit,
     onAskTheBotsClick: () -> Unit,
     onAskHappinessEngineersClick: () -> Unit,
@@ -79,49 +82,58 @@ fun SupportScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // User Profile Card
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Avatar placeholder
-                Box(
-                    modifier = Modifier
-                        .size(64.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center
+            // User Profile Card or Login Button
+            if (hasAccessToken) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (userAvatarUrl.isNullOrEmpty()) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_user_white_24dp),
-                            contentDescription = "User avatar",
-                            modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    // Avatar placeholder
+                    Box(
+                        modifier = Modifier
+                            .size(64.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (userAvatarUrl.isNullOrEmpty()) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_user_white_24dp),
+                                contentDescription = "User avatar",
+                                modifier = Modifier.size(64.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        } else {
+                            RemoteImage(
+                                imageUrl = userAvatarUrl,
+                                fallbackImageRes = R.drawable.ic_user_white_24dp,
+                                modifier = Modifier.size(64.dp)
+                                    .clip(CircleShape),
+                            )
+                        }
+                    }
+
+                    Column(
+                        modifier = Modifier.padding(start = 16.dp)
+                    ) {
+                        Text(
+                            text = userName,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold
                         )
-                    } else {
-                        RemoteImage(
-                            imageUrl = userAvatarUrl,
-                            fallbackImageRes = R.drawable.ic_user_white_24dp,
-                            modifier = Modifier.size(64.dp)
-                                .clip(CircleShape),
+                        Text(
+                            text = userEmail,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
-
-                Column(
-                    modifier = Modifier.padding(start = 16.dp)
+            } else {
+                Button(
+                    onClick = onLoginClick,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(
-                        text = userName,
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = userEmail,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    Text(text = "Log into WordPress.com")
                 }
             }
 
@@ -238,7 +250,7 @@ private fun SupportOptionItem(
     }
 }
 
-@Preview(showBackground = true, name = "Support Screen - Light")
+@Preview(showBackground = true, name = "Support Screen - Light - Logged In")
 @Composable
 private fun SupportScreenPreview() {
     AppThemeM3(isDarkTheme = false, isJetpackApp = false) {
@@ -246,9 +258,11 @@ private fun SupportScreenPreview() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
+            hasAccessToken = true,
             showAskTheBots = true,
             showAskHappinessEngineers = true,
             onBackClick = {},
+            onLoginClick = {},
             onHelpCenterClick = {},
             onAskTheBotsClick = {},
             onAskHappinessEngineersClick = {},
@@ -257,7 +271,7 @@ private fun SupportScreenPreview() {
     }
 }
 
-@Preview(showBackground = true, name = "Support Screen - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, name = "Support Screen - Dark - Logged In", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SupportScreenPreviewDark() {
     AppThemeM3(isDarkTheme = true, isJetpackApp = false) {
@@ -265,9 +279,32 @@ private fun SupportScreenPreviewDark() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
+            hasAccessToken = true,
             showAskTheBots = true,
             showAskHappinessEngineers = true,
             onBackClick = {},
+            onLoginClick = {},
+            onHelpCenterClick = {},
+            onAskTheBotsClick = {},
+            onAskHappinessEngineersClick = {},
+            onApplicationLogsClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Support Screen - Logged Out")
+@Composable
+private fun SupportScreenPreviewLoggedOut() {
+    AppThemeM3(isDarkTheme = false) {
+        SupportScreen(
+            userName = "",
+            userEmail = "",
+            userAvatarUrl = null,
+            hasAccessToken = false,
+            showAskTheBots = false,
+            showAskHappinessEngineers = false,
+            onBackClick = {},
+            onLoginClick = {},
             onHelpCenterClick = {},
             onAskTheBotsClick = {},
             onAskHappinessEngineersClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -1,10 +1,8 @@
 package org.wordpress.android.support.main.ui
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,8 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -27,18 +23,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -45,7 +45,7 @@ fun SupportScreen(
     userName: String,
     userEmail: String,
     userAvatarUrl: String?,
-    hasAccessToken: Boolean,
+    isLoggedIn: Boolean,
     showAskTheBots: Boolean,
     showAskHappinessEngineers: Boolean,
     onBackClick: () -> Unit,
@@ -84,7 +84,7 @@ fun SupportScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // User Profile Card or Login Button
-            if (hasAccessToken) {
+            if (isLoggedIn) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
@@ -261,7 +261,7 @@ private fun SupportScreenPreview() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
-            hasAccessToken = true,
+            isLoggedIn = true,
             showAskTheBots = true,
             showAskHappinessEngineers = true,
             onBackClick = {},
@@ -282,7 +282,7 @@ private fun SupportScreenPreviewDark() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
-            hasAccessToken = true,
+            isLoggedIn = true,
             showAskTheBots = true,
             showAskHappinessEngineers = true,
             onBackClick = {},
@@ -303,7 +303,7 @@ private fun SupportScreenPreviewLoggedOut() {
             userName = "",
             userEmail = "",
             userAvatarUrl = null,
-            hasAccessToken = false,
+            isLoggedIn = false,
             showAskTheBots = false,
             showAskHappinessEngineers = false,
             onBackClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -50,6 +50,8 @@ fun SupportScreen(
     userName: String,
     userEmail: String,
     userAvatarUrl: String?,
+    showAskTheBots: Boolean,
+    showAskHappinessEngineers: Boolean,
     onBackClick: () -> Unit,
     onHelpCenterClick: () -> Unit,
     onAskTheBotsClick: () -> Unit,
@@ -149,27 +151,31 @@ fun SupportScreen(
                         onClick = onHelpCenterClick
                     )
 
-                    HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant
-                    )
+                    if (showAskTheBots) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
 
-                    SupportOptionItem(
-                        title = "Ask the bots",
-                        description = "Get quick answers to common questions",
-                        onClick = onAskTheBotsClick
-                    )
+                        SupportOptionItem(
+                            title = "Ask the bots",
+                            description = "Get quick answers to common questions",
+                            onClick = onAskTheBotsClick
+                        )
+                    }
 
-                    HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant
-                    )
+                    if (showAskHappinessEngineers) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
 
-                    SupportOptionItem(
-                        title = "Ask the Happiness Engineers",
-                        description = "For your tough questions. We'll reply via email",
-                        onClick = onAskHappinessEngineersClick,
-                    )
+                        SupportOptionItem(
+                            title = "Ask the Happiness Engineers",
+                            description = "For your tough questions. We'll reply via email",
+                            onClick = onAskHappinessEngineersClick,
+                        )
+                    }
                 }
             }
 
@@ -239,6 +245,8 @@ private fun SupportScreenPreview() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
+            showAskTheBots = true,
+            showAskHappinessEngineers = true,
             onBackClick = {},
             onHelpCenterClick = {},
             onAskTheBotsClick = {},
@@ -256,6 +264,8 @@ private fun SupportScreenPreviewDark() {
             userName = "Test user",
             userEmail = "test.user@gmail.com",
             userAvatarUrl = null,
+            showAskTheBots = true,
+            showAskHappinessEngineers = true,
             onBackClick = {},
             onHelpCenterClick = {},
             onAskTheBotsClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportScreen.kt
@@ -1,0 +1,280 @@
+package org.wordpress.android.support.main.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SupportScreen(
+    userName: String,
+    userEmail: String,
+    userAvatarUrl: String?,
+    onBackClick: () -> Unit,
+    onHelpCenterClick: () -> Unit,
+    onAskTheBotsClick: () -> Unit,
+    onAskHappinessEngineersClick: () -> Unit,
+    onApplicationLogsClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            MainTopAppBar(
+                title = "Support",
+                navigationIcon = NavigationIcons.BackIcon,
+                onNavigationIconClick = onBackClick
+            )
+        }
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Support Profile Section
+            Text(
+                text = "Support Profile",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Normal
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // User Profile Card
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Avatar placeholder
+                Box(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    // TODO: Load actual avatar from userAvatarUrl
+                    Icon(
+                        painter = painterResource(R.drawable.ic_user_white_24dp),
+                        contentDescription = "User avatar",
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.padding(start = 16.dp)
+                ) {
+                    Text(
+                        text = userName,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = userEmail,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // How can we help? Section
+            Text(
+                text = "How can we help?",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Normal
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Support Options Card
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            ) {
+                Column {
+                    SupportOptionItem(
+                        title = "Help Center",
+                        description = "Documentation and Tutorials to help you get started",
+                        onClick = onHelpCenterClick
+                    )
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant
+                    )
+
+                    SupportOptionItem(
+                        title = "Ask the bots",
+                        description = "Get quick answers to common questions",
+                        onClick = onAskTheBotsClick
+                    )
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant
+                    )
+
+                    SupportOptionItem(
+                        title = "Ask the Happiness Engineers",
+                        description = "For your tough questions. We'll reply via email",
+                        onClick = onAskHappinessEngineersClick,
+                        showDivider = false
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Diagnostics Section
+            Text(
+                text = "Diagnostics",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Normal
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Application Logs Card
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+            ) {
+                SupportOptionItem(
+                    title = "Application Logs",
+                    description = "Advanced tool to debug issues",
+                    onClick = onApplicationLogsClick,
+                    showDivider = false
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SupportOptionItem(
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+    showDivider: Boolean = true
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+            contentDescription = "Navigate",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Support Screen - Light")
+@Composable
+private fun SupportScreenPreview() {
+    AppThemeM3(isDarkTheme = false, isJetpackApp = false) {
+        SupportScreen(
+            userName = "Test user",
+            userEmail = "test.user@gmail.com",
+            userAvatarUrl = null,
+            onBackClick = {},
+            onHelpCenterClick = {},
+            onAskTheBotsClick = {},
+            onAskHappinessEngineersClick = {},
+            onApplicationLogsClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Support Screen - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SupportScreenPreviewDark() {
+    AppThemeM3(isDarkTheme = true, isJetpackApp = false) {
+        SupportScreen(
+            userName = "Test user",
+            userEmail = "test.user@gmail.com",
+            userAvatarUrl = null,
+            onBackClick = {},
+            onHelpCenterClick = {},
+            onAskTheBotsClick = {},
+            onAskHappinessEngineersClick = {},
+            onApplicationLogsClick = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -60,7 +60,7 @@ class SupportViewModel @Inject constructor(
     }
 
     fun onHelpCenterClick() {
-        // TODO: Navigate to Help Center
+        // Navigate to Help Center
     }
 
     fun onAskTheBotsClick() {
@@ -80,10 +80,10 @@ class SupportViewModel @Inject constructor(
     }
 
     fun onAskHappinessEngineersClick() {
-        // TODO: Navigate to Happiness Engineers contact
+        // Navigate to Happiness Engineers contact
     }
 
     fun onApplicationLogsClick() {
-        // TODO: Navigate to Application Logs
+        // Navigate to Application Logs
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -42,15 +42,15 @@ class SupportViewModel @Inject constructor(
     private val _optionsVisibility = MutableStateFlow(SupportOptionsVisibility())
     val optionsVisibility: StateFlow<SupportOptionsVisibility> = _optionsVisibility.asStateFlow()
 
-    private val _hasAccessToken = MutableStateFlow(false)
-    val hasAccessToken: StateFlow<Boolean> = _hasAccessToken.asStateFlow()
+    private val _isLoggedIn = MutableStateFlow(false)
+    val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
 
     private val _navigationEvents = MutableSharedFlow<NavigationEvent>()
     val navigationEvents: SharedFlow<NavigationEvent> = _navigationEvents.asSharedFlow()
 
     fun init() {
         val hasAccessToken = accountStore.hasAccessToken()
-        _hasAccessToken.value = hasAccessToken
+        _isLoggedIn.value = hasAccessToken
 
         val account = accountStore.account
         _userInfo.value = UserInfo(

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -71,13 +71,15 @@ class SupportViewModel @Inject constructor(
 
     fun onAskTheBotsClick() {
         viewModelScope.launch {
+            // hasAccessToken() checks if it exists and it's not empty, not only the nullability.
+            // So, if it's true, then we are sure the token is not null
             if (!accountStore.hasAccessToken()) {
                 appLogWrapper.d(AppLog.T.SUPPORT, "Trying to open a bot conversation without access token")
             } else {
                 val account = accountStore.account
                 _navigationEvents.emit(
                     NavigationEvent.NavigateToAskTheBots(
-                        accessToken = accountStore.accessToken!!,
+                        accessToken = accountStore.accessToken!!, // access token has been checked before
                         userName = account.displayName.ifEmpty { account.userName }
                     )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -22,6 +22,7 @@ class SupportViewModel @Inject constructor(
 ) : ViewModel() {
     sealed class NavigationEvent {
         data class NavigateToAskTheBots(val accessToken: String, val userName: String) : NavigationEvent()
+        data object NavigateToLogin : NavigationEvent()
     }
 
     data class UserInfo(
@@ -41,10 +42,16 @@ class SupportViewModel @Inject constructor(
     private val _optionsVisibility = MutableStateFlow(SupportOptionsVisibility())
     val optionsVisibility: StateFlow<SupportOptionsVisibility> = _optionsVisibility.asStateFlow()
 
+    private val _hasAccessToken = MutableStateFlow(false)
+    val hasAccessToken: StateFlow<Boolean> = _hasAccessToken.asStateFlow()
+
     private val _navigationEvents = MutableSharedFlow<NavigationEvent>()
     val navigationEvents: SharedFlow<NavigationEvent> = _navigationEvents.asSharedFlow()
 
     fun init() {
+        val hasAccessToken = accountStore.hasAccessToken()
+        _hasAccessToken.value = hasAccessToken
+
         val account = accountStore.account
         _userInfo.value = UserInfo(
             userName = account.displayName.ifEmpty { account.userName },
@@ -52,7 +59,6 @@ class SupportViewModel @Inject constructor(
             avatarUrl = account.avatarUrl.takeIf { it.isNotEmpty() }
         )
 
-        val hasAccessToken = accountStore.hasAccessToken()
         _optionsVisibility.value = SupportOptionsVisibility(
             showAskTheBots = hasAccessToken,
             showAskHappinessEngineers = hasAccessToken
@@ -85,5 +91,11 @@ class SupportViewModel @Inject constructor(
 
     fun onApplicationLogsClick() {
         // Navigate to Application Logs
+    }
+
+    fun onLoginClick() {
+        viewModelScope.launch {
+            _navigationEvents.emit(NavigationEvent.NavigateToLogin)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.support.main.ui
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.wordpress.android.fluxc.store.AccountStore
+import javax.inject.Inject
+
+@HiltViewModel
+class SupportViewModel @Inject constructor(
+    private val accountStore: AccountStore,
+) : ViewModel() {
+
+    data class UserInfo(
+        val userName: String = "",
+        val userEmail: String = "",
+        val avatarUrl: String? = null
+    )
+
+    private val _userInfo = MutableStateFlow(UserInfo())
+    val userInfo: StateFlow<UserInfo> = _userInfo.asStateFlow()
+
+    fun init() {
+        val account = accountStore.account
+        _userInfo.value = UserInfo(
+            userName = account.displayName.ifEmpty { account.userName },
+            userEmail = account.email,
+            avatarUrl = account.avatarUrl.takeIf { it.isNotEmpty() }
+        )
+    }
+
+    fun onHelpCenterClick() {
+        // TODO: Navigate to Help Center
+    }
+
+    fun onAskTheBotsClick() {
+        // TODO: Navigate to AI Bot Support
+    }
+
+    fun onAskHappinessEngineersClick() {
+        // TODO: Navigate to Happiness Engineers contact
+    }
+
+    fun onApplicationLogsClick() {
+        // TODO: Navigate to Application Logs
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -30,8 +30,16 @@ class SupportViewModel @Inject constructor(
         val avatarUrl: String? = null
     )
 
+    data class SupportOptionsVisibility(
+        val showAskTheBots: Boolean = true,
+        val showAskHappinessEngineers: Boolean = true
+    )
+
     private val _userInfo = MutableStateFlow(UserInfo())
     val userInfo: StateFlow<UserInfo> = _userInfo.asStateFlow()
+
+    private val _optionsVisibility = MutableStateFlow(SupportOptionsVisibility())
+    val optionsVisibility: StateFlow<SupportOptionsVisibility> = _optionsVisibility.asStateFlow()
 
     private val _navigationEvents = MutableSharedFlow<NavigationEvent>()
     val navigationEvents: SharedFlow<NavigationEvent> = _navigationEvents.asSharedFlow()
@@ -42,6 +50,12 @@ class SupportViewModel @Inject constructor(
             userName = account.displayName.ifEmpty { account.userName },
             userEmail = account.email,
             avatarUrl = account.avatarUrl.takeIf { it.isNotEmpty() }
+        )
+
+        val hasAccessToken = accountStore.hasAccessToken()
+        _optionsVisibility.value = SupportOptionsVisibility(
+            showAskTheBots = hasAccessToken,
+            showAskHappinessEngineers = hasAccessToken
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -1,17 +1,28 @@
 package org.wordpress.android.support.main.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 @HiltViewModel
 class SupportViewModel @Inject constructor(
     private val accountStore: AccountStore,
+    private val appLogWrapper: AppLogWrapper,
 ) : ViewModel() {
+    sealed class NavigationEvent {
+        data class NavigateToAskTheBots(val accessToken: String, val userName: String) : NavigationEvent()
+    }
 
     data class UserInfo(
         val userName: String = "",
@@ -21,6 +32,9 @@ class SupportViewModel @Inject constructor(
 
     private val _userInfo = MutableStateFlow(UserInfo())
     val userInfo: StateFlow<UserInfo> = _userInfo.asStateFlow()
+
+    private val _navigationEvents = MutableSharedFlow<NavigationEvent>()
+    val navigationEvents: SharedFlow<NavigationEvent> = _navigationEvents.asSharedFlow()
 
     fun init() {
         val account = accountStore.account
@@ -36,7 +50,19 @@ class SupportViewModel @Inject constructor(
     }
 
     fun onAskTheBotsClick() {
-        // TODO: Navigate to AI Bot Support
+        viewModelScope.launch {
+            if (!accountStore.hasAccessToken()) {
+                appLogWrapper.d(AppLog.T.SUPPORT, "Trying to open a bot conversation without access token")
+            } else {
+                val account = accountStore.account
+                _navigationEvents.emit(
+                    NavigationEvent.NavigateToAskTheBots(
+                        accessToken = accountStore.accessToken!!,
+                        userName = account.displayName.ifEmpty { account.userName }
+                    )
+                )
+            }
+        }
     }
 
     fun onAskHappinessEngineersClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -34,6 +34,7 @@ import org.wordpress.android.login.LoginMode;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.networking.SSLCertsViewActivity;
 import org.wordpress.android.push.NotificationType;
+import org.wordpress.android.support.main.ui.SupportActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.accounts.LoginActivity;
@@ -99,6 +100,8 @@ import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
 import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures;
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature;
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity;
 import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailActivity;
 import org.wordpress.android.ui.prefs.categories.list.CategoriesListActivity;
@@ -1371,11 +1374,15 @@ public class ActivityLauncher {
     }
 
     public static void viewHelp(@NonNull Context context, @NonNull Origin origin, @Nullable SiteModel selectedSite,
-                                @Nullable List<String> extraSupportTags) {
+                                @Nullable List<String> extraSupportTags, @NonNull ExperimentalFeatures experimentalFeatures) {
         Map<String, String> properties = new HashMap<>();
         properties.put("origin", origin.name());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED, properties);
-        context.startActivity(HelpActivity.createIntent(context, origin, selectedSite, extraSupportTags));
+        if (experimentalFeatures.isEnabled(Feature.MODERN_SUPPORT)) {
+            context.startActivity(SupportActivity.createIntent(context));
+        } else {
+            context.startActivity(HelpActivity.createIntent(context, origin, selectedSite, extraSupportTags));
+        }
     }
 
     public static void viewFeedbackForm(@NonNull Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1374,7 +1374,8 @@ public class ActivityLauncher {
     }
 
     public static void viewHelp(@NonNull Context context, @NonNull Origin origin, @Nullable SiteModel selectedSite,
-                                @Nullable List<String> extraSupportTags, @NonNull ExperimentalFeatures experimentalFeatures) {
+                                @Nullable List<String> extraSupportTags,
+                                @NonNull ExperimentalFeatures experimentalFeatures) {
         Map<String, String> properties = new HashMap<>();
         properties.put("origin", origin.name());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED, properties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -737,7 +737,7 @@ public class LoginActivity extends BaseAppCompatActivity implements ConnectionCa
     private void viewHelp(Origin origin) {
         List<String> extraSupportTags = getLoginMode() == LoginMode.JETPACK_STATS ? Collections
                 .singletonList(ZendeskExtraTags.connectingJetpack) : null;
-        ActivityLauncher.viewHelp(this, origin, null, extraSupportTags);
+        ActivityLauncher.viewHelp(this, origin, null, extraSupportTags, mExperimentalFeatures);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.jetpack.scan.adapters.HorizontalMarginItemDecora
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.extensions.getSerializableCompat
@@ -44,6 +45,10 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
 
     @Inject
     lateinit var uiHelpers: UiHelpers
+
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private lateinit var listView: EmptyViewRecyclerView
     private var fixThreatsConfirmationDialog: AlertDialog? = null
     private val viewModel: ScanViewModel by viewModels()
@@ -125,7 +130,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 )
 
                 is ShowContactSupport ->
-                    ActivityLauncher.viewHelp(requireContext(), SCAN_SCREEN_HELP, events.site, null)
+                    ActivityLauncher.viewHelp(requireContext(), SCAN_SCREEN_HELP, events.site, null, experimentalFeatures)
 
                 is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -130,7 +130,8 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 )
 
                 is ShowContactSupport ->
-                    ActivityLauncher.viewHelp(requireContext(), SCAN_SCREEN_HELP, events.site, null, experimentalFeatures)
+                    ActivityLauncher.viewHelp(requireContext(), SCAN_SCREEN_HELP,
+                        events.site, null, experimentalFeatures)
 
                 is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
@@ -14,11 +14,16 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.jetpackplugininstall.install.compose.JetpackPluginInstallScreen
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.setContent
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackFullPluginInstallActivity : BaseAppCompatActivity() {
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private val viewModel: JetpackFullPluginInstallViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +65,8 @@ class JetpackFullPluginInstallActivity : BaseAppCompatActivity() {
                     this,
                     actionEvent.origin,
                     actionEvent.selectedSite,
-                    null
+                    null,
+                    experimentalFeatures
                 )
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -30,13 +30,18 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.Jetpa
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.state.LoadedState
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private val viewModel: JetpackFullPluginInstallOnboardingViewModel by viewModels()
 
     override fun getTheme(): Int {
@@ -111,7 +116,8 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
                     requireContext(),
                     actionEvent.origin,
                     actionEvent.selectedSite,
-                    null
+                    null,
+                    experimentalFeatures
                 )
             }
             is Dismiss -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/remoteplugin/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/remoteplugin/JetpackRemoteInstallActivity.kt
@@ -26,13 +26,17 @@ import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteI
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.LOGIN
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.MANUAL_INSTALL
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.util.extensions.setContent
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackRemoteInstallActivity : BaseAppCompatActivity() {
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
     private val viewModel: JetpackRemoteInstallViewModel by viewModels()
 
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -123,7 +127,8 @@ class JetpackRemoteInstallActivity : BaseAppCompatActivity() {
             this,
             origin,
             result.site,
-            null
+            null,
+            experimentalFeatures
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -131,6 +132,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject
     lateinit var domainManagementFeatureConfig: DomainManagementFeatureConfig
 
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private val viewModel: MeViewModel by viewModels()
     private val emailVerificationViewModel: EmailVerificationViewModel by viewModels()
 
@@ -184,7 +188,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             ActivityLauncher.viewAppSettingsForResult(activity)
         }
         rowSupport.setOnClickListener {
-            ActivityLauncher.viewHelp(requireContext(), ME_SCREEN_HELP, viewModel.getSite(), null)
+            ActivityLauncher.viewHelp(requireContext(), ME_SCREEN_HELP, viewModel.getSite(), null, experimentalFeatures)
         }
         learnMoreAtGravatar.setOnClickListener {
             ActivityLauncher.openUrlExternal(activity, GRAVATAR_URL)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.state.ErrorStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.NotificationsStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.WelcomeStep
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.UriWrapper
@@ -53,6 +54,9 @@ import javax.inject.Inject
 class JetpackMigrationFragment : Fragment() {
     @Inject
     lateinit var dispatcher: Dispatcher
+
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
 
     private val viewModel: JetpackMigrationViewModel by viewModels()
 
@@ -120,7 +124,8 @@ class JetpackMigrationFragment : Fragment() {
             requireContext(),
             JETPACK_MIGRATION_HELP,
             null,
-            null
+            null,
+            experimentalFeatures
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3704,7 +3704,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun onGotoCustomerSupportOptions() {
-        onGotoCustomerSupportOptions(this, site)
+        onGotoCustomerSupportOptions(this, site, experimentalFeatures)
     }
 
     override fun onSendEventToHost(eventName: String, properties: Map<String, Any>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostCustomerSupportHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostCustomerSupportHelper.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.EDITOR_HELP
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.SiteUtils
-import javax.inject.Inject
 
 object EditPostCustomerSupportHelper {
     fun onContactCustomerSupport(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostCustomerSupportHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostCustomerSupportHelper.kt
@@ -8,7 +8,9 @@ import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.EDITOR_HELP
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.SiteUtils
+import javax.inject.Inject
 
 object EditPostCustomerSupportHelper {
     fun onContactCustomerSupport(
@@ -30,8 +32,8 @@ object EditPostCustomerSupportHelper {
         }
     }
 
-    fun onGotoCustomerSupportOptions(context: Context, site: SiteModel) {
-        ActivityLauncher.viewHelp(context, EDITOR_HELP, site, getTagsList(site))
+    fun onGotoCustomerSupportOptions(context: Context, site: SiteModel, experimentalFeatures: ExperimentalFeatures) {
+        ActivityLauncher.viewHelp(context, EDITOR_HELP, site, getTagsList(site), experimentalFeatures)
     }
 
     private fun getTagsList(site: SiteModel): List<String>? =

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -39,6 +39,11 @@ class ExperimentalFeatures @Inject constructor(
             "experimental_application_password_feature",
             R.string.experimental_application_password_feature,
             R.string.experimental_application_password_feature_description
+        ),
+        MODERN_SUPPORT(
+            "modern_support",
+            R.string.modern_support,
+            R.string.modern_support_description
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.main.ChooseSiteActivity
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
@@ -84,6 +85,8 @@ class SiteCreationActivity : BaseAppCompatActivity(),
 
     @Inject
     internal lateinit var siteNameFeatureConfig: SiteNameFeatureConfig
+    @Inject
+    lateinit var experimentalFeatures: ExperimentalFeatures
     private val mainViewModel: SiteCreationMainVM by viewModels()
     private val hppViewModel: HomePagePickerViewModel by viewModels()
     private val siteCreationIntentsViewModel: SiteCreationIntentsViewModel by viewModels()
@@ -224,7 +227,7 @@ class SiteCreationActivity : BaseAppCompatActivity(),
     }
 
     override fun onHelpClicked(origin: Origin) {
-        ActivityLauncher.viewHelp(this, origin, null, null)
+        ActivityLauncher.viewHelp(this, origin, null, null, experimentalFeatures)
     }
 
     private fun showStep(target: WizardNavigationTarget<SiteCreationStep, SiteCreationState>) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -981,6 +981,8 @@
     <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
     <string name="experimental_application_password_feature">Application Password log in</string>
     <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites</string>
+    <string name="modern_support">Modern Support</string>
+    <string name="modern_support_description">Enable the new modern support experience</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2626,6 +2626,20 @@
     <string name="support_identity_input_dialog_enter_email">Please enter your email address</string>
     <string name="support_identity_input_dialog_email_label">Email</string>
     <string name="support_identity_input_dialog_name_label">Name</string>
+    <string name="support_screen_title">Support</string>
+    <string name="support_screen_profile_section_title">Support Profile</string>
+    <string name="support_screen_login_button">Log into WordPress.com</string>
+    <string name="support_screen_how_can_we_help_title">How can we help?</string>
+    <string name="support_screen_help_center_title">Help Center</string>
+    <string name="support_screen_help_center_description">Documentation and Tutorials to help you get started</string>
+    <string name="support_screen_ask_bots_title">Ask the bots</string>
+    <string name="support_screen_ask_bots_description">Get quick answers to common questions</string>
+    <string name="support_screen_ask_happiness_engineers_title">Ask the Happiness Engineers</string>
+    <string name="support_screen_ask_happiness_engineers_description">For your tough questions. We\'ll reply via email</string>
+    <string name="support_screen_diagnostics_section_title">Diagnostics</string>
+    <string name="support_screen_application_logs_title">Application Logs</string>
+    <string name="support_screen_application_logs_description">Advanced tool to debug issues</string>
+    <string name="support_screen_user_avatar_content_description">User avatar</string>
 
     <!--Me-->
     <string name="me_profile_photo">Profile Photo</string>

--- a/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
@@ -1,0 +1,303 @@
+package org.wordpress.android.support.main.ui
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog
+
+@ExperimentalCoroutinesApi
+class SupportViewModelTest : BaseUnitTest() {
+    @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+
+    @Mock
+    lateinit var account: AccountModel
+
+    private lateinit var viewModel: SupportViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SupportViewModel(
+            accountStore = accountStore,
+            appLogWrapper = appLogWrapper
+        )
+    }
+
+    // region init() tests
+
+    @Test
+    fun `init sets user info when user has access token`() {
+        // Given
+        val displayName = "Test User"
+        val email = "test@example.com"
+        val avatarUrl = "https://example.com/avatar.jpg"
+
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn(displayName)
+        whenever(account.email).thenReturn(email)
+        whenever(account.avatarUrl).thenReturn(avatarUrl)
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.userInfo.value.userName).isEqualTo(displayName)
+        assertThat(viewModel.userInfo.value.userEmail).isEqualTo(email)
+        assertThat(viewModel.userInfo.value.avatarUrl).isEqualTo(avatarUrl)
+    }
+
+    @Test
+    fun `init uses userName when displayName is empty`() {
+        // Given
+        val userName = "testuser"
+        val email = "test@example.com"
+
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("")
+        whenever(account.userName).thenReturn(userName)
+        whenever(account.email).thenReturn(email)
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.userInfo.value.userName).isEqualTo(userName)
+    }
+
+    @Test
+    fun `init sets avatarUrl to null when empty`() {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("Test User")
+        whenever(account.email).thenReturn("test@example.com")
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.userInfo.value.avatarUrl).isNull()
+    }
+
+    @Test
+    fun `init sets hasAccessToken to true when user has access token`() {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("Test User")
+        whenever(account.email).thenReturn("test@example.com")
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.hasAccessToken.value).isTrue()
+    }
+
+    @Test
+    fun `init sets hasAccessToken to false when user has no access token`() {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("")
+        whenever(account.userName).thenReturn("")
+        whenever(account.email).thenReturn("")
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.hasAccessToken.value).isFalse()
+    }
+
+    @Test
+    fun `init shows all support options when user has access token`() {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("Test User")
+        whenever(account.email).thenReturn("test@example.com")
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isTrue()
+        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isTrue()
+    }
+
+    @Test
+    fun `init hides support options when user has no access token`() {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("")
+        whenever(account.userName).thenReturn("")
+        whenever(account.email).thenReturn("")
+        whenever(account.avatarUrl).thenReturn("")
+
+        // When
+        viewModel.init()
+
+        // Then
+        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isFalse()
+        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isFalse()
+    }
+
+    // endregion
+
+    // region onAskTheBotsClick() tests
+
+    @Test
+    fun `onAskTheBotsClick emits NavigateToAskTheBots event when user has access token`() = test {
+        // Given
+        val accessToken = "test_access_token"
+        val displayName = "Test User"
+
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn(accessToken)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn(displayName)
+
+        // When
+        viewModel.navigationEvents.test {
+            viewModel.onAskTheBotsClick()
+
+            // Then
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(SupportViewModel.NavigationEvent.NavigateToAskTheBots::class.java)
+            val navigateEvent = event as SupportViewModel.NavigationEvent.NavigateToAskTheBots
+            assertThat(navigateEvent.accessToken).isEqualTo(accessToken)
+            assertThat(navigateEvent.userName).isEqualTo(displayName)
+        }
+    }
+
+    @Test
+    fun `onAskTheBotsClick uses userName when displayName is empty`() = test {
+        // Given
+        val accessToken = "test_access_token"
+        val userName = "testuser"
+
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn(accessToken)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.displayName).thenReturn("")
+        whenever(account.userName).thenReturn(userName)
+
+        // When
+        viewModel.navigationEvents.test {
+            viewModel.onAskTheBotsClick()
+
+            // Then
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(SupportViewModel.NavigationEvent.NavigateToAskTheBots::class.java)
+            val navigateEvent = event as SupportViewModel.NavigationEvent.NavigateToAskTheBots
+            assertThat(navigateEvent.userName).isEqualTo(userName)
+        }
+    }
+
+    @Test
+    fun `onAskTheBotsClick logs debug message and does not emit event when user has no access token`() = test {
+        // Given
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+
+        // When
+        viewModel.navigationEvents.test {
+            viewModel.onAskTheBotsClick()
+
+            // Then
+            verify(appLogWrapper).d(
+                eq(AppLog.T.SUPPORT),
+                eq("Trying to open a bot conversation without access token")
+            )
+            expectNoEvents()
+        }
+    }
+
+    // endregion
+
+    // region onLoginClick() tests
+
+    @Test
+    fun `onLoginClick emits NavigateToLogin event`() = test {
+        // When
+        viewModel.navigationEvents.test {
+            viewModel.onLoginClick()
+
+            // Then
+            val event = awaitItem()
+            assertThat(event).isEqualTo(SupportViewModel.NavigationEvent.NavigateToLogin)
+        }
+    }
+
+    // endregion
+
+    // region placeholder tests for unimplemented methods
+
+    @Test
+    fun `onHelpCenterClick does not throw exception`() {
+        // When/Then - should not throw
+        viewModel.onHelpCenterClick()
+    }
+
+    @Test
+    fun `onAskHappinessEngineersClick does not throw exception`() {
+        // When/Then - should not throw
+        viewModel.onAskHappinessEngineersClick()
+    }
+
+    @Test
+    fun `onApplicationLogsClick does not throw exception`() {
+        // When/Then - should not throw
+        viewModel.onApplicationLogsClick()
+    }
+
+    // endregion
+
+    // region StateFlow initial values tests
+
+    @Test
+    fun `userInfo has correct initial values before init`() {
+        // Then
+        assertThat(viewModel.userInfo.value.userName).isEmpty()
+        assertThat(viewModel.userInfo.value.userEmail).isEmpty()
+        assertThat(viewModel.userInfo.value.avatarUrl).isNull()
+    }
+
+    @Test
+    fun `optionsVisibility has correct initial values before init`() {
+        // Then
+        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isTrue()
+        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isTrue()
+    }
+
+    @Test
+    fun `hasAccessToken is false by default before init`() {
+        // Then
+        assertThat(viewModel.hasAccessToken.value).isFalse()
+    }
+
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
@@ -6,10 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.AccountModel
@@ -99,7 +97,7 @@ class SupportViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `init sets hasAccessToken to true when user has access token`() {
+    fun `init sets isLoggedIn to true when user has access token`() {
         // Given
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(accountStore.account).thenReturn(account)
@@ -111,7 +109,7 @@ class SupportViewModelTest : BaseUnitTest() {
         viewModel.init()
 
         // Then
-        assertThat(viewModel.hasAccessToken.value).isTrue()
+        assertThat(viewModel.isLoggedIn.value).isTrue()
     }
 
     @Test
@@ -128,7 +126,7 @@ class SupportViewModelTest : BaseUnitTest() {
         viewModel.init()
 
         // Then
-        assertThat(viewModel.hasAccessToken.value).isFalse()
+        assertThat(viewModel.isLoggedIn.value).isFalse()
     }
 
     @Test
@@ -296,7 +294,7 @@ class SupportViewModelTest : BaseUnitTest() {
     @Test
     fun `hasAccessToken is false by default before init`() {
         // Then
-        assertThat(viewModel.hasAccessToken.value).isFalse()
+        assertThat(viewModel.isLoggedIn.value).isFalse()
     }
 
     // endregion


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This PR introduces a new “Modern Support” screen gated behind an experimental feature.

The screen shows the user profile in case the user is logged into WordPress.com or a CTA to log in.
It also shows the current support options, but right now it's only linked to the "Talk to bots" feature.
If the user is not logged in, we do hide the bots and HE entries.

Adds a new experimental feature flag (MODERN_SUPPORT) and strings.
Introduces SupportActivity, SupportViewModel, and a Compose-based SupportScreen.
Alters ActivityLauncher.viewHelp to branch to SupportActivity when the feature is enabled; updates multiple call sites to pass ExperimentalFeatures.


## Testing instructions

1. Log into a self-hosted site (no WP.COM)
2. Open "Me screen" -> Help & Support
- [x] Verify you do see the old support screen
3. Enable the MODERN_SUPPORT Experimental Feature
4. Open "Me screen" -> Help & Support
- [x] Verify you do see the new support screen. Only "Help Center" and "Application Logs" entries are visible
- [x] Verify the "Log into WordPress.com" button works


https://github.com/user-attachments/assets/ca403d37-32fd-40b0-b9cc-11c6a5e6c7c7

1. Log into a  WP.COM site
2. Open "Me screen" -> Help & Support
- [x] Verify you do see the old support screen
3. Enable the MODERN_SUPPORT Experimental Feature
4. Open "Me screen" -> Help & Support
- [x] Verify you do see the new support screen with all the options
- [x] Verify the "Log into WordPress.com" button is gone

https://github.com/user-attachments/assets/e4aab1b4-460c-423e-8f43-e4b70ef06fb4


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->