### PR TITLE
CMM-1037 Home page picker fragment empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -200,7 +200,7 @@ class HistoryViewModel @Inject constructor(
             items.add(HistoryListItem.Footer(footer))
         }
 
-        return items
+        return emptyList() // TODO items
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -200,7 +200,7 @@ class HistoryViewModel @Inject constructor(
             items.add(HistoryListItem.Footer(footer))
         }
 
-        return emptyList() // TODO items
+        return items
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/res/layout/history_list_fragment.xml
+++ b/WordPress/src/main/res/layout/history_list_fragment.xml
@@ -20,7 +20,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:visibility="gone"
-                app:aevImage="@drawable/img_illustration_empty_results_216dp"
                 app:aevSubtitle="@string/history_empty_subtitle_page"
                 app:aevTitle="@string/history_empty_title"
                 tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -100,7 +100,6 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:aevButton="@string/retry"
-        app:aevImage="@drawable/img_illustration_empty_results_216dp"
         app:aevImageHiddenInLandscape="true"
         app:aevSubtitle="@string/hpp_error_subtitle"
         app:aevTitle="@string/hpp_error_title"

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -97,10 +97,9 @@
     <org.wordpress.android.ui.ActionableEmptyView
         android:id="@+id/errorView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:visibility="gone"
         app:aevButton="@string/retry"
-        app:aevImageHiddenInLandscape="true"
         app:aevSubtitle="@string/hpp_error_subtitle"
         app:aevTitle="@string/hpp_error_title"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1969,8 +1969,8 @@
     <string name="history_detail_button_next">Next</string>
     <string name="history_detail_button_previous">Previous</string>
     <string name="history_detail_title">Revision</string>
-    <string name="history_empty_subtitle_page">When you make changes to your page you\'ll be able to see the history here</string>
-    <string name="history_empty_subtitle_post">When you make changes to your post you\'ll be able to see the history here</string>
+    <string name="history_empty_subtitle_page">You\'ll see this page\'s history when you make changes to it</string>
+    <string name="history_empty_subtitle_post">You\'ll see this post\'s history when you make changes to it</string>
     <string name="history_empty_title">No history yet</string>
     <string name="history_footer_page">Page Created on %1$s at %2$s</string>
     <string name="history_footer_post">Post Created on %1$s at %2$s</string>


### PR DESCRIPTION
As part of CMM-1037, this PR updates the empty view for the `HomePagePickerFragment`.

**To test**
- Enable airplane mode
- On My Site, tap the dropdown arrow at the top right to switch sites
- When the site picker appears, tap the FAB
- Tap "Add a site"
- Tap "Create WordPress.com site"
- Skip choosing a theme
- In the subsequent screen, verify the empty view appears correctly

**Before and after shots**

<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/a24c36f7-7138-4d10-8ae5-53050798453b" />
