### PR TITLE
CMM-1011 reader blog page logged out subscribe

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1415,6 +1415,14 @@ public class ActivityLauncher {
         activity.startActivityForResult(intent, RequestCodes.CREATE_SITE);
     }
 
+    public static void showMainActivityAndMeScreen(Context context) {
+        Intent intent = new Intent(context, WPMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_ME);
+        context.startActivity(intent);
+    }
+
     public static void showMainActivityAndSiteCreationActivity(Activity activity, SiteCreationSource source) {
         // If we just wanted to have WPMainActivity in the back stack after starting SiteCreationActivity, we could have
         // used a TaskStackBuilder to do so. However, since we want to handle the SiteCreationActivity result in

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -247,6 +247,7 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     public static final String ARG_IS_CHANGING_CONFIGURATION = "IS_CHANGING_CONFIGURATION";
     public static final String ARG_BYPASS_MIGRATION = "bypass_migration";
     public static final String ARG_MEDIA = "show_media";
+    public static final String ARG_ME = "show_me";
     public static final String ARG_OPEN_PAGE_MESSAGE = "open_page_message";
     private boolean mIsChangingConfiguration = false;
     private WPMainNavigationView mBottomNav;
@@ -955,6 +956,9 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                         initSelectedSite();
                     }
                     mActivityNavigator.viewCurrentBlogMedia(this, getSelectedSite());
