### PR TITLE
CMM-1136 Select newly added self-hosted site after login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -75,19 +75,19 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
 
         if (navigationActionData.isError) {
             ActivityLauncher.showMainActivity(this)
-        } else if (navigationActionData.showSiteSelector) {
-            // Skip the site picker - just go to main activity which will auto-select a site
-            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.value)
-            ActivityLauncher.showMainActivity(this)
         } else if (navigationActionData.showPostSignupInterstitial) {
             unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.value)
             ActivityLauncher.showPostSignupInterstitial(this)
         } else {
+            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.value)
             val mainActivityIntent = Intent(this, WPMainActivity::class.java)
             mainActivityIntent.setFlags(
                 (Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
                         or Intent.FLAG_ACTIVITY_CLEAR_TASK)
             )
+            navigationActionData.newSiteLocalId?.let {
+                mainActivityIntent.putExtra(WPMainActivity.ARG_SELECTED_SITE, it)
+            }
             startActivity(mainActivityIntent)
         }
         finish()

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -169,7 +169,8 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                                 && appPrefsWrapper.shouldShowPostSignupInterstitial,
                         siteUrl = currentUrlLogin?.siteUrl,
                         oldSitesIDs = oldSitesIDs,
-                        isError = false
+                        isError = false,
+                        newSiteLocalId = site.id
                     )
                 )
             }
@@ -181,6 +182,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         val showPostSignupInterstitial: Boolean,
         val siteUrl: String?,
         val oldSitesIDs: ArrayList<Int>?,
-        val isError: Boolean
+        val isError: Boolean,
+        val newSiteLocalId: Int? = null
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1678,8 +1678,15 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
+        // Select newly added self-hosted site
+        for (SiteModel site : event.updatedSites) {
+            if (!site.isWPCom()) {
+                setSelectedSite(site);
+                return;
+            }
+        }
+
         // "Reload" selected site from the db
