### PR TITLE
Fix Aztec media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1560,6 +1560,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                     super.openContextMenu(menuView)
                     menuView = null
                 }
+                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE -> {
+                    launchCamera()
+                }
             }
         }
     }
@@ -1934,14 +1937,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private fun onUploadProgress(media: MediaModel?, progress: Float) {
         val localMediaId = media?.id.toString()
         editorMediaUploadListener?.onMediaUploadProgress(localMediaId, progress)
-    }
-
-    private fun launchPictureLibrary() {
-        WPMediaUtils.launchPictureLibrary(this, editorPhotoPicker?.allowMultipleSelection == true)
-    }
-
-    private fun launchVideoLibrary() {
-        WPMediaUtils.launchVideoLibrary(this, editorPhotoPicker?.allowMultipleSelection == true)
     }
 
     private fun launchVideoCamera() {
@@ -2679,6 +2674,16 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 }
             }
         )
+    }
+
+    override fun checkCameraPermissionAndLaunch() {
+        if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
+                this,
+                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE
+            )
+        ) {
+            launchCamera()
+        }
     }
 
     private fun setPostContentFromShareAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -52,7 +52,6 @@ import kotlinx.parcelize.parcelableCreator
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.WordPress.Companion.getContext
@@ -353,6 +352,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
 
     @Inject lateinit var featuredImageHelper: FeaturedImageHelper
+
+    @Inject lateinit var editorCameraHelper: EditorCameraHelper
 
     @Inject lateinit var reactNativeRequestHandler: ReactNativeRequestHandler
 
@@ -2656,34 +2657,18 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    override fun launchCamera() {
-        WPMediaUtils.launchCamera(
-            this,
-            BuildConfig.APPLICATION_ID,
-            object : WPMediaUtils.LaunchCameraCallback {
-                override fun onMediaCapturePathReady(mediaCapturePath: String?) {
-                  this@EditPostActivity.mediaCapturePath = mediaCapturePath
-                }
+    private val cameraCallback = object : EditorCameraHelper.CameraCallback {
+        override fun onMediaCapturePathReady(mediaCapturePath: String?) {
+            this@EditPostActivity.mediaCapturePath = mediaCapturePath
+        }
+    }
 
-                override fun onCameraError(errorMessage: String?) {
-                    ToastUtils.showToast(
-                        this@EditPostActivity,
-                        errorMessage,
-                        ToastUtils.Duration.SHORT
-                    )
-                }
-            }
-        )
+    override fun launchCamera() {
+        editorCameraHelper.launchCamera(this, cameraCallback)
     }
 
     override fun checkCameraPermissionAndLaunch() {
-        if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
-                this,
-                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE
-            )
-        ) {
-            launchCamera()
-        }
+        editorCameraHelper.checkCameraPermissionAndLaunch(this, cameraCallback)
     }
 
     private fun setPostContentFromShareAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1938,10 +1938,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         editorMediaUploadListener?.onMediaUploadProgress(localMediaId, progress)
     }
 
-    private fun launchVideoCamera() {
-        editorCameraHelper.launchVideoCamera(this)
-    }
-
     private fun showErrorAndFinish(errorMessageId: Int) {
         ToastUtils.showToast(this, errorMessageId, ToastUtils.Duration.LONG)
         finish()
@@ -3208,11 +3204,11 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun onCapturePhotoClicked() {
-        if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-            launchCamera()
-        } else {
-            editorPhotoPicker?.showNoUploadPermissionSnackbar()
-        }
+        editorCameraHelper.capturePhotoIfAllowed(
+            siteModel,
+            onLaunchCamera = { launchCamera() },
+            onNoPermission = { editorPhotoPicker?.showNoUploadPermissionSnackbar() }
+        )
     }
 
     override fun onAddVideoClicked(allowMultipleSelection: Boolean) {
@@ -3288,11 +3284,11 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun onCaptureVideoClicked() {
-        if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-            launchVideoCamera()
-        } else {
-            editorPhotoPicker?.showNoUploadPermissionSnackbar()
-        }
+        editorCameraHelper.captureVideoIfAllowed(
+            this,
+            siteModel,
+            onNoPermission = { editorPhotoPicker?.showNoUploadPermissionSnackbar() }
+        )
     }
 
     override fun onMediaDropped(mediaUris: ArrayList<Uri>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1941,7 +1941,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun launchVideoCamera() {
-        WPMediaUtils.launchVideoCamera(this)
+        editorCameraHelper.launchVideoCamera(this)
     }
 
     private fun showErrorAndFinish(errorMessageId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1561,11 +1561,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                     super.openContextMenu(menuView)
                     menuView = null
                 }
-                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE -> {
-                    launchCamera()
-                }
             }
         }
