### PR TITLE
Fix broken reader YouTube embeds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -162,10 +162,12 @@ class ReaderPostRenderer(
 
         // IMPORTANT: use loadDataWithBaseURL() since loadData() may fail
         // https://code.google.com/p/android/issues/detail?id=4401
-        // also important to use null as the baseUrl since onPageFinished
-        // doesn't appear to fire when it's set to an actual url
+        // Use android-app:// scheme as baseUrl to set HTTP referrer for YouTube embeds.
+        // Google requires this for embedded videos to work properly.
+        // https://developers.google.com/youtube/terms/required-minimum-functionality#set-the-referer
+        // https://stackoverflow.com/questions/79761743/youtube-video-in-webview-gives-error-code-153-on-android/79809094#79809094
         webView.loadDataWithBaseURL(
-            null,
+            "https://wordpress.com/reader",
             htmlContent,
             "text/html",
             "UTF-8",


### PR DESCRIPTION
## Description

YouTube added a ToS requirement that the HTTP referrer be included for all embeds. If it's not, the embed displays an error. We were aware of this in the context of the experimental editor and planned to address it, but because it's in production, this is now moved to the top of the queue.

## Testing instructions

1. Open the Reader
2. Search for a post with an embedded YouTube video. You can directly search "https://ma.tt/2025/11/bending-spoons/" if that helps
- [ ] Verify the video is embedded correctly and you can wach it

Before/After
<img width="259" height="183" alt="Screenshot 2025-11-13 at 09 10 32" src="https://github.com/user-attachments/assets/030160e3-0b86-4ec3-a2f7-518f1fa5cb7d" /> / <img width="255" height="182" alt="Screenshot 2025-11-13 at 09 41 17" src="https://github.com/user-attachments/assets/ca66c4f4-7c93-4270-8298-1c4d59d4a7c4" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->