### PR TITLE
Test PR for Danger no longer warning on `strings.xml` changes

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -19,8 +19,6 @@ end
 
 common_release_checker.check_internal_release_notes_changed(report_type: :message)
 
-android_release_checker.check_modified_strings_on_release
-
 view_changes_checker.check
 
 pr_size_checker.check_diff_size(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5197,6 +5197,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="he_support_download_video_button">Download Video</string>
 
     <!-- HE Support - New Ticket Screen -->
+    <string name="he_support_contact_support_title_test">Add for testing purposes only</string>
     <string name="he_support_contact_support_title">Contact Support</string>
     <string name="he_support_need_help_with">I need help with</string>
     <string name="he_support_category_application">Application</string>
@@ -5214,5 +5215,4 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="he_support_contact_email_message">We\'ll email you at this address.</string>
     <string name="he_support_send_ticket_button">Send</string>
     <string name="he_support_generic_error">An error occurred. Please try again later.</string>
-    <string name="he_support_forbidden_error">Sorry, you are not allowed to perform this action.</string>
 </resources>


### PR DESCRIPTION
Notice how [Danger logs errors and warnings](https://buildkite.com/automattic/wordpress-android/builds/24045/steps/canvas?sid=019addcf-c1c2-4c08-b311-2ca6a0086a41) but none about the modified `strings.xml`:

<img width="1048" height="372" alt="image" src="https://github.com/user-attachments/assets/9e1b9302-36c5-4ea6-9232-6dd99c03263b" />
