### PR TITLE
Internal: Add kotlin coding instructions to Claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ WordPress/src/main/java/org/wordpress/android/
   - Breaking parameter lists across multiple lines
   - Using proper indentation for continuation lines
 
+### Kotlin Conventions
+- **Kotlin First**: All new classes must be written in Kotlin; avoid Java for new code
+- **No Empty Lines After Braces**: Do not add empty lines immediately after opening braces (`{`)
+- **Companion Object Placement**: Place `companion object` at the bottom of the class, after all
+  other members (properties, init blocks, constructors, functions)
+
 ### Development Workflow
 - Default development flavor: `jetpackWasabi` (Jetpack app with beta suffix)
 - Remote build cache available for faster builds (requires setup)


### PR DESCRIPTION
## Description

  Adds Kotlin-specific coding conventions to CLAUDE.md to ensure consistent code style when Claude Code generates new code. The new guidelines cover:
  - Using Kotlin for all new classes (avoiding Java)
  - Prohibiting empty lines after opening braces
  - Placing companion objects at the bottom of classes

  Note: Claude created a Java class when I asked for a current issue I'm working on 😅 . So,I went ahead with this.
