### PR TITLE
CMM-1124 Skip site picker after login and auto-select default site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -360,7 +360,13 @@ public class LoginActivity extends BaseAppCompatActivity implements ConnectionCa
                 break;
             case WPCOM_LOGIN_DEEPLINK:
             case WPCOM_REAUTHENTICATE:
-                ActivityLauncher.showLoginEpilogueForResult(this, oldSitesIds, false);
+                // If sites exist, skip the site picker and return with the existing selected site
+                if (mSiteStore.hasSite()) {
+                    setResult(Activity.RESULT_OK);
+                    finish();
+                } else {
+                    ActivityLauncher.showLoginEpilogueForResult(this, oldSitesIds, false);
+                }
                 break;
             case SHARE_INTENT:
             case JETPACK_SELFHOSTED:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -19,6 +20,7 @@ import org.wordpress.android.ui.accounts.LoginNavigationEvents.SelectSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowJetpackIndividualPluginOverlay;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowPostSignupInterstitialScreen;
+import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowSitePickerUI;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
@@ -52,10 +54,21 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
 
         LoginFlowThemeHelper.injectMissingCustomAttributes(getTheme());
 
+        boolean doLoginUpdate = getIntent().getBooleanExtra(EXTRA_DO_LOGIN_UPDATE, false);
+
+        // If not waiting for login to complete, try to auto-select the default site immediately
+        // without showing the site picker UI
+        if (savedInstanceState == null && !doLoginUpdate) {
+            Integer defaultSiteLocalId = mViewModel.getDefaultSiteLocalId();
+            if (defaultSiteLocalId != null) {
+                selectSite(defaultSiteLocalId);
+                return;
+            }
+        }
+
         setContentView(R.layout.login_epilogue_activity);
 
         if (savedInstanceState == null) {
-            boolean doLoginUpdate = getIntent().getBooleanExtra(EXTRA_DO_LOGIN_UPDATE, false);
             boolean showAndReturn = getIntent().getBooleanExtra(EXTRA_SHOW_AND_RETURN, false);
             ArrayList<Integer> oldSitesIds = getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS);
 
@@ -85,8 +98,17 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
                 showNoJetpackSites();
             } else if (loginEvent instanceof ShowJetpackIndividualPluginOverlay) {
                 showJetpackIndividualPluginOverlay();
+            } else if (loginEvent instanceof ShowSitePickerUI) {
+                showSitePickerUI();
             }
         });
+    }
+
+    private void showSitePickerUI() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(LoginEpilogueFragment.TAG);
+        if (fragment != null && fragment.getView() != null) {
+            fragment.getView().setVisibility(View.VISIBLE);
+        }
     }
 
     protected void addPostLoginFragment(boolean doLoginUpdate, boolean showAndReturn, ArrayList<Integer> oldSitesIds) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.accounts;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -20,7 +19,6 @@ import org.wordpress.android.ui.accounts.LoginNavigationEvents.SelectSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowJetpackIndividualPluginOverlay;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowPostSignupInterstitialScreen;
-import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowSitePickerUI;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
@@ -56,14 +54,16 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
 
         boolean doLoginUpdate = getIntent().getBooleanExtra(EXTRA_DO_LOGIN_UPDATE, false);
 
-        // If not waiting for login to complete, try to auto-select the default site immediately
-        // without showing the site picker UI
+        // If not waiting for login to complete, skip the site picker entirely
         if (savedInstanceState == null && !doLoginUpdate) {
             Integer defaultSiteLocalId = mViewModel.getDefaultSiteLocalId();
             if (defaultSiteLocalId != null) {
                 selectSite(defaultSiteLocalId);
-                return;
+            } else {
+                // No sites - just close, main activity will handle it
+                closeWithResultOk();
             }
+            return;
         }
 
         setContentView(R.layout.login_epilogue_activity);
@@ -98,17 +98,8 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
                 showNoJetpackSites();
             } else if (loginEvent instanceof ShowJetpackIndividualPluginOverlay) {
                 showJetpackIndividualPluginOverlay();
-            } else if (loginEvent instanceof ShowSitePickerUI) {
-                showSitePickerUI();
             }
         });
-    }
-
-    private void showSitePickerUI() {
-        Fragment fragment = getSupportFragmentManager().findFragmentByTag(LoginEpilogueFragment.TAG);
-        if (fragment != null && fragment.getView() != null) {
-            fragment.getView().setVisibility(View.VISIBLE);
-        }
     }
 
     protected void addPostLoginFragment(boolean doLoginUpdate, boolean showAndReturn, ArrayList<Integer> oldSitesIds) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -16,13 +16,11 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CloseWithResultOk;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CreateNewSite;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.SelectSite;
