### PR TITLE
Debug: adding logs for gravatar loading issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -254,6 +254,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun MeFragmentBinding.showQuickEditor(
         page: AvatarPickerAndAboutEditorConfiguration.Page
     ) {
@@ -291,8 +292,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                     appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Gravatar quick editor dismissed: ${page.value}")
                 }
             )
-        } catch (throwable: Throwable) {
-            appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Error opening Gravatar quick editor: ${throwable.message}")
+        } catch (exception: Exception) {
+            appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Error opening Gravatar quick editor: ${exception.message}")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.about.UnifiedAboutActivity
@@ -130,6 +131,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     @Inject
     lateinit var domainManagementFeatureConfig: DomainManagementFeatureConfig
+
+    @Inject
+    lateinit var appLogWrapper: AppLogWrapper
 
     private val viewModel: MeViewModel by viewModels()
     private val emailVerificationViewModel: EmailVerificationViewModel by viewModels()
@@ -237,12 +241,14 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     }
 
     private fun MeFragmentBinding.showAvatarPicker() {
+        appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Opening avatar editor")
         withVeryfiedEmail(unverifiedEmailMessageRes = R.string.avatar_update_email_unverified) {
             showQuickEditor(page = AvatarPickerAndAboutEditorConfiguration.Page.AvatarPicker)
         }
     }
 
     private fun MeFragmentBinding.showProfileEditor() {
+        appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Opening profile editor")
         withVeryfiedEmail(unverifiedEmailMessageRes = R.string.about_update_email_unverified) {
             showQuickEditor(page = AvatarPickerAndAboutEditorConfiguration.Page.AboutEditor)
         }
@@ -251,35 +257,43 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     private fun MeFragmentBinding.showQuickEditor(
         page: AvatarPickerAndAboutEditorConfiguration.Page
     ) {
-        GravatarQuickEditor.show(
-            fragment = this@MeFragment,
-            gravatarQuickEditorParams = GravatarQuickEditorParams {
-                email = Email(accountStore.account.email)
-                scopeOption = QuickEditorScopeOption.avatarAndAbout {
-                    initialPage = page
-                    fields = setOf(
-                        AboutInputField.FirstName,
-                        AboutInputField.LastName,
-                        AboutInputField.DisplayName,
-                        AboutInputField.AboutMe
-                    )
-                }
-            },
-            authenticationMethod = AuthenticationMethod.Bearer(accountStore.accessToken.orEmpty()),
-            updateHandler = { event ->
-                when (event) {
-                    AvatarPickerResult -> {
-                        loadAvatar(null, true)
+        try {
+            appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Showing Gravatar quick editor: ${page.value}")
+            GravatarQuickEditor.show(
+                fragment = this@MeFragment,
+                gravatarQuickEditorParams = GravatarQuickEditorParams {
+                    email = Email(accountStore.account.email)
+                    scopeOption = QuickEditorScopeOption.avatarAndAbout {
+                        initialPage = page
+                        fields = setOf(
+                            AboutInputField.FirstName,
+                            AboutInputField.LastName,
+                            AboutInputField.DisplayName,
+                            AboutInputField.AboutMe
+                        )
                     }
+                },
+                authenticationMethod = AuthenticationMethod.Bearer(accountStore.accessToken.orEmpty()),
+                updateHandler = { event ->
+                    when (event) {
+                        AvatarPickerResult -> {
+                            loadAvatar(null, true)
+                        }
 
-                    is AboutEditorResult -> {
-                        meDisplayName.text = event.profile.displayName.ifEmpty { accountStore.account.displayName }
+                        is AboutEditorResult -> {
+                            meDisplayName.text = event.profile.displayName.ifEmpty { accountStore.account.displayName }
+                        }
+
+                        else -> Unit
                     }
-
-                    else -> Unit
+                },
+                onDismiss = {
+                    appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Gravatar quick editor dismissed: ${page.value}")
                 }
-            },
-        )
+            )
+        } catch (throwable: Throwable) {
+            appLogWrapper.d(AppLog.T.MAIN, "Gravatar: Error opening Gravatar quick editor: ${throwable.message}")
+        }
     }
 
     private fun withVeryfiedEmail(
@@ -287,8 +301,10 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         action: () -> Unit,
     ) {
         if (accountStore.account.emailVerified) {
+            appLogWrapper.d(AppLog.T.MAIN, "Email verified")
             action()
         } else {
+            appLogWrapper.d(AppLog.T.MAIN, "Email not verified")
             view?.let { view ->
                 sequencer.enqueue(
                     SnackbarItem(


### PR DESCRIPTION
## Description
This PR is adding a set of logs to see what's exactly is happening with a reported bug related to Gravatar config not loading. These logs will help to figure out if it's a Gravatar's or WP app problem.

See: https://linear.app/a8c/issue/CMM-816/jetpack-app-my-profile-section-not-loading-on-realme-5-pro-android-11

## Testing instructions

This PR is adding logs, so check the code looks good.

Side tests, to check the app does not crash:
1. Go to "Me screen"
2. Tap on Gravatar and profile row
- [ ] Verify the ap does not crash

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->