### PR TITLE
Re-enable site creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -51,7 +51,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     }
 
     fun shouldShowSiteCreationOverlay(): Boolean {
-        return !buildConfigWrapper.isJetpackApp && isInSiteCreationPhase()
+        return false
     }
 
     fun shouldDisableSiteCreation(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -50,6 +50,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         return jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
     }
 
+    @Suppress("FunctionOnlyReturningConstant")
     fun shouldShowSiteCreationOverlay(): Boolean {
         return false
     }
@@ -94,6 +95,10 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         return false
     }
 
+    @Suppress("UnusedPrivateMember")
+    // This function was added when creating wp.com sites was disabled in WPAndroid.
+    // We re-enabled site creation in WPAndroid in Jan 2026, but this is left here
+    // in case we want to disable site creation in the future.
     private fun isInSiteCreationPhase(): Boolean {
         return when (jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()) {
             null -> false

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -151,21 +151,6 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
         assertTrue(shouldShowOverlay)
     }
 
-    // @Test
-    @Suppress("MaxLineLength")
-    fun `given feature is accessed after globalOverlayFrequency, when shouldShowFeatureSpecificJetpackOverlay invoked, then return true`() {
-        setupMockForWpComSite()
-        // The feature was accessed 3 days ago and the globalOverlayFrequency for phase one is 2
-        // The passed number should not exceed feature specific globalOverlayFrequency
-        // but should be less than global overlay frequency
-        setUpMockForEarliestAccessedFeature(3L)
-
-        val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
-            .shouldShowFeatureSpecificJetpackOverlay(STATS)
-
-        assertTrue(shouldShowOverlay)
-    }
-
     @Test
     fun `shouldShowSiteCreationOverlay always returns false`() {
         val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtilTest.kt
@@ -167,48 +167,11 @@ class JetpackFeatureRemovalOverlayUtilTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given jetpack app, shouldShowSiteCreationOverlay invoked, then return false`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
-
+    fun `shouldShowSiteCreationOverlay always returns false`() {
         val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
             .shouldShowSiteCreationOverlay()
 
         assertFalse(shouldShowOverlay)
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `given feature removal not started, when shouldShowSiteCreationOverlay invoked, then return false`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()).thenReturn(null)
-
-        val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
-            .shouldShowSiteCreationOverlay()
-
-        assertFalse(shouldShowOverlay)
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `given feature removal in phase one, when shouldShowSiteCreationOverlay invoked, then return false`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase())
-            .thenReturn(JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE)
-
-        val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
-            .shouldShowSiteCreationOverlay()
-
-        assertTrue(shouldShowOverlay)
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `given feature removal in phase four, when shouldShowSiteCreationOverlay invoked, then return false`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase())
-            .thenReturn(JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO)
-
-        val shouldShowOverlay = jetpackFeatureRemovalOverlayUtil
-            .shouldShowSiteCreationOverlay()
-
-        assertTrue(shouldShowOverlay)
     }
 
     private fun setupMockForWpComSite() {


### PR DESCRIPTION
Closes CMM-1119 by re-enabling site creation in WPAndroid as discussed on Slack.

**To test**
- Use the WPAndroid build variant
- Create an account in the app, or connect to an account that has no sites yet
- Click the button to add a new site
- Choose to create a WP.com site
- Verify the site creation flow works as expected
- On My Site, dropdown the site list
- Choose to add a new WP.com site from there
- Verify the site creation flow works as expected

Note that for now I've left unused code and resources intact in the off chance we want to disable site creation again down the road. If we decide to remove them, that can be done in a separate PR.

https://github.com/user-attachments/assets/6d5cf11c-1694-4709-87a0-eb8f3506622e

