### PR TITLE
CMM-1141 create new stats screen and experimental feature flag

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -106,6 +106,12 @@
             android:label="@string/my_site_section_screen_title"
             android:exported="false" />
 
+        <activity
+            android:name=".ui.newstats.NewStatsActivity"
+            android:theme="@style/WordPress.NoActionBar"
+            android:label="@string/stats"
+            android:exported="false" />
+
         <!-- Account activities -->
         <activity
             android:name=".ui.main.MeActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.ui.newstats.NewStatsActivity
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
 import org.wordpress.android.ui.uploads.UploadService
@@ -587,6 +588,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             action.site,
             StatsLaunchedFrom.QUICK_ACTIONS
         )
+
+        is SiteNavigationAction.OpenNewStats -> NewStatsActivity.start(requireContext())
 
         is SiteNavigationAction.ConnectJetpackForStats ->
             ActivityLauncher.viewConnectJetpackForStats(activity, action.site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -42,6 +42,7 @@ sealed class SiteNavigationAction {
     data class OpenUnifiedComments(val site: SiteModel) : SiteNavigationAction()
     object StartWPComLoginForJetpackStats : SiteNavigationAction()
     data class OpenStats(val site: SiteModel) : SiteNavigationAction()
+    object OpenNewStats : SiteNavigationAction()
     data class ConnectJetpackForStats(val site: SiteModel) : SiteNavigationAction()
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
     data class OpenPaidDomainSearch(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
@@ -8,12 +8,15 @@ import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignLis
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import javax.inject.Inject
 
 class ListItemActionHandler @Inject constructor(
     private val accountStore: AccountStore,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
-    private val blazeFeatureUtils: BlazeFeatureUtils
+    private val blazeFeatureUtils: BlazeFeatureUtils,
+    private val experimentalFeatures: ExperimentalFeatures
 ) {
     fun handleAction(
         action: ListItemAction,
@@ -56,7 +59,13 @@ class ListItemActionHandler @Inject constructor(
         !accountStore.hasAccessToken() && site.isJetpackConnected -> SiteNavigationAction.StartWPComLoginForJetpackStats
 
         // If it's a WordPress.com or Jetpack site, show the Stats screen.
-        site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> SiteNavigationAction.OpenStats(site)
+        site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> {
+            if (experimentalFeatures.isEnabled(Feature.NEW_STATS)) {
+                SiteNavigationAction.OpenNewStats
+            } else {
+                SiteNavigationAction.OpenStats(site)
+            }
+        }
 
         // If it's a self-hosted site, ask to connect to Jetpack.
         else -> SiteNavigationAction.ConnectJetpackForStats(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -54,6 +54,7 @@ import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.newstats.NewStatsActivity
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.SiteSettingsFragment
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
@@ -132,6 +133,8 @@ class MenuActivity : BaseAppCompatActivity() {
                 action.site,
                 StatsLaunchedFrom.ROW
             )
+
+            is SiteNavigationAction.OpenNewStats -> NewStatsActivity.start(this)
 
             is SiteNavigationAction.OpenDomains -> ActivityLauncher.viewDomainsDashboardActivity(
                 this,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.ui.newstats
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.main.BaseAppCompatActivity
+
+@AndroidEntryPoint
+class NewStatsActivity : BaseAppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppThemeM3 {
+                NewStatsScreen(
+                    onBackPressed = onBackPressedDispatcher::onBackPressed
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun start(context: Context) {
+            context.startActivity(Intent(context, NewStatsActivity::class.java))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewStatsScreen(
+    onBackPressed: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(id = R.string.stats))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
+        }
+    ) { contentPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "New Stats Screen - Coming Soon")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NewStatsScreenPreview() {
+    AppThemeM3 {
+        NewStatsScreen(onBackPressed = {})
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -5,22 +5,29 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
@@ -45,11 +52,21 @@ class NewStatsActivity : BaseAppCompatActivity() {
     }
 }
 
+private enum class StatsTab(val titleResId: Int) {
+    TRAFFIC(R.string.stats_traffic),
+    INSIGHTS(R.string.stats_insights),
+    SUBSCRIBERS(R.string.subscribers)
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NewStatsScreen(
+private fun NewStatsScreen(
     onBackPressed: () -> Unit
 ) {
+    val tabs = StatsTab.entries
+    val pagerState = rememberPagerState(pageCount = { tabs.size })
+    val coroutineScope = rememberCoroutineScope()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -67,14 +84,42 @@ fun NewStatsScreen(
             )
         }
     ) { contentPadding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(contentPadding),
-            contentAlignment = Alignment.Center
+                .padding(contentPadding)
         ) {
-            Text(text = "New Stats Screen - Coming Soon")
+            PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
+                tabs.forEachIndexed { index, tab ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        },
+                        text = { Text(text = stringResource(id = tab.titleResId)) }
+                    )
+                }
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                StatsTabContent(tab = tabs[page])
+            }
         }
+    }
+}
+
+@Composable
+private fun StatsTabContent(tab: StatsTab) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "${stringResource(id = tab.titleResId)} - Coming Soon")
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -49,6 +49,11 @@ class ExperimentalFeatures @Inject constructor(
             "experimental_post_types",
             R.string.experimental_post_types,
             R.string.experimental_post_types_description
+        ),
+        NEW_STATS(
+            "new_stats",
+            R.string.experimental_new_stats,
+            R.string.experimental_new_stats_description
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -51,8 +51,8 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     private fun shouldShowFeature(feature: Feature): Boolean {
-        // Only show Post Types feature in debug builds
-        return if (feature == Feature.EXPERIMENTAL_POST_TYPES) {
+        // Only show Post Types and New Stats features in debug builds
+        return if (feature == Feature.EXPERIMENTAL_POST_TYPES || feature == Feature.NEW_STATS) {
             BuildConfig.DEBUG
         } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -994,6 +994,8 @@
     <string name="network_requests_disable">Disable</string>
     <string name="experimental_post_types">Post Types</string>
     <string name="experimental_post_types_description">Enable experimental post types screen</string>
+    <string name="experimental_new_stats">New Stats</string>
+    <string name="experimental_new_stats_description">Show stats in a more modern and advanced UI</string>
     <string name="post_types_screen_title">Post Types</string>
 
     <!-- Debug settings -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignLis
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
@@ -30,6 +31,8 @@ class ListItemActionHandlerTest: BaseUnitTest() {
     @Mock
     lateinit var blazeFeatureUtils: BlazeFeatureUtils
 
+    @Mock
+    lateinit var experimentalFeatures: ExperimentalFeatures
 
     private val site = SiteModel()
 
@@ -40,7 +43,8 @@ class ListItemActionHandlerTest: BaseUnitTest() {
         listItemActionHandler = ListItemActionHandler(
             accountStore,
             jetpackFeatureRemovalPhaseHelper,
-            blazeFeatureUtils
+            blazeFeatureUtils,
+            experimentalFeatures
         )
     }
 
@@ -164,6 +168,27 @@ class ListItemActionHandlerTest: BaseUnitTest() {
         assertEquals(navigationAction, SiteNavigationAction.StartWPComLoginForJetpackStats)
     }
 
+    @Test
+    fun `stats item click emits OpenNewStats when NEW_STATS feature is enabled and site is WPCom`() {
+        site.setIsWPCom(true)
+        whenever(experimentalFeatures.isEnabled(ExperimentalFeatures.Feature.NEW_STATS)).thenReturn(true)
+
+        val navigationAction = invokeItemClickAction(action = ListItemAction.STATS)
+
+        assertEquals(SiteNavigationAction.OpenNewStats, navigationAction)
+    }
+
+    @Test
+    fun `stats item click emits OpenNewStats when NEW_STATS feature is enabled and site is Jetpack`() {
+        site.setIsJetpackConnected(true)
+        site.setIsWPCom(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(experimentalFeatures.isEnabled(ExperimentalFeatures.Feature.NEW_STATS)).thenReturn(true)
+
+        val navigationAction = invokeItemClickAction(action = ListItemAction.STATS)
+
+        assertEquals(SiteNavigationAction.OpenNewStats, navigationAction)
+    }
 
     @Test
     fun `given campaigns enabled, when menu clicked, then navigated to campaign listing page`() {


### PR DESCRIPTION
## Description

  Adds a new experimental feature flag "New Stats" that enables a modern stats UI. When the feature flag is enabled, tapping on Stats in My Site opens a new Jetpack Compose activity with a tabbed interface (Traffic, Insights, Subscribers) instead of the existing stats screen.

  ## Testing instructions

  Enable the experimental feature:

  1. Go to Me → App Settings → Experimental Features
  2. Enable "New Stats"

  Test new stats navigation from My Site:

  1. With "New Stats" enabled, go to My Site
  2. Tap on "Stats"
  - [ ] Verify the new Stats screen opens with three tabs: Traffic, Insights, Subscribers

  Test new stats navigation from Menu:

  1. With "New Stats" enabled, go to My Site → More (three dots menu)
  2. Tap on "Stats"
  - [ ] Verify the new Stats screen opens

  Test legacy stats still works:

  1. Disable "New Stats" in Experimental Features
  2. Tap on "Stats" from My Site
  - [ ] Verify the existing/legacy stats screen opens