### PR TITLE
CMM-1095 Jetpack Stats are off by an hour

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1087,7 +1087,11 @@ class SiteRestClient @Inject constructor(
             site.hasWooCommerce = from.options.woocommerce_is_active
             site.adminUrl = from.options.admin_url
             site.loginUrl = from.options.login_url
-            site.timezone = from.options.gmt_offset
+            site.timezone = if (!from.options.timezone_string.isNullOrEmpty()) {
+                from.options.timezone_string
+            } else {
+                from.options.gmt_offset
+            }
             site.frameNonce = from.options.frame_nonce
             site.unmappedUrl = from.options.unmapped_url
             site.jetpackVersion = from.options.jetpack_version

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -23,6 +23,7 @@ public class SiteWPComRestResponse implements Response {
         public String admin_url;
         public String login_url;
         public String gmt_offset;
+        public String timezone_string;
         public String frame_nonce;
         public String unmapped_url;
         public String max_upload_size;

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
@@ -262,4 +262,87 @@ class SiteUtilsTest {
         // TimeZone.getTimeZone returns GMT for unrecognized IDs
         Assertions.assertThat(timeZone.id).isEqualTo("GMT")
     }
+
+    @Test
+    fun `verifies DST transition for Europe Madrid - winter time is UTC+1`() {
+        val madridSite = SiteModel().apply { timezone = "Europe/Madrid" }
+
+        // Winter time (CET, UTC+1): January 15, 2025
+        val winterDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-01-15 12:00:00")
+
+        val offsetFormat = SimpleDateFormat("XXX", Locale.ROOT)
+        val winterFormatted = SiteUtils.getDateTimeForSite(madridSite, offsetFormat, winterDate)
+
+        Assertions.assertThat(winterFormatted).isEqualTo("+01:00")
+    }
+
+    @Test
+    fun `verifies DST transition for Europe Madrid - summer time is UTC+2`() {
+        val madridSite = SiteModel().apply { timezone = "Europe/Madrid" }
+
+        // Summer time (CEST, UTC+2): July 15, 2025
+        val summerDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-07-15 12:00:00")
+
+        val offsetFormat = SimpleDateFormat("XXX", Locale.ROOT)
+        val summerFormatted = SiteUtils.getDateTimeForSite(madridSite, offsetFormat, summerDate)
+
+        Assertions.assertThat(summerFormatted).isEqualTo("+02:00")
+    }
+
+    @Test
+    fun `verifies DST transition for America New_York - winter time is UTC-5`() {
+        val newYorkSite = SiteModel().apply { timezone = "America/New_York" }
+
+        // Winter time (EST, UTC-5): January 15, 2025
+        val winterDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-01-15 12:00:00")
+
+        val offsetFormat = SimpleDateFormat("XXX", Locale.ROOT)
+        val winterFormatted = SiteUtils.getDateTimeForSite(newYorkSite, offsetFormat, winterDate)
+
+        Assertions.assertThat(winterFormatted).isEqualTo("-05:00")
+    }
+
+    @Test
+    fun `verifies DST transition for America New_York - summer time is UTC-4`() {
+        val newYorkSite = SiteModel().apply { timezone = "America/New_York" }
+
+        // Summer time (EDT, UTC-4): July 15, 2025
+        val summerDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-07-15 12:00:00")
+
+        val offsetFormat = SimpleDateFormat("XXX", Locale.ROOT)
+        val summerFormatted = SiteUtils.getDateTimeForSite(newYorkSite, offsetFormat, summerDate)
+
+        Assertions.assertThat(summerFormatted).isEqualTo("-04:00")
+    }
+
+    @Test
+    fun `numeric offset does not change between winter and summer - demonstrates the bug`() {
+        // This test demonstrates why numeric offsets are problematic:
+        // They don't adjust for DST, so the offset stays the same year-round
+        val numericOffsetSite = SiteModel().apply { timezone = "1" } // UTC+1
+
+        val winterDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-01-15 12:00:00")
+
+        val summerDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse("2025-07-15 12:00:00")
+
+        val offsetFormat = SimpleDateFormat("XXX", Locale.ROOT)
+        val winterFormatted = SiteUtils.getDateTimeForSite(numericOffsetSite, offsetFormat, winterDate)
+        val summerFormatted = SiteUtils.getDateTimeForSite(numericOffsetSite, offsetFormat, summerDate)
+
+        // Both are +01:00 because numeric offset doesn't account for DST
+        Assertions.assertThat(winterFormatted).isEqualTo("+01:00")
+        Assertions.assertThat(summerFormatted).isEqualTo("+01:00")
+    }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/utils/SiteUtilsTest.kt
@@ -176,9 +176,90 @@ class SiteUtilsTest {
     }
 
     @Test
-    fun `returns correct timezone`() {
+    fun `returns correct timezone for positive offset with plus sign`() {
         val timeZone = SiteUtils.getNormalizedTimezone("+10")
 
         Assertions.assertThat(timeZone.displayName).isEqualTo("GMT+10:00")
+    }
+
+    @Test
+    fun `returns correct timezone for positive numeric offset`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("5")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT+05:00")
+    }
+
+    @Test
+    fun `returns correct timezone for negative numeric offset`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("-8")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT-08:00")
+    }
+
+    @Test
+    fun `returns correct timezone for fractional offset`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("5.5")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT+05:30")
+    }
+
+    @Test
+    fun `returns GMT for null timezone`() {
+        val timeZone = SiteUtils.getNormalizedTimezone(null)
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT")
+    }
+
+    @Test
+    fun `returns GMT for empty timezone`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT")
+    }
+
+    @Test
+    fun `returns GMT for zero timezone`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("0")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT")
+    }
+
+    @Test
+    fun `returns named timezone for Europe Madrid`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("Europe/Madrid")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("Europe/Madrid")
+    }
+
+    @Test
+    fun `returns named timezone for America New_York`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("America/New_York")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("America/New_York")
+    }
+
+    @Test
+    fun `returns named timezone for Asia Tokyo`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("Asia/Tokyo")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("Asia/Tokyo")
+    }
+
+    @Test
+    fun `returns named timezone for Australia Sydney`() {
+        val timeZone = SiteUtils.getNormalizedTimezone("Australia/Sydney")
+
+        Assertions.assertThat(timeZone.id).isEqualTo("Australia/Sydney")
+    }
+
+    @Test
+    fun `falls back to numeric parsing for invalid named timezone`() {
+        // An invalid named timezone that contains "/" should fall back to numeric parsing
+        // which will also fail, resulting in GMT
+        val timeZone = SiteUtils.getNormalizedTimezone("Invalid/Timezone")
+
+        // Falls back to numeric parsing, which creates "GMT+Invalid/Timezone"
+        // TimeZone.getTimeZone returns GMT for unrecognized IDs
+        Assertions.assertThat(timeZone.id).isEqualTo("GMT")
     }
 }


