### PR TITLE
CMM-1081 unify media quota bar with iOS

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
@@ -60,8 +60,13 @@ class QuotaPreference(
         }
 
         view.findViewById<LinearProgressIndicator>(R.id.quota_progress)?.apply {
-            setProgress(progress)
-            updateAlphaForEnabledState(res)
+            if (progress < 0) {
+                visibility = View.GONE
+            } else {
+                visibility = View.VISIBLE
+                setProgress(progress)
+                updateAlphaForEnabledState(res)
+            }
         }
     }
 
@@ -78,11 +83,14 @@ class QuotaPreference(
 
     /**
      * Sets the progress value for the quota progress bar.
-     * @param value The progress value (0-100)
+     * @param value The progress value (0-100), or negative for unlimited storage
      */
     fun setProgress(value: Int) {
-        progress = value.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
-        notifyChanged()
+        val newProgress = if (value < 0) value else value.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
+        if (progress != newProgress) {
+            progress = newProgress
+            notifyChanged()
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
@@ -69,10 +69,7 @@ class QuotaPreference(
                     com.google.android.material.R.dimen.material_emphasis_disabled
                 )
             } else {
-                ResourcesCompat.getFloat(
-                    res,
-                    com.google.android.material.R.dimen.material_emphasis_medium
-                )
+                1f
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
@@ -1,0 +1,114 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.prefs
+
+import android.content.Context
+import android.preference.Preference
+import android.util.AttributeSet
+import android.view.View
+import android.widget.TextView
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.widget.TextViewCompat
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import org.wordpress.android.R
+
+/**
+ * A preference that displays quota information with a text summary and a progress bar.
+ * Used to show media storage quota usage in site settings.
+ */
+class QuotaPreference(
+    context: Context,
+    attrs: AttributeSet
+) : Preference(context, attrs), PreferenceHint {
+
+    private var hint: String? = null
+    private var progress: Int = 0
+
+    init {
+        layoutResource = R.layout.quota_preference
+
+        context.obtainStyledAttributes(attrs, R.styleable.QuotaPreference).apply {
+            for (i in 0 until indexCount) {
+                when (getIndex(i)) {
+                    R.styleable.QuotaPreference_longClickHint -> hint = getString(i)
+                }
+            }
+            recycle()
+        }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBindView(view: View) {
+        super.onBindView(view)
+
+        val res = context.resources
+
+        view.findViewById<TextView>(android.R.id.title)?.apply {
+            TextViewCompat.setTextAppearance(
+                this,
+                com.google.android.material.R.style.TextAppearance_MaterialComponents_Subtitle1
+            )
+            alpha = if (!isEnabled) {
+                ResourcesCompat.getFloat(
+                    res,
+                    com.google.android.material.R.dimen.material_emphasis_disabled
+                )
+            } else {
+                1f
+            }
+        }
+
+        view.findViewById<TextView>(android.R.id.summary)?.apply {
+            TextViewCompat.setTextAppearance(
+                this,
+                com.google.android.material.R.style.TextAppearance_MaterialComponents_Body2
+            )
+            alpha = if (!isEnabled) {
+                ResourcesCompat.getFloat(
+                    res,
+                    com.google.android.material.R.dimen.material_emphasis_disabled
+                )
+            } else {
+                ResourcesCompat.getFloat(
+                    res,
+                    com.google.android.material.R.dimen.material_emphasis_medium
+                )
+            }
+        }
+
+        view.findViewById<LinearProgressIndicator>(R.id.quota_progress)?.apply {
+            setProgress(progress)
+            alpha = if (!isEnabled) {
+                ResourcesCompat.getFloat(
+                    res,
+                    com.google.android.material.R.dimen.material_emphasis_disabled
+                )
+            } else {
+                1f
+            }
+        }
+    }
+
+    /**
+     * Sets the progress value for the quota progress bar.
+     * @param value The progress value (0-100)
+     */
+    fun setProgress(value: Int) {
+        progress = value.coerceIn(0, 100)
+        notifyChanged()
+    }
+
+    /**
+     * Gets the current progress value.
+     * @return The progress value (0-100)
+     */
+    fun getProgress(): Int = progress
+
+    override fun hasHint(): Boolean = !hint.isNullOrEmpty()
+
+    override fun getHint(): String? = hint
+
+    override fun setHint(hint: String?) {
+        this.hint = hint
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
@@ -20,9 +20,13 @@ class QuotaPreference(
     context: Context,
     attrs: AttributeSet
 ) : Preference(context, attrs), PreferenceHint {
-
     private var hint: String? = null
-    private var progress: Int = 0
+    private var progress: Int = MIN_PROGRESS
+
+    companion object {
+        private const val MIN_PROGRESS = 0
+        private const val MAX_PROGRESS = 100
+    }
 
     init {
         layoutResource = R.layout.quota_preference
@@ -91,7 +95,7 @@ class QuotaPreference(
      * @param value The progress value (0-100)
      */
     fun setProgress(value: Int) {
-        progress = value.coerceIn(0, 100)
+        progress = value.coerceIn(MIN_PROGRESS, MAX_PROGRESS)
         notifyChanged()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/QuotaPreference.kt
@@ -3,6 +3,7 @@
 package org.wordpress.android.ui.prefs
 
 import android.content.Context
+import android.content.res.Resources
 import android.preference.Preference
 import android.util.AttributeSet
 import android.view.View
@@ -22,11 +23,6 @@ class QuotaPreference(
 ) : Preference(context, attrs), PreferenceHint {
     private var hint: String? = null
     private var progress: Int = MIN_PROGRESS
-
-    companion object {
-        private const val MIN_PROGRESS = 0
-        private const val MAX_PROGRESS = 100
-    }
 
     init {
         layoutResource = R.layout.quota_preference
@@ -52,14 +48,7 @@ class QuotaPreference(
                 this,
                 com.google.android.material.R.style.TextAppearance_MaterialComponents_Subtitle1
             )
-            alpha = if (!isEnabled) {
-                ResourcesCompat.getFloat(
-                    res,
-                    com.google.android.material.R.dimen.material_emphasis_disabled
-                )
-            } else {
-                1f
-            }
+            updateAlphaForEnabledState(res)
         }
 
         view.findViewById<TextView>(android.R.id.summary)?.apply {
@@ -67,26 +56,23 @@ class QuotaPreference(
                 this,
                 com.google.android.material.R.style.TextAppearance_MaterialComponents_Body2
             )
-            alpha = if (!isEnabled) {
-                ResourcesCompat.getFloat(
-                    res,
-                    com.google.android.material.R.dimen.material_emphasis_disabled
-                )
-            } else {
-                1f
-            }
+            updateAlphaForEnabledState(res)
         }
 
         view.findViewById<LinearProgressIndicator>(R.id.quota_progress)?.apply {
             setProgress(progress)
-            alpha = if (!isEnabled) {
-                ResourcesCompat.getFloat(
-                    res,
-                    com.google.android.material.R.dimen.material_emphasis_disabled
-                )
-            } else {
-                1f
-            }
+            updateAlphaForEnabledState(res)
+        }
+    }
+
+    private fun View.updateAlphaForEnabledState(res: Resources) {
+        alpha = if (!isEnabled) {
+            ResourcesCompat.getFloat(
+                res,
+                com.google.android.material.R.dimen.material_emphasis_disabled
+            )
+        } else {
+            1f
         }
     }
 
@@ -111,5 +97,10 @@ class QuotaPreference(
 
     override fun setHint(hint: String?) {
         this.hint = hint
+    }
+
+    companion object {
+        private const val MIN_PROGRESS = 0
+        private const val MAX_PROGRESS = 100
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1100,6 +1100,9 @@ public class SiteSettingsFragment extends PreferenceFragment
                                             && mSite.getPlanId() != PlansConstants.JETPACK_PREMIUM_PLAN_ID
                                             && mSite.getPlanId() != PlansConstants.BUSINESS_PLAN_ID)) {
             removeJetpackMediaSettings();
+        } else if (mSiteQuotaSpacePref != null) {
+            // Premium plans show quota but don't need the long press hint
+            mSiteQuotaSpacePref.setHint(null);
         }
 
         // Simple WPCom Sites now always default to Gutenberg Editor

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -243,7 +243,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mCategoriesPref;
 
     // Media settings
-    private EditTextPreference mSiteQuotaSpacePref;
+    private QuotaPreference mSiteQuotaSpacePref;
 
     // Discussion settings preview
     private WPSwitchPreference mAllowCommentsPref;
@@ -1028,7 +1028,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mHomepagePref = (WPPreference) getChangePref(R.string.pref_key_homepage_settings);
         updateHomepageSummary();
         mAmpPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_amp);
-        mSiteQuotaSpacePref = (EditTextPreference) getChangePref(R.string.pref_key_site_quota_space);
+        mSiteQuotaSpacePref = (QuotaPreference) getChangePref(R.string.pref_key_site_quota_space);
         sortLanguages();
         mGutenbergDefaultForNewPosts =
                 (WPSwitchPreference) getChangePref(R.string.pref_key_gutenberg_default_for_new_posts);
@@ -1575,7 +1575,17 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         mPostsPerPagePref.setSummary(String.valueOf(mSiteSettings.getPostsPerPage()));
         setTimezonePref(mSiteSettings.getTimezone());
-        changeEditTextPreferenceValue(mSiteQuotaSpacePref, mSiteSettings.getQuotaDiskSpace());
+        updateQuotaSpacePreference();
+    }
+
+    private void updateQuotaSpacePreference() {
+        if (mSiteQuotaSpacePref == null) {
+            return;
+        }
+        mSiteQuotaSpacePref.setSummary(mSiteSettings.getQuotaDiskSpace());
+        if (mSite != null && mSite.hasDiskSpaceQuotaInformation()) {
+            mSiteQuotaSpacePref.setProgress((int) mSite.getSpacePercentUsed());
+        }
     }
 
     private boolean isShowingImproveSearchPreference() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1097,7 +1097,8 @@ public class SiteSettingsFragment extends PreferenceFragment
             removeJetpackSiteAcceleratorSettings();
         }
         if (!mSite.isJetpackConnected() || (mSite.getPlanId() != PlansConstants.JETPACK_BUSINESS_PLAN_ID
-                                            && mSite.getPlanId() != PlansConstants.JETPACK_PREMIUM_PLAN_ID)) {
+                                            && mSite.getPlanId() != PlansConstants.JETPACK_PREMIUM_PLAN_ID
+                                            && mSite.getPlanId() != PlansConstants.BUSINESS_PLAN_ID)) {
             removeJetpackMediaSettings();
         }
 

--- a/WordPress/src/main/res/layout/quota_preference.xml
+++ b/WordPress/src/main/res/layout/quota_preference.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/dlp_padding_start"
+    android:paddingTop="@dimen/dlp_padding_top"
+    android:paddingEnd="@dimen/dlp_padding_end"
+    android:paddingBottom="@dimen/dlp_padding_bottom">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@android:id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="marquee"
+        android:singleLine="true"
+        android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@android:id/summary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textAppearance="?attr/textAppearanceBody2" />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/quota_progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:trackCornerRadius="2dp"
+        app:trackThickness="8dp" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -64,6 +64,11 @@
         <attr name="longClickHint" />
     </declare-styleable>
 
+    <!-- QuotaPreference attributes -->
+    <declare-styleable name="QuotaPreference">
+        <attr name="longClickHint" />
+    </declare-styleable>
+
     <declare-styleable name="WPStartOverPreference">
         <attr name="preficon" format="reference" />
         <attr name="buttonText" format="string" />

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -211,7 +211,6 @@
 
         <org.wordpress.android.ui.prefs.QuotaPreference
             android:id="@+id/pref_site_quota_space"
-            android:enabled="false"
             android:key="@string/pref_key_site_quota_space"
             android:title="@string/site_settings_quota_space_title"
             app:longClickHint="@string/site_settings_quota_space_hint" />

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -209,14 +209,12 @@
         android:key="@string/pref_key_site_quota"
         android:title="@string/site_settings_quota_header">
 
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+        <org.wordpress.android.ui.prefs.QuotaPreference
             android:id="@+id/pref_site_quota_space"
             android:enabled="false"
             android:key="@string/pref_key_site_quota_space"
             android:title="@string/site_settings_quota_space_title"
-            app:longClickHint="@string/site_settings_quota_space_hint"
-            app:maxSummaryLines="1"
-            app:summaryLines="1" />
+            app:longClickHint="@string/site_settings_quota_space_hint" />
     </PreferenceCategory>
     <!-- Traffic settings -->
     <PreferenceCategory


### PR DESCRIPTION
## Description

  Add a visual progress bar to the Media Quota setting in Site Settings to follow the iOS UI. The quota preference now displays both the text summary (e.g., "50% of 3 GB") and a `LinearProgressIndicator` showing the storage usage percentage visually.

  This change introduces a new `QuotaPreference` component that extends the standard Preference with a custom layout containing title, summary text, and a progress bar.

<img width="343" height="104" alt="Screenshot 2025-12-22 at 11 35 51" src="https://github.com/user-attachments/assets/b3f82485-0d04-4b4d-b156-8c6876551f66" />
<img width="358" height="107" alt="Screenshot 2025-12-22 at 13 32 19" src="https://github.com/user-attachments/assets/2928a287-723f-4e19-94c3-a5a5099ec45a" />

  ## Testing instructions

  Media quota progress bar:

  1. Open the app and navigate to a WordPress.com site
  2. Go to Site Settings
  3. Scroll down to the "Media" section
  - [ ] Verify the "Space available" preference shows the quota text (e.g., "50% of 3 GB")
  - [ ] Verify a progress bar is displayed below the text showing the usage percentage
  - [ ] Verify the progress bar fills according to the percentage used
  4. Long press on the preference
  - [ ] Verify the long press hint toast appears

  1. Test with a self-hosted site
  - [ ] Verify the Media quota section is not displayed (as expected)