### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,25 +108,12 @@ def current_beta_version
   VERSION_FORMATTER.beta_version(current_version)
 end
 
-# Returns the beta version that is used by the code freeze
-# It first increments the minor number, which also resets the build number to 0
-# It then bumps the build number so the -rc-1 can be appended to the code freeze version
-def code_freeze_beta_version
-  # Read the current release version from the .xcconfig file and parse it into an AppVersion object
-  current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
-  # Calculate the next major version number
-  next_version = VERSION_CALCULATOR.next_release_version(version: current_version)
-  # Calculate the next build number
-  code_freeze_beta_version = VERSION_CALCULATOR.next_build_number(version: next_version)
-  # Return the formatted release version
-  VERSION_FORMATTER.beta_version(code_freeze_beta_version)
-end
-
 # Returns the beta version of the app in the format `1.2-rc-1`
 #
-def next_beta_version
+def next_beta_version(version_name: nil)
+  version_name ||= VERSION_FILE.read_version_name
   # Read the current release version from the .xcconfig file and parse it into an AppVersion object
-  current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+  current_version = VERSION_FORMATTER.parse(version_name)
   # Calculate the next beta version
   next_beta_version = VERSION_CALCULATOR.next_build_number(version: current_version)
   # Return the formatted release version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,15 +108,16 @@ def current_beta_version
   VERSION_FORMATTER.beta_version(current_version)
 end
 
-# Returns the beta version of the app in the format `1.2-rc-1`
+# Returns the next beta version in the format `1.2-rc-2` (increments the build number)
 #
 def next_beta_version(version_name: nil)
+  # Use provided version or read the current version from version.properties
   version_name ||= VERSION_FILE.read_version_name
-  # Read the current release version from the .xcconfig file and parse it into an AppVersion object
+  # Parse the version string (e.g., "1.2-rc-1") into an AppVersion object
   current_version = VERSION_FORMATTER.parse(version_name)
-  # Calculate the next beta version
+  # Increment the build number to get the next beta version
   next_beta_version = VERSION_CALCULATOR.next_build_number(version: current_version)
-  # Return the formatted release version
+  # Format as beta version (e.g., "1.2-rc-2")
   VERSION_FORMATTER.beta_version(next_beta_version)
 end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -16,15 +16,17 @@ platform :android do
     computed_version = next_release_version
     new_version = version || computed_version
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     message = <<-MESSAGE

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -9,34 +9,22 @@ platform :android do
   #
   lane :code_freeze do |version: nil, skip_confirm: false|
     ensure_git_status_clean
+
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
-    ensure_git_branch(branch: DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = next_release_version
-    new_version = version || computed_version
-
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || next_release_version
+    release_branch_name = "release/#{new_version}"
+    new_beta_version = next_beta_version(version_name: new_version)
+    new_build_code = next_build_code
 
     message = <<-MESSAGE
 
       Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{new_version}
-      • Current release version and build code: #{current_release_version} (#{current_build_code}).
-      • New release version and build code: #{code_freeze_beta_version} (#{next_build_code}).
+      • New release branch from #{DEFAULT_BRANCH}: #{release_branch_name}
 
-      Do you want to continue?
+      • Current release version and build code: #{current_release_version} (#{current_build_code}).
+      • New release version and build code: #{new_beta_version} (#{new_build_code}).
 
     MESSAGE
 
@@ -44,7 +32,6 @@ platform :android do
 
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    release_branch_name = "release/#{new_version}"
     ensure_branch_does_not_exist!(release_branch_name)
 
     # Create the release branch
@@ -56,8 +43,8 @@ platform :android do
     # Bump the version and build code
     UI.message 'Bumping beta version and build code...'
     VERSION_FILE.write_version(
-      version_name: code_freeze_beta_version,
-      version_code: next_build_code
+      version_name: new_beta_version,
+      version_code: new_build_code
     )
     commit_version_bump
     UI.success "Done! New Beta Version: #{current_beta_version}. New Build Code: #{current_build_code}"
@@ -89,7 +76,7 @@ platform :android do
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
-      to_branch: "release/#{new_version}"
+      to_branch: release_branch_name
     )
 
     begin


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane code_freeze ` 
- Run `bundle exec fastlane code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.