### PR TITLE
Simplify removing a self-hosted site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -268,7 +268,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         binding.recyclerView.adapter = adapter.apply {
             onReload = { viewModel.loadSites(this@ChooseSiteActivity.mode, searchKeyword) }
             onSiteClicked = { selectSite(it) }
-            onSiteLongClicked = { onSiteLongClick(it) }
+            onSiteRemoveClicked = { onSiteRemoveClick(it) }
         }
         binding.recyclerView.scrollBarStyle = View.SCROLLBARS_OUTSIDE_OVERLAY
         binding.recyclerView.setEmptyView(binding.actionableEmptyView)
@@ -284,11 +284,9 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         finish()
     }
 
-    private fun onSiteLongClick(siteRecord: SiteRecord) {
+    private fun onSiteRemoveClick(siteRecord: SiteRecord) {
         val site: SiteModel = siteStore.getSiteByLocalId(siteRecord.localId) ?: return
-        if (site.isUsingWpComRestApi.not()) {
-            showRemoveSelfHostedSiteDialog(site)
-        }
+        showRemoveSelfHostedSiteDialog(site)
     }
 
     private fun showRemoveSelfHostedSiteDialog(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -290,9 +290,10 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
     }
 
     private fun showRemoveSelfHostedSiteDialog(site: SiteModel) {
+        val siteName = SiteUtils.getSiteNameOrHomeURL(site)
         MaterialAlertDialogBuilder(this)
             .setTitle(resources.getText(R.string.remove_account))
-            .setMessage(resources.getText(R.string.sure_to_remove_account))
+            .setMessage(getString(R.string.confirm_remove_site, siteName))
             .setPositiveButton(
                 resources.getText(R.string.yes)
             ) { _: DialogInterface?, _: Int ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteAdapter.kt
@@ -14,7 +14,7 @@ class ChooseSiteAdapter : RecyclerView.Adapter<ChooseSiteViewHolder>() {
 
     var onReload = {}
     var onSiteClicked: (SiteRecord) -> Unit = {}
-    var onSiteLongClicked: (SiteRecord) -> Unit = {}
+    var onSiteRemoveClicked: (SiteRecord) -> Unit = {}
     var selectedSiteId: Int? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChooseSiteViewHolder =
@@ -26,7 +26,7 @@ class ChooseSiteAdapter : RecyclerView.Adapter<ChooseSiteViewHolder>() {
         holder.bind(mode, sites.getOrNull(position - 1), sites[position], selectedSiteId)
         holder.onPinUpdated = { onReload() }
         holder.onClicked = { onSiteClicked(it) }
-        holder.onLongClicked = { onSiteLongClicked(it) }
+        holder.onRemoveClicked = { onSiteRemoveClicked(it) }
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
@@ -26,7 +26,7 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
 
     var onPinUpdated = { _: SiteRecord -> }
     var onClicked = { _: SiteRecord -> }
-    var onLongClicked = { _: SiteRecord -> }
+    var onRemoveClicked = { _: SiteRecord -> }
 
     init {
         (itemView.context.applicationContext as WordPress).component().inject(this)
@@ -42,16 +42,12 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
         binding.pin.isVisible = mode is ActionMode.Pin
 
         handlePinButton(site)
+        handleRemoveButton(mode, site)
 
         if (mode is ActionMode.Pin) {
             binding.layoutContainer.setOnClickListener(null)
-            binding.layoutContainer.setOnLongClickListener(null)
         } else {
             binding.layoutContainer.setOnClickListener { onClicked(site) }
-            binding.layoutContainer.setOnLongClickListener {
-                onLongClicked(site)
-                true
-            }
         }
 
         handleHighlight(site, selectedId)
@@ -85,6 +81,16 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
         val color = if (isPinned) binding.root.context.getColor(R.color.inline_action_filled)
         else binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
         ImageViewCompat.setImageTintList(binding.pin, ColorStateList.valueOf(color))
+    }
+
+    private fun handleRemoveButton(mode: ActionMode, site: SiteRecord) {
+        val showRemove = mode !is ActionMode.Pin && site.isSelfHostedSite
+        binding.remove.isVisible = showRemove
+        if (showRemove) {
+            binding.remove.setOnClickListener { onRemoveClicked(site) }
+            val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
+            ImageViewCompat.setImageTintList(binding.remove, ColorStateList.valueOf(color))
+        }
     }
 
     private fun handleAvatar(site: SiteRecord) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
@@ -84,7 +84,7 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
     }
 
     private fun handleRemoveButton(mode: ActionMode, site: SiteRecord) {
-        val showRemove = mode !is ActionMode.Pin && site.isSelfHostedSite
+        val showRemove = shouldShowRemoveButton(mode, site.isSelfHostedSite)
         binding.remove.isVisible = showRemove
         if (showRemove) {
             binding.remove.setOnClickListener { onRemoveClicked(site) }
@@ -171,5 +171,13 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
     companion object {
         private const val TRACK_PROPERTY_BLOG_ID = "blog_id"
         private const val TRACK_PROPERTY_PINNED = "pinned"
+
+        /**
+         * Determines whether the remove button should be shown for a site.
+         * The remove button is shown only for self-hosted sites and only when not in Pin edit mode.
+         */
+        fun shouldShowRemoveButton(mode: ActionMode, isSelfHostedSite: Boolean): Boolean {
+            return mode !is ActionMode.Pin && isSelfHostedSite
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
@@ -88,8 +88,6 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
         binding.remove.isVisible = showRemove
         if (showRemove) {
             binding.remove.setOnClickListener { onRemoveClicked(site) }
-            val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
-            ImageViewCompat.setImageTintList(binding.remove, ColorStateList.valueOf(color))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SiteRecord.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SiteRecord.kt
@@ -15,6 +15,7 @@ class SiteRecord(siteModel: SiteModel) {
     val homeURL: String
     val blavatarUrl: String
     val blavatarType: ImageType
+    val isSelfHostedSite: Boolean
     var isRecentPick = false
 
     init {
@@ -26,6 +27,7 @@ class SiteRecord(siteModel: SiteModel) {
         blavatarType = SiteUtils.getSiteImageType(
             siteModel.isWpForTeamsSite, BlavatarShape.SQUARE_WITH_ROUNDED_CORNERES
         )
+        isSelfHostedSite = !siteModel.isUsingWpComRestApi
     }
 
     val blogNameOrHomeURL: String

--- a/WordPress/src/main/res/drawable/ic_remove_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_remove_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="@color/material_on_surface_emphasis_medium"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/WordPress/src/main/res/layout/item_choose_site.xml
+++ b/WordPress/src/main/res/layout/item_choose_site.xml
@@ -49,7 +49,7 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/remove_account"
             android:padding="16dp"
-            android:src="@drawable/ic_close_white_24dp"
+            android:src="@drawable/ic_remove_24dp"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/item_choose_site.xml
+++ b/WordPress/src/main/res/layout/item_choose_site.xml
@@ -50,6 +50,7 @@
             android:contentDescription="@string/remove_account"
             android:padding="16dp"
             android:src="@drawable/ic_remove_24dp"
+            android:tooltipText="@string/remove_account"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/item_choose_site.xml
+++ b/WordPress/src/main/res/layout/item_choose_site.xml
@@ -42,6 +42,27 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:visibility="visible" />
 
+        <ImageView
+            android:id="@+id/remove"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/remove_account"
+            android:padding="16dp"
+            android:src="@drawable/ic_close_white_24dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/buttons_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="start"
+            app:constraint_referenced_ids="pin,remove" />
+
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/avatar_container"
             android:layout_width="wrap_content"
@@ -75,10 +96,9 @@
             android:maxLines="1"
             android:textSize="15sp"
             app:layout_constraintBottom_toTopOf="@+id/text_domain"
-            app:layout_constraintEnd_toStartOf="@+id/pin"
+            app:layout_constraintEnd_toStartOf="@+id/buttons_barrier"
             app:layout_constraintStart_toEndOf="@+id/avatar_container"
             app:layout_constraintTop_toTopOf="@+id/avatar_container"
-            app:layout_goneMarginEnd="@dimen/margin_extra_large"
             tools:text="Around the World with Pam" />
 
         <org.wordpress.android.widgets.WPTextView
@@ -92,11 +112,10 @@
             android:maxLines="1"
             android:textSize="15sp"
             app:layout_constraintBottom_toBottomOf="@+id/avatar_container"
-            app:layout_constraintEnd_toStartOf="@+id/pin"
+            app:layout_constraintEnd_toStartOf="@+id/buttons_barrier"
             app:layout_constraintStart_toEndOf="@+id/avatar_container"
             app:layout_constraintTop_toBottomOf="@+id/text_title"
             app:layout_constraintVertical_chainStyle="packed"
-            app:layout_goneMarginEnd="@dimen/margin_extra_large"
             tools:text="pamelanguyen.com" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/item_choose_site.xml
+++ b/WordPress/src/main/res/layout/item_choose_site.xml
@@ -50,7 +50,6 @@
             android:contentDescription="@string/remove_account"
             android:padding="16dp"
             android:src="@drawable/ic_remove_24dp"
-            android:tooltipText="@string/remove_account"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="search">Search</string>
     <string name="suggestion">Suggestion:</string>
     <string name="select_all">Select all</string>
-    <string name="sure_to_remove_account">Remove this site from the app?</string>
+    <string name="confirm_remove_site">Remove \"%s\" from the app?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="error">Error</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/ChooseSiteViewHolderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/ChooseSiteViewHolderTest.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.main
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.ui.main.ChooseSiteViewHolder.Companion.shouldShowRemoveButton
+
+class ChooseSiteViewHolderTest {
+    @Test
+    fun `remove button is visible for self-hosted site in normal mode`() {
+        val result = shouldShowRemoveButton(mode = ActionMode.None, isSelfHostedSite = true)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `remove button is hidden for self-hosted site in pin mode`() {
+        val result = shouldShowRemoveButton(mode = ActionMode.Pin, isSelfHostedSite = true)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `remove button is hidden for wpcom site in normal mode`() {
+        val result = shouldShowRemoveButton(mode = ActionMode.None, isSelfHostedSite = false)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `remove button is hidden for wpcom site in pin mode`() {
+        val result = shouldShowRemoveButton(mode = ActionMode.Pin, isSelfHostedSite = false)
+
+        assertThat(result).isFalse()
+    }
+}


### PR DESCRIPTION
**Fixes CMM-180**

We've a had a long-standing issue to make it easier to remove a self-hosted site from the app. Previously you could only do it by long-pressing the site in the site picker and confirming its removal. This PR changes this to use a very visible **x** icon at the end of the site row.

**To test**

Go to the site picker, tap the **x** icon on a self-hosted site, and verify that it works as expected.

<img width="297" height="255" alt="delete" src="https://github.com/user-attachments/assets/a9df4c2d-f4fd-40ba-a16a-2333b752fe3c" />
