### PR TITLE
CMM-1125 be sure to auto generate application password when asked from the editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -288,10 +288,9 @@ class ActivityNavigator @Inject constructor() {
         activity.startActivity(intent)
     }
 
-    fun navigateToApplicationPasswordRequired(activity: Activity, authenticationUrl: String, featureName: String) {
-        val intent = Intent(activity, ApplicationPasswordRequiredDialogActivity::class.java)
-        intent.putExtra(ApplicationPasswordDialogActivity.EXTRA_SITE_URL, authenticationUrl)
-        intent.putExtra(ApplicationPasswordRequiredDialogActivity.EXTRA_FEATURE_NAME, featureName)
-        activity.startActivity(intent)
+    fun navigateToApplicationPasswordRequired(activity: Activity, site: SiteModel, featureName: String) {
+        activity.startActivity(
+            ApplicationPasswordRequiredDialogActivity.createIntent(activity, site, featureName)
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts.login.applicationpassword
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -88,7 +87,7 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
                             this@ApplicationPasswordAutoAuthDialogActivity,
                             R.string.error_generic
                         )
-                        setResult(RESULT_CANCELED)
+                        setResult(RESULT_CANCELED, Intent().putExtra(EXTRA_RESULT_ERROR, true))
                         finish()
                     }
                 }
@@ -101,9 +100,9 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
                 ApplicationPasswordAutoAuthDialog(
                     isLoading = isLoading.value,
                     onDismiss = {
-                        setResult(RESULT_DISMISSED)
+                        setResult(RESULT_CANCELED)
                         finish()
-                                },
+                    },
                     onConfirm = { viewModel.createApplicationPassword(site) }
                 )
             }
