### PR TITLE
CMM-891: support: hide bots and he entries in WP

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.support.model.UserInfo
@@ -62,8 +63,8 @@ class SupportViewModel @Inject constructor(
         )
 
         _optionsVisibility.value = SupportOptionsVisibility(
-            showAskTheBots = hasAccessToken,
-            showAskHappinessEngineers = hasAccessToken
+            showAskTheBots = hasAccessToken && BuildConfig.IS_JETPACK_APP,
+            showAskHappinessEngineers = hasAccessToken && BuildConfig.IS_JETPACK_APP
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
@@ -142,8 +142,11 @@ class SupportViewModelTest : BaseUnitTest() {
         viewModel.init()
 
         // Then
-        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isTrue()
-        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isTrue()
+        // Note: For WordPress variant (IS_JETPACK_APP=false), these options should be hidden
+        // For Jetpack variant (IS_JETPACK_APP=true), they should be shown when user has access token
+        // This test will behave differently based on which variant is being tested
+        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
+        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/main/ui/SupportViewModelTest.kt
@@ -145,8 +145,10 @@ class SupportViewModelTest : BaseUnitTest() {
         // Note: For WordPress variant (IS_JETPACK_APP=false), these options should be hidden
         // For Jetpack variant (IS_JETPACK_APP=true), they should be shown when user has access token
         // This test will behave differently based on which variant is being tested
-        assertThat(viewModel.optionsVisibility.value.showAskTheBots).isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
-        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers).isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
+        assertThat(viewModel.optionsVisibility.value.showAskTheBots)
+            .isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
+        assertThat(viewModel.optionsVisibility.value.showAskHappinessEngineers)
+            .isEqualTo(org.wordpress.android.BuildConfig.IS_JETPACK_APP)
     }
 
     @Test


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This PR hides the "Ask the Bots" and "Ask Happiness Engineers" support options in the WordPress variant of the app while keeping them visible in the Jetpack variant. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

1. Build WP app
2. Enable `MODERN_SUPPORT` FF
3. Go to "Me" -> Help & support 
- [ ] Verify "Ask the Bots" and "Ask Happiness Engineers" entries are hidden


<img width="450" height="1246" alt="Screenshot 2025-10-24 at 10 16 36" src="https://github.com/user-attachments/assets/2f1027b9-390d-4dd5-965b-ab87d1c889bd" />


1. Build JP app
2. Enable `MODERN_SUPPORT` FF
3. Go to "Me" -> Help & support 
- [ ] Verify "Ask the Bots" and "Ask Happiness Engineers" entries are shown


<img width="450" height="1252" alt="Screenshot 2025-10-24 at 10 09 21" src="https://github.com/user-attachments/assets/6474f2d7-33a5-4c31-863e-6b4b1bc247d2" />

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->