### PR TITLE
Mediagrid outdated empty state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -725,9 +725,9 @@ public class MediaBrowserActivity extends BaseAppCompatActivity implements Media
     @Override
     public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
         mMenu.findItem(R.id.menu_new_media).setVisible(true);
-        mMediaGridFragment.showActionableEmptyViewButton(true);
-        invalidateOptionsMenu();
+        mMediaGridFragment.onSearchClosed();
 
+        invalidateOptionsMenu();
         enableTabs(true);
         showQuota(true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -610,7 +610,17 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         if (isEmpty() && !TextUtils.isEmpty(mSearchTerm)) {
             updateEmptyView(EmptyViewMessageType.NO_CONTENT);
         } else {
-            mActionableEmptyView.setVisibility(View.GONE);
+            hideEmptyView();
+        }
+    }
+
+    public void onSearchClosed() {
+        mSearchTerm = null;
+        if (isEmpty()) {
+            updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+            showActionableEmptyViewButton(true);
+        } else {
+            hideEmptyView();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.fragment.app.Fragment;
@@ -644,51 +645,51 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         if (isEmpty()) {
-            int stringId;
+            @StringRes int titleId;
             switch (emptyViewMessageType) {
                 case LOADING:
-                    stringId = R.string.media_fetching;
+                    titleId = R.string.media_fetching;
                     break;
                 case NO_CONTENT:
                     if (!TextUtils.isEmpty(mSearchTerm)) {
                         mActionableEmptyView.updateLayoutForSearch(true, 0);
-                        stringId = R.string.media_empty_search_list;
+                        titleId = R.string.media_empty_search_list;
                     } else {
                         mActionableEmptyView.updateLayoutForSearch(false, 0);
                         mActionableEmptyView.image.setVisibility(View.VISIBLE);
 
                         switch (mFilter) {
                             case FILTER_IMAGES:
-                                stringId = R.string.media_empty_image_list;
+                                titleId = R.string.media_empty_image_list;
                                 break;
                             case FILTER_VIDEOS:
-                                stringId = R.string.media_empty_videos_list;
+                                titleId = R.string.media_empty_videos_list;
                                 break;
                             case FILTER_DOCUMENTS:
-                                stringId = R.string.media_empty_documents_list;
+                                titleId = R.string.media_empty_documents_list;
                                 break;
                             case FILTER_AUDIO:
-                                stringId = R.string.media_empty_audio_list;
+                                titleId = R.string.media_empty_audio_list;
                                 break;
                             default:
-                                stringId = R.string.media_empty_list;
+                                titleId = R.string.media_empty_list;
                                 break;
                         }
                     }
 
                     break;
                 case NETWORK_ERROR:
-                    stringId = R.string.no_network_message;
+                    titleId = R.string.no_network_message;
                     break;
                 case PERMISSION_ERROR:
-                    stringId = R.string.media_error_no_permission;
+                    titleId = R.string.media_error_no_permission;
                     break;
                 default:
-                    stringId = R.string.error_refresh_media;
+                    titleId = R.string.error_refresh_media;
                     break;
             }
 
-            mActionableEmptyView.title.setText(stringId);
+            mActionableEmptyView.title.setText(titleId);
             mActionableEmptyView.setVisibility(View.VISIBLE);
         } else {
             mActionableEmptyView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -607,8 +607,10 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         List<MediaModel> mediaList = getFilteredMedia();
         mGridAdapter.setMediaList(mediaList);
 
-        if (isEmpty()) {
+        if (isEmpty() && !TextUtils.isEmpty(mSearchTerm)) {
             updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+        } else {
+            mActionableEmptyView.setVisibility(View.GONE);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -646,6 +646,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
         if (isEmpty()) {
             @StringRes int titleId;
+            @StringRes int subtitleId = 0;
             switch (emptyViewMessageType) {
                 case LOADING:
                     titleId = R.string.media_fetching;
@@ -657,6 +658,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                     } else {
                         mActionableEmptyView.updateLayoutForSearch(false, 0);
                         mActionableEmptyView.image.setVisibility(View.VISIBLE);
+                        subtitleId = R.string.media_empty_list_subtitle;
 
                         switch (mFilter) {
                             case FILTER_IMAGES:
@@ -690,6 +692,12 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             }
 
             mActionableEmptyView.title.setText(titleId);
+            if (subtitleId > 0) {
+                mActionableEmptyView.subtitle.setText(subtitleId);
+                mActionableEmptyView.subtitle.setVisibility(View.VISIBLE);
+            } else {
+                mActionableEmptyView.subtitle.setVisibility(View.GONE);
+            }
             mActionableEmptyView.setVisibility(View.VISIBLE);
         } else {
             mActionableEmptyView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -669,7 +669,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                         titleId = R.string.media_empty_search_list;
                     } else {
                         mActionableEmptyView.updateLayoutForSearch(false, 0);
-                        mActionableEmptyView.image.setVisibility(View.VISIBLE);
                         subtitleId = R.string.media_empty_list_subtitle;
 
                         switch (mFilter) {

--- a/WordPress/src/main/res/layout/media_grid_fragment.xml
+++ b/WordPress/src/main/res/layout/media_grid_fragment.xml
@@ -29,8 +29,8 @@
         android:layout_width="match_parent"
         android:visibility="gone"
         app:aevButton="@string/media_empty_upload_media"
-        app:aevImage="@drawable/img_illustration_media_105dp"
         app:aevTitle="@string/media_empty_list"
+        app:aevSubtitle="@string/media_empty_list_subtitle"
         tools:visibility="visible" >
     </org.wordpress.android.ui.ActionableEmptyView>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
     <string name="media_empty_list">You don\'t have any media - yet!</string>
-    <string name="media_empty_list_subtitle">Why not upload something now?</string>
+    <string name="media_empty_list_subtitle">Why not upload something?</string>
     <string name="media_empty_search_list">No media matching your search</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -225,7 +225,8 @@
     <!-- Delete Media -->
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
-    <string name="media_empty_list">You don\'t have any media</string>
+    <string name="media_empty_list">You don\'t have any media - yet!</string>
+    <string name="media_empty_list_subtitle">Why not upload something now?</string>
     <string name="media_empty_search_list">No media matching your search</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -228,10 +228,10 @@
     <string name="media_empty_list">You don\'t have any media - yet!</string>
     <string name="media_empty_list_subtitle">Why not upload something?</string>
     <string name="media_empty_search_list">No media matching your search</string>
-    <string name="media_empty_image_list">You don\'t have any images</string>
-    <string name="media_empty_videos_list">You don\'t have any videos</string>
-    <string name="media_empty_documents_list">You don\'t have any documents</string>
-    <string name="media_empty_audio_list">You don\'t have any audio</string>
+    <string name="media_empty_image_list">You don\'t have any images - yet!</string>
+    <string name="media_empty_videos_list">You don\'t have any videos - yet!</string>
+    <string name="media_empty_documents_list">You don\'t have any documents - yet!</string>
+    <string name="media_empty_audio_list">You don\'t have any audio - yet!</string>
     <string name="media_empty_upload_media">Upload media</string>
     <string name="delete">Delete</string>
     <string name="confirm_delete_media_image">Delete this image?</string>


### PR DESCRIPTION
As part of CMM-1037, this small PR updates the media grid's empty view by:

- Removing the outdated image
- Making the title text more lively
- Adding a subtitle

I also cleaned up some of the search logic.

**To test**
- Remove all media from a test site then view the site media in the app
- Verify that the empty view works as expected
- Verify that empty search results works as expected
- Switch to a site that has media and verify it works as expected

**Before**

<img width="297" height="629" alt="MediaGridFragment-before" src="https://github.com/user-attachments/assets/756eadf7-478c-49c6-8289-e555950f9bba" />

**After**

<img width="297" height="629" alt="MediaGridFragment-after" src="https://github.com/user-attachments/assets/35306f6a-4a2b-4091-b559-99854cdd66ee" />

