### PR TITLE
CMM-1126 application password banner not being refreshed when auto generate credentials

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -57,7 +57,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
                 appLogWrapper.d(
                     AppLog.T.API,
-                    "AP: Found authorization for $siteUrl URL: $authorizationUrlComplete " +
+                    "A_P: Found authorization for $siteUrl URL: $authorizationUrlComplete " +
                             "API_ROOT_URL $apiRootUrl")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
@@ -75,7 +75,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     private fun handleAuthenticationDiscoveryError(siteUrl: String, throwable: Throwable): String {
-        appLogWrapper.e(AppLog.T.API, "AP: Error during API discovery for $siteUrl - ${throwable.message}")
+        appLogWrapper.e(AppLog.T.API, "A_P: Error during API discovery for $siteUrl - ${throwable.message}")
         AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_FAILED)
         return ""
     }
@@ -90,7 +90,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             ) {
             appLogWrapper.e(
                 AppLog.T.DB,
-                "AP: Cannot save application password credentials for: ${urlLogin.siteUrl} - bad data"
+                "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - bad data"
             )
             return false
         }
@@ -115,7 +115,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             } else {
                 appLogWrapper.e(
                     AppLog.T.DB,
-                    "AP: Cannot save application password credentials for: ${urlLogin.siteUrl} - null site"
+                    "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - null site"
                 )
                 false
             }
@@ -134,7 +134,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             },
             properties
         )
-        appLogWrapper.d(AppLog.T.DB, "AP: Saved application password credentials for: $siteUrl")
+        appLogWrapper.d(AppLog.T.DB, "A_P: Saved application password credentials for: $siteUrl")
     }
 
     fun getSiteUrlLoginFromRawData(url: String): UriLogin {
@@ -160,7 +160,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
                 dispatcherWrapper.removeApplicationPassword(site)
             }
-            appLogWrapper.d(AppLog.T.DB, "AP: Removed application password credentials for: $affectedSites sites")
+            appLogWrapper.d(AppLog.T.DB, "A_P: Removed application password credentials for: $affectedSites sites")
             affectedSites
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -58,7 +58,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
         scope.launch {
             // If the site is already authorized, no need to run the discovery
             val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
-            if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
+            if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(storedSite)) {
                 uiModelMutable.postValue(null)
                 appLogWrapper.d(AppLog.T.MAIN, "AP: Hiding card for ${site.url} - authenticated")
                 return@launch

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -60,14 +60,14 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
             val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
             if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(storedSite)) {
                 uiModelMutable.postValue(null)
-                appLogWrapper.d(AppLog.T.MAIN, "AP: Hiding card for ${site.url} - authenticated")
+                appLogWrapper.d(AppLog.T.MAIN, "A_P: Hiding card for ${site.url} - authenticated")
                 return@launch
             }
 
             val authorizationUrlComplete = applicationPasswordLoginHelper.getAuthorizationUrlComplete(site.url)
             if (authorizationUrlComplete.isEmpty()) {
                 uiModelMutable.postValue(null)
-                appLogWrapper.d(AppLog.T.MAIN, "AP: Hiding card for ${site.url} - bad discovery")
+                appLogWrapper.d(AppLog.T.MAIN, "A_P: Hiding card for ${site.url} - bad discovery")
             } else {
                 showApplicationPasswordCreateCard(site, authorizationUrlComplete)
             }
@@ -86,7 +86,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 )
             )
         )
-        appLogWrapper.d(AppLog.T.MAIN, "AP: Showing card for ${site.url}")
+        appLogWrapper.d(AppLog.T.MAIN, "A_P: Showing card for ${site.url}")
     }
 
 


### PR DESCRIPTION
  ## Description

From this [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/22470#issuecomment-3729006185)

  Fixes Application Password card visibility check by passing the correct site model to `siteHasBadCredentials`. The method was incorrectly using the input `site` parameter instead of `storedSite` (retrieved from `siteStore`), which has the actual stored credentials to validate.

  ## Testing instructions

  Application Password card visibility:

  1. Log in to a self-hosted site
  2. Disable the Applicatin Password feature if it's enabled
  3. Try to create a new post. You will be asked about generating an AP. Do it
  - [x] Verify the "Create Application Password" card is not visible in MySite screen right after the AP creation.


https://github.com/user-attachments/assets/8b229839-eb23-4d1a-b7fe-dfd7b0517cd1



Extra:
- [x] Play with the Application Password card and generation and verify it looks as expected.