### PR TITLE
Removed image from comment list empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListUiModelHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListUiModelHelper.kt
@@ -79,7 +79,6 @@ class CommentListUiModelHelper @Inject constructor(
 
         data class Empty(
             val title: UiString,
-            val image: Int? = null
         ) : CommentsListUiModel()
 
         object Loading : CommentsListUiModel()
@@ -299,7 +298,6 @@ class CommentListUiModelHelper @Inject constructor(
                 if (commentsDataResult.data.comments.isEmpty()) {
                     CommentsListUiModel.Empty(
                         UiStringRes(getEmptyViewMessageResId(commentFilter)),
-                        R.drawable.img_illustration_empty_results_216dp
                     )
                 } else {
                     WithData
@@ -317,7 +315,6 @@ class CommentListUiModelHelper @Inject constructor(
                     }
                     CommentsListUiModel.Empty(
                         errorString,
-                        R.drawable.img_illustration_empty_results_216dp
                     )
                 } else {
                     return WithData

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -217,13 +217,6 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
 
         when (uiModel) {
             is CommentsListUiModel.Empty -> {
-                if (uiModel.image != null) {
-                    actionableEmptyView.image.visibility = View.VISIBLE
-                    actionableEmptyView.image.setImageResource(uiModel.image)
-                } else {
-                    actionableEmptyView.image.visibility = View.GONE
-                }
-
                 actionableEmptyView.title.text = uiHelpers.getTextOfUiString(
                     requireContext(),
                     uiModel.title

--- a/WordPress/src/main/res/layout/unified_comment_list_fragment.xml
+++ b/WordPress/src/main/res/layout/unified_comment_list_fragment.xml
@@ -25,7 +25,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:visibility="gone"
-                app:aevImage="@drawable/img_illustration_empty_results_216dp"
                 app:aevTitle="@string/comments_empty_list"
                 tools:visibility="visible" />
 


### PR DESCRIPTION
As part of CMM-1037, this small PR removes the image from the empty view in `UnifiedCommentListFragment`. Note that unlike some of the other empty views, I didn't add a button action because I couldn't think of one suitable (also, note there's no button action on iOS, either).

**To test**
- Switch to a site that has no comments
- My Site > Comments
- Verify the empty view looks as expected

Before and after:

<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/e7906a3d-a526-43ac-b23b-5767b4bc810b" />
