### PR TITLE
CMM-1133 when log out from wp.com com all sites disappear

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1709,6 +1709,9 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         }
         if (mViewModel.getHasMultipleSites() && !ChooseSiteActivity.isRunning()) {
             ActivityLauncher.showSitePickerForResult(this, mViewModel.getFirstSite());
+        } else if (mViewModel.getFirstSite() != null) {
+            // Only one site remaining, select it automatically
+            setSelectedSite(mViewModel.getFirstSite());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -33,7 +33,9 @@ public class FluxCUtils {
      * @return true if the user is signed in a WordPress.com account or if he has a .org site.
      */
     public static boolean isSignedInWPComOrHasWPOrgSite(AccountStore accountStore, SiteStore siteStore) {
-        return accountStore.hasAccessToken() || siteStore.hasSiteAccessedViaXMLRPC();
+        return accountStore.hasAccessToken()
+                || siteStore.hasSiteAccessedViaXMLRPC()
+                || siteStore.hasSiteAccessedViaWPAPI();
     }
 
     public static MediaModel mediaModelFromMediaFile(MediaFile file) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -685,8 +685,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `isSignedInWPComOrHasWPOrgSite should be true when user has WPCom access token`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(false)
-        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(false)
+        // No need to stub site methods - short-circuit evaluation means they won't be called
 
         assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isTrue()
     }
@@ -695,7 +694,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `isSignedInWPComOrHasWPOrgSite should be true when user has XMLRPC site`() {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(true)
-        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(false)
+        // No need to stub hasSiteAccessedViaWPAPI - short-circuit evaluation
 
         assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isTrue()
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -683,6 +683,42 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `isSignedInWPComOrHasWPOrgSite should be true when user has WPCom access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(false)
+
+        assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isTrue()
+    }
+
+    @Test
+    fun `isSignedInWPComOrHasWPOrgSite should be true when user has XMLRPC site`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(true)
+        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(false)
+
+        assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isTrue()
+    }
+
+    @Test
+    fun `isSignedInWPComOrHasWPOrgSite should be true when user has WPAPI site`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(true)
+
+        assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isTrue()
+    }
+
+    @Test
+    fun `isSignedInWPComOrHasWPOrgSite should be false when user has no account and no sites`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaXMLRPC()).thenReturn(false)
+        whenever(siteStore.hasSiteAccessedViaWPAPI()).thenReturn(false)
+
+        assertThat(viewModel.isSignedInWPComOrHasWPOrgSite).isFalse()
+    }
+
+    @Test
     fun `Should track analytics event when onHelpPromptActionClicked is called`() = test {
         whenever(mainCreateSheetHelper.canCreatePromptAnswer()).thenReturn(true)
         startViewModelWithDefaultParameters()

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -281,6 +281,14 @@ class SiteSqlUtils
                 .equals(SiteModelTable.IS_DELETED, false)
                 .endGroup().endWhere()
 
+    val sitesAccessedViaWPAPI: List<SiteModel>
+        get() = WellSql.select(SiteModel::class.java)
+                .where().beginGroup()
+                .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_WPAPI)
+                .endGroup().endWhere()
+            .asModel
+            .decryptAPIRestCredentials()
+
     fun getPostFormats(site: SiteModel): List<PostFormatModel> {
         return WellSql.select(PostFormatModel::class.java)
                 .where()

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1246,6 +1246,20 @@ open class SiteStore @Inject constructor(
     }
 
     /**
+     * Returns the number of sites accessed via WP REST API (self-hosted sites using Application Passwords).
+     */
+    val sitesAccessedViaWPAPICount: Int
+        get() = siteSqlUtils.sitesAccessedViaWPAPI.count()
+
+    /**
+     * Checks whether the store contains at least one site accessed via WP REST API
+     * (self-hosted sites using Application Passwords).
+     */
+    fun hasSiteAccessedViaWPAPI(): Boolean {
+        return sitesAccessedViaWPAPICount != 0
+    }
+
+    /**
      * Given a (remote) site id, returns the corresponding (local) id.
      */
     fun getLocalIdForRemoteSiteId(siteId: Long): Int {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -519,4 +519,32 @@ class SiteStoreTest {
         val expectedErrorType = AllDomainsError(AllDomainsErrorType.GENERIC_ERROR, null).type
         assertThat(onAllDomainsFetched.error.type).isEqualTo(expectedErrorType)
     }
+
+    @Test
+    fun `hasSiteAccessedViaWPAPI returns true when WPAPI sites exist`() {
+        val wpapiSite = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPAPI
+        }
+        whenever(siteSqlUtils.sitesAccessedViaWPAPI).thenReturn(listOf(wpapiSite))
+
+        assertThat(siteStore.hasSiteAccessedViaWPAPI()).isTrue()
+    }
+
+    @Test
+    fun `hasSiteAccessedViaWPAPI returns false when no WPAPI sites exist`() {
+        whenever(siteSqlUtils.sitesAccessedViaWPAPI).thenReturn(emptyList())
+
+        assertThat(siteStore.hasSiteAccessedViaWPAPI()).isFalse()
+    }
+
+    @Test
+    fun `sitesAccessedViaWPAPICount returns correct count`() {
+        val wpapiSites = listOf(
+            SiteModel().apply { origin = SiteModel.ORIGIN_WPAPI },
+            SiteModel().apply { origin = SiteModel.ORIGIN_WPAPI }
+        )
+        whenever(siteSqlUtils.sitesAccessedViaWPAPI).thenReturn(wpapiSites)
+
+        assertThat(siteStore.sitesAccessedViaWPAPICount).isEqualTo(2)
+    }
 }


### PR DESCRIPTION
## Description

  Fixes a bug where self-hosted sites disappeared from My Sites after logging out of a WP.com account. The issue had two parts:

  1. **Main fix**: When sites were removed during logout, `handleSiteRemoved()` only handled two cases: no sites (show sign-in) and multiple sites (show picker). When exactly one self-hosted site remained, nothing happened - the selected site stayed null, making My Sites appear empty even though the site was still in the database.

  2. **Preventive fix**: Added support for detecting self-hosted sites connected via WP REST API/Application Passwords (`ORIGIN_WPAPI`) in `isSignedInWPComOrHasWPOrgSite()`, which previously only checked for XML-RPC sites.

  ## Testing instructions

  Self-hosted site preserved after WP.com logout:

  1. Log into a WP.com account
  2. Add a self-hosted site
  3. Verify both WP.com and self-hosted sites appear in My Sites
  4. Log out from WP.com (Me tab → Log out)
  - [x] Verify self-hosted site is still visible in My Sites
  - [x] Verify you can interact with the self-hosted site normally


https://github.com/user-attachments/assets/76ec8d3a-0e8a-460c-900f-2efe8082cd2e



  Multiple self-hosted sites after logout:

  1. Log into a WP.com account
  2. Add two or more self-hosted sites
  3. Log out from WP.com
  - [x] Verify self-hosted site is still visible in My Sites
  - [x] Verify you can interact with the self-hosted site normally

  No sites after logout:

  1. Log into a WP.com account (with only WP.com sites, no self-hosted)
  2. Log out from WP.com
  - [x] Verify sign-in screen is shown