### PR TITLE
Logs: adding extra logs for application password card build

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -57,7 +57,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
                 appLogWrapper.d(
                     AppLog.T.API,
-                    "WP_RS: Found authorization for $siteUrl URL: $authorizationUrlComplete " +
+                    "AP: Found authorization for $siteUrl URL: $authorizationUrlComplete " +
                             "API_ROOT_URL $apiRootUrl")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
@@ -75,7 +75,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     private fun handleAuthenticationDiscoveryError(siteUrl: String, throwable: Throwable): String {
-        appLogWrapper.e(AppLog.T.API, "WP_RS: Error during API discovery for $siteUrl - ${throwable.message}")
+        appLogWrapper.e(AppLog.T.API, "AP: Error during API discovery for $siteUrl - ${throwable.message}")
         AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_FAILED)
         return ""
     }
@@ -88,6 +88,10 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             urlLogin.siteUrl == null ||
             urlLogin.siteUrl == processedAppPasswordData
             ) {
+            appLogWrapper.e(
+                AppLog.T.DB,
+                "AP: Cannot save application password credentials for: ${urlLogin.siteUrl} - bad data"
+            )
             return false
         }
 
@@ -111,7 +115,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             } else {
                 appLogWrapper.e(
                     AppLog.T.DB,
-                    "WP_RS: Cannot save application password credentials for: ${urlLogin.siteUrl}"
+                    "AP: Cannot save application password credentials for: ${urlLogin.siteUrl} - null site"
                 )
                 false
             }
@@ -130,7 +134,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             },
             properties
         )
-        appLogWrapper.d(AppLog.T.DB, "WP_RS: Saved application password credentials for: $siteUrl")
+        appLogWrapper.d(AppLog.T.DB, "AP: Saved application password credentials for: $siteUrl")
     }
 
     fun getSiteUrlLoginFromRawData(url: String): UriLogin {
@@ -156,6 +160,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
                 dispatcherWrapper.removeApplicationPassword(site)
             }
+            appLogWrapper.d(AppLog.T.DB, "AP: Removed application password credentials for: $affectedSites sites")
             affectedSites
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts.login
 
-import android.util.Log
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -56,8 +55,10 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
                 val authorizationUrlComplete =
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
-                Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete" +
-                        " API_ROOT_URL $apiRootUrl")
+                appLogWrapper.d(
+                    AppLog.T.API,
+                    "WP_RS: Found authorization for $siteUrl URL: $authorizationUrlComplete " +
+                            "API_ROOT_URL $apiRootUrl")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem.QuickLinkItem
@@ -16,6 +17,7 @@ import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
@@ -23,6 +25,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
     private val applicationPasswordLoginHelper: ApplicationPasswordLoginHelper,
     private val siteStore: SiteStore,
     private val experimentalFeatures: ExperimentalFeatures,
+    private val appLogWrapper: AppLogWrapper,
 ) {
     lateinit var scope: CoroutineScope
 
@@ -57,12 +60,14 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
             val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
             if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
                 uiModelMutable.postValue(null)
+                appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Hiding card for ${site.url} - authenticated")
                 return@launch
             }
 
             val authorizationUrlComplete = applicationPasswordLoginHelper.getAuthorizationUrlComplete(site.url)
             if (authorizationUrlComplete.isEmpty()) {
                 uiModelMutable.postValue(null)
+                appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Hiding card for ${site.url} - bad discovery")
             } else {
                 showApplicationPasswordCreateCard(site)
             }
@@ -81,6 +86,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 )
             )
         )
+        appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Showing card for ${site.url}")
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -60,14 +60,14 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
             val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
             if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
                 uiModelMutable.postValue(null)
-                appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Hiding card for ${site.url} - authenticated")
+                appLogWrapper.d(AppLog.T.MAIN, "AP: Hiding card for ${site.url} - authenticated")
                 return@launch
             }
 
             val authorizationUrlComplete = applicationPasswordLoginHelper.getAuthorizationUrlComplete(site.url)
             if (authorizationUrlComplete.isEmpty()) {
                 uiModelMutable.postValue(null)
-                appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Hiding card for ${site.url} - bad discovery")
+                appLogWrapper.d(AppLog.T.MAIN, "AP: Hiding card for ${site.url} - bad discovery")
             } else {
                 showApplicationPasswordCreateCard(site)
             }
@@ -86,7 +86,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 )
             )
         )
-        appLogWrapper.d(AppLog.T.MAIN, "WP_RS: Showing card for ${site.url}")
+        appLogWrapper.d(AppLog.T.MAIN, "AP: Showing card for ${site.url}")
     }
 
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
@@ -41,6 +42,9 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var experimentalFeatures: ExperimentalFeatures
 
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+
     private lateinit var siteTest: SiteModel
 
     private var applicationPasswordCard: MySiteCardAndItem.Card? = null
@@ -55,6 +59,7 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
             applicationPasswordLoginHelper,
             siteStore,
             experimentalFeatures,
+            appLogWrapper
         ).apply {
             initialize(testScope())
             whenever(experimentalFeatures.isEnabled(any())).thenReturn(true)


### PR DESCRIPTION
## Description
This PR is adding new logs for the Application Password discovery process and the card build. 
These changes will help us to track possible errors.

## Testing instructions
Just check the code, and check the CI is green

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->