### PR TITLE
Add constants for OkHttp `@Named` qualifier strings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -117,6 +117,7 @@ import java.io.File
 import java.io.IOException
 import java.net.CookieManager
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -209,7 +210,7 @@ class AppInitializer @Inject constructor(
     lateinit var tracker: Tracker
 
     @Inject
-    @Named("custom-ssl")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL)
     lateinit var requestQueue: RequestQueue
 
     @Inject

--- a/WordPress/src/main/java/org/wordpress/android/auth/WordPressCookieAuthenticator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/auth/WordPressCookieAuthenticator.kt
@@ -15,6 +15,7 @@ import okhttp3.Response
 import org.wordpress.android.fluxc.utils.PreferenceUtils.PreferenceUtilsWrapper
 import org.wordpress.android.util.AppLog
 import java.io.IOException
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -30,7 +31,7 @@ import androidx.core.content.edit
  */
 @Singleton
 class WordPressCookieAuthenticator @Inject constructor(
-    @Named("regular") private val okHttpClient: OkHttpClient,
+    @Named(OkHttpClientQualifiers.REGULAR) private val okHttpClient: OkHttpClient,
     @Named("IO_THREAD") private val ioDispatcher: CoroutineDispatcher,
     private val preferenceUtils: PreferenceUtilsWrapper
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.networking.GlideMShotsLoader
 import org.wordpress.android.networking.GlideRequestFactory
 import org.wordpress.android.networking.MShot
 import java.io.InputStream
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -24,11 +25,11 @@ import javax.inject.Named
 @GlideModule
 class WordPressGlideModule : AppGlideModule() {
     @Inject
-    @Named("custom-ssl-custom-redirects")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL_CUSTOM_REDIRECTS)
     lateinit var requestQueue: RequestQueue
 
     @Inject
-    @Named("no-redirects")
+    @Named(OkHttpClientQualifiers.NO_REDIRECTS)
     lateinit var noRedirectsRequestQueue: RequestQueue
 
     @Inject

--- a/WordPress/src/main/java/org/wordpress/android/support/he/util/TempAttachmentsUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/he/util/TempAttachmentsUtil.kt
@@ -12,13 +12,14 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.util.concurrent.TimeUnit
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.collections.forEach
 
 class TempAttachmentsUtil @Inject constructor(
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
-    @Named("regular") private val okHttpClient: OkHttpClient,
+    @Named(OkHttpClientQualifiers.REGULAR) private val okHttpClient: OkHttpClient,
     private val appLogWrapper: AppLogWrapper,
     private val application: Application,
     private val accountStore: AccountStore

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.ui.WPWebView;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
@@ -86,7 +87,7 @@ public class ReaderWebView extends WPWebView {
 
     @Inject UserAgent mUserAgent;
     @Inject AccountStore mAccountStore;
-    @Inject @Named("regular") OkHttpClient mOkHttpClient;
+    @Inject @Named(OkHttpClientQualifiers.REGULAR) OkHttpClient mOkHttpClient;
 
     public ReaderWebView(Context context) {
         super(context);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
@@ -10,6 +10,7 @@ import android.webkit.WebView;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -40,7 +41,7 @@ public class WPWebViewClient extends URLFilteredWebViewClient {
     private final SiteModel mSite;
     private String mToken;
     @Inject protected MemorizingTrustManager mMemorizingTrustManager;
-    @Inject @Named("regular") protected OkHttpClient mOkHttpClient;
+    @Inject @Named(OkHttpClientQualifiers.REGULAR) protected OkHttpClient mOkHttpClient;
 
     public WPWebViewClient(SiteModel site, String token, List<String> urls,
                            ErrorManagedWebViewClientListener listener) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientModule.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientModule.java
@@ -30,27 +30,27 @@ import okhttp3.internal.tls.OkHostnameVerifier;
 public abstract class OkHttpClientModule {
     @Singleton
     @Provides
-    @Named("no-cookies")
+    @Named(OkHttpClientQualifiers.NO_COOKIES)
     public static OkHttpClient provideNoCookiesOkHttpClientBuilder(
-            @Named("regular") final OkHttpClient okHttpRegularClient) {
+            @Named(OkHttpClientQualifiers.REGULAR) final OkHttpClient okHttpRegularClient) {
         return okHttpRegularClient.newBuilder()
                                   .cookieJar(CookieJar.NO_COOKIES)
                                   .build();
     }
 
     @Provides
-    @Named("no-redirects")
+    @Named(OkHttpClientQualifiers.NO_REDIRECTS)
     public static OkHttpClient provideNoRedirectsOkHttpClientBuilder(
-            @Named("custom-ssl") final OkHttpClient okHttpRegularClient) {
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) final OkHttpClient okHttpRegularClient) {
         return okHttpRegularClient.newBuilder()
                                   .followRedirects(false)
                                   .build();
     }
 
     @Provides
-    @Named("custom-ssl-custom-redirects")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL_CUSTOM_REDIRECTS)
     public static OkHttpClient provideCustomRedirectsOkHttpClientBuilder(
-            @Named("custom-ssl") final OkHttpClient okHttpRegularClient) {
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) final OkHttpClient okHttpRegularClient) {
         OkHttpClient.Builder builder = okHttpRegularClient.newBuilder().followRedirects(false);
         CustomRedirectInterceptor customRedirectInterceptor = new CustomRedirectInterceptor();
         builder.addInterceptor(customRedirectInterceptor);
@@ -59,9 +59,9 @@ public abstract class OkHttpClientModule {
 
     @Singleton
     @Provides
-    @Named("custom-ssl")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL)
     public static OkHttpClient provideMediaOkHttpClientInstanceCustomSSL(
-            @Named("regular") final OkHttpClient okHttpClient,
+            @Named(OkHttpClientQualifiers.REGULAR) final OkHttpClient okHttpClient,
             final MemorizingTrustManager memorizingTrustManager) {
         final OkHttpClient.Builder builder = okHttpClient.newBuilder();
         try {
@@ -76,17 +76,21 @@ public abstract class OkHttpClientModule {
         return builder.build();
     }
 
-    @Multibinds abstract @Named("interceptors") Set<Interceptor> interceptorSet();
+    @Multibinds
+    @Named(OkHttpClientQualifiers.INTERCEPTORS)
+    abstract Set<Interceptor> interceptorSet();
 
-    @Multibinds abstract @Named("network-interceptors") Set<Interceptor> networkInterceptorSet();
+    @Multibinds
+    @Named(OkHttpClientQualifiers.NETWORK_INTERCEPTORS)
+    abstract Set<Interceptor> networkInterceptorSet();
 
     @Singleton
     @Provides
-    @Named("regular")
+    @Named(OkHttpClientQualifiers.REGULAR)
     public static OkHttpClient provideMediaOkHttpClientInstance(
             final CookieJar cookieJar,
-            @Named("interceptors") Set<Interceptor> interceptors,
-            @Named("network-interceptors") Set<Interceptor> networkInterceptors) {
+            @Named(OkHttpClientQualifiers.INTERCEPTORS) Set<Interceptor> interceptors,
+            @Named(OkHttpClientQualifiers.NETWORK_INTERCEPTORS) Set<Interceptor> networkInterceptors) {
         final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
         for (Interceptor interceptor : interceptors) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientQualifiers.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientQualifiers.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.module
+
+/**
+ * Constants for @Named qualifiers used with OkHttpClient and RequestQueue dependency injection.
+ *
+ * These constants should be used instead of hardcoded strings to prevent typos
+ * and enable easier refactoring.
+ */
+object OkHttpClientQualifiers {
+    const val REGULAR = "regular"
+    const val CUSTOM_SSL = "custom-ssl"
+    const val NO_REDIRECTS = "no-redirects"
+    const val NO_COOKIES = "no-cookies"
+    const val CUSTOM_SSL_CUSTOM_REDIRECTS = "custom-ssl-custom-redirects"
+    const val INTERCEPTORS = "interceptors"
+    const val NETWORK_INTERCEPTORS = "network-interceptors"
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -56,43 +56,46 @@ public class ReleaseNetworkModule {
     }
 
     @Singleton
-    @Named("regular")
+    @Named(OkHttpClientQualifiers.REGULAR)
     @Provides
-    public RequestQueue provideRequestQueue(@Named("regular") OkHttpClient okHttpClient,
+    public RequestQueue provideRequestQueue(@Named(OkHttpClientQualifiers.REGULAR) OkHttpClient okHttpClient,
                                             Context appContext) {
         return newRequestQueue(okHttpClient, appContext);
     }
 
     @Singleton
-    @Named("no-redirects")
+    @Named(OkHttpClientQualifiers.NO_REDIRECTS)
     @Provides
-    public RequestQueue provideNoRedirectsRequestQueue(@Named("no-redirects") OkHttpClient okHttpClient,
-                                                       Context appContext) {
+    public RequestQueue provideNoRedirectsRequestQueue(
+            @Named(OkHttpClientQualifiers.NO_REDIRECTS) OkHttpClient okHttpClient,
+            Context appContext) {
         return newRetryOnRedirectRequestQueue(okHttpClient, appContext);
     }
 
     @Singleton
-    @Named("custom-ssl")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL)
     @Provides
-    public RequestQueue provideRequestQueueCustomSSL(@Named("custom-ssl") OkHttpClient okHttpClient,
-                                                     Context appContext) {
-        return newRequestQueue(okHttpClient, appContext);
-    }
-
-    @Singleton
-    @Named("custom-ssl-custom-redirects")
-    @Provides
-    public RequestQueue provideRequestQueueCustomSSLWithRedirects(
-            @Named("custom-ssl-custom-redirects") OkHttpClient okHttpClient,
+    public RequestQueue provideRequestQueueCustomSSL(
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) OkHttpClient okHttpClient,
             Context appContext) {
         return newRequestQueue(okHttpClient, appContext);
     }
 
     @Singleton
-    @Named("no-cookies")
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL_CUSTOM_REDIRECTS)
     @Provides
-    public RequestQueue provideRequestQueueNoCookies(@Named("no-cookies") OkHttpClient okHttpClient,
-                                                     Context appContext) {
+    public RequestQueue provideRequestQueueCustomSSLWithRedirects(
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL_CUSTOM_REDIRECTS) OkHttpClient okHttpClient,
+            Context appContext) {
+        return newRequestQueue(okHttpClient, appContext);
+    }
+
+    @Singleton
+    @Named(OkHttpClientQualifiers.NO_COOKIES)
+    @Provides
+    public RequestQueue provideRequestQueueNoCookies(
+            @Named(OkHttpClientQualifiers.NO_COOKIES) OkHttpClient okHttpClient,
+            Context appContext) {
         return newRequestQueue(okHttpClient, appContext);
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient;
 import org.wordpress.android.fluxc.network.rest.wpapi.OnWPAPIErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 
 import java.util.List;
@@ -30,7 +31,7 @@ import static org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFi
 public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
     @Inject public DiscoveryWPAPIRestClient(
             Dispatcher dispatcher,
-            @Named("custom-ssl") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
             UserAgent userAgent) {
         super(dispatcher, requestQueue, userAgent);
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryException;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
 
@@ -36,7 +37,7 @@ import static org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFi
 public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
     @Inject public DiscoveryXMLRPCClient(
             Dispatcher dispatcher,
-            @Named("custom-ssl") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
             UserAgent userAgent,
             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.HtmlUtils
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class NonceRestClient @Inject constructor(
     private val wpApiEncodedBodyRequestBuilder: WPAPIEncodedBodyRequestBuilder,
     private val currentTimeProvider: CurrentTimeProvider,
     dispatcher: Dispatcher,
-    @Named("no-redirects") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.NO_REDIRECTS) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     private val nonceMap: MutableMap<String, Nonce> = mutableMapOf()

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.toVolleyMethod
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import java.util.Optional
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -28,7 +29,7 @@ private const val UNAUTHORIZED = 401
 
 @Singleton
 class ApplicationPasswordsNetwork @Inject constructor(
-    @Named("no-cookies") private val requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.NO_COOKIES) private val requestQueue: RequestQueue,
     private val userAgent: UserAgent,
     private val listener: Optional<ApplicationPasswordsListener>
 ) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     appContext: Context,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -28,8 +29,8 @@ import kotlin.coroutines.resume
 internal class WPApiApplicationPasswordsRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val cookieNonceAuthenticator: CookieNonceAuthenticator,
-    @Named("no-cookies") private val noCookieRequestQueue: RequestQueue,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.NO_COOKIES) private val noCookieRequestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     dispatcher: Dispatcher,
     private val userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -30,8 +31,8 @@ class JetpackWPAPIRestClient @Inject constructor(
     private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
     dispatcher: Dispatcher,
-    @Named("custom-ssl") requestQueue: RequestQueue,
-    @Named("no-redirects") private val noRedirectsRequestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.NO_REDIRECTS) private val noRedirectsRequestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun fetchJetpackConnectionUrl(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.Appli
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -22,7 +23,7 @@ import javax.inject.Singleton
 class ApplicationPasswordsMediaRestClient @Inject constructor(
     dispatcher: Dispatcher,
     coroutineEngine: CoroutineEngine,
-    @Named("no-cookies") okHttpClient: OkHttpClient,
+    @Named(OkHttpClientQualifiers.NO_COOKIES) okHttpClient: OkHttpClient,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork
 ) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient) {
     @Inject internal lateinit var applicationPasswordsManager: ApplicationPasswordsManager

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -40,12 +40,13 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Named
 
 abstract class BaseWPV2MediaRestClient constructor(
     private val dispatcher: Dispatcher,
     private val coroutineEngine: CoroutineEngine,
-    @Named("regular") private val okHttpClient: OkHttpClient
+    @Named(OkHttpClientQualifiers.REGULAR) private val okHttpClient: OkHttpClient
 ) {
     private val gson: Gson by lazy { Gson() }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.PluginCoroutineStore.WPApiPluginsPayload
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -22,7 +23,7 @@ class PluginWPAPIRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     dispatcher: Dispatcher,
-    @Named("custom-ssl") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun fetchPlugins(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -18,7 +19,7 @@ import javax.inject.Singleton
 class ReactNativeWPAPIRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     dispatcher: Dispatcher,
-    @Named("custom-ssl") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun getRequest(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
 import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class SiteWPAPIRestClient @Inject constructor(
     private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
     dispatcher: Dispatcher,
-    @Named("custom-ssl") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     companion object {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ import javax.inject.Singleton
 class JetpackTunnelWPAPINetwork @Inject constructor(
     appContext: Context,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -20,7 +21,7 @@ import javax.inject.Singleton
 class WPComNetwork @Inject constructor(
     appContext: Context,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.store.AccountStore.SubscriptionResponsePayloa
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionType;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload.SubscriptionFrequency;
 import org.wordpress.android.fluxc.utils.extensions.StringExtensionsKt;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -210,7 +211,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     @Inject public AccountRestClient(Context appContext, Dispatcher dispatcher,
-                                     @Named("regular") RequestQueue requestQueue,
+                                     @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                              AppSecrets appSecrets, AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mAppSecrets = appSecrets;

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/close/CloseAccountRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/close/CloseAccountRestClient.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -20,7 +21,7 @@ import javax.inject.Singleton
 class CloseAccountRestClient @Inject constructor(
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/signup/SignUpRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/signup/SignUpRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.account.UsernameSuggestionsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ import javax.inject.Singleton
 class SignUpRestClient @Inject constructor(
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.utils.NetworkErrorMapper
 import org.wordpress.android.fluxc.utils.TimeZoneProvider
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -63,7 +64,7 @@ class ActivityLogRestClient @Inject constructor(
     private val timeZoneProvider: TimeZoneProvider,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -92,7 +93,7 @@ public class Authenticator {
 
     @Inject public Authenticator(Context appContext,
                          Dispatcher dispatcher,
-                         @Named("regular") RequestQueue requestQueue,
+                         @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                          AppSecrets secrets) {
         mAppContext = appContext;
         mDispatcher = dispatcher;

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/bloggingprompts/BloggingPromptsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/bloggingprompts/BloggingPromptsRestClient.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.bloggingprompts.BloggingPromptsRestClient.BloggingPromptResponse
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -29,7 +30,7 @@ class BloggingPromptsRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePaylo
 import org.wordpress.android.fluxc.store.CommentStore.FetchedCommentLikesResponsePayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePayload;
 import org.wordpress.android.fluxc.utils.CommentErrorUtils;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class CommentRestClient extends BaseWPComRestClient {
     @Inject public CommentRestClient(
             Context appContext,
             Dispatcher dispatcher,
-            @Named("regular") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
             AccessToken accessToken,
             UserAgent userAgent,
             @NonNull LikesUtilsProvider likesUtilsProvider) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestRe
 import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
 import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -27,7 +28,7 @@ import javax.inject.Singleton
 class CommentsRestClient @Inject constructor(
     appContext: Context?,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardErrorType
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardErrorType
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -46,7 +47,7 @@ class CardsRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/geo/WpComGeoRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/geo/WpComGeoRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -18,7 +19,7 @@ class WpComGeoRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class JetpackAIRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAITranscriptionRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAITranscriptionRestClient.kt
@@ -23,13 +23,14 @@ import java.lang.reflect.Type
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 
 class JetpackAITranscriptionRestClient  @Inject constructor(
     private val appContext: Context,
     private val userAgent: UserAgent,
-    @Named("regular") private val okHttpClient: OkHttpClient,
+    @Named(OkHttpClientQualifiers.REGULAR) private val okHttpClient: OkHttpClient,
     private val jetpackAIUtils: JetpackAITranscriptionUtils
 ) {
     companion object {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.utils.NetworkErrorMapper
 import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import java.net.URLEncoder
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -40,7 +41,7 @@ class JetpackRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.store.MediaStore.UploadedStockMediaPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.fluxc.utils.MimeType;
 import org.wordpress.android.fluxc.utils.WPComRestClientUtils;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
@@ -91,8 +92,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     @Inject public MediaRestClient(
             Context appContext,
             Dispatcher dispatcher,
-            @Named("regular") RequestQueue requestQueue,
-            @NonNull @Named("regular") OkHttpClient okHttpClient,
+            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
+            @NonNull @Named(OkHttpClientQualifiers.REGULAR) OkHttpClient okHttpClient,
             AccessToken accessToken,
             UserAgent userAgent,
             @NonNull MediaResponseUtils mediaResponseUtils) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -19,7 +20,7 @@ import javax.inject.Singleton
 class WPComV2MediaRestClient @Inject constructor(
     dispatcher: Dispatcher,
     coroutineEngine: CoroutineEngine,
-    @Named("regular") okHttpClient: OkHttpClient,
+    @Named(OkHttpClientQualifiers.REGULAR) okHttpClient: OkHttpClient,
     private val accessToken: AccessToken,
     private val wpComNetwork: WPComNetwork
 ) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.Store.OnChangedError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class FeatureFlagsRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClient.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload
 import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload.Success
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -22,7 +23,7 @@ class JetpackMigrationRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.mobile.RemoteConfigErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.Store.OnChangedError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class RemoteConfigRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobilepay/MobilePayRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobilepay/MobilePayRestClient.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -21,7 +22,7 @@ class MobilePayRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/notifications/NotificationRestClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import com.android.volley.RequestQueue
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -43,7 +44,7 @@ import org.wordpress.android.util.PackageUtils
 class NotificationRestClient @Inject constructor(
     private val appContext: Context?,
     private val dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.planoffers.PlanOffersRestClient.PlanOffersResponse.Feature
 import org.wordpress.android.fluxc.network.rest.wpcom.planoffers.PlanOffersRestClient.PlanOffersResponse.Plan
 import org.wordpress.android.fluxc.store.PlanOffersStore.PlanOffersFetchedPayload
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,7 +24,7 @@ class PlanOffersRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plans/PlansRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plans/PlansRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -19,7 +20,7 @@ class PlansRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -28,7 +29,7 @@ import javax.inject.Singleton
 class PluginJetpackTunnelRestClient @Inject constructor(
     private val dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginError;
 import org.wordpress.android.fluxc.store.PluginStore.UpdatedSitePluginPayload;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -46,7 +47,7 @@ import javax.inject.Singleton;
 @Singleton
 public class PluginRestClient extends BaseWPComRestClient {
     @Inject public PluginRestClient(Context appContext, Dispatcher dispatcher,
-                            @Named("regular") RequestQueue requestQueue,
+                            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                             AccessToken accessToken, UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -61,6 +61,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
 import org.wordpress.android.fluxc.store.PostStore.RemoteAutoSavePostPayload;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
@@ -82,7 +83,7 @@ public class PostRestClient extends BaseWPComRestClient {
 
     @Inject public PostRestClient(Context appContext,
                                   Dispatcher dispatcher,
-                                  @Named("regular") RequestQueue requestQueue,
+                                  @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                                   AccessToken accessToken,
                                   UserAgent userAgent,
                                   LikesUtilsProvider likesUtilsProvider) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -19,7 +20,7 @@ class ProductsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/qrcodeauth/QRCodeAuthRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/qrcodeauth/QRCodeAuthRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.Store.OnChangedError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,7 +24,7 @@ class QRCodeAuthRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -21,7 +22,7 @@ class ReactNativeWPComRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reader/ReaderRestClient.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderError;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderErrorType;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderSearchSitesResponsePayload;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
 
@@ -32,7 +33,7 @@ import javax.inject.Singleton;
 @Singleton
 public class ReaderRestClient extends BaseWPComRestClient {
     @Inject public ReaderRestClient(Context appContext, Dispatcher dispatcher,
-                            @Named("regular") RequestQueue requestQueue,
+                            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                             AccessToken accessToken,
                             UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.store.ScanStore.ScanStartResultPayload
 import org.wordpress.android.fluxc.store.ScanStore.ScanStateError
 import org.wordpress.android.fluxc.store.ScanStore.ScanStateErrorType
 import org.wordpress.android.fluxc.utils.NetworkErrorMapper
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -53,7 +54,7 @@ class ScanRestClient @Inject constructor(
     private val threatMapper: ThreatMapper,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteHomepageRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteHomepageRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class SiteHomepageRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -97,6 +97,7 @@ import java.io.UnsupportedEncodingException
 import java.net.URI
 import java.net.URLEncoder
 import java.util.Locale
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -107,7 +108,7 @@ import kotlin.math.max
 class SiteRestClient @Inject constructor(
     appContext: Context?,
     dispatcher: Dispatcher?,
-    @Named("regular") requestQueue: RequestQueue?,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue?,
     private val appSecrets: AppSecrets,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     accessToken: AccessToken?,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/XPostsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/XPostsRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -21,7 +22,7 @@ class XPostsRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
     dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/AllTimeInsightsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/AllTimeInsightsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class AllTimeInsightsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/CommentsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/CommentsRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class CommentsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/FollowersRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/FollowersRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class FollowersRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/LatestPostInsightsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/LatestPostInsightsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class LatestPostInsightsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,7 +24,7 @@ class MostPopularRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -28,7 +29,7 @@ class PostingActivityRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PublicizeRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PublicizeRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class PublicizeRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,7 +24,7 @@ class SummaryRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TagsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TagsRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.StatsUtils
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class TagsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TodayInsightsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/TodayInsightsRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import org.wordpress.android.fluxc.utils.SiteUtils
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class TodayInsightsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,7 +24,7 @@ class EmailsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class SubscribersRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClient.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.network.utils.getInt
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -31,7 +32,7 @@ class AuthorsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val gson: Gson,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClient.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -29,7 +30,7 @@ class ClicksRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val gson: Gson,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class CountryViewsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -27,7 +28,7 @@ class FileDownloadsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val gson: Gson,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class PostAndPageViewsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClient.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.StatsStore.ReportReferrerAsSpamPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -35,7 +36,7 @@ class ReferrersRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val gson: Gson,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class SearchTermsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val statsUtils: StatsUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
 import java.util.Date
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -27,7 +28,7 @@ class VideoPlaysRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
     val gson: Gson,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
 import org.wordpress.android.fluxc.store.toStatsError
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class VisitAndViewsRestClient
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.util.AppLog.T.MEDIA
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.UrlUtils
 import java.util.HashMap
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -38,7 +39,7 @@ class StockMediaRestClient @Inject constructor(
     private val mediaResponseUtils: MediaResponseUtils,
     dispatcher: Dispatcher,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
     @Inject public TaxonomyRestClient(
             Context appContext,
             Dispatcher dispatcher,
-            @Named("regular") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
             AccessToken accessToken,
             UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeCoroutineRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeCoroutineRestClient.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -16,7 +17,7 @@ import javax.inject.Singleton
 class ThemeCoroutineRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     dispatcher: Dispatcher,
-    @Named("custom-ssl") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun fetchThemeDemoPages(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedWpComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ThemesError;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
@@ -49,7 +50,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
     @Inject public ThemeRestClient(
             Context appContext,
             Dispatcher dispatcher,
-            @Named("regular") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
             AccessToken accessToken,
             UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.TransactionsStore.FetchedSupportedCount
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemedShoppingCartPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +27,7 @@ class TransactionsRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/vertical/VerticalRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.VerticalStore.FetchSegmentsError
 import org.wordpress.android.fluxc.store.VerticalStore.FetchedSegmentsPayload
 import org.wordpress.android.fluxc.store.VerticalStore.VerticalErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -25,7 +26,7 @@ class VerticalRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/whatsnew/WhatsNewRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/whatsnew/WhatsNewRestClient.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.whatsnew.WhatsNewRestClient.WhatsNewResponse.Announcement
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchedPayload
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -24,7 +25,7 @@ class WhatsNewRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
+    @Named(OkHttpClientQualifiers.REGULAR) requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/wporg/plugin/PluginWPOrgClient.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPaylo
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError;
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryErrorType;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.fluxc.store.PluginStore.SearchedPluginDirectoryPayload;
 
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class PluginWPOrgClient extends BaseWPOrgAPIClient {
     private final Dispatcher mDispatcher;
 
     @Inject public PluginWPOrgClient(Dispatcher dispatcher,
-                                     @Named("regular") RequestQueue requestQueue,
+                                     @Named(OkHttpClientQualifiers.REGULAR) RequestQueue requestQueue,
                                      UserAgent userAgent) {
         super(dispatcher, requestQueue, userAgent);
         mDispatcher = dispatcher;

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePaylo
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePayload;
 import org.wordpress.android.fluxc.utils.CommentErrorUtils;
 import org.wordpress.android.fluxc.utils.extensions.SiteModelExtensionsKt;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ import javax.inject.Singleton;
 public class CommentXMLRPCClient extends BaseXMLRPCClient {
     @Inject public CommentXMLRPCClient(
             Dispatcher dispatcher,
-            @Named("custom-ssl") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
             UserAgent userAgent,
             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_E
 import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
 import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -32,7 +33,7 @@ import javax.inject.Singleton
 @Singleton
 class CommentsXMLRPCClient @Inject constructor(
     dispatcher: Dispatcher?,
-    @Named("custom-ssl") requestQueue: RequestQueue?,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue?,
     userAgent: UserAgent?,
     httpAuthManager: HTTPAuthManager?,
     private val commentErrorUtilsWrapper: CommentErrorUtilsWrapper,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.fluxc.utils.MimeType;
 import org.wordpress.android.fluxc.utils.extensions.SiteModelExtensionsKt;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -69,6 +70,7 @@ import okhttp3.Request.Builder;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
+
 @Singleton
 public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListener {
     private static final String[] REQUIRED_UPLOAD_RESPONSE_FIELDS = {
@@ -81,8 +83,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
     @Inject public MediaXMLRPCClient(
             Dispatcher dispatcher,
-            @Named("custom-ssl") RequestQueue requestQueue,
-            @NonNull @Named("custom-ssl") OkHttpClient okHttpClient,
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
+            @NonNull @Named(OkHttpClientQualifiers.CUSTOM_SSL) OkHttpClient okHttpClient,
             UserAgent userAgent,
             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 import org.wordpress.android.fluxc.store.PostStore.PostListItem;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
 import org.wordpress.android.fluxc.utils.extensions.SiteModelExtensionsKt;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -63,7 +64,7 @@ import javax.inject.Singleton;
 @Singleton
 public class PostXMLRPCClient extends BaseXMLRPCClient {
     @Inject public PostXMLRPCClient(Dispatcher dispatcher,
-                            @Named("custom-ssl") RequestQueue requestQueue,
+                            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
                             UserAgent userAgent,
                             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.util.MapUtils
 import java.util.ArrayList
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -36,7 +37,7 @@ import javax.inject.Singleton
 @Singleton
 class SiteXMLRPCClient @Inject constructor(
     dispatcher: Dispatcher?,
-    @Named("custom-ssl") requestQueue: RequestQueue?,
+    @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue?,
     userAgent: UserAgent?,
     httpAuthManager: HTTPAuthManager?,
     private val xmlrpcRequestBuilder: XMLRPCRequestBuilder

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 import org.wordpress.android.fluxc.utils.extensions.SiteModelExtensionsKt;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.MapUtils;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ import javax.inject.Singleton;
 public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     @Inject public TaxonomyXMLRPCClient(
             Dispatcher dispatcher,
-            @Named("custom-ssl") RequestQueue requestQueue,
+            @Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue requestQueue,
             UserAgent userAgent,
             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FluxCImageLoader.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FluxCImageLoader.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.HTTPAuthModel;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.utils.WPUrlUtils;
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers;
 import org.wordpress.android.util.UrlUtils;
 
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+
 
 /**
  * Image Loader that leverage the Volley queue, stored access token and stored HTTP Auth credentials
@@ -33,7 +35,7 @@ public class FluxCImageLoader extends ImageLoader {
     private HTTPAuthManager mHTTPAuthManager;
     private UserAgent mUserAgent;
 
-    @Inject public FluxCImageLoader(@Named("custom-ssl") RequestQueue queue,
+    @Inject public FluxCImageLoader(@Named(OkHttpClientQualifiers.CUSTOM_SSL) RequestQueue queue,
                             ImageCache imageCache,
                             AccessToken accessToken,
                             HTTPAuthManager httpAuthManager,


### PR DESCRIPTION
Introduces `OkHttpClientQualifiers` object with constants for all OkHttp client DI qualifiers, replacing hardcoded strings like `@Named("regular")` with type-safe constants like `@Named(OkHttpClientQualifiers.REGULAR)`.