### PR TITLE
CMM-993 reader  posts in discover are duplicated

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -153,9 +153,6 @@ class ReaderDiscoverLogic @Inject constructor(
             clearCache()
         }
         json.optJSONArray(JSON_CARDS)?.let { originalCardsJson ->
-            // Inject fake posts
-            // TODO: REMOVE THIS FAKE INJECTION
-            val fullCardsJson = injectFakePosts(originalCardsJson)
             // Parse the json into cards model objects
             val cards = parseCards(fullCardsJson)
             insertPostsIntoDb(cards.filterIsInstance<ReaderPostCard>().map { it.post })
@@ -178,81 +175,6 @@ class ReaderDiscoverLogic @Inject constructor(
 
             resultListener.onUpdateResult(HAS_NEW)
         }
-    }
-
-    private fun injectFakePosts(originalCardsJson: JSONArray): JSONArray {
-        // Create a new JSONArray with fake posts injected at the beginning
-        val modifiedCardsJson = JSONArray()
-
-        // Create the same fake post to inject twice (simulating duplicate response)
-        val fakePost = JSONObject().apply {
-            put("type", "post")
-            put("data", JSONObject().apply {
-                put("ID", 99991)
-                put("site_ID", 999999991)
-                put("author", JSONObject().apply {
-                    put("ID", 999999991)
-                    put("login", "fakeuser1")
-                    put("name", "Fake Test User 1")
-                    put("first_name", "Fake")
-                    put("last_name", "User 1")
-                    put("URL", "https://fakeuser1.wordpress.com")
-                    put(
-                        "avatar_URL",
-                        "https://0.gravatar.com/avatar/fake1?s=96&d=identicon&r=G"
-                    )
-                    put("profile_URL", "https://gravatar.com/fakeuser1")
-                })
-                put("date", "2025-11-25T10:00:00+00:00")
-                put("modified", "2025-11-25T10:00:00+00:00")
-                put("title", "🧪 FAKE POST - Testing Duplicate Detection")
-                put("URL", "https://fakeuser1.wordpress.com/2025/11/25/fake-post-1/")
-                put("short_URL", "https://wp.me/fake1")
-                put(
-                    "content",
-                    "<div class=\"is-reader\"><p>This is a FAKE injected post for testing " +
-                    "duplicate detection. This post is intentionally added TWICE to the response " +
-                    "to simulate a duplicate scenario. Only ONE instance should appear!</p></div>"
-                )
-                put("excerpt", "<p>FAKE post to test duplicate detection.</p>")
-                put("slug", "fake-post-1")
-                put("status", "publish")
-                put("discussion", JSONObject().apply {
-                    put("comments_open", true)
-                    put("comment_status", "open")
-                    put("comment_count", 0)
-                })
-                put("likes_enabled", true)
-                put("like_count", "42")
-                put("i_like", false)
-                put("is_reblogged", false)
-                put("is_following", false)
-                put("global_ID", "fake_global_id_1")
-                put("featured_image", "")
-                put("post_thumbnail", JSONObject.NULL)
-                put("format", "standard")
-                put("tags", JSONObject())
-                put("categories", JSONObject())
-                put("feed_ID", 999999991)
-                put("feed_URL", "https://fakeuser1.wordpress.com")
-                put("pseudo_ID", "fake_pseudo_id_1")
-                put("is_external", false)
-                put("site_name", "Fake Test Blog 1")
-                put("site_URL", "https://fakeuser1.wordpress.com")
-                put("site_is_private", false)
-            })
-        }
-
-        // Add the SAME fake post TWICE to simulate duplicate in JSON response
-        modifiedCardsJson.put(fakePost)
-        modifiedCardsJson.put(fakePost)
-
-        // Add all original posts
-        for (i in 0 until originalCardsJson.length()) {
-            modifiedCardsJson.put(originalCardsJson.getJSONObject(i))
-        }
-
-        return modifiedCardsJson
     }
 
     private fun parseCards(cardsJsonArray: JSONArray): ArrayList<ReaderDiscoverCard> {
@@ -308,7 +230,7 @@ class ReaderDiscoverLogic @Inject constructor(
      * It for example copies only ids from post object as we don't need to store the gigantic post in the json
      * as it's already stored in the db.
      */
-    @Suppress("NestedBlockDepth")
+    @Suppress("NestedBlockDepth", "CyclomaticComplexMethod", "LoopWithTooManyJumpStatements")
     private fun createSimplifiedJson(cardsJsonArray: JSONArray, discoverTasks: DiscoverTasks): JSONArray {
         val simplifiedJsonList = mutableListOf<JSONObject>()
         val addedPostIds = mutableSetOf<Long>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -268,6 +268,15 @@ class ReaderDiscoverLogic @Inject constructor(
                 }
                 JSON_CARD_POST -> {
                     val post = parseDiscoverCardsJsonUseCase.parsePostCard(cardJson)
+
+                    // Check for duplicate post
+                    if (addedPostIds.contains(post.postId)) {
+                        AppLog.w(READER, "Duplicate post detected in parseCards - ID: ${post.postId}, " +
+                                "skipping duplicate entry")
+                        continue
+                    }
+
+                    addedPostIds.add(post.postId)
                     cards.add(ReaderPostCard(post))
                 }
                 JSON_CARD_RECOMMENDED_BLOGS -> {
@@ -302,6 +311,7 @@ class ReaderDiscoverLogic @Inject constructor(
     @Suppress("NestedBlockDepth")
     private fun createSimplifiedJson(cardsJsonArray: JSONArray, discoverTasks: DiscoverTasks): JSONArray {
         val simplifiedJsonList = mutableListOf<JSONObject>()
+        val addedPostIds = mutableSetOf<Long>()
         var firstRecommendationCard: JSONObject? = null
         val isFirstPage = discoverTasks == REQUEST_FIRST_PAGE
         for (i in 0 until cardsJsonArray.length()) {
@@ -326,6 +336,17 @@ class ReaderDiscoverLogic @Inject constructor(
                     simplifiedJsonList.add(cardJson)
                 }
                 JSON_CARD_POST -> {
+                    // Check for duplicate posts in simplified JSON
+                    val postData = cardJson.getJSONObject(JSON_CARD_DATA)
+                    val postId = postData.optLong(POST_ID)
+
+                    if (addedPostIds.contains(postId)) {
+                        AppLog.w(READER, "Duplicate post detected in createSimplifiedJson - ID: $postId, " +
+                                "skipping duplicate entry")
+                        continue
+                    }
+
+                    addedPostIds.add(postId)
                     simplifiedJsonList.add(createSimplifiedPostJson(cardJson))
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -152,7 +152,7 @@ class ReaderDiscoverLogic @Inject constructor(
         if (taskType == REQUEST_FIRST_PAGE) {
             clearCache()
         }
-        json.optJSONArray(JSON_CARDS)?.let { originalCardsJson ->
+        json.optJSONArray(JSON_CARDS)?.let { fullCardsJson ->
             // Parse the json into cards model objects
             val cards = parseCards(fullCardsJson)
             insertPostsIntoDb(cards.filterIsInstance<ReaderPostCard>().map { it.post })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -152,7 +152,10 @@ class ReaderDiscoverLogic @Inject constructor(
         if (taskType == REQUEST_FIRST_PAGE) {
             clearCache()
         }
-        json.optJSONArray(JSON_CARDS)?.let { fullCardsJson ->
+        json.optJSONArray(JSON_CARDS)?.let { originalCardsJson ->
+            // Inject fake posts
+            // TODO: REMOVE THIS FAKE INJECTION
+            val fullCardsJson = injectFakePosts(originalCardsJson)
             // Parse the json into cards model objects
             val cards = parseCards(fullCardsJson)
             insertPostsIntoDb(cards.filterIsInstance<ReaderPostCard>().map { it.post })
@@ -177,8 +180,85 @@ class ReaderDiscoverLogic @Inject constructor(
         }
     }
 
+    private fun injectFakePosts(originalCardsJson: JSONArray): JSONArray {
+        // Create a new JSONArray with fake posts injected at the beginning
+        val modifiedCardsJson = JSONArray()
+
+        // Create the same fake post to inject twice (simulating duplicate response)
+        val fakePost = JSONObject().apply {
+            put("type", "post")
+            put("data", JSONObject().apply {
+                put("ID", 99991)
+                put("site_ID", 999999991)
+                put("author", JSONObject().apply {
+                    put("ID", 999999991)
+                    put("login", "fakeuser1")
+                    put("name", "Fake Test User 1")
+                    put("first_name", "Fake")
+                    put("last_name", "User 1")
+                    put("URL", "https://fakeuser1.wordpress.com")
+                    put(
+                        "avatar_URL",
+                        "https://0.gravatar.com/avatar/fake1?s=96&d=identicon&r=G"
+                    )
+                    put("profile_URL", "https://gravatar.com/fakeuser1")
+                })
+                put("date", "2025-11-25T10:00:00+00:00")
+                put("modified", "2025-11-25T10:00:00+00:00")
+                put("title", "🧪 FAKE POST - Testing Duplicate Detection")
+                put("URL", "https://fakeuser1.wordpress.com/2025/11/25/fake-post-1/")
+                put("short_URL", "https://wp.me/fake1")
+                put(
+                    "content",
+                    "<div class=\"is-reader\"><p>This is a FAKE injected post for testing " +
+                    "duplicate detection. This post is intentionally added TWICE to the response " +
+                    "to simulate a duplicate scenario. Only ONE instance should appear!</p></div>"
+                )
+                put("excerpt", "<p>FAKE post to test duplicate detection.</p>")
+                put("slug", "fake-post-1")
+                put("status", "publish")
+                put("discussion", JSONObject().apply {
+                    put("comments_open", true)
+                    put("comment_status", "open")
+                    put("comment_count", 0)
+                })
+                put("likes_enabled", true)
+                put("like_count", "42")
+                put("i_like", false)
+                put("is_reblogged", false)
+                put("is_following", false)
+                put("global_ID", "fake_global_id_1")
+                put("featured_image", "")
+                put("post_thumbnail", JSONObject.NULL)
+                put("format", "standard")
+                put("tags", JSONObject())
+                put("categories", JSONObject())
+                put("feed_ID", 999999991)
+                put("feed_URL", "https://fakeuser1.wordpress.com")
+                put("pseudo_ID", "fake_pseudo_id_1")
+                put("is_external", false)
+                put("site_name", "Fake Test Blog 1")
+                put("site_URL", "https://fakeuser1.wordpress.com")
+                put("site_is_private", false)
+            })
+        }
+
+        // Add the SAME fake post TWICE to simulate duplicate in JSON response
+        modifiedCardsJson.put(fakePost)
+        modifiedCardsJson.put(fakePost)
+
+        // Add all original posts
+        for (i in 0 until originalCardsJson.length()) {
+            modifiedCardsJson.put(originalCardsJson.getJSONObject(i))
+        }
+
+        return modifiedCardsJson
+    }
+
     private fun parseCards(cardsJsonArray: JSONArray): ArrayList<ReaderDiscoverCard> {
         val cards: ArrayList<ReaderDiscoverCard> = arrayListOf()
+        val addedPostIds = mutableSetOf<Long>()
+
         for (i in 0 until cardsJsonArray.length()) {
             val cardJson = cardsJsonArray.getJSONObject(i)
             when (cardJson.getString(JSON_CARD_TYPE)) {


### PR DESCRIPTION
## Description
This PR prevents duplicated card posts from appearing in the reader.

## Testing instructions
There's a mocked post injected in the code for testing purposes.
That code will be removed after reviewing the PR.

1. Open the reader -> discovery
- [ ] Verify there's ONLY one top mocked post

Note: if you keep scrolling, you will see the same post again as we are only checking duplicates in the same requests, which should be enough.

Before:
<img width="317" height="707" alt="Screenshot 2025-11-25 at 12 31 36" src="https://github.com/user-attachments/assets/adb192ac-55e9-4ac8-a879-4ec9d10eafcd" />

After:
<img width="311" height="691" alt="Screenshot 2025-11-25 at 12 27 34" src="https://github.com/user-attachments/assets/5af759de-4b48-454f-bea9-1f0fd5f7ea29" />

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->