### PR TITLE
Updated tag list empty view

### DIFF
--- a/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
+++ b/WordPress/src/main/res/layout/site_settings_tag_list_activity.xml
@@ -50,7 +50,6 @@
             android:layout_height="match_parent"
             android:visibility="gone"
             app:aevButton="@string/site_settings_tags_empty_button"
-            app:aevImage="@drawable/img_illustration_empty_results_216dp"
             app:aevSubtitle="@string/site_settings_tags_empty_subtitle"
             app:aevTitle="@string/site_settings_tags_empty_title"
             tools:visibility="visible" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -654,8 +654,8 @@
     <string name="site_settings_password_dialog_title">Update password</string>
     <string name="site_settings_default_category_title">Default Category</string>
     <string name="site_settings_tags_empty_button">Create a tag</string>
-    <string name="site_settings_tags_empty_subtitle">Add your frequently used tags here so they can be quickly selected when tagging your posts</string>
-    <string name="site_settings_tags_empty_title">You don\'t have any tags</string>
+    <string name="site_settings_tags_empty_subtitle">Why not create one to make it easier to tag a post?</string>
+    <string name="site_settings_tags_empty_title">You don\'t have any tags - yet!</string>
     <string name="site_settings_tags_empty_title_search">No tags matching your search</string>
     <string name="site_settings_tags_title">Tags</string>
     <string name="site_settings_default_format_title">Default Format</string>


### PR DESCRIPTION
As part of CMM-1037, this PR updates the empty view for the site tag list.

**To test**

- Switch to a site that has no tags, or delete all tags for an existing site
- My Site > Site Settings > Tags

**Before**

<img width="297" height="629" alt="before" src="https://github.com/user-attachments/assets/fe02439f-6bcd-4c1d-ada4-f1544db39e70" />

**After**

<img width="297" height="629" alt="after" src="https://github.com/user-attachments/assets/c63c8435-54e2-496d-86f8-6d8ffd813441" />


**Note:** I question the need to have the tag list available from site settings, but we can discuss that separately.
