### PR TITLE
CMM-1137 exclude new Application Password connected sites when the user manually turns off the feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts.login
 
-import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -142,14 +143,19 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     /**
-     * Removes all the application Password credentials
+     * Removes Application Password credentials for sites that have regular credentials as fallback.
+     * Sites without regular credentials (username/password) are excluded since they can only
+     * authenticate using Application Password.
      * @return the number of sites that were affected
      */
     suspend fun removeAllApplicationPasswordCredentials(): Int {
         return withContext(bgDispatcher) {
             val sites = siteStore.sites
-            val affectedSites = sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
-            sites.forEach { site ->
+            // Only reset sites that have regular credentials to fall back to
+            val sitesToReset = sites.filter {
+                !it.apiRestUsernameEncrypted.isNullOrEmpty() && it.hasRegularCredentials()
+            }
+            sitesToReset.forEach { site ->
                 site.apply {
                     apiRestUsernamePlain = ""
                     apiRestPasswordPlain = ""
@@ -160,13 +166,26 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
                 dispatcherWrapper.removeApplicationPassword(site)
             }
-            appLogWrapper.d(AppLog.T.DB, "A_P: Removed application password credentials for: $affectedSites sites")
-            affectedSites
+            appLogWrapper.d(
+                AppLog.T.DB,
+                "A_P: Removed application password credentials for: ${sitesToReset.size} sites"
+            )
+            sitesToReset.size
         }
     }
 
-    fun getApplicationPasswordSitesCount(): Int {
-        return siteStore.sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
+    private fun SiteModel.hasRegularCredentials(): Boolean {
+        return !username.isNullOrEmpty() && !password.isNullOrEmpty()
+    }
+
+    /**
+     * Returns the count of sites with Application Password credentials that can be reset
+     * because of having regular credentials
+     */
+    fun getResettableApplicationPasswordSitesCount(): Int {
+        return siteStore.sites.count {
+            !it.apiRestUsernameEncrypted.isNullOrEmpty() && it.hasRegularCredentials()
+        }
     }
 
     fun siteHasBadCredentials(site: SiteModel) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -71,7 +71,7 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
                 if (enabled) {
                     _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Info
                 } else {
-                    val affectedSites = applicationPasswordLoginHelper.getApplicationPasswordSitesCount()
+                    val affectedSites = applicationPasswordLoginHelper.getResettableApplicationPasswordSitesCount()
                     if (affectedSites > 0) {
                         _applicationPasswordDialogState.value =
                             ApplicationPasswordDialogState.Disable(affectedSites)

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
@@ -160,7 +160,7 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     @Test
     fun `dismissDisableApplicationPassword sets dialog state to none`() = test {
         createViewModel()
-        whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
+        whenever(applicationPasswordLoginHelper.getResettableApplicationPasswordSitesCount()).thenReturn(1)
         // Simulate dialog being shown
         viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
         assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.Disable(1))
@@ -173,7 +173,7 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     fun `confirmDisableApplicationPassword disables feature, removes credentials, and sets dialog state to none`() =
         test {
             createViewModel()
-            whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
+            whenever(applicationPasswordLoginHelper.getResettableApplicationPasswordSitesCount()).thenReturn(1)
             // Simulate dialog being shown
             viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
             assertThat(viewModel.applicationPasswordDialogState.value)
@@ -193,7 +193,7 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     fun `onFeatureToggled with application password feature disabled shows dialog but does not remove credentials`() =
         test {
             createViewModel()
-            whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
+            whenever(applicationPasswordLoginHelper.getResettableApplicationPasswordSitesCount()).thenReturn(1)
             viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
             // Dialog should be shown
             assertThat(viewModel.applicationPasswordDialogState.value)


### PR DESCRIPTION
## Description

  When the Application Password experimental feature is turned off, the app removes Application Password credentials from all sites. However, sites added via the forced Application Password new flow (self-hosted sites) don't have regular credentials to fall back to, so removing their Application Password credentials would break authentication.

  This PR modifies the credential removal logic to only reset Application Password credentials for sites that have regular credentials (username/password) as a fallback. Sites without regular credentials keep their Application Password credentials intact.

  ## Changes

  - Updated `removeAllApplicationPasswordCredentials()` to filter out sites without regular credentials
  - Added `hasRegularCredentials()` extension function to check if a site has fallback authentication
  - Renamed `getApplicationPasswordSitesCount()` to `getResettableApplicationPasswordSitesCount()` for clarity
  - Updated and added unit tests to cover the new behavior

  ## Testing instructions

  1. Log in an new self-hosted site
  2. Turn ON/OFF the Application Password experimental feature
  - [x] Verify the site is still usable by opening media

https://github.com/user-attachments/assets/2321d15a-b2e3-4481-ad0d-75a9bf85fbb4