+        editorCameraHelper.handleCameraPermissionResult(requestCode, allGranted) { launchCamera() }
     }
 
     private fun handleBackPressed(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
@@ -77,4 +77,25 @@ class EditorCameraHelper @Inject constructor() {
     fun launchVideoCamera(activity: Activity) {
         WPMediaUtils.launchVideoCamera(activity)
     }
+
+    /**
+     * Handles the camera permission result. Call this from onRequestPermissionsResult.
+     *
+     * @param requestCode The permission request code
+     * @param allGranted Whether all requested permissions were granted
+     * @param onLaunchCamera Callback to launch the camera if permission was granted
+     * @return true if this was a camera permission request and it was handled, false otherwise
+     */
+    fun handleCameraPermissionResult(
+        requestCode: Int,
+        allGranted: Boolean,
+        onLaunchCamera: () -> Unit
+    ): Boolean {
+        return if (requestCode == WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE && allGranted) {
+            onLaunchCamera()
+            true
+        } else {
+            false
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts
 import android.app.Activity
 import dagger.Reusable
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPMediaUtils
@@ -95,6 +96,50 @@ class EditorCameraHelper @Inject constructor() {
             onLaunchCamera()
             true
         } else {
+            false
+        }
+    }
+
+    /**
+     * Checks if the user can upload media and launches the photo camera if allowed.
+     *
+     * @param site The site to check upload permissions for
+     * @param onLaunchCamera Callback to launch the camera if upload is allowed
+     * @param onNoPermission Callback when user doesn't have upload permission
+     * @return true if user can upload and camera launch was initiated
+     */
+    fun capturePhotoIfAllowed(
+        site: SiteModel,
+        onLaunchCamera: () -> Unit,
+        onNoPermission: () -> Unit
+    ): Boolean {
+        return if (WPMediaUtils.currentUserCanUploadMedia(site)) {
+            onLaunchCamera()
+            true
+        } else {
+            onNoPermission()
+            false
+        }
+    }
+
+    /**
+     * Checks if the user can upload media and launches the video camera if allowed.
+     *
+     * @param activity The activity context
+     * @param site The site to check upload permissions for
+     * @param onNoPermission Callback when user doesn't have upload permission
+     * @return true if user can upload and video camera was launched
+     */
+    fun captureVideoIfAllowed(
+        activity: Activity,
+        site: SiteModel,
+        onNoPermission: () -> Unit
+    ): Boolean {
+        return if (WPMediaUtils.currentUserCanUploadMedia(site)) {
+            launchVideoCamera(activity)
+            true
+        } else {
+            onNoPermission()
             false
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
@@ -68,4 +68,13 @@ class EditorCameraHelper @Inject constructor() {
             false
         }
     }
+
+    /**
+     * Launches the video camera for capturing videos.
+     *
+     * @param activity The activity context
+     */
+    fun launchVideoCamera(activity: Activity) {
+        WPMediaUtils.launchVideoCamera(activity)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCameraHelper.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.ui.posts
+
+import android.app.Activity
+import dagger.Reusable
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.util.PermissionUtils
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.WPPermissionUtils
+import javax.inject.Inject
+
+/**
+ * Helper class that handles camera permission checks and launching the camera.
+ * Extracted from EditPostActivity and GutenbergKitActivity to reduce code duplication.
+ */
+@Reusable
+class EditorCameraHelper @Inject constructor() {
+    /**
+     * Callback interface for camera operations.
+     */
+    interface CameraCallback {
+        fun onMediaCapturePathReady(mediaCapturePath: String?)
+    }
+
+    /**
+     * Launches the camera for capturing photos.
+     *
+     * @param activity The activity context
+     * @param callback Callback to receive the media capture path
+     */
+    fun launchCamera(activity: Activity, callback: CameraCallback) {
+        WPMediaUtils.launchCamera(
+            activity,
+            BuildConfig.APPLICATION_ID,
+            object : WPMediaUtils.LaunchCameraCallback {
+                override fun onMediaCapturePathReady(mediaCapturePath: String?) {
+                    callback.onMediaCapturePathReady(mediaCapturePath)
+                }
+
+                override fun onCameraError(errorMessage: String?) {
+                    ToastUtils.showToast(
+                        activity,
+                        errorMessage,
+                        ToastUtils.Duration.SHORT
+                    )
+                }
+            }
+        )
+    }
+
+    /**
+     * Checks for camera permissions and launches the camera if granted.
+     *
+     * @param activity The activity context
+     * @param callback Callback to receive the media capture path
+     * @return true if permissions were already granted and camera was launched, false if permission
+     *         request was initiated
+     */
+    fun checkCameraPermissionAndLaunch(activity: Activity, callback: CameraCallback): Boolean {
+        return if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
+                activity,
+                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE
+            )
+        ) {
+            launchCamera(activity, callback)
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -1831,14 +1831,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
     }
 
-    private fun launchPictureLibrary() {
-        WPMediaUtils.launchPictureLibrary(this, editorPhotoPicker?.allowMultipleSelection == true)
-    }
-
-    private fun launchVideoLibrary() {
-        WPMediaUtils.launchVideoLibrary(this, editorPhotoPicker?.allowMultipleSelection == true)
-    }
-
     private fun launchVideoCamera() {
         WPMediaUtils.launchVideoCamera(this)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -202,6 +202,7 @@ import org.wordpress.android.util.StorageUtilsProvider
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPUrlUtils
@@ -1495,6 +1496,9 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                     super.openContextMenu(menuView)
                     menuView = null
                 }
+                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE -> {
+                    launchCamera()
+                }
             }
         }
     }
@@ -2410,6 +2414,16 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 }
             }
         )
