### PR TITLE
fix: Obscured GutenbergKit block toolbar

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -307,7 +307,7 @@
         <activity
             android:name=".ui.posts.GutenbergKitActivity"
             android:configChanges="locale|screenLayout|orientation|screenSize|keyboard|keyboardHidden|smallestScreenSize|uiMode"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">
             <meta-data

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity
 import org.wordpress.android.ui.posts.EditPostActivity
+import org.wordpress.android.ui.posts.GutenbergKitActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity
 import org.wordpress.android.ui.reader.ReaderCommentListActivity
@@ -114,4 +115,8 @@ private val excludedActivities = listOf(
     NotificationsDetailActivity::class.java.name,
     ReaderCommentListActivity::class.java.name,
     ReaderSubsActivity::class.java.name,
+
+    // these are excluded because they implement custom IME inset handling for proper
+    // keyboard management with edge-to-edge support
+    GutenbergKitActivity::class.java.name,
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -33,6 +33,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.util.Consumer
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
@@ -490,6 +492,10 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
 
         setContentView(R.layout.new_edit_post_activity)
+
+        // Handle edge-to-edge with IME insets for keyboard management
+        setupEdgeToEdgeWithImeInsets()
+
         backPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (isModalDialogOpen) {
@@ -612,6 +618,30 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         // check if post content needs updating
         if (postConflictResolutionFeatureConfig.isEnabled()) {
             storePostViewModel.checkIfUpdatedPostVersionExists((editPostRepository), siteModel)
+        }
+    }
+
+    /**
+     * Enables edge-to-edge display with proper IME (keyboard) inset handling.
+     * This ensures the editor toolbar remains visible above the keyboard on all devices.
+     */
+    private fun setupEdgeToEdgeWithImeInsets() {
+        val rootView = findViewById<View>(R.id.editor_activity)
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+            val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+
+            // Apply system bar insets to keep content within safe areas
+            view.setPadding(
+                systemBarsInsets.left,
+                systemBarsInsets.top,
+                systemBarsInsets.right,
+                // Use IME insets for bottom padding when keyboard is visible, otherwise system bars
+                maxOf(systemBarsInsets.bottom, imeInsets.bottom)
+            )
+
+            WindowInsetsCompat.CONSUMED
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Fix CMM-868.

Custom IME handling is necessary to ensure the virtual keyboard does not
obscure the block toolbar. The previous `BaseAppCompatActivity` approach
worked for some devices, but not all. Namely, it did not work for the
Pixel 6 Pro.

| Before | After |
-- | -- 
<img width="1440" height="3120" alt="gutenberg-kit-before" src="https://github.com/user-attachments/assets/88ebd7e6-ac44-465a-98c6-eb1982c74248" /> | <img width="1440" height="3120" alt="gutenberg-kit-after" src="https://github.com/user-attachments/assets/aaf90515-9c6a-4619-9663-48bfb98ee571" />

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Use a Pixel 6 Pro emulator.
1. Open the GutenbergKit editor.
1. **Verify** the block toolbar is visible when the virtual keyboard is opened.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
