### PR TITLE
CMM-1037 Activity log empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -137,10 +137,11 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     private fun ActivityLogTypeFilterFragmentBinding.refreshErrorScreen(uiState: Error) {
-        uiState.image?.let { image ->
+        val image = uiState.image
+        if (image != null) {
             actionableEmptyView.image.setImageResource(image)
             actionableEmptyView.image.visibility = View.VISIBLE
-        } ?: run {
+        } else {
             actionableEmptyView.image.visibility = View.GONE
         }
         uiHelpers.setTextOrHide(actionableEmptyView.title, uiState.title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -137,7 +137,12 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     private fun ActivityLogTypeFilterFragmentBinding.refreshErrorScreen(uiState: Error) {
-        actionableEmptyView.image.setImageResource(uiState.image)
+        uiState.image?.let { image ->
+            actionableEmptyView.image.setImageResource(image)
+            actionableEmptyView.image.visibility = View.VISIBLE
+        } ?: run {
+            actionableEmptyView.image.visibility = View.GONE
+        }
         uiHelpers.setTextOrHide(actionableEmptyView.title, uiState.title)
         uiHelpers.setTextOrHide(actionableEmptyView.subtitle, uiState.subtitle)
         uiHelpers.setTextOrHide(actionableEmptyView.button, uiState.buttonText)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -71,7 +71,8 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             if (response.isError) {
                 _uiState.value = buildErrorUiState()
             } else {
-                _uiState.value = buildContentUiState(response.activityTypeModels)
+               // _uiState.value = buildContentUiState(response.activityTypeModels)
+                _uiState.value = buildContentUiState(emptyList()) // TODO remove
             }
         }
     }
@@ -165,7 +166,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
 
         sealed class Error : UiState() {
             override val errorVisibility = true
-            abstract val image: Int
+            abstract val image: Int?
             abstract val title: UiString
             abstract val subtitle: UiString
             open val buttonText: UiString? = null
@@ -180,8 +181,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             }
 
             object NoActivitiesError : Error() {
-                @DrawableRes
-                override val image = R.drawable.img_illustration_empty_results_216dp
+                override val image = null
                 override val title = UiStringRes(R.string.activity_log_activity_type_empty_title)
                 override val subtitle = UiStringRes(R.string.activity_log_activity_type_empty_subtitle)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -71,8 +71,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             if (response.isError) {
                 _uiState.value = buildErrorUiState()
             } else {
-               // _uiState.value = buildContentUiState(response.activityTypeModels)
-                _uiState.value = buildContentUiState(emptyList()) // TODO remove
+                _uiState.value = buildContentUiState(response.activityTypeModels)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
@@ -174,12 +173,11 @@ class ActivityLogViewModel @Inject constructor(
     ) {
         currentRestoreEvent = restoreEvent
         currentBackupDownloadEvent = backupDownloadEvent
-        /*val eventList = activityLogStore.getActivityLogForSite(
+        val eventList = activityLogStore.getActivityLogForSite(
             site = site,
             ascending = false,
             rewindableOnly = rewindableOnly
-        )*/
-        val eventList = ArrayList<ActivityLogModel>() // TODO remove
+        )
         val items = mutableListOf<ActivityLogListItem>()
         var moveToTop = false
         val withRestoreProgressItem = restoreEvent.displayProgress && !restoreEvent.isCompleted

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
@@ -173,11 +174,12 @@ class ActivityLogViewModel @Inject constructor(
     ) {
         currentRestoreEvent = restoreEvent
         currentBackupDownloadEvent = backupDownloadEvent
-        val eventList = activityLogStore.getActivityLogForSite(
+        /*val eventList = activityLogStore.getActivityLogForSite(
             site = site,
             ascending = false,
             rewindableOnly = rewindableOnly
-        )
+        )*/
+        val eventList = ArrayList<ActivityLogModel>() // TODO remove
         val items = mutableListOf<ActivityLogListItem>()
         var moveToTop = false
         val withRestoreProgressItem = restoreEvent.displayProgress && !restoreEvent.isCompleted

--- a/WordPress/src/main/res/layout/activity_log_list_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_fragment.xml
@@ -10,7 +10,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone"
-        app:aevImage="@drawable/img_illustration_empty_results_216dp"
         app:aevSubtitle="@string/activity_log_empty_subtitle"
         app:aevTitle="@string/activity_log_empty_title"
         tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -5,6 +5,7 @@
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
This PR removes the empty view images in `ActivityLogListFragment` and  `ActivityLogTypeFilterFragment`.

**To Test**
- Change [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/3c23835e5ebd32cf584916280daea00d90470085/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt#L74) to `_uiState.value = buildContentUiState(emptyList())`
- Change [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/7b29d97a804e55a221f4fa874eba4ecdabfcf7e6/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt#L176) to `val eventList = ArrayList<ActivityLogModel>()`
- My Site > Activity log
- Verify the empty views in the two fragments no longer show an image

**List before & after**

<img width="610" height="629" alt="log" src="https://github.com/user-attachments/assets/84d7905c-e5d9-4814-9f30-00682ead165e" />

**Filters before & after**

<img width="610" height="629" alt="filter" src="https://github.com/user-attachments/assets/09b2da23-7eec-4dd8-aa48-0a84c3c23242" />

Note that I also fixed a bug with the filter screen where the close icon is overlapped by the system bar.