### PR TITLE
CMM-1069: Self-hosted sites reset modified page slugs back to original slug

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -388,7 +389,8 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         return new PostsModel(postArray);
     }
 
-    private static PostModel postResponseObjectToPostModel(@NonNull Map postObject, SiteModel site) {
+    @VisibleForTesting
+    static PostModel postResponseObjectToPostModel(@NonNull Map postObject, SiteModel site) {
         Map<?, ?> postMap = (Map<?, ?>) postObject;
         PostModel post = new PostModel();
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -476,7 +476,11 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         if (post.isPage()) {
             post.setParentId(MapUtils.getMapLong(postMap, "post_parent"));
             post.setParentTitle(MapUtils.getMapStr(postMap, "wp_page_parent"));
-            post.setSlug(MapUtils.getMapStr(postMap, "wp_slug"));
+            // Only use wp_slug if it's not empty; otherwise keep post_name (set earlier)
+            String wpSlug = MapUtils.getMapStr(postMap, "wp_slug");
+            if (!TextUtils.isEmpty(wpSlug)) {
+                post.setSlug(wpSlug);
+            }
         } else {
             // Extract featured image ID from post_thumbnail struct
             Object featuredImageObject = postMap.get("post_thumbnail");

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClientTest.kt
@@ -1,0 +1,102 @@
+package org.wordpress.android.fluxc.network.xmlrpc.post
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+
+@RunWith(RobolectricTestRunner::class)
+class PostXMLRPCClientTest {
+    private val site = SiteModel().apply { id = 1 }
+
+    @Test
+    fun `page slug is preserved when wp_slug is empty`() {
+        val expectedSlug = "my-custom-slug"
+        val postMap = createPageMap(postName = expectedSlug, wpSlug = "")
+
+        val result = PostXMLRPCClient.postResponseObjectToPostModel(postMap, site)
+
+        assertTrue(result.isPage)
+        assertEquals(expectedSlug, result.slug)
+    }
+
+    @Test
+    fun `page slug is preserved when wp_slug is missing`() {
+        val expectedSlug = "my-custom-slug"
+        val postMap = createPageMap(postName = expectedSlug, wpSlug = null)
+
+        val result = PostXMLRPCClient.postResponseObjectToPostModel(postMap, site)
+
+        assertTrue(result.isPage)
+        assertEquals(expectedSlug, result.slug)
+    }
+
+    @Test
+    fun `page slug uses wp_slug when wp_slug has value`() {
+        val wpSlugValue = "wp-slug-value"
+        val postMap = createPageMap(postName = "post-name-value", wpSlug = wpSlugValue)
+
+        val result = PostXMLRPCClient.postResponseObjectToPostModel(postMap, site)
+
+        assertTrue(result.isPage)
+        assertEquals(wpSlugValue, result.slug)
+    }
+
+    @Test
+    fun `post slug uses post_name correctly`() {
+        val expectedSlug = "my-post-slug"
+        val postMap = createPostMap(postName = expectedSlug)
+
+        val result = PostXMLRPCClient.postResponseObjectToPostModel(postMap, site)
+
+        assertFalse(result.isPage)
+        assertEquals(expectedSlug, result.slug)
+    }
+
+    private fun createPageMap(postName: String, wpSlug: String?): Map<String, Any?> {
+        return mutableMapOf<String, Any?>(
+            "post_id" to "123",
+            "post_title" to "Test Page",
+            "post_date_gmt" to java.util.Date(),
+            "post_modified_gmt" to java.util.Date(),
+            "post_content" to "Page content",
+            "link" to "https://example.com/page",
+            "terms" to arrayOf<Any>(),
+            "custom_fields" to arrayOf<Any>(),
+            "post_excerpt" to "",
+            "post_name" to postName,
+            "post_password" to "",
+            "post_status" to "publish",
+            "post_type" to "page",
+            "post_parent" to 0L,
+            "wp_page_parent" to ""
+        ).also {
+            if (wpSlug != null) {
+                it["wp_slug"] = wpSlug
+            }
+        }
+    }
+
+    private fun createPostMap(postName: String): Map<String, Any?> {
+        return mapOf(
+            "post_id" to "456",
+            "post_title" to "Test Post",
+            "post_date_gmt" to java.util.Date(),
+            "post_modified_gmt" to java.util.Date(),
+            "post_content" to "Post content",
+            "link" to "https://example.com/post",
+            "terms" to arrayOf<Any>(),
+            "custom_fields" to arrayOf<Any>(),
+            "post_excerpt" to "",
+            "post_name" to postName,
+            "post_password" to "",
+            "post_status" to "publish",
+            "post_type" to "post",
+            "post_thumbnail" to emptyMap<String, Any>(),
+            "post_format" to ""
+        )
+    }
+}


### PR DESCRIPTION
## Description                                                                                                          
                                                                                                                      
  When authenticating a self-hosted site via site credentials, editing an existing page whose slug was     
  changed results in the slug resetting to the original value. Additionally, the page settings view always displays the  
  slug as "not set."                                                                                                     
                                                                                                                         
  This issue does NOT occur when authenticating via Jetpack connection (which uses the REST API).                        
                                                                                                                         
  Root Cause                                                                                                             
                                                                                                                         
  The bug is in PostXMLRPCClient.java in the postResponseObjectToPostModel method.                                       
                                                                                                                         
  The problem:                                                                                                           
  1. Line 467: Slug is correctly set from post_name field                                                                
  2. Line 479 (before fix): For pages, slug was unconditionally overwritten from wp_slug field                           
  3. If wp_slug is missing or empty in the XML-RPC response, the slug becomes empty                                      
                                                                                                                         
  Why Jetpack works: Jetpack-connected sites use the REST API (PostRestClient.java), which handles slugs correctly with a
   single assignment from a reliable slug field.                                                                         
                                                                                                                         
  Fix                                                                                                                    
                                                                                                                         
  Modified the page-specific slug handling to only use wp_slug if it contains a value, otherwise preserve the post_name  
  value:                                                                                                                 
                                                                                                                         
  if (post.isPage()) {                                                                                                   
      post.setParentId(MapUtils.getMapLong(postMap, "post_parent"));                                                     
      post.setParentTitle(MapUtils.getMapStr(postMap, "wp_page_parent"));                                                
      // Only use wp_slug if it's not empty; otherwise keep post_name (set earlier)                                      
      String wpSlug = MapUtils.getMapStr(postMap, "wp_slug");                                                            
      if (!TextUtils.isEmpty(wpSlug)) {                                                                                  
          post.setSlug(wpSlug);                                                                                          
      }                                                                                                                  
  }                                                                                                                      
                                                                                                                                
                                                                                                                        
## Testing instructions

Prerequisites                                                                                                          
                                                                                                                         
  - A self-hosted WordPress site authenticated via site credentials (not Jetpack connection)                             
                                                                                                                         
  Test Case 1: Verify slug is preserved after editing                                                                    
                                                                                                                         
  1. Open the app and navigate to your self-hosted site                                                                  
  2. Go to Pages and create a new page with title "Test Page"                                                            
  3. Publish the page          
  4. Expected: Load the page in a browser and verify it works                                                                                          
  5. Open the page for editing                                                                                           
  6. Go to Page Settings and note the current slug is not empty                                   
  7. Change the slug and save it                                                                        
  8. Open the page in the browser with the new slug (the old one should redirect)
  9. Go to Page Settings                                                                                                 
  10. Expected: The slug should display the changed slug                                                             
  11. Before fix: The slug would show as empty or reset to original                             
  12. Modify the page content
  13. Expected: In the browser the content should be shown in the new slug path                         
                                                                                                                                                                              
                                                                                                                         
  Test Case 3: Verify posts still work correctly                                                                         
                                                                                                                         
  1. Create a new post on the self-hosted site                                                                           
  2. Publish and edit the post                                                                                           
  3. Change the slug in Post Settings                                                                                    
  4. Save and reopen the post                                                                                            
  5. Expected: The slug should be preserved correctly             
  6. Modify the post                                                       
  7. Expected: the post should be edited correctly when opened in a browser
                                                                                                                         
  Test Case 4: Verify Jetpack sites are unaffected                                                                       
                                                                                                                         
  1. Switch to a Jetpack-connected site                                                                                  
  2. Repeat Test Case 1 with pages                                                                                       
  3. Expected: Slug editing should work correctly (regression check)                                                     
                                                                                                                         


https://github.com/user-attachments/assets/38c99350-23fe-47dd-8ba3-6a036b55ce49



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->