+    }
+
+    override fun checkCameraPermissionAndLaunch() {
+        if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
+                this,
+                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE
+            )
+        ) {
+            launchCamera()
+        }
     }
 
     private fun setPostContentFromShareAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -51,7 +51,6 @@ import kotlinx.parcelize.parcelableCreator
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.WordPress.Companion.getContext
@@ -202,7 +201,6 @@ import org.wordpress.android.util.StorageUtilsProvider
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPUrlUtils
@@ -330,6 +328,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
 
     @Inject lateinit var featuredImageHelper: FeaturedImageHelper
+
+    @Inject lateinit var editorCameraHelper: EditorCameraHelper
 
     @Inject lateinit var reactNativeRequestHandler: ReactNativeRequestHandler
 
@@ -2396,34 +2396,18 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
     }
 
-    override fun launchCamera() {
-        WPMediaUtils.launchCamera(
-            this,
-            BuildConfig.APPLICATION_ID,
-            object : WPMediaUtils.LaunchCameraCallback {
-                override fun onMediaCapturePathReady(mediaCapturePath: String?) {
-                  this@GutenbergKitActivity.mediaCapturePath = mediaCapturePath
-                }
+    private val cameraCallback = object : EditorCameraHelper.CameraCallback {
+        override fun onMediaCapturePathReady(mediaCapturePath: String?) {
+            this@GutenbergKitActivity.mediaCapturePath = mediaCapturePath
+        }
+    }
 
-                override fun onCameraError(errorMessage: String?) {
-                    ToastUtils.showToast(
-                        this@GutenbergKitActivity,
-                        errorMessage,
-                        ToastUtils.Duration.SHORT
-                    )
-                }
-            }
-        )
+    override fun launchCamera() {
+        editorCameraHelper.launchCamera(this, cameraCallback)
     }
 
     override fun checkCameraPermissionAndLaunch() {
-        if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
-                this,
-                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE
-            )
-        ) {
-            launchCamera()
-        }
+        editorCameraHelper.checkCameraPermissionAndLaunch(this, cameraCallback)
     }
 
     private fun setPostContentFromShareAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -1832,7 +1832,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     }
 
     private fun launchVideoCamera() {
-        WPMediaUtils.launchVideoCamera(this)
+        editorCameraHelper.launchVideoCamera(this)
     }
 
     private fun showErrorAndFinish(errorMessageId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -1829,10 +1829,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
     }
 