-import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowJetpackIndividualPluginOverlay;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowPostSignupInterstitialScreen;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
-import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginFragment;
 import org.wordpress.android.ui.main.BaseAppCompatActivity;
 import org.wordpress.android.ui.main.ChooseSiteActivity;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
@@ -96,8 +94,6 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
                 closeWithResultOk();
             } else if (loginEvent instanceof ShowNoJetpackSites) {
                 showNoJetpackSites();
-            } else if (loginEvent instanceof ShowJetpackIndividualPluginOverlay) {
-                showJetpackIndividualPluginOverlay();
             }
         });
     }
@@ -166,10 +162,6 @@ public class LoginEpilogueActivity extends BaseAppCompatActivity implements Logi
         }
         fragmentTransaction.replace(R.id.fragment_container, fragment, tag);
         fragmentTransaction.commit();
-    }
-
-    private void showJetpackIndividualPluginOverlay() {
-        WPJetpackIndividualPluginFragment.show(getSupportFragmentManager());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -66,21 +66,11 @@ class LoginEpilogueViewModel @Inject constructor(
         val siteToSelect = getDefaultSiteLocalId()
             ?: if (firstSiteLocalId != -1) firstSiteLocalId else null
 
-        siteToSelect?.let { localId ->
-            onSiteClick(localId)
-            return
-        }
-
-        // No sites found - show the site picker UI for user interaction
-        _navigationEvents.postValue(Event(LoginNavigationEvents.ShowSitePickerUI))
-
-        // Check if we should show overlays
-        viewModelScope.launch {
-            val showOverlay = wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()
-            if (showOverlay) {
-                delay(DELAY_BEFORE_SHOWING_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY)
-                _navigationEvents.postValue(Event(LoginNavigationEvents.ShowJetpackIndividualPluginOverlay))
-            }
+        if (siteToSelect != null) {
+            onSiteClick(siteToSelect)
+        } else {
+            // No sites found - close and let main activity handle it
+            _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -6,16 +6,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginHelper
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class LoginEpilogueViewModel @Inject constructor(
+    private val accountStore: AccountStore,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository,
     private val siteStore: SiteStore,
     private val wpJetpackIndividualPluginHelper: WPJetpackIndividualPluginHelper,
 ) : ViewModel() {
@@ -57,10 +61,20 @@ class LoginEpilogueViewModel @Inject constructor(
         if (doLoginUpdate && !siteStore.hasSite()) handleNoSitesFound()
     }
 
-    fun onSiteListLoaded() {
-        // don't check if already shown
-        if (_navigationEvents.value?.peekContent() == LoginNavigationEvents.ShowJetpackIndividualPluginOverlay) return
+    fun onSiteListLoaded(firstSiteLocalId: Int = -1) {
+        // Skip the site picker and auto-select the default site
+        val siteToSelect = getDefaultSiteLocalId()
+            ?: if (firstSiteLocalId != -1) firstSiteLocalId else null
 
+        siteToSelect?.let { localId ->
+            onSiteClick(localId)
+            return
+        }
+
+        // No sites found - show the site picker UI for user interaction
+        _navigationEvents.postValue(Event(LoginNavigationEvents.ShowSitePickerUI))
+
+        // Check if we should show overlays
         viewModelScope.launch {
             val showOverlay = wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()
             if (showOverlay) {
@@ -68,6 +82,38 @@ class LoginEpilogueViewModel @Inject constructor(
                 _navigationEvents.postValue(Event(LoginNavigationEvents.ShowJetpackIndividualPluginOverlay))
             }
         }
+    }
+
+    /**
+     * Returns the default site local ID using the same logic as WPMainActivity.initSelectedSite():
+     * 1. Previously selected site from preferences
+     * 2. Primary WordPress.com site
+     * 3. First site in the list
+     */
+    fun getDefaultSiteLocalId(): Int? {
+        // Try previously selected site from preferences
+        val selectedSiteLocalId = selectedSiteRepository.getSelectedSiteLocalId(fromPrefs = true)
+        if (selectedSiteLocalId != SelectedSiteRepository.UNAVAILABLE) {
+            val site = siteStore.getSiteByLocalId(selectedSiteLocalId)
+            if (site != null) {
+                return site.id
+            }
+        }
+
+        // Try primary WordPress.com site
+        val primarySiteId = accountStore.account.primarySiteId
+        val primarySite = siteStore.getSiteBySiteId(primarySiteId)
+        if (primarySite != null) {
+            return primarySite.id
+        }
+
+        // Fall back to first site in the list
+        val sites = siteStore.sites
+        if (sites.isNotEmpty()) {
+            return sites[0].id
+        }
+
+        return null
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -3,12 +3,8 @@ package org.wordpress.android.ui.accounts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
@@ -21,7 +17,6 @@ class LoginEpilogueViewModel @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val siteStore: SiteStore,
-    private val wpJetpackIndividualPluginHelper: WPJetpackIndividualPluginHelper,
 ) : ViewModel() {
     private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
     val navigationEvents: LiveData<Event<LoginNavigationEvents>> = _navigationEvents
@@ -106,7 +101,4 @@ class LoginEpilogueViewModel @Inject constructor(
         return null
     }
 
-    companion object {
-        private const val DELAY_BEFORE_SHOWING_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY = 500L
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
@@ -14,5 +14,4 @@ sealed class LoginNavigationEvents {
     object showWPcomLoginScreen : LoginNavigationEvents()
     object ShowLoginViaSiteAddressScreen : LoginNavigationEvents()
     object ShowJetpackIndividualPluginOverlay : LoginNavigationEvents()
-    object ShowSitePickerUI : LoginNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
@@ -13,5 +13,4 @@ sealed class LoginNavigationEvents {
     object CloseWithResultOk : LoginNavigationEvents()
     object showWPcomLoginScreen : LoginNavigationEvents()
     object ShowLoginViaSiteAddressScreen : LoginNavigationEvents()
-    object ShowJetpackIndividualPluginOverlay : LoginNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
@@ -14,4 +14,5 @@ sealed class LoginNavigationEvents {
     object showWPcomLoginScreen : LoginNavigationEvents()
     object ShowLoginViaSiteAddressScreen : LoginNavigationEvents()
     object ShowJetpackIndividualPluginOverlay : LoginNavigationEvents()
+    object ShowSitePickerUI : LoginNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -58,10 +58,12 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     private RecyclerView mSitesList;
     @Nullable private View mBottomShadow;
+    @Nullable private View mRootView;
 
     private SitePickerAdapter mAdapter;
     private boolean mDoLoginUpdate;
     private boolean mShowAndReturn;
+    private boolean mLoginFinished;
     private ArrayList<Integer> mOldSitesIds;
 
     private LoginEpilogueListener mLoginEpilogueListener;
@@ -105,7 +107,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     @Override
     protected ViewGroup createMainView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return (ViewGroup) inflater.inflate(loginEpilogueScreenResource(), container, false);
+        ViewGroup view = (ViewGroup) inflater.inflate(loginEpilogueScreenResource(), container, false);
+        mRootView = view;
+        // Start with content invisible - will be shown in onAfterLoad() if we need user interaction
+        view.setVisibility(View.INVISIBLE);
+        return view;
     }
 
     @LayoutRes
@@ -160,6 +166,8 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mDoLoginUpdate = requireArguments().getBoolean(ARG_DO_LOGIN_UPDATE, false);
         mShowAndReturn = requireArguments().getBoolean(ARG_SHOW_AND_RETURN, false);
         mOldSitesIds = requireArguments().getIntegerArrayList(ARG_OLD_SITES_IDS);
+        // If not waiting for login update, consider login already finished
+        mLoginFinished = !mDoLoginUpdate;
 
         initAdapter();
     }
@@ -221,6 +229,12 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                         return;
                     }
 
+                    // Don't proceed until login has finished (for doLoginUpdate=true case)
+                    // The adapter will be recreated in onLoginFinished() and this will be called again
+                    if (!mLoginFinished) {
+                        return;
+                    }
+
                     if (mBottomShadow != null) {
                         if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
                             mBottomShadow.setVisibility(View.VISIBLE);
@@ -229,7 +243,15 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                         }
                     }
 
-                    mParentViewModel.onSiteListLoaded();
+                    // Get the first site's local ID from the adapter (position 1 accounts for header)
+                    int firstSiteLocalId = -1;
+                    if (mAdapter != null && mAdapter.getItemCount() > 1) {
+                        long itemId = mAdapter.getItemId(1);
+                        if (itemId > 0) {
+                            firstSiteLocalId = (int) itemId;
+                        }
+                    }
+                    mParentViewModel.onSiteListLoaded(firstSiteLocalId);
                 });
             }
         };
@@ -389,6 +411,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     @Override
     protected void onLoginFinished() {
         // we needed to complete the login process so, now just show an updated screen to the user
+        mLoginFinished = true;
 
         AnalyticsUtils.trackAnalyticsSignIn(mAccountStore, mSiteStore, true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -58,7 +58,6 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     private RecyclerView mSitesList;
     @Nullable private View mBottomShadow;
-    @Nullable private View mRootView;
 
     private SitePickerAdapter mAdapter;
     private boolean mDoLoginUpdate;
@@ -107,11 +106,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     @Override
     protected ViewGroup createMainView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        ViewGroup view = (ViewGroup) inflater.inflate(loginEpilogueScreenResource(), container, false);
-        mRootView = view;
-        // Start with content invisible - will be shown in onAfterLoad() if we need user interaction
-        view.setVisibility(View.INVISIBLE);
-        return view;
+        return (ViewGroup) inflater.inflate(loginEpilogueScreenResource(), container, false);
     }
 
     @LayoutRes

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -477,12 +477,19 @@ public class WPMainActivity extends BaseAppCompatActivity implements
             UpdateTokenPayload payload = new UpdateTokenPayload(authTokenToSet);
             mDispatcher.dispatch(AccountActionBuilder.newUpdateAccessTokenAction(payload));
         } else if (getIntent().getBooleanExtra(ARG_SHOW_LOGIN_EPILOGUE, false) && savedInstanceState == null) {
-            ActivityLauncher.showLoginEpilogue(
-                    this,
-                    getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false),
-                    getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS),
-                    mBuildConfigWrapper.isSiteCreationEnabled()
-            );
+            boolean doLoginUpdate = getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false);
+            // If not waiting for login to complete and sites are available,
+            // skip the site picker and auto-select the default site
+            if (!doLoginUpdate && mSiteStore.hasSite()) {
+                initSelectedSite();
+            } else {
+                ActivityLauncher.showLoginEpilogue(
+                        this,
+                        doLoginUpdate,
+                        getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS),
+                        mBuildConfigWrapper.isSiteCreationEnabled()
+                );
+            }
         } else if (getIntent().getBooleanExtra(ARG_SHOW_SIGNUP_EPILOGUE, false) && savedInstanceState == null) {
             ActivityLauncher.showSignupEpilogue(this,
                     getIntent().getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_DISPLAY_NAME),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -478,9 +478,9 @@ public class WPMainActivity extends BaseAppCompatActivity implements
             mDispatcher.dispatch(AccountActionBuilder.newUpdateAccessTokenAction(payload));
         } else if (getIntent().getBooleanExtra(ARG_SHOW_LOGIN_EPILOGUE, false) && savedInstanceState == null) {
             boolean doLoginUpdate = getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false);
