### PR TITLE
Remove check for modified main `strings.xml` outside release branch

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -19,8 +19,6 @@ end
 
 common_release_checker.check_internal_release_notes_changed(report_type: :message)
 
-android_release_checker.check_modified_strings_on_release
-
 view_changes_checker.check
 
 pr_size_checker.check_diff_size(


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This Danger check was out of place as
`WordPress/src/main/res/values/strings.xml` is the source of truth for localizations.

Unlike in Apple projects, where we use `genstrings` to find localized strings in the codebase to assemble the `strings` file, in Android, as far as I understand, `<app>/src/main/res/valudes/strings.xml` is the source of truth.

I believe this check ended up in `Dangerfile` accidentally. It was introduced in
https://github.com/wordpress-mobile/WordPress-Android/pull/20132. The update was done across our suite of apps, see for example https://github.com/woocommerce/woocommerce-android/pull/10692 and https://github.com/woocommerce/woocommerce-ios/pull/11926. Given I couldn't find a comment explicitly about adopting this check, I guess neither @iangmaia nor myself notice the same pattern as iOS was adopted in the Android repo.

To reinforce the idea that this check is out of place, notice that WooCommerce Android does not implement the check. _Of course, it could be that WooCommerce is wrong, but lacking code to update `strings.xml` as part of the code freeze process, that explanation is not satisfying._


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

See this test PR: https://github.com/wordpress-mobile/WordPress-Android/pull/22383
<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->