### PR TITLE
CMM-1068: fix the bot chat edit text being overlapped by the android navigation bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/aibot/ui/AIBotConversationDetailScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/aibot/ui/AIBotConversationDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -259,6 +260,7 @@ private fun ChatInputBar(
         modifier = Modifier
             .fillMaxWidth()
             .imePadding()
+            .navigationBarsPadding()
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)


### PR DESCRIPTION
## Description

  Problem

  When users enable 3-button navigation in Android settings, the bottom chat input field in the AI Bot Support conversation screen was being overlapped by the navigation buttons, making it difficult to type messages.

  Solution

  Added .navigationBarsPadding() modifier to the ChatInputBar composable in AIBotConversationDetailScreen.kt. This modifier adds appropriate padding to account for the system navigation bar, similar to how HEConversationDetailScreen handles it.


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

  - Enable 3-button navigation in Android settings (Settings > System > Gestures > System navigation)
  - Enable Modern Support and open AI Bot Support and navigate to a conversation
  - Verify the chat input field is fully visible above the navigation bar

Before / After

<img width="426" height="151" alt="Screenshot 2025-12-16 at 14 13 20" src="https://github.com/user-attachments/assets/a1487a00-c8f0-4872-b01b-50986f45554d" />
<img width="452" height="218" alt="Screenshot 2025-12-16 at 14 24 58" src="https://github.com/user-attachments/assets/ce4eb8af-ba50-4777-b9a9-925947c19187" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->