### PR TITLE
Migrate release pipelines to mac-metal queue

### DIFF
--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     agents:
-       queue: "tumblr-metal"
+       queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :snowflake: Complete Code Freeze'
       bundle exec fastlane complete_code_freeze skip_confirm:true
     agents:
-       queue: "tumblr-metal"
+       queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/finalize-hotfix-release.yml
+++ b/.buildkite/finalize-hotfix-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :shipit: Finalize hotfix'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     agents:
-       queue: tumblr-metal
+       queue: mac-metal
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true
     agents:
-       queue: "tumblr-metal"
+       queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/new-beta-release.yml
+++ b/.buildkite/new-beta-release.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true
     agents:
-       queue: "tumblr-metal"
+       queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/new-hotfix-release.yml
+++ b/.buildkite/new-hotfix-release.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :shipit: Start new hotfix'
       bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" build_code:"$BUILD_CODE" skip_confirm:true
     agents:
-       queue: tumblr-metal
+       queue: mac-metal
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/publish-release.yml
+++ b/.buildkite/publish-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :package: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
     agents:
-       queue: tumblr-metal
+       queue: mac-metal
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -17,7 +17,7 @@ steps:
       echo '--- :memo: Update Release Notes'
       bundle exec fastlane update_appstore_strings version:${RELEASE_VERSION}
     agents:
-       queue: "tumblr-metal"
+       queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite


### PR DESCRIPTION
Fixes AINFRA-1664

Migrate release pipeline jobs from `tumblr-metal` to `mac-metal` queue.