### PR TITLE
CMM-1057 show the mobile support page using Custom Tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -146,7 +146,7 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
     }
 
     private fun navigateToHelpCenter() {
-        val intent = Intent(Intent.ACTION_VIEW, "https://wordpress.com/support/".toUri()).apply {
+        val intent = Intent(Intent.ACTION_VIEW, "https://apps.wordpress.com/support/mobile".toUri()).apply {
             addCategory(Intent.CATEGORY_BROWSABLE)
             setPackage(null) // Ensure it doesn't match internal activities
         }

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -27,10 +26,15 @@ import org.wordpress.android.support.aibot.ui.AIBotSupportActivity
 import org.wordpress.android.support.he.ui.HESupportActivity
 import org.wordpress.android.support.logs.ui.LogsActivity
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SupportActivity : AppCompatActivity() {
+    @Inject
+    lateinit var activityNavigator: ActivityNavigator
+
     private val viewModel by viewModels<SupportViewModel>()
 
     private lateinit var composeView: ComposeView
@@ -146,11 +150,7 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
     }
 
     private fun navigateToHelpCenter() {
-        val intent = Intent(Intent.ACTION_VIEW, "https://apps.wordpress.com/support/mobile".toUri()).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE)
-            setPackage(null) // Ensure it doesn't match internal activities
-        }
-        startActivity(intent)
+        activityNavigator.openInCustomTab(this, HELP_CENTER_URL)
         AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
     }
 
@@ -163,6 +163,8 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
     }
 
     companion object {
+        private const val HELP_CENTER_URL = "https://apps.wordpress.com/support/mobile"
+
         @JvmStatic
         fun createIntent(context: Context): Intent = Intent(context, SupportActivity::class.java)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -242,6 +242,7 @@ class ActivityNavigator @Inject constructor() {
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun openInCustomTab(activity: Activity, url: String) {
         val intent = getCustomTabsIntent(activity)
         try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -242,6 +242,26 @@ class ActivityNavigator @Inject constructor() {
         }
     }
 
+    fun openInCustomTab(activity: Activity, url: String) {
+        val intent = getCustomTabsIntent(activity)
+        try {
+            intent.launchUrl(activity, url.toUri())
+        } catch (e: RuntimeException) {
+            when (e) {
+                is ActivityNotFoundException,
+                is SecurityException -> {
+                    AppLog.e(
+                        AppLog.T.UTILS,
+                        "Error opening URL in CustomTabsIntent, attempting external browser",
+                        e
+                    )
+                    ActivityLauncher.openUrlExternal(activity, url)
+                }
+                else -> throw e
+            }
+        }
+    }
+
     private fun getCustomTabsIntent(activity: Activity): CustomTabsIntent {
         return CustomTabsIntent.Builder()
             .setShareState(CustomTabsIntent.SHARE_STATE_OFF)


### PR DESCRIPTION
## Description
Following this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/22420) feedback, I'm using CustomTabs to open the Help Center

## Testing instructions

1. Enable the "Modern Support" experimental flag
2. Open support
3. Tap on "Help Center"
- [ ] Verify it opens the mobile support page

<img width="450" height="914" alt="Screenshot 2025-12-12 at 13 37 42" src="https://github.com/user-attachments/assets/9882f320-6eff-495e-a20a-bfc2953a0ec6" />

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->