### PR TITLE
CMM-953 fix reader subscribe when logged out

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -57,6 +57,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -934,8 +935,16 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
             is ReaderNavigationEvents.ShowPostDetail,
             is ReaderNavigationEvents.ShowVideoViewer,
-            is ReaderNavigationEvents.ShowReaderSubs,
-            is ReaderNavigationEvents.ShowSignIn -> Unit // Do Nothing
+            is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
+            is ReaderNavigationEvents.ShowSignIn -> navigateToLogin()
+        }
+    }
+
+    private fun navigateToLogin() {
+        if (BuildConfig.IS_JETPACK_APP) {
+            ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
+        } else {
+            ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -934,7 +934,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
             is ReaderNavigationEvents.ShowPostDetail,
             is ReaderNavigationEvents.ShowVideoViewer,
-            is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
+            is ReaderNavigationEvents.ShowReaderSubs,
+            is ReaderNavigationEvents.ShowSignIn -> Unit // Do Nothing
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import org.wordpress.android.BuildConfig
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -39,6 +40,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReade
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderSubs
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportUser
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSignIn
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
@@ -220,7 +222,16 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
             OpenUrlType.INTERNAL
         )
         is ShowReaderSubs -> ReaderActivityLauncher.showReaderSubs(requireActivity())
+        is ShowSignIn -> navigateToLogin()
         else -> Unit // Do Nothing
+    }
+
+    private fun navigateToLogin() {
+        if (BuildConfig.IS_JETPACK_APP) {
+            ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
+        } else {
+            ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
+        }
     }
 
     private fun showBookmarkSavedLocallyDialog(bookmarkDialog: ShowBookmarkedSavedOnlyLocallyDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -69,4 +69,5 @@ sealed class ReaderNavigationEvents {
     ) : ReaderNavigationEvents()
 
     data object ShowReadingPreferences : ReaderNavigationEvents()
+    data object ShowSignIn : ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction.DELETE
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction.NEW
 import org.wordpress.android.models.ReaderPost
@@ -100,6 +101,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
     private val appReviewsManagerWrapper: AppReviewsManagerWrapper,
     private val seenStatusToggleUseCase: ReaderSeenStatusToggleUseCase,
     private val readerBlogTableWrapper: ReaderBlogTableWrapper,
+    private val accountStore: AccountStore,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     private lateinit var coroutineScope: CoroutineScope
@@ -299,6 +301,12 @@ class ReaderPostCardActionsHandler @Inject constructor(
         recommendedBlogUiState: ReaderRecommendedBlogUiState,
         source: String
     ) {
+        if (!accountStore.hasAccessToken()) {
+            _snackbarEvents.postValue(
+                Event(SnackbarMessageHolder(UiStringRes(R.string.reader_toast_err_cannot_follow_logged_out)))
+            )
+            return
+        }
         val param = ReaderSiteFollowUseCase.Param(
             blogId = recommendedBlogUiState.blogId,
             blogName = recommendedBlogUiState.name,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -327,6 +327,20 @@ class ReaderPostCardActionsHandler @Inject constructor(
         post: ReaderPost,
         source: String
     ) {
+        if (!accountStore.hasAccessToken()) {
+            _snackbarEvents.postValue(
+                Event(
+                    SnackbarMessageHolder(
+                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
+                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
+                        buttonAction = {
+                            _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
+                        }
+                    )
+                )
+            )
+            return
+        }
         followSite(
             ReaderSiteFollowUseCase.Param(
                 post.blogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -302,17 +302,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         source: String
     ) {
         if (!accountStore.hasAccessToken()) {
-            _snackbarEvents.postValue(
-                Event(
-                    SnackbarMessageHolder(
-                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
-                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
-                        buttonAction = {
-                            _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
-                        }
-                    )
-                )
-            )
+            showSignInPrompt()
             return
         }
         val param = ReaderSiteFollowUseCase.Param(
@@ -328,17 +318,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         source: String
     ) {
         if (!accountStore.hasAccessToken()) {
-            _snackbarEvents.postValue(
-                Event(
-                    SnackbarMessageHolder(
-                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
-                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
-                        buttonAction = {
-                            _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
-                        }
-                    )
-                )
-            )
+            showSignInPrompt()
             return
         }
         followSite(
@@ -347,6 +327,20 @@ class ReaderPostCardActionsHandler @Inject constructor(
                 post.feedId,
                 post.blogName
             ), source
+        )
+    }
+
+    private fun showSignInPrompt() {
+        _snackbarEvents.postValue(
+            Event(
+                SnackbarMessageHolder(
+                    UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
+                    UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
+                    buttonAction = {
+                        _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
+                    }
+                )
+            )
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -303,7 +303,15 @@ class ReaderPostCardActionsHandler @Inject constructor(
     ) {
         if (!accountStore.hasAccessToken()) {
             _snackbarEvents.postValue(
-                Event(SnackbarMessageHolder(UiStringRes(R.string.reader_toast_err_cannot_follow_logged_out)))
+                Event(
+                    SnackbarMessageHolder(
+                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
+                        UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
+                        buttonAction = {
+                            _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
+                        }
+                    )
+                )
             )
             return
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2355,7 +2355,8 @@
 
     <!-- snackbar messages -->
     <string name="reader_snackbar_err_cannot_like_post_logged_out">Can\'t like while logged out of WordPress.com</string>
-    <string name="reader_toast_err_cannot_follow_logged_out">Can\'t follow while logged out of WordPress.com</string>
+    <string name="reader_snackbar_err_cannot_follow_logged_out">Log in to follow this site</string>
+    <string name="reader_snackbar_err_cannot_follow_logged_out_action">Log In</string>
 
     <!-- failure messages when retrieving a single reader post -->
     <string name="reader_err_get_post_generic">Unable to retrieve this post</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2355,7 +2355,7 @@
 
     <!-- snackbar messages -->
     <string name="reader_snackbar_err_cannot_like_post_logged_out">Can\'t like while logged out of WordPress.com</string>
-    <string name="reader_snackbar_err_cannot_follow_logged_out">Log in to follow this site</string>
+    <string name="reader_snackbar_err_cannot_follow_logged_out">Log in to WordPress.com to subscribe to this site</string>
     <string name="reader_snackbar_err_cannot_follow_logged_out_action">Log In</string>
 
     <!-- failure messages when retrieving a single reader post -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2355,6 +2355,7 @@
 
     <!-- snackbar messages -->
     <string name="reader_snackbar_err_cannot_like_post_logged_out">Can\'t like while logged out of WordPress.com</string>
+    <string name="reader_toast_err_cannot_follow_logged_out">Can\'t follow while logged out of WordPress.com</string>
 
     <!-- failure messages when retrieving a single reader post -->
     <string name="reader_err_get_post_generic">Unable to retrieve this post</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -130,6 +131,9 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     private lateinit var dispatcher: Dispatcher
 
     @Mock
+    private lateinit var accountStore: AccountStore
+
+    @Mock
     private lateinit var resourceProvider: ResourceProvider
 
     @Mock
@@ -155,12 +159,14 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             mock(),
             seenStatusToggleUseCase,
             readerBlogTableWrapper,
+            accountStore,
             testDispatcher()
         )
         actionHandler.initScope(testScope())
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
         whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(any(), anyVararg())).thenReturn(mock())
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(mock())
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
     }
 
     /** BOOKMARK ACTION begin **/


### PR DESCRIPTION
## Description
This PR is showing an informative message when the user is logged out and try to subscribe to a blog.
In addition to the message, we offer the option to open the login flow
<!-- Describe the changes, why they are needed, and how they address the issue -->

## Testing instructions

Test Case 1: Discovery Reader - Recommended Blogs

  1. Log into the app with a self-hosted page
  2. Navigate to Reader → Discover tab
  3. Scroll until you see "Recommended Blogs" section
  4. Tap the Subscribe/Follow button on any recommended blog
  5. Expected: A snackbar appears with message "Log in to follow this site" and a "Log In" action button
  6. Tap the Log In button
  7. Expected: The sign-in screen opens
  8. Log in
  9. Verify you can now subscribe

  Test Case 2: Post Detail - Menu Subscribe

  1. Log into the app with a self-hosted page
  2. Navigate to Reader → Discover tab
  3. Tap on any post to open the post detail view
  4. Tap the three-dot menu (⋮) in the top right
  5. Tap Subscribe option
  6. Expected: A snackbar appears with message "Log in to follow this site" and a "Log In" action button
  7. Tap the Log In button
  10. Expected: The sign-in screen opens
  11. Log in
  12.  Verify you can now subscribe



https://github.com/user-attachments/assets/a24b332a-3348-40d6-9adb-ed982b37fa03


https://github.com/user-attachments/assets/44a11f73-6d57-4d8d-a6a9-84c02480f6b8



<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->