### PR TITLE
Modal layout picker emptyview

### DIFF
--- a/WordPress/src/main/res/layout/modal_layout_picker_error.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_error.xml
@@ -10,8 +10,6 @@
         android:id="@+id/actionableEmptyView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:aevImage="@drawable/img_illustration_empty_results_216dp"
-        app:aevImageHiddenInLandscape="true"
         app:aevSubtitle="@string/mlp_error_subtitle"
         app:aevTitle="@string/mlp_error_title" />
 </FrameLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3734,9 +3734,9 @@
     <string name="mlp_notice_page_created">Page created</string>
     <string name="mlp_notice_blank_page_created">Blank page created</string>
     <string name="mlp_error_title">Layouts not available due to an error</string>
-    <string name="mlp_error_subtitle">Tap retry or create a blank page using the button below.</string>
+    <string name="mlp_error_subtitle">Tap retry or create a blank page</string>
     <string name="mlp_network_error_title">Layouts not available while offline</string>
-    <string name="mlp_network_error_subtitle">Tap retry when you\'re back online or create a blank page using the button below.</string>
+    <string name="mlp_network_error_subtitle">Tap retry when you\'re back online or create a blank page</string>
 
     <!-- Home Page Picker -->
     <string name="hpp_title">Choose a theme</string>


### PR DESCRIPTION
As part of CMM-1037, this PR updates the empty view in `ModalLayoutPickerFragment`. To test:

- Turn on airplane mode
- Click the My Site FAB and choose to create a site page so the layout picker appears
- Note the empty view looks as expected (no image, shorter subtitle)

Before and after:

<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/f07f744f-c7c7-49e9-b8b5-6ab9654a8b23" />