-    private fun launchVideoCamera() {
-        editorCameraHelper.launchVideoCamera(this)
-    }
-
     private fun showErrorAndFinish(errorMessageId: Int) {
         ToastUtils.showToast(this, errorMessageId, ToastUtils.Duration.LONG)
         finish()
@@ -2779,19 +2775,19 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     }
 
     override fun onCapturePhotoClicked() {
-        if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-            launchCamera()
-        } else {
-            editorPhotoPicker?.showNoUploadPermissionSnackbar()
-        }
+        editorCameraHelper.capturePhotoIfAllowed(
+            siteModel,
+            onLaunchCamera = { launchCamera() },
+            onNoPermission = { editorPhotoPicker?.showNoUploadPermissionSnackbar() }
+        )
     }
 
     override fun onCaptureVideoClicked() {
-        if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-            launchVideoCamera()
-        } else {
-            editorPhotoPicker?.showNoUploadPermissionSnackbar()
-        }
+        editorCameraHelper.captureVideoIfAllowed(
+            this,
+            siteModel,
+            onNoPermission = { editorPhotoPicker?.showNoUploadPermissionSnackbar() }
+        )
     }
 
     override fun onAuthHeaderRequested(url: String): Map<String, String> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -1496,11 +1496,9 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                     super.openContextMenu(menuView)
                     menuView = null
                 }
-                WPPermissionUtils.AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE -> {
-                    launchCamera()
-                }
             }
         }
+        editorCameraHelper.handleCameraPermissionResult(requestCode, allGranted) { launchCamera() }
     }
 
     private fun handleBackPressed(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -186,11 +186,31 @@ class EditorPhotoPicker(
         }
     }
 
-    @Deprecated("Used only by AztecEditorFragment")
     override fun onMediaToolbarButtonClicked(action: MediaToolbarAction?) {
-        // MediaPickerFragment handles its own toolbar actions through FAB and menu,
-        // so this method is no longer needed for the embedded picker.
-        // The actions are now handled through MediaPickerListener.onIconClicked()
+        val siteModel = siteModelProvider()
+        when (action) {
+            MediaToolbarAction.GALLERY -> {
+                // Show the embedded photo picker for selecting media from device
+                showPhotoPicker(siteModel)
+            }
+            MediaToolbarAction.CAMERA -> {
+                // Launch the camera to capture a photo
+                if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
+                    editorMediaActions.launchCamera()
+                } else {
+                    showNoUploadPermissionSnackbar()
+                }
+            }
+            MediaToolbarAction.LIBRARY -> {
+                // Open the WP Media Library
+                mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+                    activity,
+                    siteModel,
+                    MediaBrowserType.EDITOR_PICKER
+                )
+            }
+            null -> { /* no-op */ }
+        }
     }
 
     fun onOrientationChanged(@Orientation newOrientation: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -39,6 +39,13 @@ interface EditorPhotoPickerListener {
  */
 interface EditorMediaActions {
     fun launchCamera()
+
+    /**
+     * Checks for camera permissions and launches the camera if granted.
+     * If permissions are not granted, requests them from the user.
+     * The activity should handle the permission result and call launchCamera() when granted.
+     */
+    fun checkCameraPermissionAndLaunch()
 }
 
 /**
@@ -194,9 +201,9 @@ class EditorPhotoPicker(
                 showPhotoPicker(siteModel)
             }
             MediaToolbarAction.CAMERA -> {
-                // Launch the camera to capture a photo
+                // Launch the camera to capture a photo (after checking permissions)
                 if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-                    editorMediaActions.launchCamera()
+                    editorMediaActions.checkCameraPermissionAndLaunch()
                 } else {
                     showNoUploadPermissionSnackbar()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -35,6 +35,7 @@ public class WPPermissionUtils {
     public static final int MEDIA_PREVIEW_PERMISSION_REQUEST_CODE = 30;
     public static final int PHOTO_PICKER_MEDIA_PERMISSION_REQUEST_CODE = 40;
     public static final int PHOTO_PICKER_CAMERA_PERMISSION_REQUEST_CODE = 41;
+    public static final int AZTEC_EDITOR_CAMERA_PERMISSION_REQUEST_CODE = 42;
     public static final int EDITOR_MEDIA_PERMISSION_REQUEST_CODE = 60;
     public static final int READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE = 80;
 


### PR DESCRIPTION
As noted in [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/22427#issuecomment-3666759726), [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/22427) broke media selection in the Aztec editor. This PR restores it and updates the related tests. 

I've labeled this as **high priority** because until this is merged, media selection in the Aztec editor is broken.

**To test**
- Use a fresh install to ensure no permissions have been granted
- Switch to a self-hosted site
- In Site Settings, disable the block editor to force the app to use the Aztec editor
- Create a post
- In the editor, click the **+** icon
- Ensure all three media icons in the toolbar work and that permissions are correctly requested
- Also test when permissions are not granted

<img width="297" height="629" alt="Screenshot_20251220_110529" src="https://github.com/user-attachments/assets/0b1767d7-8fd1-4dff-b08e-87b7422e61fc" />
