### PR TITLE
CMM-919 new support visual glitches

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsListScreen.kt
@@ -97,7 +97,7 @@ private fun <T : Conversation> ConversationsList(
     conversationListItem: @Composable (T) -> Unit
 ) {
     when {
-        conversations.isEmpty() && conversationsState is ConversationsSupportViewModel.ConversationsState.Loading -> {
+        conversationsState is ConversationsSupportViewModel.ConversationsState.Loading -> {
             Box(
                 modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsListScreen.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.support.common.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -15,7 +17,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.wordpress.android.support.common.model.Conversation
 import org.wordpress.android.ui.compose.components.MainTopAppBar
@@ -53,13 +58,26 @@ fun <T : Conversation> ConversationsListScreen(
             )
         }
     ) { contentPadding ->
+        val isRefreshing = conversationsState is ConversationsSupportViewModel.ConversationsState.Refreshing
+        val pullToRefreshState = rememberPullToRefreshState()
+
         PullToRefreshBox(
-            isRefreshing = conversationsState is ConversationsSupportViewModel.ConversationsState.Loading,
+            state = pullToRefreshState,
+            isRefreshing = isRefreshing,
             onRefresh = onRefresh,
-            modifier = modifier.fillMaxSize()
+            modifier = modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+            indicator = {
+                PullToRefreshDefaults.Indicator(
+                    state = pullToRefreshState,
+                    isRefreshing = isRefreshing,
+                    modifier = Modifier.align(Alignment.TopCenter)
+                )
+            }
         ) {
             ConversationsList(
-                modifier = Modifier.padding(contentPadding),
+                modifier = Modifier,
                 conversations = conversations,
                 conversationsState = conversationsState,
                 onCreateNewConversationClick = onCreateNewConversationClick,
@@ -78,27 +96,40 @@ private fun <T : Conversation> ConversationsList(
     onCreateNewConversationClick: () -> Unit,
     conversationListItem: @Composable (T) -> Unit
 ) {
-    if (conversations.isEmpty() && conversationsState is ConversationsSupportViewModel.ConversationsState.Loaded) {
-        EmptyConversationsView(
-            modifier = modifier,
-            onCreateNewConversationClick = onCreateNewConversationClick
-        )
-    } else if (conversationsState is ConversationsSupportViewModel.ConversationsState.NoNetwork) {
-        OfflineConversationsView()
-    } else if (conversationsState is ConversationsSupportViewModel.ConversationsState.Error) {
-        ErrorConversationsView()
-    } else {
-        LazyColumn(
-            modifier = modifier.fillMaxSize()
-        ) {
-            items(
-                items = conversations,
-                key = { it.getConversationId() }
-            ) { conversation ->
-                conversationListItem(conversation)
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                )
+    when {
+        conversations.isEmpty() && conversationsState is ConversationsSupportViewModel.ConversationsState.Loading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        conversations.isEmpty() && conversationsState is ConversationsSupportViewModel.ConversationsState.Loaded -> {
+            EmptyConversationsView(
+                modifier = modifier,
+                onCreateNewConversationClick = onCreateNewConversationClick
+            )
+        }
+        conversationsState is ConversationsSupportViewModel.ConversationsState.NoNetwork -> {
+            OfflineConversationsView()
+        }
+        conversationsState is ConversationsSupportViewModel.ConversationsState.Error -> {
+            ErrorConversationsView()
+        }
+        else -> {
+            LazyColumn(
+                modifier = modifier.fillMaxSize()
+            ) {
+                items(
+                    items = conversations,
+                    key = { it.getConversationId() }
+                ) { conversation ->
+                    conversationListItem(conversation)
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsSupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsSupportViewModel.kt
@@ -96,14 +96,14 @@ abstract class ConversationsSupportViewModel<ConversationType: Conversation>(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadConversations(refresh: Boolean = false) {
+    private suspend fun loadConversations(isRefresh: Boolean = false) {
         try {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 _conversationsState.value = ConversationsState.NoNetwork
                 return
             }
 
-            _conversationsState.value = if (refresh) ConversationsState.Refreshing else ConversationsState.Loading
+            _conversationsState.value = if (isRefresh) ConversationsState.Refreshing else ConversationsState.Loading
             val conversations = getConversations()
             _conversations.value = conversations
             _conversationsState.value = ConversationsState.Loaded
@@ -121,7 +121,7 @@ abstract class ConversationsSupportViewModel<ConversationType: Conversation>(
 
     fun refreshConversations() {
         viewModelScope.launch {
-            loadConversations(refresh = true)
+            loadConversations(isRefresh = true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsSupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/common/ui/ConversationsSupportViewModel.kt
@@ -29,6 +29,7 @@ abstract class ConversationsSupportViewModel<ConversationType: Conversation>(
 
     sealed class ConversationsState {
         data object Loading : ConversationsState()
+        data object Refreshing : ConversationsState()
         data object Loaded : ConversationsState()
         data object NoNetwork : ConversationsState()
         data object Error : ConversationsState()
@@ -95,14 +96,14 @@ abstract class ConversationsSupportViewModel<ConversationType: Conversation>(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadConversations() {
+    private suspend fun loadConversations(refresh: Boolean = false) {
         try {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 _conversationsState.value = ConversationsState.NoNetwork
                 return
             }
 
-            _conversationsState.value = ConversationsState.Loading
+            _conversationsState.value = if (refresh) ConversationsState.Refreshing else ConversationsState.Loading
             val conversations = getConversations()
             _conversations.value = conversations
             _conversationsState.value = ConversationsState.Loaded
@@ -120,7 +121,7 @@ abstract class ConversationsSupportViewModel<ConversationType: Conversation>(
 
     fun refreshConversations() {
         viewModelScope.launch {
-            loadConversations()
+            loadConversations(refresh = true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/MarkdownUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/MarkdownUtils.kt
@@ -95,9 +95,9 @@ private fun AnnotatedString.Builder.processNode(node: Node) {
                 withLink(LinkAnnotation.Url(child.destination)) {
                     val start = length
                     processNode(child)
+                    // Inherit text color from theme; only add underline for discoverability
                     addStyle(
                         SpanStyle(
-                            color = Color.Blue,
                             textDecoration = TextDecoration.Underline
                         ),
                         start,


### PR DESCRIPTION
## Description
This PR is fixing a couple of UI glitches i the new support screens:

1. Markdown links were low-contrast, specially in dark mode
2. Conversations loading spinner was not properly shown

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

1. Log into a WP.COM site
2. Enable `MODERN_SUPPORT` Experimental Feature
3. Go to "Me" -> Help & Support -> Ask the Bots
4. If y don't have conversations, create new ones
- [ ] Verify you do see a loading spinner when loading or refreshing conversations 

https://github.com/user-attachments/assets/81f601fb-4e68-44db-8e2f-db206d6c19d8

1. Ask the bot to answer you with a markdown message, including links
- [ ] Verify the links color are following the JP theme and have good contrast with the message box.

Before:
<img width="300" height="1146" alt="Screenshot 2025-10-31 at 11 43 16" src="https://github.com/user-attachments/assets/797699ba-9f05-45b8-9bda-696f22aef83f" /><img width="300" height="1140" alt="Screenshot 2025-10-31 at 11 43 45" src="https://github.com/user-attachments/assets/bf2a87c7-777b-4b87-af4b-2200eb079797" />


After:

<img width="300" height="1144" alt="Screenshot 2025-10-31 at 11 41 40" src="https://github.com/user-attachments/assets/442daba2-a65d-4882-9b54-5108f00fc413" /><img width="300" height="1142" alt="Screenshot 2025-10-31 at 11 41 22" src="https://github.com/user-attachments/assets/c2d72acf-3476-4c4c-8b5d-a6ae2b43635c" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->