### PR TITLE
[Tooling] Update Claude Build Analysis to consider any failing job

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is dynamically uploaded at the end of the build after a wait step
+
+agents:
+  queue: default
+
+steps:
+  - label: ":claude: Claude Build Analysis"
+    key: claude-analysis
+    if: build.state == "failing"
+    soft_fail: true
+    command: "exit 1"
+    plugins:
+      - $CLAUDE_PLUGIN:
+          api_key: "$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          analysis_level: "build"
+          trigger: "always"
+          custom_prompt: "Do not mention successful points, focus on failures and recovery to keep the analysis succint. Only add the `Best Practices` section if the changes in this PR are directly relevant to it. Only add a `Root Cause` section when you're sure about the issues' causes."
+          model: "claude-sonnet-4-5"
+
+  - label: ":claude: 💬 Comment Claude Analysis"
+    command: .buildkite/commands/comment-claude-analysis.sh
+    depends_on: claude-analysis
+    allow_dependency_failure: true
+    if: build.pull_request.id != null
+    plugins:
+      - $CI_TOOLKIT
+

--- a/.buildkite/commands/comment-claude-analysis.sh
+++ b/.buildkite/commands/comment-claude-analysis.sh
@@ -1,16 +1,14 @@
 #!/bin/bash -eu
 
-# Check if unit tests failed (matches both hard_failed and soft_failed outcomes)
-if buildkite-agent step get outcome --step unit-tests | grep -q "failed"; then
-  comment_on_pr --id claude-test-analysis "$(cat <<EOF
+# The claude-analysis step only runs when there are build failures,
+# so if it ran (and soft_failed), it means there were failures that Claude analyzed.
+CLAUDE_OUTCOME=$(buildkite-agent step get outcome --step claude-analysis 2>/dev/null || echo "not_run")
 
-## 🤖 Test Failure Analysis
+if [[ "${CLAUDE_OUTCOME}" == "soft_failed" ]]; then
+  comment_on_pr --id claude-build-analysis "## 🤖 Build Failure Analysis
 
-Your tests failed. Claude has analyzed the failures - <a href="${BUILDKITE_BUILD_URL}/annotations#annotation-claude-analysis-${BUILDKITE_BUILD_ID}" target="_blank">check the annotation</a> for details.
-EOF
-)"
-
+This build has failures. Claude has analyzed them - <a href=\"${BUILDKITE_BUILD_URL}/annotations\" target=\"_blank\">check the build annotations</a> for details."
 else
-  # Remove the comment if tests are now passing
-  comment_on_pr --id claude-test-analysis --if-exist delete
+  # Remove the comment if the build is now passing (claude-analysis did not run)
+  comment_on_pr --id claude-build-analysis --if-exist delete
 fi

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -52,6 +52,8 @@ declare -A TEST_RESULT_DIRS=(
   ["login"]="libs/login/build/test-results/testDebugUnitTest"
 )
 
+exit 1
+
 # Create temporary directory for collecting all test results
 temp_test_results_dir=$(mktemp -d)
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -52,8 +52,6 @@ declare -A TEST_RESULT_DIRS=(
   ["login"]="libs/login/build/test-results/testDebugUnitTest"
 )
 
-exit 1
-
 # Create temporary directory for collecting all test results
 temp_test_results_dir=$(mktemp -d)
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,20 +109,9 @@ steps:
       - $TEST_COLLECTOR :
           <<: *test_collector_common_params
           api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
-      - $CLAUDE_PLUGIN:
-          api_key: "$ANTHROPIC_API_KEY"
-          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
     artifact_paths:
       - "**/build/test-results/merged-test-results.xml"
       - "**/build/reports/kover/*.xml"
-
-  - label: "💬 Comment Claude Analysis"
-    command: .buildkite/commands/comment-claude-analysis.sh
-    depends_on: unit-tests
-    allow_dependency_failure: true
-    if: build.pull_request.id != null
-    plugins:
-      - $CI_TOOLKIT
 
   #################
   # Instrumented (aka UI) Tests
@@ -173,4 +162,17 @@ steps:
       - label: ":jetpack: Populate Gradle build cache"
         command: ".buildkite/commands/gradle-cache-build.sh jetpack"
         plugins: [ $CI_TOOLKIT ]
+
+  #################
+  # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
+  #################
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
+    command: |
+      source .buildkite/shared-pipeline-vars
+      buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+    agents:
+      queue: upload
 


### PR DESCRIPTION
Fixes AINFRA-1695

## Description
Follow-up to https://github.com/wordpress-mobile/WordPress-Android/pull/22267.

Claude will then from now on run and analyze any build job that has failed, adding a report annotation about the build failure. We'll also add a PR comment mentioning the Claude build analysis.

## Testing
See failed test [build](https://buildkite.com/automattic/wordpress-android/builds/24347) with annotation:
<img width="1569" height="592" alt="Screenshot 2026-01-06 at 13 28 18" src="https://github.com/user-attachments/assets/39eeae6b-56ef-4437-badd-6b4fcad91db6" />

If you want, you can also check the annotation by creating a Pull Request based on this branch and breaking any of the jobs in the build.