### PR TITLE
Support new "reader" deeplinks

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -634,6 +634,18 @@
                 </data>
 
                 <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
+                    android:scheme="https" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
+                    android:scheme="http" >
+                </data>
+
+                <data
                     android:host="*.wordpress.com"
                     android:pathPattern="/2.../../../.*"
                     android:scheme="https" >

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -634,18 +634,6 @@
                 </data>
 
                 <data
-                    android:host="wordpress.com"
-                    android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="https" >
-                </data>
-
-                <data
-                    android:host="wordpress.com"
-                    android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="http" >
-                </data>
-
-                <data
                     android:host="*.wordpress.com"
                     android:pathPattern="/2.../../../.*"
                     android:scheme="https" >
@@ -666,6 +654,18 @@
                 <data
                     android:host="*.wordpress.com"
                     android:pathPattern="/19../../../.*"
+                    android:scheme="http" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
+                    android:scheme="https" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
                     android:scheme="http" >
                 </data>
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandler.kt
@@ -66,6 +66,7 @@ class ReaderLinkHandler
      * `wordpress://viewpost?blogId={blogId}&postId={postId}`
      * wordpress.com/read/feeds/feedId/posts/feedItemId
      * wordpress.com/read/blogs/feedId/posts/feedItemId
+     * wordpress.com/reader/feeds/feedId/posts/feedItemId
      * domain.wordpress.com/2.../../../postId
      * domain.wordpress.com/19../../../postId
      */
@@ -95,9 +96,11 @@ class ReaderLinkHandler
                 buildString {
                     val segments = uri.pathSegments
                     // Handled URLs look like this: http[s]://wordpress.com/read/feeds/{feedId}/posts/{feedItemId}
-                    // with the first segment being 'read'.
+                    // or http[s]://wordpress.com/reader/feeds/{feedId}/posts/{feedItemId}
+                    // with the first segment being 'read' or 'reader'.
                     append(stripHost(uri))
-                    if (segments.firstOrNull() == "read") {
+                    val firstSegment = segments.firstOrNull()
+                    if (firstSegment == "read" || firstSegment == "reader") {
                         appendReadPath(segments)
                     } else if (segments.size > DATE_URL_SEGMENTS) {
                         append("/YYYY/MM/DD/$POST_ID")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -431,11 +431,12 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         val segments = uri.pathSegments
 
         // Handled URLs look like this: http[s]://wordpress.com/read/feeds/{feedId}/posts/{feedItemId}
-        // with the first segment being 'read'.
+        // or http[s]://wordpress.com/reader/feeds/{feedId}/posts/{feedItemId}
+        // with the first segment being 'read' or 'reader'.
         if (segments != null) {
             // Builds stripped URI for tracking purposes
             val wrappedUri = UriWrapper(uri)
-            if (segments[0] == "read") {
+            if (segments[0] == "read" || segments[0] == "reader") {
                 if (segments.size > 2) {
                     blogIdentifier = segments[2]
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandlerTest.kt
@@ -190,6 +190,16 @@ class ReaderLinkHandlerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `correctly strips reader feeds URI`() {
+        val uri = buildUri("wordpress.com", "reader", "feeds", feedId.toString(), "posts", postId.toString())
+
+        val strippedUrl = readerLinkHandler.stripUrl(uri)
+
+        // Note: both 'reader' and 'read' paths are normalized to 'read' for analytics tracking
+        assertThat(strippedUrl).isEqualTo("wordpress.com/read/feeds/feedId/posts/feedItemId")
+    }
+
+    @Test
     fun `correctly strips 2xxx URI`() {
         val uri = buildUri("wordpress.com", "2020", "10", "1", postId.toString())
 

--- a/config/lint/baseline.xml
+++ b/config/lint/baseline.xml
@@ -4919,6 +4919,28 @@
     </issue>
 
     <issue
+        id="IntentFilterUniqueDataAttributes"
+        message="Consider splitting data tag into multiple tags with individual attributes to avoid confusion"
+        errorLine1="                &lt;data"
+        errorLine2="                ^">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="660"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="IntentFilterUniqueDataAttributes"
+        message="Consider splitting data tag into multiple tags with individual attributes to avoid confusion"
+        errorLine1="                &lt;data"
+        errorLine2="                ^">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="666"
+            column="17"/>
+    </issue>
+
+    <issue
         id="NonConstantResourceId"
         message="Resource IDs will be non-final by default in Android Gradle Plugin version 8.0, avoid using them in switch case statements"
         errorLine1="                        case R.id.radio_circles:"


### PR DESCRIPTION
## Description
This PR adds support for the "reader" deeplinks

## Testing instructions

- [ ] Open the following deeplinks and verify they are opened in the app


https://wordpress.com/read/feeds/138734090/posts/5879194632

https://wordpress.com/reader/feeds/138734090/posts/5879194632

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->