### PR TITLE
CMM-1057 Show the mobile support page when opening the Help Center

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -146,7 +146,7 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
     }
 
     private fun navigateToHelpCenter() {
-        val intent = Intent(Intent.ACTION_VIEW, "https://wordpress.com/support/".toUri()).apply {
+        val intent = Intent(Intent.ACTION_VIEW, "https://apps.wordpress.com/support/mobile".toUri()).apply {
             addCategory(Intent.CATEGORY_BROWSABLE)
             setPackage(null) // Ensure it doesn't match internal activities
         }


### PR DESCRIPTION
## Description
This PR is changing the URL when tapping on the new "Help Center" entry in the support screen to open the mobile support page.

## Testing instructions

1. Enable the "Modern Support" experimental flag
2. Open support
3. Tap on "Help Center"
- [ ] Verify it opens the mobile support page

<img width="329" height="690" alt="Screenshot 2025-12-12 at 12 10 44" src="https://github.com/user-attachments/assets/37cf3737-9557-4b61-b193-5a085be43ba9" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->