+                    break;
+                case ARG_ME:
+                    if (mBottomNav != null) mBottomNav.setCurrentSelectedPage(PageType.ME);
                     break;
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -35,6 +35,8 @@ public class ReaderInterfaces {
         void onFollowTapped(View view, String blogName, long blogId, long feedId);
 
         void onFollowingTapped();
+
+        void onFollowTappedWhenLoggedOut();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderLoginRequiredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderLoginRequiredBottomSheetFragment.kt
@@ -1,0 +1,75 @@
+package org.wordpress.android.ui.reader
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.R
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.widgets.WPTextView
+
+/**
+ * A bottom sheet that prompts the user to log in to WordPress.com.
+ * Used when a logged-out user tries to perform actions that require authentication,
+ * such as subscribing to a blog.
+ *
+ * This fragment reuses the same layout as [SubfilterPageFragment] to maintain visual consistency
+ * with the empty state shown in the subfilter bottom sheet.
+ */
+class ReaderLoginRequiredBottomSheetFragment : BottomSheetDialogFragment() {
+    companion object {
+        const val TAG = "ReaderLoginRequiredBottomSheetFragment"
+
+        fun newInstance(): ReaderLoginRequiredBottomSheetFragment {
+            return ReaderLoginRequiredBottomSheetFragment()
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.subfilter_page_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Hide the recycler view since we only want to show the empty state
+        view.findViewById<RecyclerView>(R.id.content_recycler_view).visibility = View.GONE
+
+        // Show and configure the empty state container
+        val emptyStateContainer = view.findViewById<LinearLayout>(R.id.empty_state_container)
+        emptyStateContainer.visibility = View.VISIBLE
+
+        // Hide title (matching the logged-out empty state behavior)
+        view.findViewById<WPTextView>(R.id.title).visibility = View.GONE
+
+        // Set the text for logged-out users
+        view.findViewById<WPTextView>(R.id.text).setText(
+            R.string.reader_filter_self_hosted_empty_blogs_list
+        )
+
+        // Configure primary button for login
+        val primaryButton = view.findViewById<Button>(R.id.action_button_primary)
+        primaryButton.visibility = View.VISIBLE
+        primaryButton.setText(R.string.reader_filter_self_hosted_empty_sites_tags_action)
+        primaryButton.setOnClickListener {
+            dismiss()
+            if (BuildConfig.IS_JETPACK_APP) {
+                ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
+            } else {
+                ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
+            }
+        }
+
+        // Hide secondary button (not needed for login-only scenario)
+        view.findViewById<Button>(R.id.action_button_secondary).visibility = View.GONE
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderLoginRequiredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderLoginRequiredBottomSheetFragment.kt
@@ -8,7 +8,6 @@ import android.widget.Button
 import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.widgets.WPTextView
@@ -62,11 +61,7 @@ class ReaderLoginRequiredBottomSheetFragment : BottomSheetDialogFragment() {
         primaryButton.setText(R.string.reader_filter_self_hosted_empty_sites_tags_action)
         primaryButton.setOnClickListener {
             dismiss()
-            if (BuildConfig.IS_JETPACK_APP) {
-                ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
-            } else {
-                ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
-            }
+            ActivityLauncher.showMainActivityAndMeScreen(requireContext())
         }
 
         // Hide secondary button (not needed for login-only scenario)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -57,7 +57,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -936,16 +935,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             is ReaderNavigationEvents.ShowPostDetail,
             is ReaderNavigationEvents.ShowVideoViewer,
             is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
-            is ReaderNavigationEvents.ShowSignIn -> navigateToLogin()
+            is ReaderNavigationEvents.ShowLoginRequiredBottomSheet -> showLoginRequiredBottomSheet()
         }
     }
 
-    private fun navigateToLogin() {
-        if (BuildConfig.IS_JETPACK_APP) {
-            ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
-        } else {
-            ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
-        }
+    private fun showLoginRequiredBottomSheet() {
+        ReaderLoginRequiredBottomSheetFragment.newInstance()
+            .show(childFragmentManager, ReaderLoginRequiredBottomSheetFragment.TAG)
     }
 
     private fun updateFeaturedImage(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -2822,10 +2822,10 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
 
     override fun onFollowTappedWhenLoggedOut() {
         getSnackbarParent()?.let { snackbarParent ->
-            Snackbar.make(
-                snackbarParent,
-                R.string.reader_snackbar_err_cannot_follow_logged_out,
-                Snackbar.LENGTH_LONG
+            make(
+                view = snackbarParent,
+                text = getString(R.string.reader_snackbar_err_cannot_follow_logged_out),
+                duration = Snackbar.LENGTH_LONG
             ).setAction(R.string.reader_snackbar_err_cannot_follow_logged_out_action) {
                 if (BuildConfig.IS_JETPACK_APP) {
                     ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -38,6 +38,7 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -2817,6 +2818,22 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
 
     override fun onFollowingTapped() {
         dispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction())
+    }
+
+    override fun onFollowTappedWhenLoggedOut() {
+        getSnackbarParent()?.let { snackbarParent ->
+            Snackbar.make(
+                snackbarParent,
+                R.string.reader_snackbar_err_cannot_follow_logged_out,
+                Snackbar.LENGTH_LONG
+            ).setAction(R.string.reader_snackbar_err_cannot_follow_logged_out_action) {
+                if (BuildConfig.IS_JETPACK_APP) {
+                    ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
+                } else {
+                    ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
+                }
+            }.show()
+        }
     }
 
     @Suppress("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -38,7 +38,6 @@ import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -2821,19 +2820,8 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
     }
 
     override fun onFollowTappedWhenLoggedOut() {
-        getSnackbarParent()?.let { snackbarParent ->
-            make(
-                view = snackbarParent,
-                text = getString(R.string.reader_snackbar_err_cannot_follow_logged_out),
-                duration = Snackbar.LENGTH_LONG
-            ).setAction(R.string.reader_snackbar_err_cannot_follow_logged_out_action) {
-                if (BuildConfig.IS_JETPACK_APP) {
-                    ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
-                } else {
-                    ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
-                }
-            }.show()
-        }
+        ReaderLoginRequiredBottomSheetFragment.newInstance()
+            .show(childFragmentManager, ReaderLoginRequiredBottomSheetFragment.TAG)
     }
 
     @Suppress("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import org.wordpress.android.BuildConfig
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -24,6 +23,7 @@ import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType
+import org.wordpress.android.ui.reader.ReaderLoginRequiredBottomSheetFragment
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.comments.ThreadedCommentsActionSource.READER_POST_CARD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
@@ -40,7 +40,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReade
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderSubs
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportUser
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSignIn
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowLoginRequiredBottomSheet
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
@@ -222,16 +222,13 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
             OpenUrlType.INTERNAL
         )
         is ShowReaderSubs -> ReaderActivityLauncher.showReaderSubs(requireActivity())
-        is ShowSignIn -> navigateToLogin()
+        is ShowLoginRequiredBottomSheet -> showLoginRequiredBottomSheet()
         else -> Unit // Do Nothing
     }
 
-    private fun navigateToLogin() {
-        if (BuildConfig.IS_JETPACK_APP) {
-            ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
-        } else {
-            ActivityLauncher.showSignInForResultWpComOnly(requireActivity())
-        }
+    private fun showLoginRequiredBottomSheet() {
+        ReaderLoginRequiredBottomSheetFragment.newInstance()
+            .show(childFragmentManager, ReaderLoginRequiredBottomSheetFragment.TAG)
     }
 
     private fun showBookmarkSavedLocallyDialog(bookmarkDialog: ShowBookmarkedSavedOnlyLocallyDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -69,5 +69,5 @@ sealed class ReaderNavigationEvents {
     ) : ReaderNavigationEvents()
 
     data object ShowReadingPreferences : ReaderNavigationEvents()
-    data object ShowSignIn : ReaderNavigationEvents()
+    data object ShowLoginRequiredBottomSheet : ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -331,17 +331,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
     }
 
     private fun showSignInPrompt() {
-        _snackbarEvents.postValue(
-            Event(
-                SnackbarMessageHolder(
-                    UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out),
-                    UiStringRes(R.string.reader_snackbar_err_cannot_follow_logged_out_action),
-                    buttonAction = {
-                        _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowSignIn))
-                    }
-                )
-            )
-        )
+        _navigationEvents.postValue(Event(ReaderNavigationEvents.ShowLoginRequiredBottomSheet))
     }
 
     private suspend fun followSite(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.views
 
 import dagger.Reusable
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.reader.discover.ReaderPostTagsUiStateBuilder
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder
@@ -16,7 +15,6 @@ import javax.inject.Inject
 
 @Reusable
 class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
-    private val accountStore: AccountStore,
     private val postUiStateBuilder: ReaderPostUiStateBuilder,
     private val readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
@@ -25,7 +23,6 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
         post: ReaderPost,
         onHeaderAction: (ReaderPostDetailsHeaderAction) -> Unit,
     ): ReaderPostDetailsHeaderUiState {
-        val hasAccessToken = accountStore.hasAccessToken()
         val textTitle = post
             .takeIf { post.hasTitle() }
             ?.title?.let { UiStringText(it) }
@@ -44,7 +41,6 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
             ),
             followButtonUiState = buildFollowButtonUiState(
                 post,
-                hasAccessToken,
                 onFollowClicked = { onHeaderAction(ReaderPostDetailsHeaderAction.FollowClicked) }
             ),
             dateLine = buildDateLine(post),
@@ -68,14 +64,13 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
 
     private fun buildFollowButtonUiState(
         post: ReaderPost,
-        hasAccessToken: Boolean,
         onFollowClicked: () -> Unit
     ): FollowButtonUiState {
         return FollowButtonUiState(
             onFollowButtonClicked = onFollowClicked,
             isFollowed = post.isFollowedByCurrentUser,
-            isEnabled = hasAccessToken,
-            isVisible = hasAccessToken
+            isEnabled = true,
+            isVisible = true
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -189,18 +189,20 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         loadFollowCount(blogInfo, txtFollowCount);
 
-        if (!mAccountStore.hasAccessToken()) {
-            mFollowButton.setVisibility(View.GONE);
-        } else {
-            mFollowButton.setVisibility(View.VISIBLE);
-            mFollowButton.setIsFollowed(blogInfo.isFollowing);
-            mFollowButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View v) {
+        mFollowButton.setVisibility(View.VISIBLE);
+        mFollowButton.setIsFollowed(blogInfo.isFollowing);
+        mFollowButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!mAccountStore.hasAccessToken()) {
+                    if (mFollowListener != null) {
+                        mFollowListener.onFollowTappedWhenLoggedOut();
+                    }
+                } else {
                     toggleFollowStatus(v, source);
                 }
-            });
-        }
+            }
+        });
 
         if (layoutInfo.getVisibility() != View.VISIBLE) {
             layoutInfo.setVisibility(View.VISIBLE);


### PR DESCRIPTION
## Description
This PR follows the same approach for Subscribe CTA in blog page as done before for recommended cards and posts [here](https://github.com/wordpress-mobile/WordPress-Android/pull/22370)

So, when the users us logged out, they will see the subscribe button and will be directed to the "log in " screen when tapped on it.

## Testing instructions

1. Log in with a self-hosted site
2. Go to the reader and open a blog page
3. Tap on subscribe
- [ ] Verify you see the "log in message"
4. Follow the login action and log yourself
- [ ] Verify you can now subscribe to blogs


https://github.com/user-attachments/assets/507a0fb5-637e-419a-934d-cf578a36c3c1



<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->