### PR TITLE
CMM-1038 show error for corrupted reader deeplinks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
@@ -37,6 +37,8 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView.OnBlogInfoFail
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import javax.inject.Inject
@@ -71,6 +73,9 @@ class ReaderPostListActivity : BaseAppCompatActivity(), OnBlogInfoFailedListener
 
     @Inject
     lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Inject
+    lateinit var appLogWrapper: AppLogWrapper
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -336,7 +341,8 @@ class ReaderPostListActivity : BaseAppCompatActivity(), OnBlogInfoFailedListener
     private fun getSnackbarAttachView(): View? = findViewById(R.id.coordinator)
 
     override fun onBlogInfoFailed() {
-        ToastUtils.showToast(this, R.string.reader_toast_err_follow_blog_could_not_be_found)
+        appLogWrapper.d(AppLog.T.READER, "Blog or feed not found for siteId: $siteId")
+        ToastUtils.showToast(this, R.string.reader_toast_err_blog_not_found)
         finish()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.posts.EditorLauncher
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView.OnBlogInfoFailedListener
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
@@ -44,7 +45,7 @@ import javax.inject.Inject
 * serves as the host for ReaderPostListFragment when showing blog preview & tag preview
 */
 @AndroidEntryPoint
-class ReaderPostListActivity : BaseAppCompatActivity() {
+class ReaderPostListActivity : BaseAppCompatActivity(), OnBlogInfoFailedListener {
     private var source: String? = null
     private var postListType: ReaderPostListType = ReaderTypes.DEFAULT_POST_LIST_TYPE
     private var siteId: Long = 0
@@ -333,6 +334,11 @@ class ReaderPostListActivity : BaseAppCompatActivity() {
      * Returns the view to attach the snackbar to. Note that this view isn't part of this activity.
      */
     private fun getSnackbarAttachView(): View? = findViewById(R.id.coordinator)
+
+    override fun onBlogInfoFailed() {
+        ToastUtils.showToast(this, R.string.reader_toast_err_follow_blog_could_not_be_found)
+        finish()
+    }
 
     @Deprecated("Deprecated in Java")
     @Suppress("NestedBlockDepth")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -811,6 +811,9 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             intent.putExtra(ReaderTagsFeedFragment.RESULT_SHOULD_REFRESH_TAGS_FEED, true)
             activity.setResult(Activity.RESULT_OK, intent)
         }
+        if (activity is OnBlogInfoFailedListener) {
+            readerPostAdapter!!.setOnBlogInfoFailedListener(activity as OnBlogInfoFailedListener?)
+        }
     }
 
     private fun initReaderSubsActivityResultLauncher() {
@@ -836,7 +839,6 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
     override fun onDetach() {
         super.onDetach()
         bottomNavController = null
-        readerPostAdapter?.setOnBlogInfoLoadedListener(null)
         readerPostAdapter?.setOnBlogInfoFailedListener(null)
     }
 
@@ -2031,9 +2033,6 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             readerPostAdapter!!.setOnDataRequestedListener(dataRequestedListener)
             if (activity is OnBlogInfoLoadedListener) {
                 readerPostAdapter!!.setOnBlogInfoLoadedListener(activity as OnBlogInfoLoadedListener?)
-            }
-            if (activity is OnBlogInfoFailedListener) {
-                readerPostAdapter!!.setOnBlogInfoFailedListener(activity as OnBlogInfoFailedListener?)
             }
             if (getPostListType().isTagType) {
                 readerPostAdapter!!.setCurrentTag(currentTag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -836,6 +836,7 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
     override fun onDetach() {
         super.onDetach()
         bottomNavController = null
+        readerPostAdapter?.setOnBlogInfoLoadedListener(null)
         readerPostAdapter?.setOnBlogInfoFailedListener(null)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -811,9 +811,6 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             intent.putExtra(ReaderTagsFeedFragment.RESULT_SHOULD_REFRESH_TAGS_FEED, true)
             activity.setResult(Activity.RESULT_OK, intent)
         }
-        if (activity is OnBlogInfoFailedListener) {
-            readerPostAdapter!!.setOnBlogInfoFailedListener(activity as OnBlogInfoFailedListener?)
-        }
     }
 
     private fun initReaderSubsActivityResultLauncher() {
@@ -2033,6 +2030,9 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             readerPostAdapter!!.setOnDataRequestedListener(dataRequestedListener)
             if (activity is OnBlogInfoLoadedListener) {
                 readerPostAdapter!!.setOnBlogInfoLoadedListener(activity as OnBlogInfoLoadedListener?)
+            }
+            if (activity is OnBlogInfoFailedListener) {
+                readerPostAdapter!!.setOnBlogInfoFailedListener(activity as OnBlogInfoFailedListener?)
             }
             if (getPostListType().isTagType) {
                 readerPostAdapter!!.setCurrentTag(currentTag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -836,6 +836,8 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
     override fun onDetach() {
         super.onDetach()
         bottomNavController = null
+        readerPostAdapter?.setOnBlogInfoLoadedListener(null)
+        readerPostAdapter?.setOnBlogInfoFailedListener(null)
     }
 
     override fun onStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -127,6 +127,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.viewmodels.ReaderModeInfo
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
+import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView.OnBlogInfoFailedListener
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView.OnBlogInfoLoadedListener
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
@@ -2028,6 +2029,9 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             readerPostAdapter!!.setOnDataRequestedListener(dataRequestedListener)
             if (activity is OnBlogInfoLoadedListener) {
                 readerPostAdapter!!.setOnBlogInfoLoadedListener(activity as OnBlogInfoLoadedListener?)
+            }
+            if (activity is OnBlogInfoFailedListener) {
+                readerPostAdapter!!.setOnBlogInfoFailedListener(activity as OnBlogInfoFailedListener?)
             }
             if (getPostListType().isTagType) {
                 readerPostAdapter!!.setCurrentTag(currentTag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -107,6 +107,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
+    private ReaderSiteHeaderView.OnBlogInfoFailedListener mBlogInfoFailedListener;
 
     // the large "tbl_posts.text" column is unused here, so skip it when querying
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
@@ -300,6 +301,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else if (holder instanceof SiteHeaderViewHolder) {
             SiteHeaderViewHolder siteHolder = (SiteHeaderViewHolder) holder;
             siteHolder.mSiteHeaderView.setOnBlogInfoLoadedListener(mBlogInfoLoadedListener);
+            siteHolder.mSiteHeaderView.setOnBlogInfoFailedListener(mBlogInfoFailedListener);
             if (isDiscover()) {
                 siteHolder.mSiteHeaderView.loadBlogInfo(
                         ReaderConstants.DISCOVER_SITE_ID,
@@ -636,6 +638,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnBlogInfoLoadedListener(ReaderSiteHeaderView.OnBlogInfoLoadedListener listener) {
         mBlogInfoLoadedListener = listener;
+    }
+
+    public void setOnBlogInfoFailedListener(ReaderSiteHeaderView.OnBlogInfoFailedListener listener) {
+        mBlogInfoFailedListener = listener;
     }
 
     private ReaderTypes.ReaderPostListType getPostListType() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -341,4 +341,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
             mFollowButton.setIsFollowed(!isAskingToFollow);
         }
     }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        mBlogInfoFailedListener = null;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -280,7 +280,9 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
     private void setFollowButtonLoading(boolean isLoading) {
         mFollowButton.setIsLoading(isLoading);
-        mFollowProgress.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        if (mFollowProgress != null) {
+            mFollowProgress.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        }
     }
 
     private void toggleFollowStatus(final View followButton, final String source) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -225,8 +225,9 @@ public class ReaderSiteHeaderView extends LinearLayout {
             @Override
             public void onClick(View v) {
                 if (!mAccountStore.hasAccessToken()) {
-                    if (mFollowListener != null) {
-                        mFollowListener.onFollowTappedWhenLoggedOut();
+                    OnFollowListener followListener = mFollowListenerRef != null ? mFollowListenerRef.get() : null;
+                    if (followListener != null) {
+                        followListener.onFollowTappedWhenLoggedOut();
                     }
                 } else {
                     toggleFollowStatus(v, source);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -13,7 +13,6 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -66,9 +66,9 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private ReaderFollowButton mFollowButton;
     @Nullable private ProgressBar mFollowProgress;
     private ReaderBlog mBlogInfo;
-    private OnBlogInfoLoadedListener mBlogInfoListener;
+    @Nullable private WeakReference<OnBlogInfoLoadedListener> mBlogInfoListenerRef;
     @Nullable private WeakReference<OnBlogInfoFailedListener> mBlogInfoFailedListenerRef;
-    private OnFollowListener mFollowListener;
+    @Nullable private WeakReference<OnFollowListener> mFollowListenerRef;
 
     private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
     private final Handler mMainHandler = new Handler(Looper.getMainLooper());
@@ -99,16 +99,16 @@ public class ReaderSiteHeaderView extends LinearLayout {
         view.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
     }
 
-    public void setOnFollowListener(OnFollowListener listener) {
-        mFollowListener = listener;
+    public void setOnFollowListener(@Nullable OnFollowListener listener) {
+        mFollowListenerRef = listener != null ? new WeakReference<>(listener) : null;
     }
 
-    public void setOnBlogInfoLoadedListener(OnBlogInfoLoadedListener listener) {
-        mBlogInfoListener = listener;
+    public void setOnBlogInfoLoadedListener(@Nullable OnBlogInfoLoadedListener listener) {
+        mBlogInfoListenerRef = listener != null ? new WeakReference<>(listener) : null;
     }
 
-    public void setOnBlogInfoFailedListener(@NonNull OnBlogInfoFailedListener listener) {
-        mBlogInfoFailedListenerRef = new WeakReference<>(listener);
+    public void setOnBlogInfoFailedListener(@Nullable OnBlogInfoFailedListener listener) {
+        mBlogInfoFailedListenerRef = listener != null ? new WeakReference<>(listener) : null;
     }
 
     public void loadBlogInfo(
@@ -239,8 +239,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
             layoutInfo.setVisibility(View.VISIBLE);
         }
 
-        if (mBlogInfoListener != null) {
-            mBlogInfoListener.onBlogInfoLoaded(blogInfo);
+        OnBlogInfoLoadedListener blogInfoListener =
+                mBlogInfoListenerRef != null ? mBlogInfoListenerRef.get() : null;
+        if (blogInfoListener != null) {
+            blogInfoListener.onBlogInfoLoaded(blogInfo);
         }
     }
 
@@ -298,15 +300,17 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         mFollowButton.setIsFollowed(isAskingToFollow);
 
-        if (mFollowListener != null) {
+        OnFollowListener followListener =
+                mFollowListenerRef != null ? mFollowListenerRef.get() : null;
+        if (followListener != null) {
             if (isAskingToFollow) {
-                mFollowListener.onFollowTapped(
+                followListener.onFollowTapped(
                         followButton,
                         mBlogInfo.getName(),
                         mIsFeed ? 0 : mBlogInfo.blogId,
                         mBlogInfo.feedId);
             } else {
-                mFollowListener.onFollowingTapped();
+                followListener.onFollowingTapped();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -53,6 +53,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
         void onBlogInfoLoaded(ReaderBlog blogInfo);
     }
 
+    public interface OnBlogInfoFailedListener {
+        void onBlogInfoFailed();
+    }
+
     private long mBlogId;
     private long mFeedId;
     private boolean mIsFeed;
@@ -61,6 +65,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     @Nullable private ProgressBar mFollowProgress;
     private ReaderBlog mBlogInfo;
     private OnBlogInfoLoadedListener mBlogInfoListener;
+    private OnBlogInfoFailedListener mBlogInfoFailedListener;
     private OnFollowListener mFollowListener;
 
     private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
@@ -100,6 +105,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
         mBlogInfoListener = listener;
     }
 
+    public void setOnBlogInfoFailedListener(OnBlogInfoFailedListener listener) {
+        mBlogInfoFailedListener = listener;
+    }
+
     public void loadBlogInfo(
             final long blogId,
             final long feedId,
@@ -110,6 +119,9 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         if (blogId == 0 && feedId == 0) {
             ToastUtils.showToast(getContext(), R.string.reader_toast_err_show_blog);
+            if (mBlogInfoFailedListener != null) {
+                mBlogInfoFailedListener.onBlogInfoFailed();
+            }
             return;
         }
 
@@ -132,7 +144,12 @@ public class ReaderSiteHeaderView extends LinearLayout {
                 if (localBlogInfo == null || ReaderBlogTable.isTimeToUpdateBlogInfo(localBlogInfo)) {
                     ReaderActions.UpdateBlogInfoListener listener = serverBlogInfo -> {
                         if (isAttachedToWindow()) {
-                            showBlogInfo(serverBlogInfo, source);
+                            if (serverBlogInfo != null) {
+                                showBlogInfo(serverBlogInfo, source);
+                            } else if (localBlogInfo == null && mBlogInfoFailedListener != null) {
+                                // No local info and server returned null - blog/feed not found
+                                mBlogInfoFailedListener.onBlogInfoFailed();
+                            }
                         }
                     };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -13,6 +13,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.R;
@@ -34,6 +35,7 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageManager;
 
+import java.lang.ref.WeakReference;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -65,7 +67,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
     @Nullable private ProgressBar mFollowProgress;
     private ReaderBlog mBlogInfo;
     private OnBlogInfoLoadedListener mBlogInfoListener;
-    private OnBlogInfoFailedListener mBlogInfoFailedListener;
+    @Nullable private WeakReference<OnBlogInfoFailedListener> mBlogInfoFailedListenerRef;
     private OnFollowListener mFollowListener;
 
     private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
@@ -105,8 +107,8 @@ public class ReaderSiteHeaderView extends LinearLayout {
         mBlogInfoListener = listener;
     }
 
-    public void setOnBlogInfoFailedListener(OnBlogInfoFailedListener listener) {
-        mBlogInfoFailedListener = listener;
+    public void setOnBlogInfoFailedListener(@NonNull OnBlogInfoFailedListener listener) {
+        mBlogInfoFailedListenerRef = new WeakReference<>(listener);
     }
 
     public void loadBlogInfo(
@@ -119,8 +121,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         if (blogId == 0 && feedId == 0) {
             ToastUtils.showToast(getContext(), R.string.reader_toast_err_show_blog);
-            if (mBlogInfoFailedListener != null) {
-                mBlogInfoFailedListener.onBlogInfoFailed();
+            OnBlogInfoFailedListener failedListener =
+                    mBlogInfoFailedListenerRef != null ? mBlogInfoFailedListenerRef.get() : null;
+            if (failedListener != null) {
+                failedListener.onBlogInfoFailed();
             }
             return;
         }
@@ -146,9 +150,14 @@ public class ReaderSiteHeaderView extends LinearLayout {
                         if (isAttachedToWindow()) {
                             if (serverBlogInfo != null) {
                                 showBlogInfo(serverBlogInfo, source);
-                            } else if (localBlogInfo == null && mBlogInfoFailedListener != null) {
+                            } else if (localBlogInfo == null) {
                                 // No local info and server returned null - blog/feed not found
-                                mBlogInfoFailedListener.onBlogInfoFailed();
+                                OnBlogInfoFailedListener failedListener =
+                                        mBlogInfoFailedListenerRef != null
+                                                ? mBlogInfoFailedListenerRef.get() : null;
+                                if (failedListener != null) {
+                                    failedListener.onBlogInfoFailed();
+                                }
                             }
                         }
                     };
@@ -340,11 +349,5 @@ public class ReaderSiteHeaderView extends LinearLayout {
             setFollowButtonLoading(false);
             mFollowButton.setIsFollowed(!isAskingToFollow);
         }
-    }
-
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        mBlogInfoFailedListener = null;
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2355,6 +2355,7 @@
     <string name="reader_toast_err_share_intent">Unable to share</string>
     <string name="reader_toast_err_view_image">Unable to view image</string>
     <string name="reader_toast_err_show_blog">Unable to show this blog</string>
+    <string name="reader_toast_err_blog_not_found">Error: Unable to find the blog</string>
     <string name="reader_toast_err_already_follow_this_blog">You are already subscribed to this blog</string>
     <string name="reader_toast_err_unable_to_follow_blog">Unable to subscribe to this blog</string>
     <string name="reader_toast_err_follow_blog_could_not_be_found">This blog could not be found</string>


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

Fixes an issue where opening Reader deeplinks with corrupted or invalid feed IDs would show an empty blog screen instead of an error message.


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

Test the following corrupted deeplink. They should show a "not found" error:
- https://wordpress.com/read/feeds/1387340
- https://wordpress.com/reader/feeds/1387390

For regression, test the following valid ones:
- https://wordpress.com/read/feeds/138734090
- https://wordpress.com/reader/feeds/138734090


https://github.com/user-attachments/assets/c6a2d1f2-cc90-44be-9000-f75b94a83487



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->