-            // If not waiting for login to complete and sites are available,
-            // skip the site picker and auto-select the default site
-            if (!doLoginUpdate && mSiteStore.hasSite()) {
+            // If not waiting for login to complete, skip the epilogue entirely
+            // (main activity/MySiteFragment handles the no-sites case)
+            if (!doLoginUpdate) {
                 initSelectedSite();
             } else {
                 ActivityLauncher.showLoginEpilogue(

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -7,8 +7,12 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginHelper
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 
@@ -17,10 +21,16 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: LoginEpilogueViewModel
 
     @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
     @Mock
     lateinit var buildConfigWrapper: BuildConfigWrapper
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
 
     @Mock
     lateinit var siteStore: SiteStore
@@ -30,9 +40,16 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        whenever(selectedSiteRepository.getSelectedSiteLocalId(true))
+            .thenReturn(SelectedSiteRepository.UNAVAILABLE)
+        whenever(accountStore.account).thenReturn(AccountModel())
+        whenever(siteStore.sites).thenReturn(emptyList())
+
         viewModel = LoginEpilogueViewModel(
+            accountStore,
             appPrefsWrapper,
             buildConfigWrapper,
+            selectedSiteRepository,
             siteStore,
             wpJetpackIndividualPluginHelper
         )
@@ -272,7 +289,7 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onSiteListLoaded is invoked then show jetpack individual plugin overlay`() =
+    fun `given no sites, when onSiteListLoaded is invoked then show jetpack individual plugin overlay`() =
         test {
             val navigationEvents = initObservers().navigationEvents
             whenever(wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()).thenReturn(true)
@@ -284,7 +301,7 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when onSiteListLoaded is invoked then don't show jetpack individual plugin overlay`() =
+    fun `given no sites, when onSiteListLoaded is invoked then show site picker UI`() =
         test {
             val navigationEvents = initObservers().navigationEvents
             whenever(wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()).thenReturn(false)
@@ -292,8 +309,62 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
             viewModel.onSiteListLoaded()
             advanceUntilIdle()
 
-            assertThat(navigationEvents.lastOrNull()).isNull()
+            assertThat(navigationEvents.first()).isEqualTo(LoginNavigationEvents.ShowSitePickerUI)
         }
+
+    @Test
+    fun `given previously selected site exists, when onSiteListLoaded, then auto-select that site`() {
+        val localId = 123
+        val site = SiteModel().apply { id = localId }
+        whenever(selectedSiteRepository.getSelectedSiteLocalId(true)).thenReturn(localId)
+        whenever(siteStore.getSiteByLocalId(localId)).thenReturn(site)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onSiteListLoaded()
+
+        val event = navigationEvents.first() as LoginNavigationEvents.SelectSite
+        assertThat(event.localId).isEqualTo(localId)
+    }
+
+    @Test
+    fun `given primary site exists, when onSiteListLoaded, then auto-select primary site`() {
+        val primarySiteId = 456L
+        val localId = 789
+        val account = AccountModel().apply { setPrimarySiteId(primarySiteId) }
+        val primarySite = SiteModel().apply { id = localId }
+        whenever(accountStore.account).thenReturn(account)
+        whenever(siteStore.getSiteBySiteId(primarySiteId)).thenReturn(primarySite)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onSiteListLoaded()
+
+        val event = navigationEvents.first() as LoginNavigationEvents.SelectSite
+        assertThat(event.localId).isEqualTo(localId)
+    }
+
+    @Test
+    fun `given sites exist, when onSiteListLoaded, then auto-select first site`() {
+        val localId = 111
+        val site = SiteModel().apply { id = localId }
+        whenever(siteStore.sites).thenReturn(listOf(site))
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onSiteListLoaded()
+
+        val event = navigationEvents.first() as LoginNavigationEvents.SelectSite
+        assertThat(event.localId).isEqualTo(localId)
+    }
+
+    @Test
+    fun `given no default site but firstSiteLocalId provided, when onSiteListLoaded, then auto-select first site`() {
+        val firstSiteLocalId = 222
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onSiteListLoaded(firstSiteLocalId)
+
+        val event = navigationEvents.first() as LoginNavigationEvents.SelectSite
+        assertThat(event.localId).isEqualTo(firstSiteLocalId)
+    }
 
     private data class Observers(val navigationEvents: List<LoginNavigationEvents>)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
@@ -35,9 +34,6 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var siteStore: SiteStore
 
-    @Mock
-    private lateinit var wpJetpackIndividualPluginHelper: WPJetpackIndividualPluginHelper
-
     @Before
     fun setUp() {
         whenever(selectedSiteRepository.getSelectedSiteLocalId(true))
@@ -50,8 +46,7 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
             appPrefsWrapper,
             buildConfigWrapper,
             selectedSiteRepository,
-            siteStore,
-            wpJetpackIndividualPluginHelper
+            siteStore
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -289,28 +289,13 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no sites, when onSiteListLoaded is invoked then show jetpack individual plugin overlay`() =
-        test {
-            val navigationEvents = initObservers().navigationEvents
-            whenever(wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()).thenReturn(true)
+    fun `given no sites, when onSiteListLoaded is invoked then close with result ok`() {
+        val navigationEvents = initObservers().navigationEvents
 
-            viewModel.onSiteListLoaded()
-            advanceUntilIdle()
+        viewModel.onSiteListLoaded()
 
-            assertThat(navigationEvents.last()).isEqualTo(LoginNavigationEvents.ShowJetpackIndividualPluginOverlay)
-        }
-
-    @Test
-    fun `given no sites, when onSiteListLoaded is invoked then show site picker UI`() =
-        test {
-            val navigationEvents = initObservers().navigationEvents
-            whenever(wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()).thenReturn(false)
-
-            viewModel.onSiteListLoaded()
-            advanceUntilIdle()
-
-            assertThat(navigationEvents.first()).isEqualTo(LoginNavigationEvents.ShowSitePickerUI)
-        }
+        assertThat(navigationEvents.first()).isEqualTo(LoginNavigationEvents.CloseWithResultOk)
+    }
 
     @Test
     fun `given previously selected site exists, when onSiteListLoaded, then auto-select that site`() {


### PR DESCRIPTION
After login, automatically select the user's default site instead of showing the site picker. The default site is determined by:

1. Previously selected site from preferences
2. Primary WordPress.com site
3. First site in the list