### PR TITLE
Migrate `HttpURLConnection` usages to `OkHttp`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/he/util/TempAttachmentsUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/he/util/TempAttachmentsUtil.kt
@@ -8,15 +8,17 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.util.AppLog
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.collections.forEach
 
 class TempAttachmentsUtil @Inject constructor(
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
+    @Named("regular") private val okHttpClient: OkHttpClient,
     private val appLogWrapper: AppLogWrapper,
     private val application: Application,
     private val accountStore: AccountStore
@@ -97,44 +99,46 @@ class TempAttachmentsUtil @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     suspend fun createVideoTempFile(videoUrl: String): File? = withContext(ioDispatcher) {
         var tempFile: File? = null
-        var connection: HttpURLConnection? = null
 
         try {
             tempFile = File.createTempFile("video_", ".mp4", application.cacheDir)
-            connection = (URL(videoUrl).openConnection() as HttpURLConnection).apply {
-                requestMethod = "GET"
-                setRequestProperty("Authorization", "Bearer ${accountStore.accessToken}")
-                instanceFollowRedirects = true
-                connectTimeout = CONNECTION_TIMEOUT_MS
-                readTimeout = READ_TIMEOUT_MS
-            }
 
-            connection.connect()
+            val request = Request.Builder()
+                .url(videoUrl)
+                .addHeader("Authorization", "Bearer ${accountStore.accessToken}")
+                .build()
 
-            val responseCode = connection.responseCode
-            AppLog.d(AppLog.T.SUPPORT, "Download response code: $responseCode")
+            val client = okHttpClient.newBuilder()
+                .connectTimeout(CONNECTION_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
+                .readTimeout(READ_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
+                .build()
 
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                connection.inputStream.use { input ->
-                    tempFile.outputStream().use { output ->
-                        input.copyTo(output)
+            client.newCall(request).execute().use { response ->
+                val responseCode = response.code
+                AppLog.d(AppLog.T.SUPPORT, "Download response code: $responseCode")
+
+                if (response.isSuccessful) {
+                    response.body?.byteStream()?.use { input ->
+                        tempFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
                     }
-                }
 
-                AppLog.d(AppLog.T.SUPPORT, "Video downloaded: ${tempFile.absolutePath}")
-                tempFile
-            } else {
-                val deleted = tempFile?.delete()
-                AppLog.e(AppLog.T.SUPPORT, "Failed to download video. Deleted: ${deleted} - " +
-                        "Response code: $responseCode")
-                null
+                    AppLog.d(AppLog.T.SUPPORT, "Video downloaded: ${tempFile.absolutePath}")
+                    tempFile
+                } else {
+                    val deleted = tempFile?.delete()
+                    AppLog.e(
+                        AppLog.T.SUPPORT,
+                        "Failed to download video. Deleted: $deleted - Response code: $responseCode"
+                    )
+                    null
+                }
             }
         } catch (e: Exception) {
             val deleted = tempFile?.delete()
-            AppLog.e(AppLog.T.SUPPORT, "Error downloading video: ${e.message} Deleted: ${deleted}")
+            AppLog.e(AppLog.T.SUPPORT, "Error downloading video: ${e.message} Deleted: $deleted")
             null
-        } finally {
-            connection?.disconnect()
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -27,11 +27,16 @@ import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.helpers.WebChromeClientWithVideoPoster;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 /*
  * WebView descendant used by ReaderPostDetailFragment - handles
@@ -81,6 +86,7 @@ public class ReaderWebView extends WPWebView {
 
     @Inject UserAgent mUserAgent;
     @Inject AccountStore mAccountStore;
+    @Inject @Named("regular") OkHttpClient mOkHttpClient;
 
     public ReaderWebView(Context context) {
         super(context);
@@ -106,7 +112,7 @@ public class ReaderWebView extends WPWebView {
 
             mReaderChromeClient = new ReaderWebChromeClient(this);
             this.setWebChromeClient(mReaderChromeClient);
-            this.setWebViewClient(new ReaderWebViewClient(this, mUserAgent));
+            this.setWebViewClient(new ReaderWebViewClient(this, mUserAgent, mOkHttpClient));
             this.getSettings().setUserAgentString(mUserAgent.getWebViewUserAgent());
 
             // Enable third-party cookies since they are disabled by default;
@@ -265,13 +271,15 @@ public class ReaderWebView extends WPWebView {
     private static class ReaderWebViewClient extends WebViewClient {
         private final ReaderWebView mReaderWebView;
         private final UserAgent mUserAgent;
+        private final OkHttpClient mOkHttpClient;
 
-        ReaderWebViewClient(ReaderWebView readerWebView, UserAgent userAgent) {
+        ReaderWebViewClient(ReaderWebView readerWebView, UserAgent userAgent, OkHttpClient okHttpClient) {
             if (readerWebView == null) {
                 throw new IllegalArgumentException("ReaderWebViewClient requires readerWebView");
             }
             mReaderWebView = readerWebView;
             mUserAgent = userAgent;
+            mOkHttpClient = okHttpClient;
         }
 
 
@@ -310,15 +318,26 @@ public class ReaderWebView extends WPWebView {
             if (imageUrl != null && WPUrlUtils.safeToAddWordPressComAuthToken(imageUrl)
                 && !TextUtils.isEmpty(mToken)) {
                 try {
-                    HttpURLConnection conn = (HttpURLConnection) imageUrl.openConnection();
-                    conn.setRequestProperty("Authorization", "Bearer " + mToken);
-                    conn.setReadTimeout(TIMEOUT_MS);
-                    conn.setConnectTimeout(TIMEOUT_MS);
-                    conn.setRequestProperty("User-Agent", mUserAgent.getWebViewUserAgent());
-                    conn.setRequestProperty("Connection", "Keep-Alive");
-                    return new WebResourceResponse(conn.getContentType(),
-                            conn.getContentEncoding(),
-                            conn.getInputStream());
+                    Request request = new Request.Builder()
+                            .url(imageUrl)
+                            .addHeader("Authorization", "Bearer " + mToken)
+                            .addHeader("User-Agent", mUserAgent.getWebViewUserAgent())
+                            .addHeader("Connection", "Keep-Alive")
+                            .build();
+
+                    OkHttpClient client = mOkHttpClient.newBuilder()
+                            .connectTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                            .readTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                            .build();
+
+                    Response okResponse = client.newCall(request).execute();
+                    if (okResponse.body() != null) {
+                        return new WebResourceResponse(
+                                okResponse.header("Content-Type"),
+                                okResponse.header("Content-Encoding"),
+                                okResponse.body().byteStream()
+                        );
+                    }
                 } catch (IOException e) {
                     AppLog.e(AppLog.T.READER, e);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
@@ -12,13 +12,18 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import static org.wordpress.android.util.SelfSignedSSLUtils.sslCertificateToX509;
 
@@ -35,6 +40,7 @@ public class WPWebViewClient extends URLFilteredWebViewClient {
     private final SiteModel mSite;
     private String mToken;
     @Inject protected MemorizingTrustManager mMemorizingTrustManager;
+    @Inject @Named("regular") protected OkHttpClient mOkHttpClient;
 
     public WPWebViewClient(SiteModel site, String token, List<String> urls,
                            ErrorManagedWebViewClientListener listener) {
@@ -72,16 +78,24 @@ public class WPWebViewClient extends URLFilteredWebViewClient {
             && !TextUtils.isEmpty(mToken)) {
             try {
                 // Force use of HTTPS for the resource, otherwise the request will fail for private sites
-                HttpURLConnection urlConnection = (HttpURLConnection) imageUrl.openConnection();
-                urlConnection.setRequestProperty("Authorization", "Bearer " + mToken);
-                urlConnection.setReadTimeout(TIMEOUT_MS);
-                urlConnection.setConnectTimeout(TIMEOUT_MS);
-                WebResourceResponse response = new WebResourceResponse(urlConnection.getContentType(),
-                                                                       urlConnection.getContentEncoding(),
-                                                                       urlConnection.getInputStream());
-                return response;
-            } catch (ClassCastException e) {
-                AppLog.e(AppLog.T.POSTS, "Invalid connection type - URL: " + stringUrl);
+                Request request = new Request.Builder()
+                        .url(imageUrl)
+                        .addHeader("Authorization", "Bearer " + mToken)
+                        .build();
+
+                OkHttpClient client = mOkHttpClient.newBuilder()
+                        .connectTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        .readTimeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        .build();
+
+                Response okResponse = client.newCall(request).execute();
+                if (okResponse.body() != null) {
+                    return new WebResourceResponse(
+                            okResponse.header("Content-Type"),
+                            okResponse.header("Content-Encoding"),
+                            okResponse.body().byteStream()
+                    );
+                }
             } catch (MalformedURLException e) {
                 AppLog.e(AppLog.T.POSTS, "Malformed URL: " + stringUrl);
             } catch (IOException e) {


### PR DESCRIPTION
## Summary

Migrate remaining `HttpURLConnection` usages to `OkHttp` for consistency with the rest of the codebase. Using the shared `OkHttpClient` provides unified configuration, better connection pooling, and consistent timeout/auth handling.

## Changes

- **`VideoLoader`**: Use OkHttp HEAD request to fetch video Content-Length header
- **`TempAttachmentsUtil`**: Use OkHttp for downloading video attachments in support tickets
- **`WPWebViewClient`**: Use OkHttp for intercepting private site image requests in WebViews
- **`ReaderWebView`**: Use OkHttp for intercepting private post image requests in Reader

## Test Instructions

- [x] **Private site images**: View a post with images on a private site in Reader - images should load correctly
- [x] **Post preview**: Preview a post with images on a private site - images should load correctly
- [x] **Support video attachment**: Contact Support → attach a video → submit ticket - video should attach successfully
- [x] **Media library thumbnails**: My Site → More → Media - verify video thumbnails display correctly (requires at least one video < 10MB)
