### PR TITLE
Fix stats location endpoint

### DIFF
--- a/libs/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -122,7 +122,7 @@
 /sites/$site/stats/referrers/spam/new
 /sites/$site/stats/referrers/spam/delete
 /sites/$site/stats/clicks
-/sites/$site/stats/country-views
+/sites/$site/stats/location-views/country
 /sites/$site/stats/top-authors
 /sites/$site/stats/video-plays
 /sites/$site/stats/comments

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClient.kt
@@ -39,7 +39,7 @@ class CountryViewsRestClient
         itemsToLoad: Int,
         forced: Boolean
     ): FetchStatsPayload<CountryViewsResponse> {
-        val url = WPCOMREST.sites.site(site.siteId).stats.country_views.urlV1_1
+        val url = WPCOMREST.sites.site(site.siteId).stats.location_views.country.urlV1_1
         val params = mapOf(
                 "period" to granularity.toString(),
                 "max" to itemsToLoad.toString(),

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -118,7 +118,7 @@ class CountryViewsRestClientTest {
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/location-views/country")
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/location-views/country/")
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "max" to pageSize.toString(),

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -118,7 +118,7 @@ class CountryViewsRestClientTest {
         assertThat(responseModel.response).isNotNull()
         assertThat(responseModel.response).isEqualTo(response)
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/country-views/")
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/location-views/country")
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "max" to pageSize.toString(),

--- a/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-day.json
+++ b/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-day.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/country-views/",
+        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/location-views/country",
         "queryParameters": {
             "period": {
                 "equalTo": "day"
@@ -27,7 +27,7 @@
                         {
                             "country_code": "US",
                             "views": 7
-                        }            
+                        }
                     ],
                     "other_views": 0,
                     "total_views": 17

--- a/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-month.json
+++ b/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-month.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/country-views/",
+        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/        \"urlPathPattern\": \"/rest/v1.1/sites/([0-9]+)/stats/location-views/country\",\n",
         "queryParameters": {
             "period": {
                 "equalTo": "month"

--- a/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-year.json
+++ b/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_country-views-year.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/country-views/",
+        "urlPathPattern": "/rest/v1.1/sites/([0-9]+)/stats/        \"urlPathPattern\": \"/rest/v1.1/sites/([0-9]+)/stats/location-views/country\",\n",
         "queryParameters": {
             "period": {
                 "equalTo": "year"


### PR DESCRIPTION
As noted in [this iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/25105), we've been using the wrong endpoint for the stats location view. This PR resolves the issue.

Here's what the location view previously showed:

<img width="297" height="629" alt="stats-before" src="https://github.com/user-attachments/assets/24ad1f60-aa4f-44eb-a34c-8b7143da9fc3" />

But the web app shows different data for this period:

<img width="1256" height="591" alt="Screenshot 2026-01-07 at 10 54 47 AM" src="https://github.com/user-attachments/assets/d933104d-c16e-48f6-bf84-63b194ad1e4e" />

Updating the endpoint in this PR now shows the same data:

<img width="297" height="629" alt="stats-after" src="https://github.com/user-attachments/assets/20831430-dd91-4fdf-bdd3-f1fd2af6df16" />

To test, simply verify the location stats are the same between the app and the web.

