### PR TITLE
CMM-959: fix reader comment loading spinner margin

### DIFF
--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -221,7 +221,7 @@
             style="?android:attr/progressBarStyleSmall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
+            android:layout_alignEnd="@+id/comment_body_container"
             android:layout_centerVertical="true"
             android:visibility="gone"
             tools:visibility="visible" />


### PR DESCRIPTION
## Description
Fixes the alignment of the loading spinner shown when submitting a comment in the Reader

Before / After
<img width="350" height="147" alt="Screenshot 2025-12-05 at 17 30 36" src="https://github.com/user-attachments/assets/56def979-535f-4d6e-88ab-f1a4c97eefc6" /> / <img width="350" height="154" alt="Screenshot 2025-12-05 at 17 30 46" src="https://github.com/user-attachments/assets/9fe5ba3d-af1c-4748-a0b9-808eb1f18423" />


## Testing instructions

1. Open a post in the Reader
2. Submit a comment
- [ ] Verify the loading spinner aligns with the three-dots menu icon above it

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->