### PR DESCRIPTION
## Description

  Fixes stats displaying incorrect day boundaries for users in timezones that observe Daylight Saving Time (DST).

**The problem was that the "Today stats" were being reset at 24:00 instead of 00:00 because of the day saving time.**

  The app was using `gmt_offset` (a static numeric offset like "2") instead of `timezone_string` (a named timezone like "Europe/Madrid") for timezone calculations. Since `gmt_offset` doesn't account for DST transitions, users in DST-observing timezones would see stats "reset" at the wrong hour (e.g., 23:00 instead of 00:00 in Spain during winter).

  This fix follows the same approach as the webapp: [wp-calypso#107284](https://github.com/Automattic/wp-calypso/pull/107284)

  **Changes:**
  - Added `timezone_string` field to `SiteWPComRestResponse` to capture named timezone from API
  - Updated `SiteRestClient` to prefer `timezone_string` over `gmt_offset` when available
  - Updated `SiteUtils.getNormalizedTimezone()` to handle named timezones (e.g., "Europe/Madrid") which correctly handle DST via Java's `TimeZone` class
  - Added unit tests for named timezone handling

  Fixes: CMM-1095

  ## Testing instructions

  Verify stats timezone handling with named timezone:

  1. Log in to a site that has a DST-observing timezone set (e.g., Europe/Madrid, America/New_York)
  2. Navigate to Stats
  - [ ] Check that Today's stats show the correct date boundary
  3. Change time to something between 23 and 00 hours
  - [ ] Verify the today starts are still correct

 
<img width="588" height="488" alt="Screenshot 2026-01-14 at 12 15 51" src="https://github.com/user-attachments/assets/6303f1fd-48de-46c5-99da-2c2a2293c5d2" />
