### PR TITLE
CMM-955 reader subscribe button unresponsive on quick tap

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -348,8 +348,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 new FollowButtonUiState(
                         onFollowButtonClicked,
                         ReaderTagTable.isFollowedTagName(currentTag.getTagSlug()),
-                        isFollowButtonEnabled,
-                        true
+                        isFollowButtonEnabled, // isVisible
+                        false // isFollowActionRunning
                 )
         );
         tagHolder.onBind(uiState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -122,7 +122,7 @@ sealed class ReaderCardUiState {
             val description: String?,
             val iconUrl: String?,
             val isFollowed: Boolean,
-            val isFollowEnabled: Boolean,
+            val isFollowActionRunning: Boolean = false,
             val onItemClicked: (Long, Long, Boolean) -> Unit,
             val onFollowClicked: (ReaderRecommendedBlogUiState) -> Unit
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -183,23 +183,32 @@ class ReaderDiscoverViewModel @Inject constructor(
 
         return newCards.map { card ->
             if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
-                val updatedBlogs = card.blogs.map { blog ->
-                    val currentBlog = currentUiState.cards
-                        .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
-                        .flatMap { it.blogs }
-                        .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
-
-                    if (currentBlog != null && currentBlog.isFollowActionRunning) {
-                        blog.copy(isFollowActionRunning = true)
-                    } else {
-                        blog
-                    }
-                }
-                card.copy(blogs = updatedBlogs)
+                preserveBlogCardFollowState(card, currentUiState)
             } else {
                 card
             }
         }
+    }
+
+    private fun preserveBlogCardFollowState(
+        card: ReaderCardUiState.ReaderRecommendedBlogsCardUiState,
+        currentUiState: DiscoverUiState.ContentUiState
+    ): ReaderCardUiState.ReaderRecommendedBlogsCardUiState {
+        val currentBlogs = currentUiState.cards
+            .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
+            .flatMap { it.blogs }
+
+        val updatedBlogs = card.blogs.map { blog ->
+            val currentBlog = currentBlogs.find {
+                it.blogId == blog.blogId && it.feedId == blog.feedId
+            }
+            if (currentBlog?.isFollowActionRunning == true) {
+                blog.copy(isFollowActionRunning = true)
+            } else {
+                blog
+            }
+        }
+        return card.copy(blogs = updatedBlogs)
     }
 
     private fun dismissAnnouncementCard() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.models.ReaderPost
@@ -178,29 +179,30 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
-    private fun preserveFollowActionRunningState(newCards: List<ReaderCardUiState>): List<ReaderCardUiState> {
-        val currentUiState = _uiState.value as? DiscoverUiState.ContentUiState ?: return newCards
+    private suspend fun preserveFollowActionRunningState(newCards: List<ReaderCardUiState>): List<ReaderCardUiState> =
+        withContext(ioDispatcher) {
+            val currentUiState = _uiState.value as? DiscoverUiState.ContentUiState ?: return@withContext newCards
 
-        return newCards.map { card ->
-            if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
-                val updatedBlogs = card.blogs.map { blog ->
-                    val currentBlog = currentUiState.cards
-                        .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
-                        .flatMap { it.blogs }
-                        .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
+            newCards.map { card ->
+                if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
+                    val updatedBlogs = card.blogs.map { blog ->
+                        val currentBlog = currentUiState.cards
+                            .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
+                            .flatMap { it.blogs }
+                            .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
 
-                    if (currentBlog != null && currentBlog.isFollowActionRunning) {
-                        blog.copy(isFollowActionRunning = true)
-                    } else {
-                        blog
+                        if (currentBlog != null && currentBlog.isFollowActionRunning) {
+                            blog.copy(isFollowActionRunning = true)
+                        } else {
+                            blog
+                        }
                     }
+                    card.copy(blogs = updatedBlogs)
+                } else {
+                    card
                 }
-                card.copy(blogs = updatedBlogs)
-            } else {
-                card
             }
         }
-    }
 
     private fun dismissAnnouncementCard() {
         readerAnnouncementHelper.dismissReaderAnnouncement()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -200,7 +200,10 @@ class ReaderDiscoverViewModel @Inject constructor(
                 for (j in mutableBlogs.indices) {
                     val blog = mutableBlogs[j]
                     if (blog.blogId == data.blogId && blog.feedId == data.feedId) {
-                        mutableBlogs[j] = blog.copy(isFollowed = data.following, isFollowEnabled = data.isChangeFinal)
+                        mutableBlogs[j] = blog.copy(
+                            isFollowed = data.following,
+                            isFollowActionRunning = !data.isChangeFinal
+                        )
                         hasChangedBlogs = true
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -157,8 +157,11 @@ class ReaderDiscoverViewModel @Inject constructor(
                         emptyList()
                     }
 
+                    val newCards = convertCardsToUiStates(posts)
+                    val cardsWithPreservedState = preserveFollowActionRunningState(newCards)
+
                     _uiState.value = DiscoverUiState.ContentUiState(
-                        announcement + convertCardsToUiStates(posts),
+                        announcement + cardsWithPreservedState,
                         reloadProgressVisibility = false,
                         loadMoreProgressVisibility = false,
                     )
@@ -171,6 +174,30 @@ class ReaderDiscoverViewModel @Inject constructor(
                         _navigationEvents.value = Event(ShowReaderSubs)
                     }
                 }
+            }
+        }
+    }
+
+    private fun preserveFollowActionRunningState(newCards: List<ReaderCardUiState>): List<ReaderCardUiState> {
+        val currentUiState = _uiState.value as? DiscoverUiState.ContentUiState ?: return newCards
+
+        return newCards.map { card ->
+            if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
+                val updatedBlogs = card.blogs.map { blog ->
+                    val currentBlog = currentUiState.cards
+                        .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
+                        .flatMap { it.blogs }
+                        .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
+
+                    if (currentBlog != null && currentBlog.isFollowActionRunning) {
+                        blog.copy(isFollowActionRunning = true)
+                    } else {
+                        blog
+                    }
+                }
+                card.copy(blogs = updatedBlogs)
+            } else {
+                card
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.models.ReaderPost
@@ -179,30 +178,29 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
-    private suspend fun preserveFollowActionRunningState(newCards: List<ReaderCardUiState>): List<ReaderCardUiState> =
-        withContext(ioDispatcher) {
-            val currentUiState = _uiState.value as? DiscoverUiState.ContentUiState ?: return@withContext newCards
+    private fun preserveFollowActionRunningState(newCards: List<ReaderCardUiState>): List<ReaderCardUiState> {
+        val currentUiState = _uiState.value as? DiscoverUiState.ContentUiState ?: return newCards
 
-            newCards.map { card ->
-                if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
-                    val updatedBlogs = card.blogs.map { blog ->
-                        val currentBlog = currentUiState.cards
-                            .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
-                            .flatMap { it.blogs }
-                            .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
+        return newCards.map { card ->
+            if (card is ReaderCardUiState.ReaderRecommendedBlogsCardUiState) {
+                val updatedBlogs = card.blogs.map { blog ->
+                    val currentBlog = currentUiState.cards
+                        .filterIsInstance<ReaderCardUiState.ReaderRecommendedBlogsCardUiState>()
+                        .flatMap { it.blogs }
+                        .find { it.blogId == blog.blogId && it.feedId == blog.feedId }
 
-                        if (currentBlog != null && currentBlog.isFollowActionRunning) {
-                            blog.copy(isFollowActionRunning = true)
-                        } else {
-                            blog
-                        }
+                    if (currentBlog != null && currentBlog.isFollowActionRunning) {
+                        blog.copy(isFollowActionRunning = true)
+                    } else {
+                        blog
                     }
-                    card.copy(blogs = updatedBlogs)
-                } else {
-                    card
                 }
+                card.copy(blogs = updatedBlogs)
+            } else {
+                card
             }
         }
+    }
 
     private fun dismissAnnouncementCard() {
         readerAnnouncementHelper.dismissReaderAnnouncement()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -200,7 +200,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     description = it.description.ifEmpty { null },
                     iconUrl = it.imageUrl,
                     isFollowed = it.isFollowing,
-                    isFollowEnabled = true,
                     onFollowClicked = onFollowClicked,
                     onItemClicked = onItemClicked
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.databinding.ReaderRecommendedBlogItemBinding
@@ -29,12 +30,16 @@ class ReaderRecommendedBlogViewHolder(
         uiState: ReaderRecommendedBlogUiState,
         binding: ReaderRecommendedBlogItemBinding
     ) {
-        with(binding.siteFollowButton) {
-            isEnabled = uiState.isFollowEnabled
-            setIsFollowed(uiState.isFollowed)
-            contentDescription = context.getString(uiState.followContentDescription.stringRes)
-            setOnClickListener {
-                uiState.onFollowClicked(uiState)
+        with(binding) {
+            siteFollowProgress.visibility = if (uiState.isFollowActionRunning) View.VISIBLE else View.GONE
+            siteFollowButton.apply {
+                setIsLoading(uiState.isFollowActionRunning)
+                isEnabled = !uiState.isFollowActionRunning
+                setIsFollowed(uiState.isFollowed)
+                contentDescription = context.getString(uiState.followContentDescription.stringRes)
+                setOnClickListener {
+                    uiState.onFollowClicked(uiState)
+                }
             }
         }
     }
@@ -50,4 +55,5 @@ class ReaderRecommendedBlogViewHolder(
             imageManager.cancelRequestAndClearImageView(siteIcon)
         }
     }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
@@ -55,5 +55,4 @@ class ReaderRecommendedBlogViewHolder(
             imageManager.cancelRequestAndClearImageView(siteIcon)
         }
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -529,7 +530,9 @@ class ReaderPostDetailViewModel @Inject constructor(
     }
 
     fun onUpdatePost(post: ReaderPost) {
-        _uiState.value = convertPostToUiState(post)
+        viewModelScope.launch {
+            _uiState.value = convertPostToUiState(post)
+        }
     }
 
     fun onTagItemClicked(tagSlug: String) {
@@ -605,7 +608,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         )
     }
 
-    private fun convertPostToUiState(
+    private suspend fun convertPostToUiState(
         post: ReaderPost
     ): ReaderPostDetailsUiState {
         val newUiState = postDetailUiStateBuilder.mapPostToUiState(
@@ -616,13 +619,13 @@ class ReaderPostDetailViewModel @Inject constructor(
         return preserveFollowActionRunningState(newUiState)
     }
 
-    private fun preserveFollowActionRunningState(
+    private suspend fun preserveFollowActionRunningState(
         newUiState: ReaderPostDetailsUiState
-    ): ReaderPostDetailsUiState {
-        val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return newUiState
+    ): ReaderPostDetailsUiState = withContext(ioDispatcher) {
+        val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return@withContext newUiState
         val currentFollowButtonState = currentUiState.headerUiState.followButtonUiState
 
-        return if (currentFollowButtonState.isFollowActionRunning) {
+        if (currentFollowButtonState.isFollowActionRunning) {
             val updatedFollowButtonUiState = newUiState.headerUiState.followButtonUiState.copy(
                 isFollowActionRunning = true
             )
@@ -647,10 +650,12 @@ class ReaderPostDetailViewModel @Inject constructor(
     )
 
     private fun updatePostDetailsUi() {
-        post?.let {
-            readerTracker.trackPost(Stat.READER_ARTICLE_RENDERED, it)
-            _navigationEvents.postValue(Event(ShowPostInWebView(it)))
-            _uiState.value = convertPostToUiState(it)
+        viewModelScope.launch {
+            post?.let {
+                readerTracker.trackPost(Stat.READER_ARTICLE_RENDERED, it)
+                _navigationEvents.postValue(Event(ShowPostInWebView(it)))
+                _uiState.value = convertPostToUiState(it)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -608,7 +607,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         )
     }
 
-    private suspend fun convertPostToUiState(
+    private fun convertPostToUiState(
         post: ReaderPost
     ): ReaderPostDetailsUiState {
         val newUiState = postDetailUiStateBuilder.mapPostToUiState(
@@ -619,13 +618,13 @@ class ReaderPostDetailViewModel @Inject constructor(
         return preserveFollowActionRunningState(newUiState)
     }
 
-    private suspend fun preserveFollowActionRunningState(
+    private fun preserveFollowActionRunningState(
         newUiState: ReaderPostDetailsUiState
-    ): ReaderPostDetailsUiState = withContext(ioDispatcher) {
-        val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return@withContext newUiState
+    ): ReaderPostDetailsUiState {
+        val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return newUiState
         val currentFollowButtonState = currentUiState.headerUiState.followButtonUiState
 
-        if (currentFollowButtonState.isFollowActionRunning) {
+        return if (currentFollowButtonState.isFollowActionRunning) {
             val updatedFollowButtonUiState = newUiState.headerUiState.followButtonUiState.copy(
                 isFollowActionRunning = true
             )
@@ -650,12 +649,10 @@ class ReaderPostDetailViewModel @Inject constructor(
     )
 
     private fun updatePostDetailsUi() {
-        viewModelScope.launch {
-            post?.let {
-                readerTracker.trackPost(Stat.READER_ARTICLE_RENDERED, it)
-                _navigationEvents.postValue(Event(ShowPostInWebView(it)))
-                _uiState.value = convertPostToUiState(it)
-            }
+        post?.let {
+            readerTracker.trackPost(Stat.READER_ARTICLE_RENDERED, it)
+            _navigationEvents.postValue(Event(ShowPostInWebView(it)))
+            _uiState.value = convertPostToUiState(it)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -622,16 +622,17 @@ class ReaderPostDetailViewModel @Inject constructor(
         val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return newUiState
         val currentFollowButtonState = currentUiState.headerUiState.followButtonUiState
 
-        if (currentFollowButtonState.isFollowActionRunning) {
+        return if (currentFollowButtonState.isFollowActionRunning) {
             val updatedFollowButtonUiState = newUiState.headerUiState.followButtonUiState.copy(
                 isFollowActionRunning = true
             )
             val updatedHeaderUiState = newUiState.headerUiState.copy(
                 followButtonUiState = updatedFollowButtonUiState
             )
-            return newUiState.copy(headerUiState = updatedHeaderUiState)
+            newUiState.copy(headerUiState = updatedHeaderUiState)
+        } else {
+            newUiState
         }
-        return newUiState
     }
 
     private fun convertRelatedPostsToUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -255,7 +255,7 @@ class ReaderPostDetailViewModel @Inject constructor(
                     updateFollowButtonUiState(
                         currentUiState = currentUiState,
                         isFollowed = post.isFollowedByCurrentUser,
-                        isFollowEnabled = data.isChangeFinal
+                        isFollowActionRunning = !data.isChangeFinal
                     )
                 }
             }
@@ -608,11 +608,30 @@ class ReaderPostDetailViewModel @Inject constructor(
     private fun convertPostToUiState(
         post: ReaderPost
     ): ReaderPostDetailsUiState {
-        return postDetailUiStateBuilder.mapPostToUiState(
+        val newUiState = postDetailUiStateBuilder.mapPostToUiState(
             post = post,
             onButtonClicked = this@ReaderPostDetailViewModel::onButtonClicked,
             onHeaderAction = { action -> onHeaderAction(post, action) },
         )
+        return preserveFollowActionRunningState(newUiState)
+    }
+
+    private fun preserveFollowActionRunningState(
+        newUiState: ReaderPostDetailsUiState
+    ): ReaderPostDetailsUiState {
+        val currentUiState = _uiState.value as? ReaderPostDetailsUiState ?: return newUiState
+        val currentFollowButtonState = currentUiState.headerUiState.followButtonUiState
+
+        if (currentFollowButtonState.isFollowActionRunning) {
+            val updatedFollowButtonUiState = newUiState.headerUiState.followButtonUiState.copy(
+                isFollowActionRunning = true
+            )
+            val updatedHeaderUiState = newUiState.headerUiState.copy(
+                followButtonUiState = updatedFollowButtonUiState
+            )
+            return newUiState.copy(headerUiState = updatedHeaderUiState)
+        }
+        return newUiState
     }
 
     private fun convertRelatedPostsToUiState(
@@ -637,12 +656,15 @@ class ReaderPostDetailViewModel @Inject constructor(
     private fun updateFollowButtonUiState(
         currentUiState: ReaderPostDetailsUiState,
         isFollowed: Boolean,
-        isFollowEnabled: Boolean,
+        isFollowActionRunning: Boolean,
     ) {
         val updatedFollowButtonUiState = currentUiState
             .headerUiState
             .followButtonUiState
-            .copy(isFollowed = isFollowed, isEnabled = isFollowEnabled)
+            .copy(
+                isFollowed = isFollowed,
+                isFollowActionRunning = isFollowActionRunning
+            )
 
         val updatedHeaderUiState = currentUiState
             .headerUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -24,6 +24,7 @@ class ReaderFollowButton @JvmOverloads constructor(
 ) : MaterialButton(context, attrs, defStyleAttr) {
     private var isFollowed = false
     private var showCaption = false
+    private var isLoading = false
 
     init {
         initView(context, attrs)
@@ -57,6 +58,14 @@ class ReaderFollowButton @JvmOverloads constructor(
     fun setIsFollowedAnimated(isFollowed: Boolean) {
         setIsFollowed(isFollowed, true)
     }
+
+    fun setIsLoading(loading: Boolean) {
+        if (isLoading == loading) return
+        isLoading = loading
+        isEnabled = !loading
+    }
+
+    fun getIsLoading(): Boolean = isLoading
 
     @SuppressLint("Recycle")
     private fun setIsFollowed(isFollowed: Boolean, animateChanges: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
@@ -58,7 +58,7 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
         uiHelpers.setTextOrHide(layoutBlogSection.blogSectionTextBlogName, uiState.blogSectionUiState.blogName)
 
-        headerFollowButton.update(uiState.followButtonUiState)
+        updateFollowButton(uiState.followButtonUiState)
 
         updateAvatars(uiState.blogSectionUiState)
         updateBlogSectionClick(uiState.blogSectionUiState)
@@ -113,11 +113,17 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
         }
     }
 
-    private fun ReaderFollowButton.update(followButtonUiState: FollowButtonUiState) {
-        isEnabled = followButtonUiState.isEnabled
-        setVisible(followButtonUiState.isVisible)
-        setIsFollowed(followButtonUiState.isFollowed)
-        setOnClickListener { followButtonUiState.onFollowButtonClicked?.invoke() }
+    private fun ReaderPostDetailHeaderViewBinding.updateFollowButton(
+        followButtonUiState: FollowButtonUiState
+    ) {
+        headerFollowButtonContainer.setVisible(followButtonUiState.isVisible)
+        headerFollowProgress.setVisible(followButtonUiState.isFollowActionRunning)
+        headerFollowButton.apply {
+            setIsLoading(followButtonUiState.isFollowActionRunning)
+            isEnabled = !followButtonUiState.isFollowActionRunning
+            setIsFollowed(followButtonUiState.isFollowed)
+            setOnClickListener { followButtonUiState.onFollowButtonClicked?.invoke() }
+        }
     }
 
     private fun setAuthorAndDate(authorName: String?, dateLine: String) = with(binding.layoutBlogSection) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
@@ -74,7 +74,6 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
         return FollowButtonUiState(
             onFollowButtonClicked = onFollowClicked,
             isFollowed = post.isFollowedByCurrentUser,
-            isEnabled = hasAccessToken,
             isVisible = hasAccessToken
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -13,6 +13,8 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderBlogTable;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -56,7 +56,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private boolean mIsFeed;
 
     private ReaderFollowButton mFollowButton;
-    private ProgressBar mFollowProgress;
+    @Nullable private ProgressBar mFollowProgress;
     private ReaderBlog mBlogInfo;
     private OnBlogInfoLoadedListener mBlogInfoListener;
     private OnFollowListener mFollowListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -55,6 +56,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private boolean mIsFeed;
 
     private ReaderFollowButton mFollowButton;
+    private ProgressBar mFollowProgress;
     private ReaderBlog mBlogInfo;
     private OnBlogInfoLoadedListener mBlogInfoListener;
     private OnFollowListener mFollowListener;
@@ -84,6 +86,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private void initView(Context context) {
         final View view = inflate(context, R.layout.reader_site_header_view, this);
         mFollowButton = view.findViewById(R.id.follow_button);
+        mFollowProgress = view.findViewById(R.id.follow_button_progress);
         view.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
     }
 
@@ -244,12 +247,17 @@ public class ReaderSiteHeaderView extends LinearLayout {
                 PhotonUtils.getPhotonImageUrl(blogInfo.getImageUrl(), mBlavatarSz, mBlavatarSz, Quality.HIGH));
     }
 
+    private void setFollowButtonLoading(boolean isLoading) {
+        mFollowButton.setIsLoading(isLoading);
+        mFollowProgress.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+    }
+
     private void toggleFollowStatus(final View followButton, final String source) {
         if (!NetworkUtils.checkConnection(getContext())) {
             return;
         }
-        // disable follow button until API call returns
-        mFollowButton.setEnabled(false);
+        // disable follow button and show loading indicator until API call returns
+        setFollowButtonLoading(true);
 
         final boolean isAskingToFollow;
         if (mIsFeed) {
@@ -276,7 +284,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
             if (getContext() == null) {
                 return;
             }
-            mFollowButton.setEnabled(true);
+            setFollowButtonLoading(false);
             if (!succeeded) {
                 int errResId = isAskingToFollow ? R.string.reader_toast_err_unable_to_follow_blog
                         : R.string.reader_toast_err_unable_to_unfollow_blog;
@@ -308,6 +316,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
         }
 
         if (!result) {
+            setFollowButtonLoading(false);
             mFollowButton.setIsFollowed(!isAskingToFollow);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -48,7 +48,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
         with(uiState.followButtonUiState) {
             val followButton = binding.followContainer.followButton
             followButton.setIsFollowed(isFollowed)
-            followButton.isEnabled = isEnabled
+            followButton.isEnabled = !isFollowActionRunning
             onFollowBtnClicked = onFollowButtonClicked
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/FollowButtonUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/FollowButtonUiState.kt
@@ -3,6 +3,6 @@ package org.wordpress.android.ui.reader.views.uistates
 data class FollowButtonUiState(
     val onFollowButtonClicked: (() -> Unit)?,
     val isFollowed: Boolean,
-    val isEnabled: Boolean,
-    val isVisible: Boolean = true
+    val isVisible: Boolean = true,
+    val isFollowActionRunning: Boolean = false
 )

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
         android:textColor="?attr/colorOnSurface"
-        app:layout_constraintBottom_toTopOf="@+id/follow_button"
+        app:layout_constraintBottom_toTopOf="@+id/follow_button_container"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginBottom="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -18,13 +18,29 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="123 posts • 1.2m followers" />
 
-    <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/follow_button"
-        style="@style/Reader.Follow.Button.New"
+    <FrameLayout
+        android:id="@+id/follow_button_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count" />
+        app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count">
+
+        <org.wordpress.android.ui.reader.views.ReaderFollowButton
+            android:id="@+id/follow_button"
+            style="@style/Reader.Follow.Button.New"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <ProgressBar
+            android:id="@+id/follow_button_progress"
+            android:layout_width="@dimen/reader_follow_button_progress_size"
+            android:layout_height="@dimen/reader_follow_button_progress_size"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -18,19 +18,35 @@
         android:clickable="true"
         android:focusable="true"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/header_follow_button"
+        app:layout_constraintEnd_toStartOf="@id/header_follow_button_container"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/header_follow_button"
-        style="@style/Reader.Follow.Button.New"
+    <FrameLayout
+        android:id="@+id/header_follow_button_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/layout_blog_section"
         app:layout_constraintBottom_toBottomOf="@id/layout_blog_section"
-        tools:visibility="visible" />
+        tools:visibility="visible">
+
+        <org.wordpress.android.ui.reader.views.ReaderFollowButton
+            android:id="@+id/header_follow_button"
+            style="@style/Reader.Follow.Button.New"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+        <ProgressBar
+            android:id="@+id/header_follow_progress"
+            android:layout_width="@dimen/reader_follow_button_progress_size"
+            android:layout_height="@dimen/reader_follow_button_progress_size"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_title"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
@@ -34,7 +34,7 @@
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toTopOf="@+id/site_url"
-        app:layout_constraintEnd_toStartOf="@id/site_follow_button"
+        app:layout_constraintEnd_toStartOf="@id/site_follow_container"
         app:layout_constraintStart_toEndOf="@id/site_icon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -55,14 +55,30 @@
         app:layout_constraintTop_toBottomOf="@+id/site_name"
         tools:text="site.com site.com site.com site.com site.com site.com site.com site.com " />
 
-    <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/site_follow_button"
-        style="@style/Reader.Follow.Button.New"
+    <FrameLayout
+        android:id="@+id/site_follow_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/reader_btn_subscribe"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <org.wordpress.android.ui.reader.views.ReaderFollowButton
+            android:id="@+id/site_follow_button"
+            style="@style/Reader.Follow.Button.New"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:contentDescription="@string/reader_btn_subscribe" />
+
+        <ProgressBar
+            android:id="@+id/site_follow_progress"
+            android:layout_width="@dimen/reader_follow_button_progress_size"
+            android:layout_height="@dimen/reader_follow_button_progress_size"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -192,6 +192,7 @@
     <dimen name="reader_more_icon">36dp</dimen>
     <dimen name="reader_follow_icon">24dp</dimen>
     <dimen name="reader_follow_button_min_height">36dp</dimen>
+    <dimen name="reader_follow_button_progress_size">24dp</dimen>
 
     <dimen name="reader_post_card_new_more_icon">24dp</dimen>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -745,7 +745,6 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
                     onItemClicked = onItemClicked,
                     onFollowClicked = onFollowClicked,
                     isFollowed = it.isFollowing,
-                    isFollowEnabled = true,
                 )
             }
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -625,6 +625,97 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
         verify(readerDiscoverDataProvider).refreshCards()
     }
 
+    @Test
+    fun `When follow status changes and is not final, isFollowActionRunning is true`() = test {
+        // Arrange
+        val (uiStates) = init(autoUpdateFeed = false)
+        fakeDiscoverFeed.value = ReaderDiscoverCards(createReaderRecommendedBlogsCardList())
+
+        // Act
+        fakeFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = 1L,
+            feedId = 0L,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Assert
+        val contentUiState = uiStates.last() as ContentUiState
+        val blogCard = contentUiState.cards.first() as ReaderRecommendedBlogsCardUiState
+        assertThat(blogCard.blogs[0].isFollowActionRunning).isTrue
+    }
+
+    @Test
+    fun `When follow status changes and is final, isFollowActionRunning is false`() = test {
+        // Arrange
+        val (uiStates) = init(autoUpdateFeed = false)
+        fakeDiscoverFeed.value = ReaderDiscoverCards(createReaderRecommendedBlogsCardList())
+
+        // Act
+        fakeFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = 1L,
+            feedId = 0L,
+            following = true,
+            isChangeFinal = true
+        )
+
+        // Assert
+        val contentUiState = uiStates.last() as ContentUiState
+        val blogCard = contentUiState.cards.first() as ReaderRecommendedBlogsCardUiState
+        assertThat(blogCard.blogs[0].isFollowActionRunning).isFalse
+    }
+
+    @Test
+    fun `When feed updates during follow action, isFollowActionRunning state is preserved`() = test {
+        // Arrange
+        val (uiStates) = init(autoUpdateFeed = false)
+        fakeDiscoverFeed.value = ReaderDiscoverCards(createReaderRecommendedBlogsCardList())
+
+        // Simulate follow action starting (not final)
+        fakeFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = 1L,
+            feedId = 0L,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Act - simulate feed refresh while follow action is running
+        fakeDiscoverFeed.value = ReaderDiscoverCards(createReaderRecommendedBlogsCardList())
+
+        // Assert - the running state should be preserved
+        val contentUiState = uiStates.last() as ContentUiState
+        val blogCard = contentUiState.cards.first() as ReaderRecommendedBlogsCardUiState
+        assertThat(blogCard.blogs[0].isFollowActionRunning).isTrue
+    }
+
+    @Test
+    fun `When follow action completes after feed refresh, isFollowActionRunning becomes false`() = test {
+        // Arrange
+        val (uiStates) = init(autoUpdateFeed = false)
+        fakeDiscoverFeed.value = ReaderDiscoverCards(createReaderRecommendedBlogsCardList())
+
+        // Simulate follow action starting (not final)
+        fakeFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = 1L,
+            feedId = 0L,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Act - complete the follow action
+        fakeFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = 1L,
+            feedId = 0L,
+            following = true,
+            isChangeFinal = true
+        )
+
+        // Assert
+        val contentUiState = uiStates.last() as ContentUiState
+        val blogCard = contentUiState.cards.first() as ReaderRecommendedBlogsCardUiState
+        assertThat(blogCard.blogs[0].isFollowActionRunning).isFalse
+    }
+
     private fun init(autoUpdateFeed: Boolean = true): Observers {
         val uiStates = mutableListOf<DiscoverUiState>()
         viewModel.uiState.observeForever {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -1141,6 +1141,90 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         verify(readerTracker).track(AnalyticsTracker.Stat.READER_ARTICLE_TEXT_HIGHLIGHTED)
     }
 
+    /* FOLLOW BUTTON LOADING STATE */
+    @Test
+    fun `when follow status changes and is not final, isFollowActionRunning is true`() = test {
+        // Arrange
+        val observers = init()
+
+        // Act
+        fakePostFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = readerPost.blogId,
+            feedId = readerPost.feedId,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Assert
+        val uiState = observers.uiStates.last() as ReaderPostDetailsUiState
+        assertThat(uiState.headerUiState.followButtonUiState.isFollowActionRunning).isTrue
+    }
+
+    @Test
+    fun `when follow status changes and is final, isFollowActionRunning is false`() = test {
+        // Arrange
+        val observers = init()
+
+        // Act
+        fakePostFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = readerPost.blogId,
+            feedId = readerPost.feedId,
+            following = true,
+            isChangeFinal = true
+        )
+
+        // Assert
+        val uiState = observers.uiStates.last() as ReaderPostDetailsUiState
+        assertThat(uiState.headerUiState.followButtonUiState.isFollowActionRunning).isFalse
+    }
+
+    @Test
+    fun `when post updates during follow action, isFollowActionRunning state is preserved`() = test {
+        // Arrange
+        val observers = init()
+
+        // Simulate follow action starting (not final)
+        fakePostFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = readerPost.blogId,
+            feedId = readerPost.feedId,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Act - simulate post update while follow action is running
+        viewModel.onUpdatePost(readerPost)
+
+        // Assert - the running state should be preserved
+        val uiState = observers.uiStates.last() as ReaderPostDetailsUiState
+        assertThat(uiState.headerUiState.followButtonUiState.isFollowActionRunning).isTrue
+    }
+
+    @Test
+    fun `when follow action completes, isFollowActionRunning becomes false`() = test {
+        // Arrange
+        val observers = init()
+
+        // Simulate follow action starting (not final)
+        fakePostFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = readerPost.blogId,
+            feedId = readerPost.feedId,
+            following = true,
+            isChangeFinal = false
+        )
+
+        // Act - complete the follow action
+        fakePostFollowStatusChangedFeed.value = FollowStatusChanged(
+            blogId = readerPost.blogId,
+            feedId = readerPost.feedId,
+            following = true,
+            isChangeFinal = true
+        )
+
+        // Assert
+        val uiState = observers.uiStates.last() as ReaderPostDetailsUiState
+        assertThat(uiState.headerUiState.followButtonUiState.isFollowActionRunning).isFalse
+    }
+
     private fun <T> testWithoutLocalPost(block: suspend CoroutineScope.() -> T) {
         test {
             whenever(readerGetPostUseCase.get(any(), any(), any())).thenReturn(Pair(null, false))

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -1197,7 +1197,6 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
                 FollowButtonUiState(
                     onFollowButtonClicked = mock(),
                     isFollowed = false,
-                    isEnabled = true,
                     isVisible = true
                 ),
                 "",


### PR DESCRIPTION
## Description

This PR adds loading indicators and disables subscribe/unsubscribe buttons while the follow action is in progress across multiple Reader screens. 
The previous UX was a bit poor, allowing the user to tap multiple times with no visual feedback and causing unexpected outputs.
The changes prevent users from tapping the button multiple times between actions, so it feels smoother and does not cause confusion/unexpected behavior.

Bug:

https://github.com/user-attachments/assets/38dfddbd-8a3c-4e42-8762-f716e641b123




## Testing instructions
Reader Discover - Recommended Blogs Card

  - Open Reader > Discover tab
  - Scroll to find a "Recommended Blogs" card
  - Tap the Subscribe button on any blog
  - Verify a spinner appears on the button and it becomes disabled
  - Verify the spinner disappears when the action completes
  - Verify the button shows the correct state (Subscribed/Subscribe)
  - Repeat for unsubscribe action

  Post Detail Screen

  - Open any post from the Reader
  - Tap the Subscribe button in the post header
  - Verify a spinner appears on the button and it becomes disabled
  - Verify the spinner disappears when the action completes
  - Verify the button shows the correct state (Subscribed/Subscribe)
  - Repeat for unsubscribe action
  - Scroll down and back up while loading - verify spinner persists

  Blog/Site Header View

  - From a post, tap on the blog name/avatar to open the blog
  - Tap the Subscribe button in the blog header
  - Verify a spinner appears on the button and it becomes disabled
  - Verify the spinner disappears when the action completes
  - Verify the button shows the correct state (Subscribed/Subscribe)
  - Repeat for unsubscribe action


https://github.com/user-attachments/assets/4022a149-8cae-4cba-9020-7361fbd93f05

https://github.com/user-attachments/assets/38ce75b5-3b0e-4f22-9c5b-1146b1df25de

https://github.com/user-attachments/assets/4ef54794-c98a-44f6-ba05-9e52886de7b6


<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->