### PR TITLE
CMM-954 reader when editing a comment markup tags are shown

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -252,11 +252,7 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     }
 
     private fun htmlToPlainText(html: String): String {
-        return if (html.contains("<") || html.contains("&")) {
-            htmlCompatWrapper.fromHtml(html).toString().trim()
-        } else {
-            html
-        }
+        return htmlCompatWrapper.fromHtml(html).toString().trim()
     }
 
     private suspend fun updateComment(editedCommentEssentials: CommentEssentials) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
@@ -55,7 +56,8 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     private val getCommentUseCase: GetCommentUseCase,
     private val notificationActionsWrapper: NotificationsActionsWrapper,
     private val readerCommentTableWrapper: ReaderCommentTableWrapper,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
+    private val htmlCompatWrapper: HtmlCompatWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<EditCommentUiState>()
     private val _uiActionEvent = MutableLiveData<Event<EditCommentActionEvent>>()
@@ -239,13 +241,21 @@ class UnifiedCommentsEditViewModel @Inject constructor(
             CommentEssentials(
                 commentId = commentEntity.id,
                 userName = commentEntity.authorName ?: "",
-                commentText = commentEntity.content ?: "",
+                commentText = htmlToPlainText(commentEntity.content ?: ""),
                 userUrl = commentEntity.authorUrl ?: "",
                 userEmail = commentEntity.authorEmail ?: "",
                 isFromRegisteredUser = commentEntity.authorId > 0
             )
         } else {
             CommentEssentials()
+        }
+    }
+
+    private fun htmlToPlainText(html: String): String {
+        return if (html.contains("<") || html.contains("&")) {
+            htmlCompatWrapper.fromHtml(html).toString().trim()
+        } else {
+            html
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.comments.unified.usecase.GetCommentUseCase
 import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
@@ -73,6 +74,9 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
 
+    @Mock
+    lateinit var htmlCompatWrapper: HtmlCompatWrapper
+
     private lateinit var viewModel: UnifiedCommentsEditViewModel
 
     private var uiState: MutableList<EditCommentUiState> = mutableListOf()
@@ -102,6 +106,9 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
         whenever(readerCommentTableWrapper.getComment(REMOTE_SITE_ID, postId, remoteCommentId))
             .thenReturn(READER_COMMENT_ENTITY)
 
+        whenever(htmlCompatWrapper.fromHtml(any(), any()))
+            .thenReturn(COMMENT_CONTENT_PLAIN)
+
         viewModel = UnifiedCommentsEditViewModel(
             mainDispatcher = testDispatcher(),
             bgDispatcher = testDispatcher(),
@@ -112,7 +119,8 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
             getCommentUseCase = getCommentUseCase,
             notificationActionsWrapper = notificationActionsWrapper,
             readerCommentTableWrapper = readerCommentTableWrapper,
-            analyticsUtilsWrapper
+            analyticsUtilsWrapper = analyticsUtilsWrapper,
+            htmlCompatWrapper = htmlCompatWrapper
         )
 
         setupObservers()
@@ -503,6 +511,8 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
     companion object {
         private const val LOCAL_SITE_ID = 123
         private const val REMOTE_SITE_ID = 456L
+        private const val COMMENT_CONTENT_HTML = "<p>content</p>"
+        private const val COMMENT_CONTENT_PLAIN = "content"
 
         private val COMMENT_ENTITY = CommentEntity(
             id = 1000,
@@ -519,7 +529,7 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
             status = null,
             datePublished = null,
             publishedTimestamp = 0,
-            content = "content",
+            content = COMMENT_CONTENT_HTML,
             url = null,
             hasParent = false,
             parentId = 0,
@@ -541,7 +551,7 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
             status = null,
             datePublished = null,
             publishedTimestamp = 0,
-            content = "content",
+            content = COMMENT_CONTENT_HTML,
             url = null,
             hasParent = false,
             parentId = 0,
@@ -553,13 +563,13 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
             authorUrl = "authorUrl"
             authorName = "authorName"
             authorEmail = "authorEmail"
-            text = "content"
+            text = COMMENT_CONTENT_PLAIN
         }
 
         private val COMMENT_ESSENTIALS = CommentEssentials(
             commentId = COMMENT_ENTITY.id,
             userName = COMMENT_ENTITY.authorName!!,
-            commentText = COMMENT_ENTITY.content!!,
+            commentText = COMMENT_CONTENT_PLAIN,
             userUrl = COMMENT_ENTITY.authorUrl!!,
             userEmail = COMMENT_ENTITY.authorEmail!!
         )


### PR DESCRIPTION
## Description
When editing a comment in the Reader, the comment text was displaying raw HTML markup tags (e.g., \<p>, \<br>) instead of plain text. This made the editing experience confusing as users would see the underlying HTML structure rather than the formatted content.

## Testing instructions

  1. Open the app and navigate to the Reader
  2. Find or create a post to comment.
  3. Comment it
  4. Tap on the comment to view details
  5. Tap the three dots icon to edit the comment
- [ ]  Verify: The comment text should display as plain text without any HTML tags like \<p>,\<br>, etc
  6. Edit the comment text and save
- [ ]  Verify: The comment is saved correctly and displays properly

Before/After
<img width="256" height="571" alt="Screenshot 2025-11-27 at 14 53 25" src="https://github.com/user-attachments/assets/b82b48a1-73cd-43e9-93b8-2fdccd07b929" /> / <img width="258" height="573" alt="Screenshot 2025-11-27 at 14 54 03" src="https://github.com/user-attachments/assets/9d19c285-4403-4065-9afc-da33deccdf6f" />

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->