### PR TITLE
Ensure the site creation button isn't offscreen

### DIFF
--- a/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
@@ -21,10 +21,12 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:scrollbars="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/orLayout"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0" />
 
     <include
         android:id="@+id/orLayout"
@@ -34,8 +36,7 @@
         android:layout_marginTop="@dimen/margin_extra_medium_large"
         app:layout_constraintBottom_toTopOf="@+id/bottom_button"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/recycler_view" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/bottom_button"
@@ -46,7 +47,7 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
         android:text="@string/login_epilogue_create_new_site_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/orLayout" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_screen_new.xml
@@ -25,8 +25,8 @@
         android:scrollbars="vertical"
         app:layout_constraintBottom_toTopOf="@+id/orLayout"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <include
         android:id="@+id/orLayout"


### PR DESCRIPTION
Fixes CMM-1120

On the login epilogue fragment, the button to create a site can be pushed offscreen, and there's no way to scroll it into view. This PR resolves the problem.

**To test**
- Log out of the app
- Log back in and verify the create a site button appears below the site list in the epilogue

<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/069f1a4b-09ce-425f-9cec-9b7fb376db26" />