@@ -112,12 +111,7 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
 
     companion object {
         private const val EXTRA_SITE = "extra_site"
-
-        // Use standard Android result codes for consistency
-        // Keeping these constants for backward compatibility with existing callers
-        const val RESULT_SUCCESS = Activity.RESULT_OK
-        const val RESULT_ERROR = Activity.RESULT_CANCELED
-        const val RESULT_DISMISSED = 1
+        const val EXTRA_RESULT_ERROR = "extra_result_error"
 
         fun createIntent(context: Context, site: SiteModel): Intent {
             return Intent(context, ApplicationPasswordAutoAuthDialogActivity::class.java).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -82,6 +83,10 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
                         finish()
                     }
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Error -> {
+                        ToastUtils.showToast(
+                            this@ApplicationPasswordAutoAuthDialogActivity,
+                            R.string.error_generic
+                        )
                         setResult(RESULT_ERROR)
                         finish()
                     }
@@ -107,7 +112,7 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
     companion object {
         private const val EXTRA_SITE = "extra_site"
         const val RESULT_SUCCESS = -1
-        const val RESULT_ERROR = -0
+        const val RESULT_ERROR = 0
         const val RESULT_DISMISSED = 1
 
         fun createIntent(context: Context, site: SiteModel): Intent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
@@ -38,11 +38,16 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
+    @Inject
+    lateinit var activityNavigator: ActivityNavigator
+
     private val viewModel: ApplicationPasswordAutoAuthDialogViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -67,6 +72,13 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
                 when (event) {
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Success -> {
                         setResult(RESULT_SUCCESS)
+                        finish()
+                    }
+                    is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.FallbackToManualLogin -> {
+                        activityNavigator.openApplicationPasswordLogin(
+                            this@ApplicationPasswordAutoAuthDialogActivity,
+                            event.authUrl
+                        )
                         finish()
                     }
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Error -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts.login.applicationpassword
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -72,7 +73,7 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
             viewModel.navigationEvent.collect { event ->
                 when (event) {
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Success -> {
-                        setResult(RESULT_SUCCESS)
+                        setResult(RESULT_OK)
                         finish()
                     }
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.FallbackToManualLogin -> {
@@ -87,7 +88,7 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
                             this@ApplicationPasswordAutoAuthDialogActivity,
                             R.string.error_generic
                         )
-                        setResult(RESULT_ERROR)
+                        setResult(RESULT_CANCELED)
                         finish()
                     }
                 }
@@ -111,8 +112,11 @@ class ApplicationPasswordAutoAuthDialogActivity : ComponentActivity() {
 
     companion object {
         private const val EXTRA_SITE = "extra_site"
-        const val RESULT_SUCCESS = -1
-        const val RESULT_ERROR = 0
+
+        // Use standard Android result codes for consistency
+        // Keeping these constants for backward compatibility with existing callers
+        const val RESULT_SUCCESS = Activity.RESULT_OK
+        const val RESULT_ERROR = Activity.RESULT_CANCELED
         const val RESULT_DISMISSED = 1
 
         fun createIntent(context: Context, site: SiteModel): Intent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -47,11 +47,11 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
     fun createApplicationPassword(site: SiteModel) {
         viewModelScope.launch {
             try {
-                require(site.username.isNotBlank()) { "Site username is required for cookie authentication" }
-                require(site.password.isNotBlank()) { "Site password is required for cookie authentication" }
-
                 // Assume that the Application Password experimental feature can be enabled
                 enableApplicationPasswordIfNecessary()
+
+                require(site.username.isNotBlank()) { "Site username is required for cookie authentication" }
+                require(site.password.isNotBlank()) { "Site password is required for cookie authentication" }
 
                 _isLoading.value = true
                 val client = wpApiClientProvider.getWpApiClientCookiesNonceAuthentication(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -49,7 +49,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             try {
                 // Assume that the Application Password experimental feature can be enabled
                 enableApplicationPasswordIfNecessary()
-
+                
                 require(site.username.isNotBlank()) { "Site username is required for cookie authentication" }
                 require(site.password.isNotBlank()) { "Site password is required for cookie authentication" }
 
@@ -90,12 +90,12 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
 
                     else -> {
                         appLogWrapper.e(AppLog.T.API, "Error creating application password")
-                        _navigationEvent.emit(NavigationEvent.Error)
+                        fallbackToManualLogin(site.url)
                     }
                 }
             } catch (e: Exception) {
                 appLogWrapper.e(AppLog.T.API, "Exception creating application password: ${e.message}")
-                _navigationEvent.emit(NavigationEvent.Error)
+                fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false
             }
@@ -108,8 +108,19 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
         }
     }
 
+    private suspend fun fallbackToManualLogin(siteUrl: String) {
+        try {
+            val authUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(siteUrl)
+            _navigationEvent.emit(NavigationEvent.FallbackToManualLogin(authUrl))
+        } catch (e: Exception) {
+            appLogWrapper.e(AppLog.T.API, "Failed to get authorization URL: ${e.message}")
+            _navigationEvent.emit(NavigationEvent.Error)
+        }
+    }
+
     sealed class NavigationEvent {
         object Success : NavigationEvent()
+        data class FallbackToManualLogin(val authUrl: String) : NavigationEvent()
         object Error : NavigationEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.Companion.ANDROID_JETPACK_CLIENT
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.Companion.ANDROID_WORDPRESS_CLIENT
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.UriLogin
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import rs.wordpress.api.kotlin.WpRequestResult
@@ -33,6 +35,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
     private val applicationPasswordLoginHelper: ApplicationPasswordLoginHelper,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val appLogWrapper: AppLogWrapper,
+    private val experimentalFeatures: ExperimentalFeatures,
 ) : ViewModel() {
     private val _navigationEvent = MutableSharedFlow<NavigationEvent>()
     val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent.asSharedFlow()
@@ -46,6 +49,9 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             try {
                 require(site.username.isNotBlank()) { "Site username is required for cookie authentication" }
                 require(site.password.isNotBlank()) { "Site password is required for cookie authentication" }
+
+                // Assume that the Application Password experimental feature can be enabled
+                enableApplicationPasswordIfNecessary()
 
                 _isLoading.value = true
                 val client = wpApiClientProvider.getWpApiClientCookiesNonceAuthentication(
@@ -93,6 +99,12 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             } finally {
                 _isLoading.value = false
             }
+        }
+    }
+
+    private fun enableApplicationPasswordIfNecessary() {
+        if (!experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE)) {
+            experimentalFeatures.setEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -94,7 +94,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(AppLog.T.API, "Exception creating application password: ${e.message}")
+                appLogWrapper.e(AppLog.T.API, "Exception creating application password", e)
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -49,7 +49,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             try {
                 // Assume that the Application Password experimental feature can be enabled
                 enableApplicationPasswordIfNecessary()
-                
+
                 require(site.username.isNotBlank()) { "Site username is required for cookie authentication" }
                 require(site.password.isNotBlank()) { "Site password is required for cookie authentication" }
 
@@ -102,12 +102,14 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun enableApplicationPasswordIfNecessary() {
         if (!experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE)) {
             experimentalFeatures.setEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun fallbackToManualLogin(siteUrl: String) {
         try {
             val authUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(siteUrl)

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -94,7 +94,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(AppLog.T.API, "Exception creating application password", e)
+                appLogWrapper.e(AppLog.T.API, "Exception creating application password: ${e.message}")
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -71,6 +72,10 @@ class ApplicationPasswordRequiredDialogActivity : ComponentActivity() {
                         finish()
                     }
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Error -> {
+                        ToastUtils.showToast(
+                            this@ApplicationPasswordRequiredDialogActivity,
+                            R.string.error_generic
+                        )
                         setResult(RESULT_CANCELED)
                         finish()
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
@@ -28,10 +28,15 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ApplicationPasswordRequiredDialogActivity : ComponentActivity() {
+    @Inject
+    lateinit var activityNavigator: ActivityNavigator
+
     private val viewModel: ApplicationPasswordAutoAuthDialogViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,6 +61,13 @@ class ApplicationPasswordRequiredDialogActivity : ComponentActivity() {
                 when (event) {
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Success -> {
                         setResult(RESULT_OK)
+                        finish()
+                    }
+                    is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.FallbackToManualLogin -> {
+                        activityNavigator.openApplicationPasswordLogin(
+                            this@ApplicationPasswordRequiredDialogActivity,
+                            event.authUrl
+                        )
                         finish()
                     }
                     is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Error -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
@@ -1,21 +1,150 @@
 package org.wordpress.android.ui.accounts.login.applicationpassword
 
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @AndroidEntryPoint
-class ApplicationPasswordRequiredDialogActivity : ApplicationPasswordDialogActivity() {
-    override fun getTitleResource(): Int = R.string.application_password_required
-    override fun getDescriptionString(): String {
-        val baseDescription = intent.getStringExtra(EXTRA_FEATURE_NAME)?.let {
-            resources.getString(R.string.application_password_required_description, it)
-        } ?: resources.getString(R.string.application_password_info_description_1)
+class ApplicationPasswordRequiredDialogActivity : ComponentActivity() {
+    private val viewModel: ApplicationPasswordAutoAuthDialogViewModel by viewModels()
 
-        return baseDescription + resources.getString(R.string.application_password_experimental_feature_note)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val site: SiteModel? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(EXTRA_SITE, SiteModel::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(EXTRA_SITE)
+        }
+
+        if (site == null) {
+            finish()
+            return
+        }
+
+        val featureName = intent.getStringExtra(EXTRA_FEATURE_NAME)
+
+        lifecycleScope.launch {
+            viewModel.navigationEvent.collect { event ->
+                when (event) {
+                    is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Success -> {
+                        setResult(RESULT_OK)
+                        finish()
+                    }
+                    is ApplicationPasswordAutoAuthDialogViewModel.NavigationEvent.Error -> {
+                        setResult(RESULT_CANCELED)
+                        finish()
+                    }
+                }
+            }
+        }
+
+        setContent {
+            AppThemeM3 {
+                val isLoading = viewModel.isLoading.collectAsState()
+                ApplicationPasswordRequiredDialog(
+                    featureName = featureName,
+                    isLoading = isLoading.value,
+                    onDismiss = { finish() },
+                    onConfirm = { viewModel.createApplicationPassword(site) }
+                )
+            }
+        }
     }
-    override fun getButtonTextResource(): Int = R.string.get_started
 
     companion object {
+        private const val EXTRA_SITE = "extra_site"
         const val EXTRA_FEATURE_NAME = "feature_name_arg"
+
+        fun createIntent(context: Context, site: SiteModel, featureName: String): Intent {
+            return Intent(context, ApplicationPasswordRequiredDialogActivity::class.java).apply {
+                putExtra(EXTRA_SITE, site)
+                putExtra(EXTRA_FEATURE_NAME, featureName)
+            }
+        }
     }
+}
+
+@Composable
+fun ApplicationPasswordRequiredDialog(
+    featureName: String?,
+    isLoading: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val description = if (featureName != null) {
+        stringResource(R.string.application_password_required_description, featureName) +
+            stringResource(R.string.application_password_experimental_feature_note)
+    } else {
+        stringResource(R.string.application_password_info_description_1) +
+            stringResource(R.string.application_password_experimental_feature_note)
+    }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Lock,
+                contentDescription = null
+            )
+        },
+        title = { Text(text = stringResource(R.string.application_password_required)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(text = description)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isLoading
+            ) {
+                Text(text = stringResource(R.string.cancel))
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = !isLoading
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(text = stringResource(R.string.create))
+                }
+            }
+        }
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -158,16 +158,19 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     ) { result ->
         pendingApplicationPasswordSite?.let { site ->
             when (result.resultCode) {
-                ApplicationPasswordAutoAuthDialogActivity.RESULT_SUCCESS -> {
+                Activity.RESULT_OK -> {
                     viewModel.onApplicationPasswordCreated(site)
                 }
-                ApplicationPasswordAutoAuthDialogActivity.RESULT_ERROR -> {
-                    pendingApplicationPasswordUrl?.let {
-                        activityNavigator.openApplicationPasswordLogin(requireActivity(), it)
-                    } ?: viewModel.onApplicationPasswordCreationError(site)
-                }
-                ApplicationPasswordAutoAuthDialogActivity.RESULT_DISMISSED -> {
-                    // User dismissed the dialog, no action needed
+                Activity.RESULT_CANCELED -> {
+                    val wasError = result.data
+                        ?.getBooleanExtra(ApplicationPasswordAutoAuthDialogActivity.EXTRA_RESULT_ERROR, false)
+                        ?: false
+                    if (wasError) {
+                        pendingApplicationPasswordUrl?.let {
+                            activityNavigator.openApplicationPasswordLogin(requireActivity(), it)
+                        } ?: viewModel.onApplicationPasswordCreationError(site)
+                    }
+                    // If not an error, user dismissed the dialog - no action needed
                 }
             }
             pendingApplicationPasswordSite = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -519,8 +519,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         if (shouldRequireApplicationPassword()) {
             activityNavigator.navigateToApplicationPasswordRequired(
                 this,
-               siteModel.url,
-               resources.getString(R.string.application_password_required_block_editor)
+                siteModel,
+                resources.getString(R.string.application_password_required_block_editor)
             )
             finish()
             return


### PR DESCRIPTION
## Description

  Updates the "Application Password Required" dialog to use automatic Application Password generation instead of redirecting to the browser for manual creation. When auto-generation fails, it falls back to the existing manual browser-based flow.

  **Key changes:**
  - `ApplicationPasswordRequiredDialogActivity` now uses `ApplicationPasswordAutoAuthDialogViewModel` for auto-generation
  - Button text changed from "Get Started" to "Create"
  - Experimental feature flag is automatically enabled when the user initiates the flow
  - On auto-generation failure, falls back to manual browser-based Application Password creation

  ## Testing instructions

  Auto-generation success flow:

  1. Log in with a self-hosted site
  2. Try to create a new post using the new block editor
  3. See the "Application Password Required" dialog appear
  4. Tap "Create"
  - [ ] Verify the Application Password is created automatically and you can create a post


https://github.com/user-attachments/assets/39f29869-0ed2-45a9-8064-5801790b96e6


  Auto-generation fallback flow:

  1. Disable the Application Password feature
  2. Add a fail line to `ApplicationPasswordAutoAuthDialogViewModel:createApplicationPassword()`

<img width="545" height="136" alt="Screenshot 2026-01-09 at 12 58 39" src="https://github.com/user-attachments/assets/8a72d37f-e313-42bf-be01-a0301b0a5f79" />

  4. Try to create a new post using the new block editor
  5. See the "Application Password Required" dialog appear
  6. Tap "Create"
  - [ ] Verify the browser opens with the manual Application Password creation flow


https://github.com/user-attachments/assets/ab097d87-5007-41c4-b4a9-2d96db935391

