### PR TITLE
CMM-1037 History list fragment empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -200,7 +200,7 @@ class HistoryViewModel @Inject constructor(
             items.add(HistoryListItem.Footer(footer))
         }
 
-        return items
+        return emptyList() // TODO items
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -200,7 +200,7 @@ class HistoryViewModel @Inject constructor(
             items.add(HistoryListItem.Footer(footer))
         }
 
-        return emptyList() // TODO items
+        return items
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/res/layout/history_list_fragment.xml
+++ b/WordPress/src/main/res/layout/history_list_fragment.xml
@@ -20,7 +20,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:visibility="gone"
-                app:aevImage="@drawable/img_illustration_empty_results_216dp"
                 app:aevSubtitle="@string/history_empty_subtitle_page"
                 app:aevTitle="@string/history_empty_title"
                 tools:visibility="visible" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1969,8 +1969,8 @@
     <string name="history_detail_button_next">Next</string>
     <string name="history_detail_button_previous">Previous</string>
     <string name="history_detail_title">Revision</string>
-    <string name="history_empty_subtitle_page">When you make changes to your page you\'ll be able to see the history here</string>
-    <string name="history_empty_subtitle_post">When you make changes to your post you\'ll be able to see the history here</string>
+    <string name="history_empty_subtitle_page">You\'ll see this page\'s history when you make changes to it</string>
+    <string name="history_empty_subtitle_post">You\'ll see this post\'s history when you make changes to it</string>
     <string name="history_empty_title">No history yet</string>
     <string name="history_footer_page">Page Created on %1$s at %2$s</string>
     <string name="history_footer_post">Post Created on %1$s at %2$s</string>


### PR DESCRIPTION
This PR removes the image from the `HistoryListFragment` empty view and shortens the wording of the empty view subtitle.

**To test**
- Change [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/9e0980127313b6cadc90517ed59c503dced0d586/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt#L203) to `return emptyList()`
- Edit a post
- Tap the dot-dot-dot menu
- Select History
- Verify the empty view appears correctly

**Before and after shots**

<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/0f86cdd5-45ae-45ad-be63-0307eb364359" />
