### PR TITLE
CMM-1052 support bar deeplinks in addition to mbar

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -474,6 +474,10 @@
                     android:host="public-api.wordpress.com"
                     android:pathPattern="/mbar/.*"
                     android:scheme="https" />
+                <data
+                    android:host="public-api.wordpress.com"
+                    android:pathPattern="/bar/.*"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
 
@@ -765,6 +769,76 @@
                     android:host="wordpress.com"
                     android:pathPattern="/reader/feeds/.*/posts/.*"
                     android:scheme="http" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/blogs/.*/posts/.*"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/reader/blogs/.*/posts/.*"
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/read/feeds/.*/posts/.*"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/read/feeds/.*/posts/.*"
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/read/blogs/.*/posts/.*"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/read/blogs/.*/posts/.*"
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/reader/feeds/.*/posts/.*"
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/reader/blogs/.*/posts/.*"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
+                </data>
+
+                <data
+                    android:host="www.wordpress.com"
+                    android:pathPattern="/reader/blogs/.*/posts/.*"
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
                 </data>
 
                 <action android:name="org.wordpress.android.action.VIEW_POST" />

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -762,13 +762,15 @@
                 <data
                     android:host="wordpress.com"
                     android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="https" >
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
                 </data>
 
                 <data
                     android:host="wordpress.com"
                     android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="http" >
+                    android:scheme="http"
+                    tools:ignore="IntentFilterUniqueDataAttributes" >
                 </data>
 
                 <data

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -761,20 +761,6 @@
 
                 <data
                     android:host="wordpress.com"
-                    android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="https"
-                    tools:ignore="IntentFilterUniqueDataAttributes" >
-                </data>
-
-                <data
-                    android:host="wordpress.com"
-                    android:pathPattern="/reader/feeds/.*/posts/.*"
-                    android:scheme="http"
-                    tools:ignore="IntentFilterUniqueDataAttributes" >
-                </data>
-
-                <data
-                    android:host="wordpress.com"
                     android:pathPattern="/reader/blogs/.*/posts/.*"
                     android:scheme="https"
                     tools:ignore="IntentFilterUniqueDataAttributes" >

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtils.kt
@@ -34,12 +34,14 @@ class DeepLinkUriUtils
     }
 
     /**
-     * Tracking URIs like `public-api.wordpress.com/mbar/...` come from emails and should be handled here
+     * Tracking URIs like `public-api.wordpress.com/mbar/...` or `public-api.wordpress.com/bar/...`
+     * come from emails and should be handled here
      */
     fun isTrackingUrl(uri: UriWrapper): Boolean {
-        // https://public-api.wordpress.com/mbar/
+        // https://public-api.wordpress.com/mbar/ or https://public-api.wordpress.com/bar/
+        val path = uri.pathSegments.firstOrNull()
         return uri.host == HOST_API_WORDPRESS_COM &&
-                uri.pathSegments.firstOrNull() == MOBILE_TRACKING_PATH
+                (path == MOBILE_TRACKING_PATH || path == REGULAR_TRACKING_PATH)
     }
 
     fun isWpLoginUrl(uri: UriWrapper): Boolean {
@@ -51,6 +53,7 @@ class DeepLinkUriUtils
     companion object {
         private const val HOST_API_WORDPRESS_COM = "public-api.wordpress.com"
         private const val MOBILE_TRACKING_PATH = "mbar"
+        private const val REGULAR_TRACKING_PATH = "bar"
         private const val WP_LOGIN = "wp-login.php"
         private const val REDIRECT_TO_PARAM = "redirect_to"
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -654,6 +654,9 @@ class ReaderPostDetailViewModel @Inject constructor(
             readerTracker.trackPost(Stat.READER_ARTICLE_RENDERED, it)
             _navigationEvents.postValue(Event(ShowPostInWebView(it)))
             _uiState.value = convertPostToUiState(it)
+            if (commentsSnippetFeatureConfig.isEnabled()) {
+                onRefreshCommentsData(it.blogId, it.postId)
+            }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtilsTest.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.util.UriUtilsWrapper
 
-@RunWith(MockitoJUnitRunner::class)
+@RunWith(MockitoJUnitRunner.Silent::class)
 class DeepLinkUriUtilsTest {
     @Mock
     lateinit var siteStore: SiteStore
@@ -28,6 +28,42 @@ class DeepLinkUriUtilsTest {
         site = SiteModel()
         val buildUri = buildUri("example.com")
         whenever(uriUtilsWrapper.parse(host)).thenReturn(buildUri)
+    }
+
+    @Test
+    fun `isTrackingUrl returns true for mbar path`() {
+        val uri = buildUri("public-api.wordpress.com", "mbar")
+
+        val result = deepLinkUriUtils.isTrackingUrl(uri)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isTrackingUrl returns true for bar path`() {
+        val uri = buildUri("public-api.wordpress.com", "bar")
+
+        val result = deepLinkUriUtils.isTrackingUrl(uri)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isTrackingUrl returns false for other paths`() {
+        val uri = buildUri("public-api.wordpress.com", "other")
+
+        val result = deepLinkUriUtils.isTrackingUrl(uri)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isTrackingUrl returns false for different host`() {
+        val uri = buildUri("wordpress.com", "mbar")
+
+        val result = deepLinkUriUtils.isTrackingUrl(uri)
+
+        assertThat(result).isFalse()
     }
 
     @Test


### PR DESCRIPTION
## Description
  - Add support for /bar/ tracking deep links in addition to existing /mbar/ links
  - Add support for www.wordpress.com Reader post URLs
  - Add missing /reader/blogs/.*/posts/.* URL pattern support
  - Fix comments section not loading when opening posts via deep link

## Testing instructions

1. If you are subscribed to any blog, open a notification email and tap on "Read on Reader". Otherwise, sibscribe to a blog that posts periodically (Matts blog) and wait for the notification email.
<img width="204" height="72" alt="Screenshot 2025-12-09 at 15 02 24" src="https://github.com/user-attachments/assets/069a6b5b-3f10-4d8b-9b36-0ee18362432e" />

- [x] Verify the post is correclty opened in the app's Reader

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->