-        // It would be better if the OnSiteChanged provided the list of changed sites.
         if (getSelectedSite() == null && mSiteStore.hasSite()) {
             setSelectedSite(mSiteStore.getSites().get(0));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -165,8 +165,10 @@ import org.wordpress.android.workers.weeklyroundup.WeeklyRoundupScheduler;
 
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -241,6 +243,9 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
     private static final String BLOGGING_REMINDERS_BOTTOM_SHEET_TAG = "BLOGGING_REMINDERS_BOTTOM_SHEET_TAG";
     private final Handler mHandler = new Handler();
+
+    // Tracks site IDs before navigating away, used to detect newly added sites
+    private static Set<Integer> sSiteIdsBeforeNavigation = null;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -1062,6 +1067,9 @@ public class WPMainActivity extends BaseAppCompatActivity implements
 
         mWpAppNotifierHandler.addListener(this);
 
+        // Check if a new site was added while we were away (e.g., during login)
+        selectNewlyAddedSiteIfNeeded();
+
         // Load selected site
         initSelectedSite();
 
@@ -1319,6 +1327,8 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                 if (resultCode == RESULT_OK) {
                     // Register for Cloud messaging
                     startWithNewAccount();
+                    // Select the newly added site if one was returned
+                    setSite(data);
                 } else if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
                     // can't do anything if user isn't signed in (either to wp.com or self-hosted)
                     finish();
@@ -1552,6 +1562,28 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     }
 
     /**
+     * Checks if a new site was added while the activity was paused (e.g., during self-hosted login)
+     * and selects it if so.
+     */
+    private void selectNewlyAddedSiteIfNeeded() {
+        if (sSiteIdsBeforeNavigation == null) {
+            return;
+        }
+
+        // Find any newly added sites
+        for (SiteModel site : mSiteStore.getSites()) {
+            if (!sSiteIdsBeforeNavigation.contains(site.getId())) {
+                // Found a new site, select it
+                setSelectedSite(site);
+                break;
+            }
+        }
+
+        // Clear the saved IDs
+        sSiteIdsBeforeNavigation = null;
+    }
+
+    /**
      * This should not be moved to a SiteUtils.getSelectedSite() or similar static method. We don't want
      * this to be used globally like WordPress.getCurrentBlog() was used. The state is maintained by this
      * Activity and the selected site parameter is passed along to other activities / fragments.
@@ -1736,6 +1768,12 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         super.onPause();
 
         mWpAppNotifierHandler.removeListener(this);
+
+        // Save current site IDs so we can detect newly added sites when we resume
+        sSiteIdsBeforeNavigation = new HashSet<>();
+        for (SiteModel site : mSiteStore.getSites()) {
+            sSiteIdsBeforeNavigation.add(site.getId());
+        }
     }
 
     private void enableDeepLinkingComponentsIfNeeded() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -457,7 +457,14 @@ public class WPMainActivity extends BaseAppCompatActivity implements
             onSetPromptReminderClick(getIntent().getIntExtra(ARG_OPEN_BLOGGING_REMINDERS, 0));
         }
 
-        if (!mSelectedSiteRepository.hasSelectedSite()) {
+        // Check if a specific site should be selected (e.g., after adding a self-hosted site)
+        int selectedSiteId = getIntent().getIntExtra(ARG_SELECTED_SITE, SelectedSiteRepository.UNAVAILABLE);
+        if (selectedSiteId != SelectedSiteRepository.UNAVAILABLE) {
+            SiteModel site = mSiteStore.getSiteByLocalId(selectedSiteId);
+            if (site != null) {
+                setSelectedSite(site);
+            }
+        } else if (!mSelectedSiteRepository.hasSelectedSite()) {
             initSelectedSite();
         }
 
@@ -1327,7 +1334,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                 if (resultCode == RESULT_OK) {
                     // Register for Cloud messaging
                     startWithNewAccount();
-                    // Select the newly added site if one was returned
                     setSite(data);
                 } else if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
                     // can't do anything if user isn't signed in (either to wp.com or self-hosted)
@@ -1678,14 +1684,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        // Select newly added self-hosted site
-        for (SiteModel site : event.updatedSites) {
-            if (!site.isWPCom()) {
-                setSelectedSite(site);
-                return;
-            }
-        }
-
         // "Reload" selected site from the db
         if (getSelectedSite() == null && mSiteStore.hasSite()) {
             setSelectedSite(mSiteStore.getSites().get(0));

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -165,10 +165,8 @@ import org.wordpress.android.workers.weeklyroundup.WeeklyRoundupScheduler;
 
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -243,9 +241,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
     private static final String BLOGGING_REMINDERS_BOTTOM_SHEET_TAG = "BLOGGING_REMINDERS_BOTTOM_SHEET_TAG";
     private final Handler mHandler = new Handler();
-
-    // Tracks site IDs before navigating away, used to detect newly added sites
-    private static Set<Integer> sSiteIdsBeforeNavigation = null;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -1075,9 +1070,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
 
         mWpAppNotifierHandler.addListener(this);
 
-        // Check if a new site was added while we were away (e.g., during login)
-        selectNewlyAddedSiteIfNeeded();
-
         // Load selected site
         initSelectedSite();
 
@@ -1569,28 +1561,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     }
 
     /**
-     * Checks if a new site was added while the activity was paused (e.g., during self-hosted login)
-     * and selects it if so.
-     */
-    private void selectNewlyAddedSiteIfNeeded() {
-        if (sSiteIdsBeforeNavigation == null) {
-            return;
-        }
-
-        // Find any newly added sites
-        for (SiteModel site : mSiteStore.getSites()) {
-            if (!sSiteIdsBeforeNavigation.contains(site.getId())) {
-                // Found a new site, select it
-                setSelectedSite(site);
-                break;
-            }
-        }
-
-        // Clear the saved IDs
-        sSiteIdsBeforeNavigation = null;
-    }
-
-    /**
      * This should not be moved to a SiteUtils.getSelectedSite() or similar static method. We don't want
      * this to be used globally like WordPress.getCurrentBlog() was used. The state is maintained by this
      * Activity and the selected site parameter is passed along to other activities / fragments.
@@ -1774,12 +1744,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         super.onPause();
 
         mWpAppNotifierHandler.removeListener(this);
-
-        // Save current site IDs so we can detect newly added sites when we resume
-        sSiteIdsBeforeNavigation = new HashSet<>();
-        for (SiteModel site : mSiteStore.getSites()) {
-            sSiteIdsBeforeNavigation.add(site.getId());
-        }
     }
 
     private void enableDeepLinkingComponentsIfNeeded() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -460,6 +460,7 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         // Check if a specific site should be selected (e.g., after adding a self-hosted site)
         int selectedSiteId = getIntent().getIntExtra(ARG_SELECTED_SITE, SelectedSiteRepository.UNAVAILABLE);
         if (selectedSiteId != SelectedSiteRepository.UNAVAILABLE) {
+            getIntent().removeExtra(ARG_SELECTED_SITE);
             SiteModel site = mSiteStore.getSiteByLocalId(selectedSiteId);
             if (site != null) {
                 setSelectedSite(site);

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -194,7 +194,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = false
+                isError = false,
+                newSiteLocalId = testSite.id
             )
             whenever(siteStore.hasSite()).thenReturn(true)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
@@ -231,7 +232,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = false
+                isError = false,
+                newSiteLocalId = testSite.id
             )
             whenever(siteStore.hasSite()).thenReturn(false)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
@@ -268,7 +270,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = false
+                isError = false,
+                newSiteLocalId = testSite.id
             )
             whenever(siteStore.hasSite()).thenReturn(true)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
@@ -305,7 +308,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = false
+                isError = false,
+                newSiteLocalId = testSite.id
             )
             whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(false)


### PR DESCRIPTION
Partially resolves CMM-1136

Prior to this PR, if you're logged into wp.com and add a self-hosted site, the previously selected wp.com site would remain selected. This PR makes the added self-hosted site the selected site after logging into it.

To test:
- Log into wp.com
- Add a self-hosted site
- Verify that the self-hosted site is shown after logging into it