### PR TITLE
CMM-1136 Show correct site after login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1423,6 +1423,16 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                 break;
             case RequestCodes.ADD_ACCOUNT:
                 if (resultCode == RESULT_OK) {
+                    // If a new self-hosted site was added, save its ID to prefs so it becomes selected
+                    if (data != null) {
+                        int newSiteLocalId = data.getIntExtra(
+                                ChooseSiteActivity.KEY_SITE_LOCAL_ID,
+                                SelectedSiteRepository.UNAVAILABLE
+                        );
+                        if (newSiteLocalId != SelectedSiteRepository.UNAVAILABLE) {
+                            AppPrefs.setSelectedSite(newSiteLocalId);
+                        }
+                    }
                     // Register for Cloud messaging
                     startWithNewAccount();
                 } else if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
@@ -1805,6 +1815,38 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     public void onSiteChanged(OnSiteChanged event) {
         // "Reload" selected site from the db
         // It would be better if the OnSiteChanged provided the list of changed sites.
+
+        // Check if prefs has a site that should be selected (e.g., after self-hosted login)
+        int prefsSelectedSiteId = mSelectedSiteRepository.getSelectedSiteLocalId(true);
+        if (prefsSelectedSiteId != SelectedSiteRepository.UNAVAILABLE) {
+            SiteModel prefsSite = mSiteStore.getSiteByLocalId(prefsSelectedSiteId);
+            if (prefsSite != null) {
+                SiteModel currentSite = getSelectedSite();
+                if (currentSite == null || currentSite.getId() != prefsSite.getId()) {
+                    setSelectedSite(prefsSite);
+                    return;
+                }
+            }
+        }
+
+        // After wp.com login, select the primary site if currently selected site is not a wp.com site
+        if (mAccountStore.hasAccessToken()) {
+            SiteModel currentSite = getSelectedSite();
+            boolean currentSiteIsWpCom = currentSite != null
+                    && (currentSite.isWPCom() || currentSite.isJetpackConnected());
+            if (!currentSiteIsWpCom) {
+                long primarySiteId = mAccountStore.getAccount().getPrimarySiteId();
+                if (primarySiteId > 0) {
+                    SiteModel primarySite = mSiteStore.getSiteBySiteId(primarySiteId);
+                    if (primarySite != null) {
+                        AppPrefs.setSelectedSite(primarySite.getId());
+                        setSelectedSite(primarySite);
+                        return;
+                    }
+                }
+            }
+        }
+
         if (getSelectedSite() == null && mSiteStore.hasSite()) {
             setSelectedSite(mSiteStore.getSites().get(0));
         }


### PR DESCRIPTION
**Closes CMM-1136**

Currently in trunk, if you log into wp.com, select a site, then add a self-hosted site, it still shows the previously selected site. It should show the just-added self-hosted site instead.

The reverse is also true. If you add a self-hosted site, then log into wp.com, it still shows the self-hosted site instead of the primary wp.com site.

This PR addresses these issues.

**To test**

Verify the above issues no longer occur.