### PR TITLE
Refactor EditPostActivity by extracting helper classes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1,6 +1,7 @@
 @file:Suppress("DEPRECATION")
 package org.wordpress.android.ui.posts
 
+import android.app.Activity
 import android.app.ProgressDialog
 import android.content.DialogInterface
 import android.content.Intent
@@ -168,8 +169,11 @@ import org.wordpress.android.ui.posts.editor.EditorTracker
 import org.wordpress.android.ui.posts.editor.ImageEditorTracker
 import org.wordpress.android.ui.posts.editor.PostLoadingState
 import org.wordpress.android.ui.posts.editor.PostLoadingState.Companion.fromInt
+import org.wordpress.android.ui.posts.editor.EditorActivityResultHandler
 import org.wordpress.android.ui.posts.editor.EditorIntentProcessor
 import org.wordpress.android.ui.posts.editor.EditorIntentProcessor.IntentProcessResult
+import org.wordpress.android.ui.posts.editor.EditorMediaPickerHandler
+import org.wordpress.android.ui.posts.editor.ShareContentHandler
 import org.wordpress.android.ui.posts.editor.PostLoadingStateManager
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction
@@ -271,7 +275,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     EditorPhotoPickerListener, EditorMediaListener, EditPostSettingsFragment.EditorDataProvider,
     HistoryItemClickInterface, PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger,
     SiteSettingsListener, MediaUploadCoordinator.UploadEventListener,
-    PostLoadingStateManager.StateChangeListener {
+    PostLoadingStateManager.StateChangeListener, EditorMediaPickerHandler.MediaPickerListener,
+    EditorActivityResultHandler.ActivityResultListener, ShareContentHandler.ShareContentListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
 
@@ -417,6 +422,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var mediaUploadCoordinator: MediaUploadCoordinator
     @Inject lateinit var postLoadingStateManager: PostLoadingStateManager
     @Inject lateinit var editorIntentProcessor: EditorIntentProcessor
+    @Inject lateinit var editorMediaPickerHandler: EditorMediaPickerHandler
+    @Inject lateinit var editorActivityResultHandler: EditorActivityResultHandler
+    @Inject lateinit var shareContentHandler: ShareContentHandler
     private lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
     private lateinit var prepublishingViewModel: PrepublishingViewModel
@@ -538,6 +546,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         editorMedia.start(siteModel, this)
         mediaUploadCoordinator.start(this, editorMediaUploadListener)
         postLoadingStateManager.setListener(this)
+        editorMediaPickerHandler.start(this)
+        editorActivityResultHandler.start(this)
+        shareContentHandler.start(this)
         startObserving()
         editorFragment?.let {
             hasSetPostContent = true
@@ -1884,6 +1895,57 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             findViewById(R.id.editor_activity),
             getString(R.string.remote_preview_operation_error)
         )
+    }
+
+    // EditorMediaPickerHandler.MediaPickerListener implementation
+    override fun getActivity(): Activity = this
+
+    override fun getSiteModel(): SiteModel = siteModel
+
+    override fun getEditorPhotoPicker(): EditorPhotoPicker? = editorPhotoPicker
+
+    override fun showNoUploadPermissionSnackbar() {
+        editorPhotoPicker?.showNoUploadPermissionSnackbar()
+    }
+
+    // EditorActivityResultHandler.ActivityResultListener implementation
+    override fun getEditorFragment(): EditorFragmentAbstract? = editorFragment
+
+    override fun navigateToEditor() {
+        editPostNavigationViewModel.navigateTo(EditPostDestination.Editor)
+    }
+
+    override fun getRevisionFromBundle(): Any? {
+        return if (dB?.hasParcel(KEY_REVISION) == true) {
+            revision = dB?.getParcel(KEY_REVISION, parcelableCreator())
+            revision
+        } else {
+            null
+        }
+    }
+
+    override fun clearSuggestionCallback() {
+        onGetSuggestionResult = null
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getSuggestionCallback(): java.util.function.Consumer<String?>? {
+        return onGetSuggestionResult as? java.util.function.Consumer<String?>?
+    }
+
+    override fun triggerLoadRevision() {
+        loadRevision()
+    }
+
+    override fun handleLastTakenPicture() {
+        addLastTakenPicture()
+    }
+
+    // ShareContentHandler.ShareContentListener implementation
+    override fun isShowGutenbergEditor(): Boolean = showGutenbergEditor
+
+    override fun setHasSetPostContent(value: Boolean) {
+        hasSetPostContent = value
     }
 
     private fun showErrorAndFinish(errorMessageId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -174,6 +174,8 @@ import org.wordpress.android.ui.posts.editor.EditorIntentProcessor
 import org.wordpress.android.ui.posts.editor.EditorIntentProcessor.IntentProcessResult
 import org.wordpress.android.ui.posts.editor.EditorMediaPickerHandler
 import org.wordpress.android.ui.posts.editor.ShareContentHandler
+import org.wordpress.android.ui.posts.editor.EditorModeHandler
+import org.wordpress.android.ui.posts.editor.EditorNavigationManager
 import org.wordpress.android.ui.posts.editor.PostLoadingStateManager
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction
@@ -234,10 +236,8 @@ import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
-import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource
 import org.wordpress.android.util.config.ContactSupportFeatureConfig
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
-import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.util.helpers.MediaGallery
 import org.wordpress.android.util.image.BlavatarShape
@@ -276,7 +276,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     HistoryItemClickInterface, PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger,
     SiteSettingsListener, MediaUploadCoordinator.UploadEventListener,
     PostLoadingStateManager.StateChangeListener, EditorMediaPickerHandler.MediaPickerListener,
-    EditorActivityResultHandler.ActivityResultListener, ShareContentHandler.ShareContentListener {
+    EditorActivityResultHandler.ActivityResultListener, ShareContentHandler.ShareContentListener,
+    EditorModeHandler.EditorModeListener, EditorNavigationManager.NavigationListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
 
@@ -325,7 +326,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private var menuHasRedo: Boolean = false
     private var showPrepublishingBottomSheetHandler: Handler? = null
     private var showPrepublishingBottomSheetRunnable: Runnable? = null
-    private var htmlModeMenuStateOn: Boolean = false
     private var updatingPostArea: FrameLayout? = null
 
     @Inject lateinit var dispatcher: Dispatcher
@@ -425,6 +425,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var editorMediaPickerHandler: EditorMediaPickerHandler
     @Inject lateinit var editorActivityResultHandler: EditorActivityResultHandler
     @Inject lateinit var shareContentHandler: ShareContentHandler
+    @Inject lateinit var editorModeHandler: EditorModeHandler
+    @Inject lateinit var editorNavigationManager: EditorNavigationManager
     private lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
     private lateinit var prepublishingViewModel: PrepublishingViewModel
@@ -549,6 +551,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         editorMediaPickerHandler.start(this)
         editorActivityResultHandler.start(this)
         shareContentHandler.start(this)
+        editorModeHandler.start(this)
+        editorNavigationManager.start(this)
         startObserving()
         editorFragment?.let {
             hasSetPostContent = true
@@ -1005,56 +1009,14 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
      * Updates ViewPager position based on navigation destination.
      */
     private fun updateViewPagerPosition(destination: EditPostDestination) {
-        val targetPage = when (destination) {
-            EditPostDestination.Editor -> VIEW_PAGER_PAGE_CONTENT
-            EditPostDestination.Settings -> VIEW_PAGER_PAGE_SETTINGS
-            EditPostDestination.PublishSettings -> VIEW_PAGER_PAGE_PUBLISH_SETTINGS
-            EditPostDestination.History -> VIEW_PAGER_PAGE_HISTORY
-        }
-
-        viewPager?.let { pager ->
-            if (pager.currentItem != targetPage) {
-                AppLog.d(AppLog.T.POSTS, "EditPostActivity: Moving ViewPager from ${pager.currentItem} to $targetPage")
-                pager.currentItem = targetPage
-            }
-        }
+        editorNavigationManager.updateViewPagerPosition(destination)
     }
 
     /**
      * Updates UI elements based on current navigation destination.
      */
     private fun updateUIForDestination(destination: EditPostDestination) {
-        when (destination) {
-            EditPostDestination.Editor -> {
-                title = SiteUtils.getSiteNameOrHomeURL(siteModel)
-                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
-                toolbar?.setBackgroundResource(R.drawable.tab_layout_background)
-            }
-
-            EditPostDestination.Settings -> {
-                setTitle(if (editPostRepository.isPage) R.string.page_settings else R.string.post_settings)
-                editorPhotoPicker?.hidePhotoPicker()
-                appBarLayout?.liftOnScrollTargetViewId = R.id.settings_fragment_root
-                toolbar?.background = null
-            }
-
-            EditPostDestination.PublishSettings -> {
-                setTitle(R.string.publish_date)
-                editorPhotoPicker?.hidePhotoPicker()
-                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
-                toolbar?.background = null
-            }
-
-            EditPostDestination.History -> {
-                setTitle(R.string.history_title)
-                editorPhotoPicker?.hidePhotoPicker()
-                appBarLayout?.liftOnScrollTargetViewId = R.id.empty_recycler_view
-                toolbar?.background = null
-            }
-        }
-
-        // Refresh options menu as visibility may change based on destination
-        invalidateOptionsMenu()
+        editorNavigationManager.updateUIForDestination(destination)
     }
 
     private fun handleSuccessfulWpComCookieAuthState() {
@@ -1336,7 +1298,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             EditorConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE,
             editorPhotoPicker?.isPhotoPickerShowing() ?: false
         )
-        outState.putBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON, htmlModeMenuStateOn)
+        outState.putBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON, editorModeHandler.isHtmlModeOn())
         outState.putBoolean(EditorConstants.STATE_KEY_UNDO, menuHasUndo)
         outState.putBoolean(EditorConstants.STATE_KEY_REDO, menuHasRedo)
         outState.putSerializable(WordPress.SITE, siteModel)
@@ -1358,7 +1320,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        htmlModeMenuStateOn = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON)
+        editorModeHandler.setHtmlModeOn(savedInstanceState.getBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON))
         menuHasUndo = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_UNDO)
         menuHasRedo = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_REDO)
         if (savedInstanceState.getBoolean(EditorConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
@@ -1480,7 +1442,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 hasPost = editPostRepository.hasPost(),
                 menuHasUndo = menuHasUndo,
                 menuHasRedo = menuHasRedo,
-                htmlModeMenuStateOn = htmlModeMenuStateOn,
+                htmlModeMenuStateOn = editorModeHandler.isHtmlModeOn(),
                 isNewPost = isNewPost,
                 isPage = isPage,
                 isUsingWpComRestApi = siteModel.isUsingWpComRestApi,
@@ -1772,30 +1734,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun toggleHtmlModeOnMenu() {
-        htmlModeMenuStateOn = !htmlModeMenuStateOn
-        trackPostSessionEditorModeSwitch()
-        invalidateOptionsMenu()
-        showEditorModeSwitchedNotice()
-    }
-
-    private fun showEditorModeSwitchedNotice() {
-        val message: String = getString(
-            if (htmlModeMenuStateOn)
-                R.string.menu_html_mode_switched_notice
-            else R.string.menu_visual_mode_switched_notice
-        )
-        editorFragment?.showNotice(message)
-    }
-
-    private fun trackPostSessionEditorModeSwitch() {
-        val isGutenberg: Boolean = editorFragment is GutenbergEditorFragment
-        postEditorAnalyticsSession?.switchEditor(
-            when {
-                htmlModeMenuStateOn -> PostEditorAnalyticsSession.Editor.HTML
-                isGutenberg -> PostEditorAnalyticsSession.Editor.GUTENBERG
-                else -> PostEditorAnalyticsSession.Editor.CLASSIC
-            }
-        )
+        editorModeHandler.toggleHtmlMode()
     }
 
     private fun performPrimaryAction() {
@@ -1818,38 +1757,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    private fun showGutenbergInformativeDialog() {
-        // We are no longer showing the dialog, but we are leaving all the surrounding logic because
-        // this is going in shortly before release, and we're going to remove all this logic in the
-        // very near future.
-        AppPrefs.setGutenbergInfoPopupDisplayed(siteModel.url, true)
-    }
-
-    private fun showGutenbergRolloutV2InformativeDialog() {
-        // We are no longer showing the dialog, but we are leaving all the surrounding logic because
-        // this is going in shortly before release, and we're going to remove all this logic in the
-        // very near future.
-        AppPrefs.setGutenbergInfoPopupDisplayed(siteModel.url, true)
-    }
-
     private fun setGutenbergEnabledIfNeeded() {
-        if (AppPrefs.isGutenbergInfoPopupDisplayed(siteModel.url)) {
-            return
-        }
-        val showPopup = AppPrefs.shouldShowGutenbergInfoPopupForTheNewPosts(siteModel.url)
-        val showRolloutPopupPhase2 = AppPrefs.shouldShowGutenbergInfoPopupPhase2ForNewPosts(siteModel.url)
-        if (TextUtils.isEmpty(siteModel.mobileEditor) && !isNewPost) {
-            SiteUtils.enableBlockEditor(dispatcher, siteModel)
-            AnalyticsUtils.trackWithSiteDetails(
-                Stat.EDITOR_GUTENBERG_ENABLED, siteModel,
-                BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.asPropertyMap()
-            )
-        }
-        if (showPopup) {
-            showGutenbergInformativeDialog()
-        } else if (showRolloutPopupPhase2) {
-            showGutenbergRolloutV2InformativeDialog()
-        }
+        editorModeHandler.setGutenbergEnabledIfNeeded()
     }
 
     private fun savePostOnline(isFirstTimePublish: Boolean): ActivityFinishState {
@@ -1947,6 +1856,18 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     override fun setHasSetPostContent(value: Boolean) {
         hasSetPostContent = value
     }
+
+    // EditorModeHandler.EditorModeListener implementation
+    override fun getPostEditorAnalyticsSession(): PostEditorAnalyticsSession? = postEditorAnalyticsSession
+
+    override fun isNewPost(): Boolean = isNewPost
+
+    // EditorNavigationManager.NavigationListener implementation
+    override fun provideViewPager(): WPViewPager? = viewPager
+
+    override fun getAppBarLayout(): AppBarLayout? = appBarLayout
+
+    override fun getToolbar(): Toolbar? = toolbar
 
     private fun showErrorAndFinish(errorMessageId: Int) {
         ToastUtils.showToast(this, errorMessageId, ToastUtils.Duration.LONG)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts
 
 import android.app.Activity
 import android.app.ProgressDialog
+import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
@@ -81,11 +82,9 @@ import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
-import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
-import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.model.EditorTheme
 import org.wordpress.android.fluxc.model.EditorThemeSupport
@@ -177,6 +176,7 @@ import org.wordpress.android.ui.posts.editor.ShareContentHandler
 import org.wordpress.android.ui.posts.editor.EditorModeHandler
 import org.wordpress.android.ui.posts.editor.EditorNavigationManager
 import org.wordpress.android.ui.posts.editor.PostLoadingStateManager
+import org.wordpress.android.ui.posts.editor.PostPublishingCoordinator
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction
 import org.wordpress.android.ui.posts.editor.StorePostViewModel
@@ -277,7 +277,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     SiteSettingsListener, MediaUploadCoordinator.UploadEventListener,
     PostLoadingStateManager.StateChangeListener, EditorMediaPickerHandler.MediaPickerListener,
     EditorActivityResultHandler.ActivityResultListener, ShareContentHandler.ShareContentListener,
-    EditorModeHandler.EditorModeListener, EditorNavigationManager.NavigationListener {
+    EditorModeHandler.EditorModeListener, EditorNavigationManager.NavigationListener,
+    PostPublishingCoordinator.PublishingListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
 
@@ -427,6 +428,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var shareContentHandler: ShareContentHandler
     @Inject lateinit var editorModeHandler: EditorModeHandler
     @Inject lateinit var editorNavigationManager: EditorNavigationManager
+    @Inject lateinit var postPublishingCoordinator: PostPublishingCoordinator
     private lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
     private lateinit var prepublishingViewModel: PrepublishingViewModel
@@ -553,6 +555,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         shareContentHandler.start(this)
         editorModeHandler.start(this)
         editorNavigationManager.start(this)
+        postPublishingCoordinator.start(this)
         startObserving()
         editorFragment?.let {
             hasSetPostContent = true
@@ -1738,23 +1741,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun performPrimaryAction() {
-        when (primaryAction) {
-            PrimaryEditorAction.PUBLISH_NOW -> {
-                analyticsTrackerWrapper.track(Stat.EDITOR_POST_PUBLISH_TAPPED)
-                showPrepublishingNudgeBottomSheet()
-                return
-            }
-
-            PrimaryEditorAction.UPDATE,
-            PrimaryEditorAction.CONTINUE,
-            PrimaryEditorAction.SCHEDULE,
-            PrimaryEditorAction.SUBMIT_FOR_REVIEW -> {
-                showPrepublishingNudgeBottomSheet()
-                return
-            }
-
-            PrimaryEditorAction.SAVE -> uploadPost(false)
-        }
+        postPublishingCoordinator.performPrimaryAction()
     }
 
     private fun setGutenbergEnabledIfNeeded() {
@@ -2127,7 +2114,16 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    private fun showPrepublishingNudgeBottomSheet() {
+    // PostPublishingCoordinator.PublishingListener implementation
+    override fun getContext(): Context = this
+
+    override fun provideStorePostViewModel(): StorePostViewModel = storePostViewModel
+
+    override fun providePrimaryAction(): PrimaryEditorAction = primaryAction
+
+    override fun isPage(): Boolean = editPostRepository.isPage
+
+    override fun showPrepublishingNudgeBottomSheet() {
         editPostNavigationViewModel.navigateTo(EditPostDestination.Editor)
         ActivityUtils.hideKeyboard(this)
         val delayMs = EditorConstants.PREPUBLISHING_NUDGE_BOTTOM_SHEET_DELAY
@@ -2136,106 +2132,19 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    private fun uploadPost(publishPost: Boolean) {
+    override fun updateAndSavePostAsyncOnEditorExit(onComplete: (UpdatePostResult) -> Unit) {
         updateAndSavePostAsyncOnEditorExit(object : OnPostUpdatedFromUIListener {
             override fun onPostUpdatedFromUI(updatePostResult: UpdatePostResult) {
-                if (shouldPerformPostUpdateAndPublish()) {
-                    performPostUpdateAndPublish(publishPost)
-                }
+                onComplete(updatePostResult)
             }
         })
     }
-    @Suppress("ReturnCount")
-    private fun shouldPerformPostUpdateAndPublish() : Boolean {
-        val account: AccountModel = accountStore.account
-        // prompt user to verify e-mail before publishing
-        if (!account.emailVerified) {
-            storePostViewModel.hideSavingProgressDialog()
-            val message: String =
-                if (TextUtils.isEmpty(account.email)) getString(R.string.editor_confirm_email_prompt_message)
-                else String.format(
-                    getString(R.string.editor_confirm_email_prompt_message_with_email),
-                    account.email
-                )
-            val builder: AlertDialog.Builder = MaterialAlertDialogBuilder(this)
-            builder.setTitle(R.string.editor_confirm_email_prompt_title)
-                .setMessage(message)
-                .setPositiveButton(android.R.string.ok
-                ) { _, _ ->
-                    ToastUtils.showToast(
-                        this@EditPostActivity,
-                        getString(R.string.toast_saving_post_as_draft)
-                    )
-                    savePostAndOptionallyFinish(doFinish = true, forceSave = false)
-                }
-                .setNegativeButton(
-                    R.string.editor_confirm_email_prompt_negative
-                ) { _, _ ->
-                    dispatcher
-                        .dispatch(AccountActionBuilder.newSendVerificationEmailAction())
-                }
-            builder.create().show()
-            return false
-        }
 
-        editPostRepository.getPost()?.let {
-            if (!postUtilsWrapper.isPublishable(it)) {
-                storePostViewModel.hideSavingProgressDialog()
-                // TODO we don't want to show "publish" message when the user clicked on eg. save
-                editPostRepository.updateStatusFromPostSnapshotWhenEditorOpened()
-                runOnUiThread {
-                    val message: String = getString(
-                        if (isPage) R.string.error_publish_empty_page else R.string.error_publish_empty_post
-                    )
-                    ToastUtils.showToast(
-                        this@EditPostActivity,
-                        message,
-                        ToastUtils.Duration.SHORT
-                    )
-                }
-                return false
-            }
-        }
-        return true
+    private fun uploadPost(publishPost: Boolean) {
+        postPublishingCoordinator.uploadPost(publishPost)
     }
 
-    private fun performPostUpdateAndPublish(publishPost: Boolean) {
-        storePostViewModel.showSavingProgressDialog()
-        val isFirstTimePublish: Boolean = isFirstTimePublish(publishPost)
-        editPostRepository.updateAsync( { postModel: PostModel ->
-            if (publishPost) {
-                // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
-                // otherwise we'd have an incorrect value
-                // also re-set the published date in case it was SCHEDULED and they want to publish NOW
-                if ((postModel.status == PostStatus.SCHEDULED.toString())) {
-                    postModel.setDateCreated(dateTimeUtils.currentTimeInIso8601())
-                }
-                if (uploadUtilsWrapper.userCanPublish(site)) {
-                    postModel.setStatus(PostStatus.PUBLISHED.toString())
-                } else {
-                    postModel.setStatus(PostStatus.PENDING.toString())
-                }
-                postEditorAnalyticsSession?.setOutcome(Outcome.PUBLISH)
-            } else {
-                postEditorAnalyticsSession?.setOutcome(Outcome.SAVE)
-            }
-            AppLog.d(
-                AppLog.T.POSTS,
-                "User explicitly confirmed changes. Post Title: " + postModel.title
-            )
-            // the user explicitly confirmed an intention to upload the post
-            postModel.setChangesConfirmedContentHashcode(postModel.contentHashcode())
-            true
-        } )
-        { _: PostImmutableModel?, result: UpdatePostResult ->
-            if (result === Updated) {
-                val activityFinishState: ActivityFinishState = savePostOnline(isFirstTimePublish)
-                storePostViewModel.finish(activityFinishState)
-            }
-        }
-    }
-
-    private fun savePostAndOptionallyFinish(doFinish: Boolean, forceSave: Boolean) {
+    override fun savePostAndOptionallyFinish(doFinish: Boolean, forceSave: Boolean) {
         if (editorFragment?.isAdded != true) {
             AppLog.e(AppLog.T.POSTS, "Fragment not initialized")
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -102,7 +102,6 @@ import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.fluxc.store.EditorThemeStore.FetchEditorThemePayload
 import org.wordpress.android.fluxc.store.EditorThemeStore.OnEditorThemeChanged
 import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
@@ -169,6 +168,9 @@ import org.wordpress.android.ui.posts.editor.EditorTracker
 import org.wordpress.android.ui.posts.editor.ImageEditorTracker
 import org.wordpress.android.ui.posts.editor.PostLoadingState
 import org.wordpress.android.ui.posts.editor.PostLoadingState.Companion.fromInt
+import org.wordpress.android.ui.posts.editor.EditorIntentProcessor
+import org.wordpress.android.ui.posts.editor.EditorIntentProcessor.IntentProcessResult
+import org.wordpress.android.ui.posts.editor.PostLoadingStateManager
 import org.wordpress.android.ui.posts.editor.PrimaryEditorAction
 import org.wordpress.android.ui.posts.editor.SecondaryEditorAction
 import org.wordpress.android.ui.posts.editor.StorePostViewModel
@@ -180,6 +182,7 @@ import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.ui.posts.editor.media.EditorMedia
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddMediaToPostUiState
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.posts.editor.media.MediaUploadCoordinator
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment.Companion.newInstance
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.PublishPostImmediatelyUseCase
@@ -197,7 +200,6 @@ import org.wordpress.android.ui.suggestion.SuggestionActivity
 import org.wordpress.android.ui.suggestion.SuggestionType
 import org.wordpress.android.ui.uploads.PostEvents.PostMediaCanceled
 import org.wordpress.android.ui.uploads.PostEvents.PostOpenedInEditor
-import org.wordpress.android.ui.uploads.PostEvents.PostPreviewingInEditor
 import org.wordpress.android.ui.uploads.ProgressEvent
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadService.UploadMediaRetryEvent
@@ -214,7 +216,6 @@ import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.MediaUtils
-import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PerAppLocaleManager
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ReblogUtils
@@ -269,7 +270,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     ActivityCompat.OnRequestPermissionsResultCallback, EditorMediaActions,
     EditorPhotoPickerListener, EditorMediaListener, EditPostSettingsFragment.EditorDataProvider,
     HistoryItemClickInterface, PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger,
-    SiteSettingsListener {
+    SiteSettingsListener, MediaUploadCoordinator.UploadEventListener,
+    PostLoadingStateManager.StateChangeListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
 
@@ -412,6 +414,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
     @Inject lateinit var editorBloggingPromptsViewModel: EditorBloggingPromptsViewModel
     @Inject lateinit var editorJetpackSocialViewModel: EditorJetpackSocialViewModel
+    @Inject lateinit var mediaUploadCoordinator: MediaUploadCoordinator
+    @Inject lateinit var postLoadingStateManager: PostLoadingStateManager
+    @Inject lateinit var editorIntentProcessor: EditorIntentProcessor
     private lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
     private lateinit var prepublishingViewModel: PrepublishingViewModel
@@ -442,32 +447,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             PostOpenedInEditor(editPostRepository.localSiteId, editPostRepository.id)
         )
         shortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST)
-    }
-
-    private fun newPostFromShareAction() {
-        if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
-            newPostSetup()
-            setPostMediaFromShareAction()
-        } else {
-            val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
-            val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-            val content = EditorUnitFunctions.migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text?:""))
-            newPostSetup(title, content)
-        }
-    }
-
-    private fun newReblogPostSetup() {
-        val title = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_TITLE)
-        val quote = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_QUOTE)
-        val citation = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_CITATION)
-        val image = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_IMAGE)
-        val content = reblogUtils.reblogContent(image, quote ?: "", title, citation)
-        newPostSetup(title, content)
-    }
-
-    private fun newPageFromLayoutPickerSetup(title: String?, layoutSlug: String?) {
-        val content = siteStore.getBlockLayoutContent(siteModel, layoutSlug ?: "")
-        newPostSetup(title, content)
     }
 
     private fun createPostEditorAnalyticsSessionTracker(
@@ -557,6 +536,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             return
         }
         editorMedia.start(siteModel, this)
+        mediaUploadCoordinator.start(this, editorMediaUploadListener)
+        postLoadingStateManager.setListener(this)
         startObserving()
         editorFragment?.let {
             hasSetPostContent = true
@@ -660,70 +641,42 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
     private fun getSiteModelForExtraQuickPressBlogIdIfRequested(extras: Bundle?): SiteModel? {
-        if (extras == null || extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID)) {
-            return null
-        }
-
-        val isActionSendOrNewMedia = EditorUnitFunctions.isActionSendOrNewMedia(intent.action)
-        val hasQuickPressFlag = extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
-        val hasQuickPressBlogId = extras.containsKey(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID)
-
-        // QuickPress might want to use a different blog than the current blog
-        return if ((isActionSendOrNewMedia || hasQuickPressFlag) && hasQuickPressBlogId) {
-            val localSiteId = intent.getIntExtra(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID, -1)
-            siteStore.getSiteByLocalId(localSiteId)
-        } else {
-            null
-        }
+        return editorIntentProcessor.getSiteForQuickPress(intent, extras)
     }
 
-    @Suppress("CyclomaticComplexMethod")
     private fun handleIntentExtras(extras: Bundle?, isRestarting: Boolean) {
         extras ?: return
-        val action = intent.action
 
-        if (!extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID) ||
-            EditorUnitFunctions.isActionSendOrNewMedia(intent.action) ||
-            extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
-        ) {
-            isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
-            if (isPage && !TextUtils.isEmpty(extras.getString(EditorConstants.EXTRA_PAGE_TITLE))) {
-                newPageFromLayoutPickerSetup(
-                    extras.getString(EditorConstants.EXTRA_PAGE_TITLE),
-                    extras.getString(EditorConstants.EXTRA_PAGE_TEMPLATE)
-                )
-            } else if ((Intent.ACTION_SEND == action)) {
-                newPostFromShareAction()
-            } else if ((EditorConstants.ACTION_REBLOG == action)) {
-                newReblogPostSetup()
-            } else {
-                newPostSetup()
+        // Extract isPage flag from extras (needed for UI state)
+        isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
+
+        // Process intent using the processor
+        when (val result = editorIntentProcessor.processIntent(intent, extras, siteModel, isRestarting)) {
+            is IntentProcessResult.NewPost -> {
+                isPage = result.isPage
+                newPostSetup(result.title, result.content)
             }
-        } else {
-            editPostRepository.loadPostByLocalPostId(extras.getInt(EditorConstants.EXTRA_POST_LOCAL_ID))
-            // Load post from extra's
-            if (editPostRepository.hasPost()) {
-                if (extras.getBoolean(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION)) {
-                    editPostRepository.update { postModel: PostModel ->
-                        val updateTitle = !TextUtils.isEmpty(postModel.autoSaveTitle)
-                        if (updateTitle) {
-                            postModel.setTitle(postModel.autoSaveTitle)
-                        }
-                        val updateContent = !TextUtils.isEmpty(postModel.autoSaveContent)
-                        if (updateContent) {
-                            postModel.setContent(postModel.autoSaveContent)
-                        }
-                        val updateExcerpt = !TextUtils.isEmpty(postModel.autoSaveExcerpt)
-                        if (updateExcerpt) {
-                            postModel.setExcerpt(postModel.autoSaveExcerpt)
-                        }
-                        updateTitle || updateContent || updateExcerpt
-                    }
-                    editPostRepository.savePostSnapshot()
-                }
-                initializePostObject()
-            } else if (isRestarting) {
+            is IntentProcessResult.ShareActionText -> {
+                newPostSetup(result.title, result.content)
+            }
+            is IntentProcessResult.ShareActionMedia -> {
                 newPostSetup()
+                // Queue media for adding to editor (handled after editor is initialized)
+                editorMedia.addNewMediaItemsToEditorAsync(result.mediaUris, false)
+                // Remove from intent so it doesn't re-add on Activity recreation
+                intent.removeExtra(Intent.EXTRA_STREAM)
+            }
+            is IntentProcessResult.Reblog -> {
+                newPostSetup(result.title, result.content)
+            }
+            is IntentProcessResult.PageFromLayout -> {
+                newPostSetup(result.title, result.content)
+            }
+            is IntentProcessResult.ExistingPost -> {
+                handleExistingPostIntent(result, isRestarting)
+            }
+            is IntentProcessResult.InvalidIntent -> {
+                // Do nothing, post initialization will fail later
             }
         }
 
@@ -737,6 +690,33 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         if (isRestarting && extras.containsKey(EditorConstants.STATE_KEY_EDITOR_SESSION_DATA)) {
             postEditorAnalyticsSession = PostEditorAnalyticsSession
                 .fromBundle(extras, EditorConstants.STATE_KEY_EDITOR_SESSION_DATA, analyticsTrackerWrapper)
+        }
+    }
+
+    private fun handleExistingPostIntent(result: IntentProcessResult.ExistingPost, isRestarting: Boolean) {
+        editPostRepository.loadPostByLocalPostId(result.localPostId)
+        if (editPostRepository.hasPost()) {
+            if (result.loadAutoSaveRevision) {
+                editPostRepository.update { postModel: PostModel ->
+                    val updateTitle = !TextUtils.isEmpty(postModel.autoSaveTitle)
+                    if (updateTitle) {
+                        postModel.setTitle(postModel.autoSaveTitle)
+                    }
+                    val updateContent = !TextUtils.isEmpty(postModel.autoSaveContent)
+                    if (updateContent) {
+                        postModel.setContent(postModel.autoSaveContent)
+                    }
+                    val updateExcerpt = !TextUtils.isEmpty(postModel.autoSaveExcerpt)
+                    if (updateExcerpt) {
+                        postModel.setExcerpt(postModel.autoSaveExcerpt)
+                    }
+                    updateTitle || updateContent || updateExcerpt
+                }
+                editPostRepository.savePostSnapshot()
+            }
+            initializePostObject()
+        } else if (isRestarting) {
+            newPostSetup()
         }
     }
 
@@ -785,6 +765,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 editorFragment = frag
                 if (frag is EditorMediaUploadListener) {
                     editorMediaUploadListener = frag
+                    mediaUploadCoordinator.setEditorMediaUploadListener(frag)
                 }
             }
         }
@@ -1773,62 +1754,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         fillContentEditorFields()
     }
 
-    private fun setPreviewingInEditorSticky(enable: Boolean, post: PostImmutableModel?) {
-        if (enable) {
-            if (post != null) {
-                EventBus.getDefault().postSticky(
-                    PostPreviewingInEditor(post.localSiteId, post.id)
-                )
-            }
-        } else {
-            val stickyEvent: PostPreviewingInEditor? = EventBus.getDefault().getStickyEvent(
-                PostPreviewingInEditor::class.java
-            )
-            if (stickyEvent != null) {
-                EventBus.getDefault().removeStickyEvent(stickyEvent)
-            }
-        }
-    }
-
-    private fun managePostLoadingStateTransitions(
-        postLoadingState: PostLoadingState,
-        post: PostImmutableModel?
-    ) {
-        when (postLoadingState) {
-            PostLoadingState.NONE -> setPreviewingInEditorSticky(false, post)
-            PostLoadingState.UPLOADING_FOR_PREVIEW,
-            PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW,
-            PostLoadingState.PREVIEWING,
-            PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR -> setPreviewingInEditorSticky(
-                true,
-                post
-            )
-
-            PostLoadingState.LOADING_REVISION -> {}
-        }
-    }
-
-    private fun updatePostLoadingAndDialogState(postLoadingState: PostLoadingState, post: PostImmutableModel? = null) {
-        // We need only transitions, so...
-        if (this.postLoadingState === postLoadingState) return
-        AppLog.d(
-            AppLog.T.POSTS,
-            "Editor post loading state machine: transition from ${this.postLoadingState} to $postLoadingState"
-        )
-
-        // update the state
-        this.postLoadingState = postLoadingState
-
-        // take care of exit actions on state transition
-        managePostLoadingStateTransitions(postLoadingState, post)
-
-        // update the progress dialog state
-        progressDialog = progressDialogHelper.updateProgressDialogState(
-            this,
-            progressDialog,
-            this.postLoadingState.progressDialogUiState,
-            (uiHelpers)
-        )
+    private fun updatePostLoadingAndDialogState(newState: PostLoadingState, post: PostImmutableModel? = null) {
+        postLoadingStateManager.transitionTo(this, newState, post)
+        // Keep local state in sync for any remaining direct references
+        postLoadingState = postLoadingStateManager.state
     }
 
     private fun toggleHtmlModeOnMenu() {
@@ -1919,23 +1848,42 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         return storePostViewModel.savePostOnline(isFirstTimePublish, this, (editPostRepository), siteModel)
     }
 
-    private fun onUploadSuccess(media: MediaModel?) {
-        if (media != null) {
-            // TODO Should this statement check media.getLocalPostId() == mEditPostRepository.getId()?
-            if (!media.markedLocallyAsFeatured && editorMediaUploadListener != null) {
-                editorMediaUploadListener?.onMediaUploadSucceeded(
-                    media.id.toString(),
-                    FluxCUtils.mediaFileFromMediaModel(media)
-                )
-            } else if (media.markedLocallyAsFeatured && media.localPostId == editPostRepository.id) {
-                setFeaturedImageId(media.mediaId, imagePicked = false, isGutenbergEditor = false)
-            }
+    // MediaUploadCoordinator.UploadEventListener implementation
+    override fun onFeaturedImageUploaded(mediaId: Long) {
+        setFeaturedImageId(mediaId, imagePicked = false, isGutenbergEditor = false)
+    }
+
+    override fun getPostId(): Int = editPostRepository.id
+
+    override fun showUploadError(message: String) {
+        editorFragment?.view?.let { view ->
+            uploadUtilsWrapper.showSnackbarError(view, message)
         }
     }
 
-    private fun onUploadProgress(media: MediaModel?, progress: Float) {
-        val localMediaId = media?.id.toString()
-        editorMediaUploadListener?.onMediaUploadProgress(localMediaId, progress)
+    // PostLoadingStateManager.StateChangeListener implementation
+    override fun onProgressDialogChanged(newDialog: ProgressDialog?) {
+        progressDialog = newDialog
+    }
+
+    override fun onLaunchPreview(previewType: RemotePreviewType) {
+        ActivityLauncher.previewPostOrPageForResult(
+            this@EditPostActivity,
+            siteModel,
+            editPostRepository.getPost(),
+            previewType
+        )
+    }
+
+    override fun onPreviewUploadSuccess() {
+        updateOnSuccessfulUpload()
+    }
+
+    override fun onPreviewUploadError() {
+        uploadUtilsWrapper.showSnackbarError(
+            findViewById(R.id.editor_activity),
+            getString(R.string.remote_preview_operation_error)
+        )
     }
 
     private fun showErrorAndFinish(errorMessageId: Int) {
@@ -2452,6 +2400,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                     }
                     if (editorFragment is EditorMediaUploadListener) {
                         editorMediaUploadListener = editorFragment as EditorMediaUploadListener?
+                        mediaUploadCoordinator.setEditorMediaUploadListener(editorMediaUploadListener)
 
                         // Set up custom headers for the visual editor's internal WebView
                         editorFragment?.setCustomHttpHeader("User-Agent", userAgent.webViewUserAgent)
@@ -3654,67 +3603,26 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     // FluxC events
-    @Suppress("unused", "CyclomaticComplexMethod")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onMediaUploaded(event: OnMediaUploaded) {
-        if (isFinishing) {
-            return
-        }
-
-        if (event.isError && !NetworkUtils.isNetworkAvailable(this)) {
-            editorMediaUploadListener?.let { listener ->
-                event.media?.let { media ->
-                    editorMedia.onMediaUploadPaused(listener, media, event.error)
-                }
-            }
-            return
-        }
-
-        event.media?.let {
-            if (event.isError) {
-                handleOnMediaUploadedError(event)
-            } else if (event.completed) {
-                handleOnMediaUploadedCompleted(event)
-            } else {
-                onUploadProgress(event.media, event.progress)
-            }
-        } ?: run {
-            // event for unknown media, ignoring
-            AppLog.w(AppLog.T.MEDIA, "Media event carries null media object, not recognized")
-        }
-    }
-    private fun handleOnMediaUploadedError(event: OnMediaUploaded) {
-        val view: View? = editorFragment?.view
-        if (view != null) {
-            uploadUtilsWrapper.showSnackbarError(
-                view,
-                String.format(
-                    getString(R.string.error_media_upload_failed_for_reason),
-                    UploadUtils.getErrorMessageFromMedia(this, event.media as MediaModel)
+        // Show error message if upload failed (need Activity context for string formatting)
+        if (event.isError && event.media != null) {
+            editorFragment?.view?.let { view ->
+                uploadUtilsWrapper.showSnackbarError(
+                    view,
+                    String.format(
+                        getString(R.string.error_media_upload_failed_for_reason),
+                        UploadUtils.getErrorMessageFromMedia(this, event.media as MediaModel)
+                    )
                 )
-            )
-        }
-        editorMediaUploadListener?.let { listener ->
-            event.media?.let { media ->
-                editorMedia.onMediaUploadError(listener, media, event.error)
             }
         }
-    }
-
-    private fun handleOnMediaUploadedCompleted(event: OnMediaUploaded){
-        // if the remote url on completed is null, we consider this upload wasn't successful
-        val media = event.media ?: return
-
-        editorMediaUploadListener?.let { listener ->
-            if (TextUtils.isEmpty(media.url)) {
-                val error = MediaError(MediaErrorType.GENERIC_ERROR)
-                if (!NetworkUtils.isNetworkAvailable(this)) {
-                    editorMedia.onMediaUploadPaused(listener, media, error)
-                } else {
-                    editorMedia.onMediaUploadError(listener, media, error)
-                }
-            } else {
-                onUploadSuccess(media)
+        // Delegate event processing to coordinator
+        if (!mediaUploadCoordinator.processMediaUploadedEvent(event)) {
+            // Event was not processed (unknown media)
+            if (event.media == null) {
+                AppLog.w(AppLog.T.MEDIA, "Media event carries null media object, not recognized")
             }
         }
     }
@@ -3767,17 +3675,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private val isRemotePreviewingFromEditor: Boolean
-        get() {
-            return (postLoadingState === PostLoadingState.UPLOADING_FOR_PREVIEW
-                    ) || (postLoadingState === PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW
-                    ) || (postLoadingState === PostLoadingState.PREVIEWING
-                    ) || (postLoadingState === PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR)
-        }
+        get() = postLoadingStateManager.isRemotePreviewingFromEditor
+
     private val isUploadingPostForPreview: Boolean
-        get() {
-            return (postLoadingState === PostLoadingState.UPLOADING_FOR_PREVIEW
-                    || postLoadingState === PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW)
-        }
+        get() = postLoadingStateManager.isUploadingPostForPreview
 
     private fun updateOnSuccessfulUpload() {
         isNewPost = false
@@ -3785,31 +3686,17 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private val isRemoteAutoSaveError: Boolean
-        get() {
-            return postLoadingState === PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR
-        }
+        get() = postLoadingStateManager.isRemoteAutoSaveError
 
-    private fun handleRemotePreviewUploadResult(isError: Boolean, param: RemotePreviewType) {
-        // We are in the process of remote previewing a post from the editor
-        if (!isError && isUploadingPostForPreview) {
-            // We were uploading post for preview and we got no error:
-            // update post status and preview it in the internal browser
-            updateOnSuccessfulUpload()
-            ActivityLauncher.previewPostOrPageForResult(
-                this@EditPostActivity,
-                siteModel,
-                editPostRepository.getPost(),
-                param
-            )
-            updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, editPostRepository.getPost())
-        } else if (isError || isRemoteAutoSaveError) {
-            // We got an error from the uploading or from the remote auto save of a post: show snackbar error
-            updatePostLoadingAndDialogState(PostLoadingState.NONE)
-            uploadUtilsWrapper.showSnackbarError(
-                findViewById(R.id.editor_activity),
-                getString(R.string.remote_preview_operation_error)
-            )
-        }
+    private fun handleRemotePreviewUploadResult(isError: Boolean, previewType: RemotePreviewType) {
+        postLoadingStateManager.handleRemotePreviewUploadResult(
+            this,
+            isError,
+            previewType,
+            editPostRepository.getPost()
+        )
+        // Keep local state in sync
+        postLoadingState = postLoadingStateManager.state
     }
 
     @Suppress("unused")
@@ -3845,29 +3732,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ProgressEvent) {
-        if (!isFinishing) {
-            // use upload progress rather than optimizer progress since the former includes upload+optimization
-            val progress: Float = UploadService.getUploadProgressForMedia(event.media)
-            onUploadProgress(event.media, progress)
-        }
+        mediaUploadCoordinator.processProgressEvent(event)
     }
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: UploadMediaRetryEvent) {
-        if ((!isFinishing
-                    && (event.mediaModelList != null
-                    ) && (editorMediaUploadListener != null))
-        ) {
-            for (media: MediaModel in event.mediaModelList) {
-                val localMediaId = media.id.toString()
-                val mediaType: EditorFragmentAbstract.MediaType =
-                    if (media.isVideo)
-                        EditorFragmentAbstract.MediaType.VIDEO
-                    else EditorFragmentAbstract.MediaType.IMAGE
-                editorMediaUploadListener?.onMediaUploadRetry(localMediaId, mediaType)
-            }
-        }
+        mediaUploadCoordinator.processUploadRetryEvent(event)
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorActivityResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorActivityResultHandler.kt
@@ -1,0 +1,277 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import dagger.Reusable
+import org.wordpress.android.editor.AztecEditorFragment
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.ui.media.MediaBrowserActivity
+import org.wordpress.android.ui.photopicker.MediaPickerConstants
+import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
+import org.wordpress.android.ui.posts.editor.media.EditorMedia
+import org.wordpress.android.ui.suggestion.SuggestionActivity
+import org.wordpress.android.util.WPMediaUtils
+import java.util.function.Consumer
+import javax.inject.Inject
+
+/**
+ * Handles activity results for the post editor.
+ *
+ * This class extracts activity result handling logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class EditorActivityResultHandler @Inject constructor(
+    private val editorMedia: EditorMedia,
+    private val imageEditorTracker: ImageEditorTracker
+) {
+    /**
+     * Listener for activity result events that require Activity-level handling.
+     */
+    interface ActivityResultListener {
+        fun getEditorFragment(): EditorFragmentAbstract?
+        fun navigateToEditor()
+        fun triggerLoadRevision()
+        fun getRevisionFromBundle(): Any?
+        fun clearSuggestionCallback()
+        fun getSuggestionCallback(): Consumer<String?>?
+        fun handleLastTakenPicture()
+    }
+
+    private var listener: ActivityResultListener? = null
+
+    /**
+     * Initializes the handler with the required listener.
+     */
+    fun start(listener: ActivityResultListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Handles a non-OK result from an activity.
+     *
+     * @param requestCode The request code of the activity.
+     * @return true if the result was handled.
+     */
+    fun handleNotOKResult(requestCode: Int): Boolean {
+        // for all media related intents, let editor fragment know about cancellation
+        return when (requestCode) {
+            RequestCodes.MULTI_SELECT_MEDIA_PICKER,
+            RequestCodes.SINGLE_SELECT_MEDIA_PICKER,
+            RequestCodes.PHOTO_PICKER,
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT,
+            RequestCodes.MEDIA_LIBRARY,
+            RequestCodes.PICTURE_LIBRARY,
+            RequestCodes.TAKE_PHOTO,
+            RequestCodes.VIDEO_LIBRARY,
+            RequestCodes.TAKE_VIDEO,
+            RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT,
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK -> {
+                listener?.getEditorFragment()?.mediaSelectionCancelled()
+                true
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * Handles an OK result from an activity.
+     *
+     * @param requestCode The request code of the activity.
+     * @param data The intent data returned from the activity.
+     * @return true if the result was handled.
+     */
+    @Suppress("ReturnCount", "LongMethod")
+    fun handleOKResult(requestCode: Int, data: Intent?): Boolean {
+        return when (requestCode) {
+            RequestCodes.MULTI_SELECT_MEDIA_PICKER,
+            RequestCodes.SINGLE_SELECT_MEDIA_PICKER -> {
+                handleMediaPickerResult(data)
+                true
+            }
+            RequestCodes.PHOTO_PICKER,
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT -> {
+                handlePhotoPickerResult(data)
+                true
+            }
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK -> {
+                handleStockMediaPickerSingleSelect(data)
+                true
+            }
+            RequestCodes.MEDIA_LIBRARY,
+            RequestCodes.PICTURE_LIBRARY,
+            RequestCodes.VIDEO_LIBRARY -> {
+                handleLibraries(data)
+                true
+            }
+            RequestCodes.TAKE_PHOTO -> {
+                addLastTakenPicture()
+                true
+            }
+            RequestCodes.TAKE_VIDEO -> {
+                handleTakeVideo(data)
+                true
+            }
+            RequestCodes.MEDIA_SETTINGS -> {
+                handleMediaSettings(data)
+                true
+            }
+            RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT -> {
+                handleStockMediaPickerMultiSelect(data)
+                true
+            }
+            RequestCodes.GIF_PICKER_SINGLE_SELECT,
+            RequestCodes.GIF_PICKER_MULTI_SELECT -> {
+                handleGifPicker(data)
+                true
+            }
+            RequestCodes.HISTORY_DETAIL -> {
+                handleHistoryDetail()
+                true
+            }
+            RequestCodes.IMAGE_EDITOR_EDIT_IMAGE -> {
+                handleImageEditor(data)
+                true
+            }
+            RequestCodes.SELECTED_USER_MENTION -> {
+                handleUserMention(data)
+                true
+            }
+            RequestCodes.FILE_LIBRARY,
+            RequestCodes.AUDIO_LIBRARY -> {
+                handleFileOrAudioLibrary(data)
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun handleStockMediaPickerSingleSelect(data: Intent?) {
+        if (data?.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID) == true) {
+            // pass array with single item
+            val mediaIds = longArrayOf(data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0))
+            editorMedia.addExistingMediaToEditorAsync(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, mediaIds)
+        }
+    }
+
+    private fun handleLibraries(data: Intent?) {
+        editorMedia.addNewMediaItemsToEditorAsync(
+            WPMediaUtils.retrieveMediaUris(data),
+            false
+        )
+    }
+
+    private fun handleTakeVideo(data: Intent?) {
+        data?.data?.let {
+            editorMedia.addNewMediaToEditorAsync(it, true)
+        }
+    }
+
+    private fun handleMediaSettings(data: Intent?) {
+        val editorFragment = listener?.getEditorFragment()
+        if (editorFragment is AztecEditorFragment) {
+            editorFragment.onActivityResult(
+                AztecEditorFragment.EDITOR_MEDIA_SETTINGS,
+                Activity.RESULT_OK,
+                data
+            )
+        }
+    }
+
+    private fun handleStockMediaPickerMultiSelect(data: Intent?) {
+        val key = MediaBrowserActivity.RESULT_IDS
+        if (data?.hasExtra(key) == true) {
+            val mediaIds: LongArray? = data.getLongArrayExtra(key)
+            mediaIds?.let {
+                editorMedia.addExistingMediaToEditorAsync(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, it)
+            }
+        }
+    }
+
+    private fun handleGifPicker(data: Intent?) {
+        val localIds = data?.getIntArrayExtra(MediaPickerConstants.EXTRA_SAVED_MEDIA_MODEL_LOCAL_IDS)
+        if (localIds != null && localIds.isNotEmpty()) {
+            editorMedia.addGifMediaToPostAsync(localIds)
+        }
+    }
+
+    private fun handleHistoryDetail() {
+        val revision = listener?.getRevisionFromBundle()
+
+        if (revision != null) {
+            listener?.navigateToEditor()
+            Handler(Looper.getMainLooper()).postDelayed(
+                { listener?.triggerLoadRevision() },
+                HISTORY_DETAIL_DELAY_MS
+            )
+        }
+    }
+
+    companion object {
+        private const val HISTORY_DETAIL_DELAY_MS = 300L
+    }
+
+    private fun handleImageEditor(data: Intent?) {
+        val uris: List<Uri> = WPMediaUtils.retrieveImageEditorResult(data)
+        imageEditorTracker.trackAddPhoto(uris)
+        uris.forEach { item ->
+            editorMedia.addNewMediaToEditorAsync(item, false)
+        }
+    }
+
+    private fun handleUserMention(data: Intent?) {
+        val callback = listener?.getSuggestionCallback()
+        if (callback != null) {
+            val selectedMention: String? = data?.getStringExtra(SuggestionActivity.SELECTED_VALUE)
+            callback.accept(selectedMention)
+            listener?.clearSuggestionCallback()
+        }
+    }
+
+    private fun handleFileOrAudioLibrary(data: Intent?) {
+        val uriList = WPMediaUtils.retrieveMediaUris(data)
+        for (uri in uriList) {
+            editorMedia.addNewMediaToEditorAsync(uri, false)
+        }
+    }
+
+    private fun addLastTakenPicture() {
+        listener?.handleLastTakenPicture()
+    }
+
+    private fun handlePhotoPickerResult(data: Intent?) {
+        data ?: return
+
+        if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)) {
+            val uriList: List<Uri> = convertStringArrayIntoUrisList(
+                data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
+            )
+            editorMedia.addNewMediaItemsToEditorAsync(uriList, false)
+        } else if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
+            val mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0)
+            editorMedia.addExistingMediaToEditorAsync(AddExistingMediaSource.WP_MEDIA_LIBRARY, longArrayOf(mediaId))
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun handleMediaPickerResult(data: Intent?) {
+        data ?: return
+
+        if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
+            val ids = data.getLongArrayExtra(MediaBrowserActivity.RESULT_IDS) ?: return
+            if (ids.isEmpty()) return
+
+            editorMedia.addExistingMediaToEditorAsync(AddExistingMediaSource.WP_MEDIA_LIBRARY, ids)
+        }
+    }
+
+    private fun convertStringArrayIntoUrisList(stringArray: Array<String>?): List<Uri> {
+        return stringArray?.mapNotNull { Uri.parse(it) } ?: emptyList()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessor.kt
@@ -1,0 +1,259 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.text.TextUtils
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.posts.EditorConstants
+import org.wordpress.android.ui.posts.EditorUnitFunctions
+import org.wordpress.android.util.AutolinkUtils
+import org.wordpress.android.util.ReblogUtils
+import org.wordpress.android.util.ShortcutUtils
+import javax.inject.Inject
+
+/**
+ * Processes intents for the post editor, determining what action should be taken
+ * based on the intent's action, extras, and data.
+ *
+ * This class extracts intent processing logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class EditorIntentProcessor @Inject constructor(
+    private val siteStore: SiteStore,
+    private val reblogUtils: ReblogUtils,
+    private val shortcutUtils: ShortcutUtils
+) {
+    /**
+     * Represents the result of processing an editor intent.
+     */
+    sealed class IntentProcessResult {
+        /**
+         * Create a new post with optional title and content.
+         */
+        data class NewPost(
+            val title: String? = null,
+            val content: String? = null,
+            val isPage: Boolean = false
+        ) : IntentProcessResult()
+
+        /**
+         * Load an existing post by its local ID.
+         */
+        data class ExistingPost(
+            val localPostId: Int,
+            val loadAutoSaveRevision: Boolean = false
+        ) : IntentProcessResult()
+
+        /**
+         * Create a new post from a share action with text content.
+         */
+        data class ShareActionText(
+            val title: String?,
+            val content: String
+        ) : IntentProcessResult()
+
+        /**
+         * Create a new post from a share action with media.
+         */
+        data class ShareActionMedia(
+            val mediaUris: List<Uri>
+        ) : IntentProcessResult()
+
+        /**
+         * Create a new post from a reblog action.
+         */
+        data class Reblog(
+            val title: String?,
+            val content: String
+        ) : IntentProcessResult()
+
+        /**
+         * Create a new page from a layout picker selection.
+         */
+        data class PageFromLayout(
+            val title: String?,
+            val content: String?
+        ) : IntentProcessResult()
+
+        /**
+         * The intent was invalid or missing required data.
+         */
+        object InvalidIntent : IntentProcessResult()
+    }
+
+    /**
+     * Processes an intent and returns the appropriate action to take.
+     *
+     * @param intent The intent to process.
+     * @param extras The intent's extras bundle (can be null).
+     * @param siteModel The current site model.
+     * @param isRestarting Whether the editor is restarting (e.g., after editor switch).
+     * @return An [IntentProcessResult] indicating what action should be taken.
+     */
+    @Suppress("ReturnCount")
+    fun processIntent(
+        intent: Intent,
+        extras: Bundle?,
+        siteModel: SiteModel,
+        isRestarting: Boolean
+    ): IntentProcessResult {
+        if (extras == null) {
+            return IntentProcessResult.InvalidIntent
+        }
+
+        val action = intent.action
+        val hasLocalPostId = extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID)
+        val isActionSendOrNewMedia = EditorUnitFunctions.isActionSendOrNewMedia(action)
+        val isQuickPress = extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
+        val isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
+
+        // Check if we should create a new post vs load an existing one
+        if (!hasLocalPostId || isActionSendOrNewMedia || isQuickPress) {
+            // Creating a new post
+            return processNewPostIntent(intent, extras, siteModel, isPage)
+        } else {
+            // Loading an existing post
+            return processExistingPostIntent(extras, isRestarting)
+        }
+    }
+
+    /**
+     * Gets a site model for QuickPress if one was specified in the intent.
+     *
+     * @param intent The editor intent.
+     * @param extras The intent's extras bundle.
+     * @return The site model for QuickPress, or null if not applicable.
+     */
+    fun getSiteForQuickPress(intent: Intent, extras: Bundle?): SiteModel? {
+        if (extras == null || extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID)) {
+            return null
+        }
+
+        val isActionSendOrNewMedia = EditorUnitFunctions.isActionSendOrNewMedia(intent.action)
+        val hasQuickPressFlag = extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
+        val hasQuickPressBlogId = extras.containsKey(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID)
+
+        return if ((isActionSendOrNewMedia || hasQuickPressFlag) && hasQuickPressBlogId) {
+            val localSiteId = intent.getIntExtra(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID, -1)
+            siteStore.getSiteByLocalId(localSiteId)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Extracts media URIs from a share intent.
+     *
+     * @param intent The share intent.
+     * @return A list of media URIs, or empty if none found.
+     */
+    fun extractMediaUrisFromShareIntent(intent: Intent): List<Uri> {
+        if (!intent.hasExtra(Intent.EXTRA_STREAM)) {
+            return emptyList()
+        }
+
+        val action = intent.action
+        val sharedUris = mutableListOf<Uri>()
+
+        if (Intent.ACTION_SEND_MULTIPLE == action) {
+            intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.forEach { uri ->
+                if (EditorUnitFunctions.isMediaTypeIntent(intent, uri)) {
+                    sharedUris.add(uri)
+                }
+            }
+        } else {
+            // Single media share - only allow images and video types
+            if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
+                intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.let {
+                    sharedUris.add(it)
+                }
+            }
+        }
+
+        return sharedUris
+    }
+
+    /**
+     * Reports that a shortcut was used to create a new post.
+     */
+    fun reportNewPostShortcutUsed() {
+        shortcutUtils.reportShortcutUsed(org.wordpress.android.ui.Shortcut.CREATE_NEW_POST)
+    }
+
+    @Suppress("ReturnCount")
+    private fun processNewPostIntent(
+        intent: Intent,
+        extras: Bundle,
+        siteModel: SiteModel,
+        isPage: Boolean
+    ): IntentProcessResult {
+        val action = intent.action
+
+        // Check for page from layout picker
+        if (isPage && !TextUtils.isEmpty(extras.getString(EditorConstants.EXTRA_PAGE_TITLE))) {
+            val title = extras.getString(EditorConstants.EXTRA_PAGE_TITLE)
+            val layoutSlug = extras.getString(EditorConstants.EXTRA_PAGE_TEMPLATE)
+            val content = siteStore.getBlockLayoutContent(siteModel, layoutSlug ?: "")
+            return IntentProcessResult.PageFromLayout(title, content)
+        }
+
+        // Check for share action
+        if (Intent.ACTION_SEND == action) {
+            return processShareAction(intent)
+        }
+
+        // Check for reblog action
+        if (EditorConstants.ACTION_REBLOG == action) {
+            return processReblogAction(intent)
+        }
+
+        // Default: create a new empty post
+        return IntentProcessResult.NewPost(isPage = isPage)
+    }
+
+    private fun processShareAction(intent: Intent): IntentProcessResult {
+        // Check if this is a media share
+        if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
+            val mediaUris = extractMediaUrisFromShareIntent(intent)
+            return if (mediaUris.isNotEmpty()) {
+                IntentProcessResult.ShareActionMedia(mediaUris)
+            } else {
+                IntentProcessResult.NewPost()
+            }
+        }
+
+        // Text share
+        val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
+        val content = EditorUnitFunctions.migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text))
+        return IntentProcessResult.ShareActionText(title, content)
+    }
+
+    private fun processReblogAction(intent: Intent): IntentProcessResult {
+        val title = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_TITLE)
+        val quote = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_QUOTE)
+        val citation = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_CITATION)
+        val image = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_IMAGE)
+        val content = reblogUtils.reblogContent(image, quote ?: "", title, citation)
+        return IntentProcessResult.Reblog(title, content)
+    }
+
+    private fun processExistingPostIntent(extras: Bundle, isRestarting: Boolean): IntentProcessResult {
+        val localPostId = extras.getInt(EditorConstants.EXTRA_POST_LOCAL_ID)
+
+        // If restarting and no post found, we'll need to create a new one
+        // This is handled by the Activity based on whether the post is found
+        if (localPostId == 0 && isRestarting) {
+            return IntentProcessResult.NewPost()
+        }
+
+        val loadAutoSaveRevision = extras.getBoolean(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION)
+        return IntentProcessResult.ExistingPost(localPostId, loadAutoSaveRevision)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessor.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.posts.EditorUnitFunctions
 import org.wordpress.android.util.AutolinkUtils
 import org.wordpress.android.util.ReblogUtils
-import org.wordpress.android.util.ShortcutUtils
 import javax.inject.Inject
 
 /**
@@ -27,7 +26,6 @@ import javax.inject.Inject
 class EditorIntentProcessor @Inject constructor(
     private val siteStore: SiteStore,
     private val reblogUtils: ReblogUtils,
-    private val shortcutUtils: ShortcutUtils
 ) {
     /**
      * Represents the result of processing an editor intent.
@@ -114,12 +112,12 @@ class EditorIntentProcessor @Inject constructor(
         val isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
 
         // Check if we should create a new post vs load an existing one
-        if (!hasLocalPostId || isActionSendOrNewMedia || isQuickPress) {
+        return if (!hasLocalPostId || isActionSendOrNewMedia || isQuickPress) {
             // Creating a new post
-            return processNewPostIntent(intent, extras, siteModel, isPage)
+            processNewPostIntent(intent, extras, siteModel, isPage)
         } else {
             // Loading an existing post
-            return processExistingPostIntent(extras, isRestarting)
+            processExistingPostIntent(extras, isRestarting)
         }
     }
 
@@ -177,13 +175,6 @@ class EditorIntentProcessor @Inject constructor(
         }
 
         return sharedUris
-    }
-
-    /**
-     * Reports that a shortcut was used to create a new post.
-     */
-    fun reportNewPostShortcutUsed() {
-        shortcutUtils.reportShortcutUsed(org.wordpress.android.ui.Shortcut.CREATE_NEW_POST)
     }
 
     @Suppress("ReturnCount")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMediaPickerHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorMediaPickerHandler.kt
@@ -1,0 +1,254 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.app.Activity
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.media.MediaBrowserType
+import org.wordpress.android.ui.photopicker.MediaPickerLauncher
+import org.wordpress.android.ui.posts.EditorCameraHelper
+import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.util.WPMediaUtils
+import javax.inject.Inject
+
+/**
+ * Handles media picker launching for the post editor.
+ *
+ * This class extracts media picker launching logic from EditPostActivity to improve
+ * testability and separation of concerns. It coordinates with EditorPhotoPicker for
+ * embedded picker and MediaPickerLauncher for full-screen pickers.
+ */
+@Reusable
+class EditorMediaPickerHandler @Inject constructor(
+    private val mediaPickerLauncher: MediaPickerLauncher,
+    private val editorCameraHelper: EditorCameraHelper
+) {
+    /**
+     * Listener for media picker events that require Activity-level handling.
+     */
+    interface MediaPickerListener {
+        fun getActivity(): Activity
+        fun getSiteModel(): SiteModel
+        fun getPostId(): Int
+        fun getEditorPhotoPicker(): EditorPhotoPicker?
+        fun launchCamera()
+        fun showNoUploadPermissionSnackbar()
+    }
+
+    private var listener: MediaPickerListener? = null
+
+    /**
+     * Initializes the handler with the required listener.
+     */
+    fun start(listener: MediaPickerListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Handles the add media button click, toggling the photo picker.
+     */
+    @Suppress("ReturnCount")
+    fun onAddMediaClicked() {
+        val photoPicker = listener?.getEditorPhotoPicker() ?: return
+        val site = listener?.getSiteModel() ?: return
+        val activity = listener?.getActivity() ?: return
+
+        if (photoPicker.isPhotoPickerShowing()) {
+            photoPicker.hidePhotoPicker()
+        } else if (WPMediaUtils.currentUserCanUploadMedia(site)) {
+            photoPicker.showPhotoPicker(site)
+        } else {
+            // show the WP media library instead of the photo picker if the user doesn't have upload permission
+            mediaPickerLauncher.viewWPMediaLibraryPickerForResult(activity, site, MediaBrowserType.EDITOR_PICKER)
+        }
+    }
+
+    /**
+     * Launches the image picker from the WP media library.
+     */
+    fun onAddMediaImageClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        listener?.getEditorPhotoPicker()?.setAllowMultipleSelection(allowMultipleSelection)
+        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+            activity,
+            site,
+            MediaBrowserType.GUTENBERG_IMAGE_PICKER
+        )
+    }
+
+    /**
+     * Launches the video picker from the WP media library.
+     */
+    fun onAddMediaVideoClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        listener?.getEditorPhotoPicker()?.setAllowMultipleSelection(allowMultipleSelection)
+        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+            activity,
+            site,
+            MediaBrowserType.GUTENBERG_VIDEO_PICKER
+        )
+    }
+
+    /**
+     * Launches the media library picker.
+     */
+    fun onAddLibraryMediaClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        listener?.getEditorPhotoPicker()?.setAllowMultipleSelection(allowMultipleSelection)
+        if (allowMultipleSelection) {
+            mediaPickerLauncher.viewWPMediaLibraryPickerForResult(activity, site, MediaBrowserType.EDITOR_PICKER)
+        } else {
+            mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+                activity,
+                site,
+                MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER
+            )
+        }
+    }
+
+    /**
+     * Launches the file picker from the media library.
+     */
+    fun onAddLibraryFileClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        listener?.getEditorPhotoPicker()?.setAllowMultipleSelection(allowMultipleSelection)
+        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+            activity,
+            site,
+            MediaBrowserType.GUTENBERG_SINGLE_FILE_PICKER
+        )
+    }
+
+    /**
+     * Launches the audio file picker from the media library.
+     */
+    @Suppress("UnusedParameter")
+    fun onAddLibraryAudioFileClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
+            activity,
+            site,
+            MediaBrowserType.GUTENBERG_SINGLE_AUDIO_FILE_PICKER
+        )
+    }
+
+    /**
+     * Launches the photo picker for device photos.
+     */
+    @Suppress("ReturnCount")
+    fun onAddPhotoClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        val postId = listener?.getPostId() ?: return
+        val browserType = if (allowMultipleSelection) {
+            MediaBrowserType.GUTENBERG_IMAGE_PICKER
+        } else {
+            MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
+        }
+        mediaPickerLauncher.showPhotoPickerForResult(activity, browserType, site, postId)
+    }
+
+    /**
+     * Captures a photo using the device camera.
+     */
+    fun onCapturePhotoClicked() {
+        val site = listener?.getSiteModel() ?: return
+        editorCameraHelper.capturePhotoIfAllowed(
+            site,
+            onLaunchCamera = { listener?.launchCamera() },
+            onNoPermission = { listener?.showNoUploadPermissionSnackbar() }
+        )
+    }
+
+    /**
+     * Launches the video picker for device videos.
+     */
+    @Suppress("ReturnCount")
+    fun onAddVideoClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        val postId = listener?.getPostId() ?: return
+        val browserType = if (allowMultipleSelection) {
+            MediaBrowserType.GUTENBERG_VIDEO_PICKER
+        } else {
+            MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER
+        }
+        mediaPickerLauncher.showPhotoPickerForResult(activity, browserType, site, postId)
+    }
+
+    /**
+     * Launches the device media picker (photos and videos).
+     */
+    @Suppress("ReturnCount")
+    fun onAddDeviceMediaClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        val postId = listener?.getPostId() ?: return
+        val browserType = if (allowMultipleSelection) {
+            MediaBrowserType.GUTENBERG_MEDIA_PICKER
+        } else {
+            MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER
+        }
+        mediaPickerLauncher.showPhotoPickerForResult(activity, browserType, site, postId)
+    }
+
+    /**
+     * Launches the stock media picker.
+     */
+    fun onAddStockMediaClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        val requestCode = if (allowMultipleSelection) {
+            RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT
+        } else {
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK
+        }
+        mediaPickerLauncher.showStockMediaPickerForResult(activity, site, requestCode, allowMultipleSelection)
+    }
+
+    /**
+     * Launches the GIF picker.
+     */
+    fun onAddGifClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        mediaPickerLauncher.showGifPickerForResult(activity, site, allowMultipleSelection)
+    }
+
+    /**
+     * Launches the file picker.
+     */
+    fun onAddFileClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        mediaPickerLauncher.showFilePicker(activity, allowMultipleSelection, site)
+    }
+
+    /**
+     * Launches the audio file picker.
+     */
+    fun onAddAudioFileClicked(allowMultipleSelection: Boolean) {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        mediaPickerLauncher.showAudioFilePicker(activity, allowMultipleSelection, site)
+    }
+
+    /**
+     * Captures a video using the device camera.
+     */
+    fun onCaptureVideoClicked() {
+        val activity = listener?.getActivity() ?: return
+        val site = listener?.getSiteModel() ?: return
+        editorCameraHelper.captureVideoIfAllowed(
+            activity,
+            site,
+            onNoPermission = { listener?.showNoUploadPermissionSnackbar() }
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorModeHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorModeHandler.kt
@@ -1,0 +1,151 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.text.TextUtils
+import dagger.Reusable
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+import org.wordpress.android.ui.prefs.AppPrefs
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource
+import javax.inject.Inject
+
+/**
+ * Handles editor mode switching (HTML/Visual/Gutenberg) for the post editor.
+ *
+ * This class extracts editor mode management logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class EditorModeHandler @Inject constructor(
+    private val dispatcher: Dispatcher
+) {
+    /**
+     * Listener for editor mode events that require Activity-level handling.
+     */
+    interface EditorModeListener {
+        fun getEditorFragment(): EditorFragmentAbstract?
+        fun getSiteModel(): SiteModel
+        fun getPostEditorAnalyticsSession(): PostEditorAnalyticsSession?
+        fun isNewPost(): Boolean
+        fun invalidateOptionsMenu()
+        fun getString(resId: Int): String
+    }
+
+    private var listener: EditorModeListener? = null
+    private var htmlModeOn: Boolean = false
+
+    /**
+     * Initializes the handler with the required listener.
+     */
+    fun start(listener: EditorModeListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Returns whether HTML mode is currently enabled.
+     */
+    fun isHtmlModeOn(): Boolean = htmlModeOn
+
+    /**
+     * Sets the HTML mode state. Used for state restoration.
+     */
+    fun setHtmlModeOn(isOn: Boolean) {
+        htmlModeOn = isOn
+    }
+
+    /**
+     * Toggles between HTML and Visual mode.
+     */
+    fun toggleHtmlMode() {
+        htmlModeOn = !htmlModeOn
+        trackEditorModeSwitch()
+        listener?.invalidateOptionsMenu()
+        showModeSwitchedNotice()
+    }
+
+    /**
+     * Shows a notice indicating which mode the editor switched to.
+     */
+    private fun showModeSwitchedNotice() {
+        val listener = this.listener ?: return
+        val messageResId = if (htmlModeOn) {
+            org.wordpress.android.R.string.menu_html_mode_switched_notice
+        } else {
+            org.wordpress.android.R.string.menu_visual_mode_switched_notice
+        }
+        val message = listener.getString(messageResId)
+        listener.getEditorFragment()?.showNotice(message)
+    }
+
+    /**
+     * Tracks the editor mode switch in analytics.
+     */
+    private fun trackEditorModeSwitch() {
+        val editorFragment = listener?.getEditorFragment()
+        val isGutenberg = editorFragment is GutenbergEditorFragment
+        val editor = when {
+            htmlModeOn -> PostEditorAnalyticsSession.Editor.HTML
+            isGutenberg -> PostEditorAnalyticsSession.Editor.GUTENBERG
+            else -> PostEditorAnalyticsSession.Editor.CLASSIC
+        }
+        listener?.getPostEditorAnalyticsSession()?.switchEditor(editor)
+    }
+
+    /**
+     * Enables Gutenberg editor if needed and shows informative dialogs.
+     * Called when opening a post that may need Gutenberg enabled.
+     */
+    fun setGutenbergEnabledIfNeeded() {
+        val listener = this.listener ?: return
+        val site = listener.getSiteModel()
+
+        if (AppPrefs.isGutenbergInfoPopupDisplayed(site.url)) {
+            return
+        }
+
+        val showPopup = AppPrefs.shouldShowGutenbergInfoPopupForTheNewPosts(site.url)
+        val showRolloutPopupPhase2 = AppPrefs.shouldShowGutenbergInfoPopupPhase2ForNewPosts(site.url)
+
+        if (TextUtils.isEmpty(site.mobileEditor) && !listener.isNewPost()) {
+            SiteUtils.enableBlockEditor(dispatcher, site)
+            AnalyticsUtils.trackWithSiteDetails(
+                Stat.EDITOR_GUTENBERG_ENABLED,
+                site,
+                BlockEditorEnabledSource.ON_BLOCK_POST_OPENING.asPropertyMap()
+            )
+        }
+
+        if (showPopup) {
+            showGutenbergInformativeDialog(site)
+        } else if (showRolloutPopupPhase2) {
+            showGutenbergRolloutV2InformativeDialog(site)
+        }
+    }
+
+    /**
+     * Shows the Gutenberg informative dialog.
+     * Note: Dialog display is currently disabled but preference is still set.
+     */
+    private fun showGutenbergInformativeDialog(site: SiteModel) {
+        // We are no longer showing the dialog, but we are leaving all the surrounding logic because
+        // this is going in shortly before release, and we're going to remove all this logic in the
+        // very near future.
+        AppPrefs.setGutenbergInfoPopupDisplayed(site.url, true)
+    }
+
+    /**
+     * Shows the Gutenberg rollout V2 informative dialog.
+     * Note: Dialog display is currently disabled but preference is still set.
+     */
+    private fun showGutenbergRolloutV2InformativeDialog(site: SiteModel) {
+        // We are no longer showing the dialog, but we are leaving all the surrounding logic because
+        // this is going in shortly before release, and we're going to remove all this logic in the
+        // very near future.
+        AppPrefs.setGutenbergInfoPopupDisplayed(site.url, true)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorNavigationManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorNavigationManager.kt
@@ -1,0 +1,137 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.view.View
+import androidx.appcompat.widget.Toolbar
+import com.google.android.material.appbar.AppBarLayout
+import dagger.Reusable
+import org.wordpress.android.widgets.WPViewPager
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.navigation.EditPostDestination
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
+import javax.inject.Inject
+
+/**
+ * Manages ViewPager navigation and UI updates for different editor destinations.
+ *
+ * This class extracts navigation-related logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class EditorNavigationManager @Inject constructor() {
+    /**
+     * Listener for navigation events that require Activity-level handling.
+     */
+    interface NavigationListener {
+        fun getSiteModel(): SiteModel
+        fun getEditPostRepository(): EditPostRepository
+        fun provideViewPager(): WPViewPager?
+        fun getAppBarLayout(): AppBarLayout?
+        fun getToolbar(): Toolbar?
+        fun getEditorPhotoPicker(): EditorPhotoPicker?
+        fun setTitle(title: CharSequence)
+        fun setTitle(resId: Int)
+        fun invalidateOptionsMenu()
+    }
+
+    private var listener: NavigationListener? = null
+
+    companion object {
+        const val VIEW_PAGER_PAGE_CONTENT = 0
+        const val VIEW_PAGER_PAGE_SETTINGS = 1
+        const val VIEW_PAGER_PAGE_PUBLISH_SETTINGS = 2
+        const val VIEW_PAGER_PAGE_HISTORY = 3
+        const val VIEW_PAGER_OFFSCREEN_PAGE_LIMIT = 4
+    }
+
+    /**
+     * Initializes the manager with the required listener.
+     */
+    fun start(listener: NavigationListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Updates ViewPager position based on navigation destination.
+     */
+    fun updateViewPagerPosition(destination: EditPostDestination) {
+        val targetPage = when (destination) {
+            EditPostDestination.Editor -> VIEW_PAGER_PAGE_CONTENT
+            EditPostDestination.Settings -> VIEW_PAGER_PAGE_SETTINGS
+            EditPostDestination.PublishSettings -> VIEW_PAGER_PAGE_PUBLISH_SETTINGS
+            EditPostDestination.History -> VIEW_PAGER_PAGE_HISTORY
+        }
+
+        listener?.provideViewPager()?.let { pager ->
+            if (pager.currentItem != targetPage) {
+                AppLog.d(
+                    AppLog.T.POSTS,
+                    "EditorNavigationManager: Moving ViewPager from ${pager.currentItem} to $targetPage"
+                )
+                pager.currentItem = targetPage
+            }
+        }
+    }
+
+    /**
+     * Updates UI elements based on current navigation destination.
+     */
+    @Suppress("LongMethod")
+    fun updateUIForDestination(destination: EditPostDestination) {
+        val listener = this.listener ?: return
+        val appBarLayout = listener.getAppBarLayout()
+        val toolbar = listener.getToolbar()
+
+        when (destination) {
+            EditPostDestination.Editor -> {
+                listener.setTitle(SiteUtils.getSiteNameOrHomeURL(listener.getSiteModel()))
+                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                toolbar?.setBackgroundResource(R.drawable.tab_layout_background)
+            }
+
+            EditPostDestination.Settings -> {
+                val titleResId = if (listener.getEditPostRepository().isPage) {
+                    R.string.page_settings
+                } else {
+                    R.string.post_settings
+                }
+                listener.setTitle(titleResId)
+                listener.getEditorPhotoPicker()?.hidePhotoPicker()
+                appBarLayout?.liftOnScrollTargetViewId = R.id.settings_fragment_root
+                toolbar?.background = null
+            }
+
+            EditPostDestination.PublishSettings -> {
+                listener.setTitle(R.string.publish_date)
+                listener.getEditorPhotoPicker()?.hidePhotoPicker()
+                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                toolbar?.background = null
+            }
+
+            EditPostDestination.History -> {
+                listener.setTitle(R.string.history_title)
+                listener.getEditorPhotoPicker()?.hidePhotoPicker()
+                appBarLayout?.liftOnScrollTargetViewId = R.id.empty_recycler_view
+                toolbar?.background = null
+            }
+        }
+
+        // Refresh options menu as visibility may change based on destination
+        listener.invalidateOptionsMenu()
+    }
+
+    /**
+     * Returns the target page index for a given destination.
+     */
+    fun getPageForDestination(destination: EditPostDestination): Int {
+        return when (destination) {
+            EditPostDestination.Editor -> VIEW_PAGER_PAGE_CONTENT
+            EditPostDestination.Settings -> VIEW_PAGER_PAGE_SETTINGS
+            EditPostDestination.PublishSettings -> VIEW_PAGER_PAGE_PUBLISH_SETTINGS
+            EditPostDestination.History -> VIEW_PAGER_PAGE_HISTORY
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingStateManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostLoadingStateManager.kt
@@ -1,0 +1,237 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.app.ProgressDialog
+import android.content.Context
+import dagger.Reusable
+import org.greenrobot.eventbus.EventBus
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.ui.posts.ProgressDialogHelper
+import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
+import org.wordpress.android.ui.uploads.PostEvents.PostPreviewingInEditor
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+
+/**
+ * Manages post loading states and progress dialog visibility during editor operations.
+ *
+ * This class encapsulates the state machine for post loading states (preview, revision loading, etc.)
+ * and coordinates progress dialog display. It extracts state management logic from EditPostActivity
+ * to improve testability and separation of concerns.
+ */
+@Reusable
+class PostLoadingStateManager @Inject constructor(
+    private val progressDialogHelper: ProgressDialogHelper,
+    private val uiHelpers: UiHelpers
+) {
+    /**
+     * Listener interface for state changes that require Activity-level handling.
+     */
+    interface StateChangeListener {
+        /**
+         * Called when the state transitions and Activity needs to update its progress dialog.
+         * @param newDialog The new progress dialog (may be null if dialog should be hidden).
+         */
+        fun onProgressDialogChanged(newDialog: ProgressDialog?)
+
+        /**
+         * Called when a preview should be launched.
+         * @param previewType The type of remote preview to launch.
+         */
+        fun onLaunchPreview(previewType: RemotePreviewType)
+
+        /**
+         * Called when preview upload was successful and Activity state should be updated.
+         */
+        fun onPreviewUploadSuccess()
+
+        /**
+         * Called when preview upload failed and error should be shown.
+         */
+        fun onPreviewUploadError()
+    }
+
+    private var currentState: PostLoadingState = PostLoadingState.NONE
+    private var listener: StateChangeListener? = null
+    private var currentDialog: ProgressDialog? = null
+
+    /**
+     * The current post loading state.
+     */
+    val state: PostLoadingState
+        get() = currentState
+
+    /**
+     * Returns true if the editor is in any remote previewing state.
+     */
+    val isRemotePreviewingFromEditor: Boolean
+        get() = currentState == PostLoadingState.UPLOADING_FOR_PREVIEW ||
+                currentState == PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW ||
+                currentState == PostLoadingState.PREVIEWING ||
+                currentState == PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR
+
+    /**
+     * Returns true if the post is currently being uploaded for preview.
+     */
+    val isUploadingPostForPreview: Boolean
+        get() = currentState == PostLoadingState.UPLOADING_FOR_PREVIEW ||
+                currentState == PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW
+
+    /**
+     * Returns true if a remote auto-save preview error occurred.
+     */
+    val isRemoteAutoSaveError: Boolean
+        get() = currentState == PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR
+
+    /**
+     * Sets the listener for state change callbacks.
+     */
+    fun setListener(listener: StateChangeListener?) {
+        this.listener = listener
+    }
+
+    /**
+     * Transitions to a new state, updating the progress dialog as needed.
+     *
+     * @param context The context for creating progress dialogs.
+     * @param newState The new state to transition to.
+     * @param post The current post (used for sticky event posting).
+     * @return true if the transition occurred, false if already in the requested state.
+     */
+    fun transitionTo(context: Context, newState: PostLoadingState, post: PostImmutableModel? = null): Boolean {
+        // Only process actual transitions
+        if (currentState == newState) return false
+
+        AppLog.d(
+            AppLog.T.POSTS,
+            "Editor post loading state machine: transition from $currentState to $newState"
+        )
+
+        // Update the state
+        currentState = newState
+
+        // Handle exit/entry actions on state transition
+        manageStateTransitions(post)
+
+        // Update the progress dialog
+        currentDialog = progressDialogHelper.updateProgressDialogState(
+            context,
+            currentDialog,
+            currentState.progressDialogUiState,
+            uiHelpers
+        )
+        listener?.onProgressDialogChanged(currentDialog)
+
+        return true
+    }
+
+    /**
+     * Handles the result of a remote preview upload operation.
+     *
+     * @param context The context for creating progress dialogs.
+     * @param isError Whether the upload resulted in an error.
+     * @param previewType The type of remote preview.
+     * @param post The current post.
+     * @return A [RemotePreviewResult] indicating what action should be taken.
+     */
+    fun handleRemotePreviewUploadResult(
+        context: Context,
+        isError: Boolean,
+        previewType: RemotePreviewType,
+        post: PostImmutableModel?
+    ): RemotePreviewResult {
+        return when {
+            !isError && isUploadingPostForPreview -> {
+                // Upload succeeded - launch preview
+                listener?.onPreviewUploadSuccess()
+                listener?.onLaunchPreview(previewType)
+                transitionTo(context, PostLoadingState.PREVIEWING, post)
+                RemotePreviewResult.PREVIEW_LAUNCHED
+            }
+            isError || isRemoteAutoSaveError -> {
+                // Upload failed - show error
+                transitionTo(context, PostLoadingState.NONE)
+                listener?.onPreviewUploadError()
+                RemotePreviewResult.ERROR
+            }
+            else -> {
+                RemotePreviewResult.NO_ACTION
+            }
+        }
+    }
+
+    /**
+     * Gets the state value for saving to instance state.
+     */
+    fun getStateValue(): Int = currentState.value
+
+    /**
+     * Restores the state from a saved instance state value.
+     *
+     * @param context The context for creating progress dialogs.
+     * @param value The saved state value.
+     */
+    fun restoreState(context: Context, value: Int) {
+        val restoredState = PostLoadingState.fromInt(value)
+        if (restoredState != currentState) {
+            currentState = restoredState
+            currentDialog = progressDialogHelper.updateProgressDialogState(
+                context,
+                currentDialog,
+                currentState.progressDialogUiState,
+                uiHelpers
+            )
+            listener?.onProgressDialogChanged(currentDialog)
+        }
+    }
+
+    /**
+     * Clears the current state and dismisses any progress dialog.
+     */
+    fun clear() {
+        currentState = PostLoadingState.NONE
+        currentDialog?.dismiss()
+        currentDialog = null
+    }
+
+    private fun manageStateTransitions(post: PostImmutableModel?) {
+        when (currentState) {
+            PostLoadingState.NONE -> setPreviewingInEditorSticky(false, post)
+            PostLoadingState.UPLOADING_FOR_PREVIEW,
+            PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW,
+            PostLoadingState.PREVIEWING,
+            PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR -> setPreviewingInEditorSticky(true, post)
+            PostLoadingState.LOADING_REVISION -> {
+                // No action needed
+            }
+        }
+    }
+
+    private fun setPreviewingInEditorSticky(enable: Boolean, post: PostImmutableModel?) {
+        if (enable) {
+            post?.let {
+                EventBus.getDefault().postSticky(
+                    PostPreviewingInEditor(it.localSiteId, it.id)
+                )
+            }
+        } else {
+            EventBus.getDefault().getStickyEvent(PostPreviewingInEditor::class.java)?.let {
+                EventBus.getDefault().removeStickyEvent(it)
+            }
+        }
+    }
+
+    /**
+     * Result of handling a remote preview upload.
+     */
+    enum class RemotePreviewResult {
+        /** Preview was launched successfully */
+        PREVIEW_LAUNCHED,
+        /** An error occurred and was reported */
+        ERROR,
+        /** No action was taken (state didn't require handling) */
+        NO_ACTION
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinator.kt
@@ -1,0 +1,229 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Context
+import android.text.TextUtils
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.Reusable
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult.Updated
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome
+import org.wordpress.android.ui.posts.PostUtilsWrapper
+import org.wordpress.android.ui.posts.editor.StorePostViewModel.ActivityFinishState
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+
+/**
+ * Coordinates post publishing and upload operations for the post editor.
+ *
+ * This class extracts publishing logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class PostPublishingCoordinator @Inject constructor(
+    private val accountStore: AccountStore,
+    private val dispatcher: Dispatcher,
+    private val postUtilsWrapper: PostUtilsWrapper,
+    private val uploadUtilsWrapper: UploadUtilsWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+) {
+    /**
+     * Listener for publishing events that require Activity-level handling.
+     */
+    interface PublishingListener {
+        fun getContext(): Context
+        fun getEditPostRepository(): EditPostRepository
+        fun provideStorePostViewModel(): StorePostViewModel
+        fun getSiteModel(): SiteModel
+        fun getEditorFragment(): Any?
+        fun getPostEditorAnalyticsSession(): PostEditorAnalyticsSession?
+        fun providePrimaryAction(): PrimaryEditorAction
+        fun isPage(): Boolean
+        fun showPrepublishingNudgeBottomSheet()
+        fun updateAndSavePostAsyncOnEditorExit(onComplete: (UpdatePostResult) -> Unit)
+        fun savePostAndOptionallyFinish(doFinish: Boolean, forceSave: Boolean)
+    }
+
+    private var listener: PublishingListener? = null
+
+    /**
+     * Initializes the coordinator with the required listener.
+     */
+    fun start(listener: PublishingListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Handles the primary action button click based on the current action type.
+     */
+    fun performPrimaryAction() {
+        val listener = this.listener ?: return
+
+        when (listener.providePrimaryAction()) {
+            PrimaryEditorAction.PUBLISH_NOW -> {
+                analyticsTrackerWrapper.track(Stat.EDITOR_POST_PUBLISH_TAPPED)
+                listener.showPrepublishingNudgeBottomSheet()
+            }
+
+            PrimaryEditorAction.UPDATE,
+            PrimaryEditorAction.CONTINUE,
+            PrimaryEditorAction.SCHEDULE,
+            PrimaryEditorAction.SUBMIT_FOR_REVIEW -> {
+                listener.showPrepublishingNudgeBottomSheet()
+            }
+
+            PrimaryEditorAction.SAVE -> uploadPost(false)
+        }
+    }
+
+    /**
+     * Initiates the post upload process.
+     */
+    fun uploadPost(publishPost: Boolean) {
+        listener?.updateAndSavePostAsyncOnEditorExit { _ ->
+            if (shouldPerformPostUpdateAndPublish()) {
+                performPostUpdateAndPublish(publishPost)
+            }
+        }
+    }
+
+    /**
+     * Validates whether the post can be published.
+     * Checks email verification and post content.
+     */
+    @Suppress("ReturnCount")
+    fun shouldPerformPostUpdateAndPublish(): Boolean {
+        val listener = this.listener ?: return false
+        val context = listener.getContext()
+        val account: AccountModel = accountStore.account
+
+        // Prompt user to verify email before publishing
+        if (!account.emailVerified) {
+            listener.provideStorePostViewModel().hideSavingProgressDialog()
+            val message: String = if (TextUtils.isEmpty(account.email)) {
+                context.getString(R.string.editor_confirm_email_prompt_message)
+            } else {
+                String.format(
+                    context.getString(R.string.editor_confirm_email_prompt_message_with_email),
+                    account.email
+                )
+            }
+
+            val builder: AlertDialog.Builder = MaterialAlertDialogBuilder(context)
+            builder.setTitle(R.string.editor_confirm_email_prompt_title)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    ToastUtils.showToast(
+                        context,
+                        context.getString(R.string.toast_saving_post_as_draft)
+                    )
+                    listener.savePostAndOptionallyFinish(doFinish = true, forceSave = false)
+                }
+                .setNegativeButton(R.string.editor_confirm_email_prompt_negative) { _, _ ->
+                    dispatcher.dispatch(AccountActionBuilder.newSendVerificationEmailAction())
+                }
+            builder.create().show()
+            return false
+        }
+
+        listener.getEditPostRepository().getPost()?.let {
+            if (!postUtilsWrapper.isPublishable(it)) {
+                listener.provideStorePostViewModel().hideSavingProgressDialog()
+                listener.getEditPostRepository().updateStatusFromPostSnapshotWhenEditorOpened()
+
+                val message: String = context.getString(
+                    if (listener.isPage()) {
+                        R.string.error_publish_empty_page
+                    } else {
+                        R.string.error_publish_empty_post
+                    }
+                )
+                ToastUtils.showToast(context, message, ToastUtils.Duration.SHORT)
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * Performs the actual post update and publish operation.
+     */
+    fun performPostUpdateAndPublish(publishPost: Boolean) {
+        val listener = this.listener ?: return
+        val storePostViewModel = listener.provideStorePostViewModel()
+        val editPostRepository = listener.getEditPostRepository()
+
+        storePostViewModel.showSavingProgressDialog()
+        val isFirstTimePublish: Boolean = editPostRepository.isFirstTimePublish(publishPost)
+
+        editPostRepository.updateAsync({ postModel: PostModel ->
+            if (publishPost) {
+                // Now set status to PUBLISHED - only do this AFTER we have run the
+                // isFirstTimePublish() check, otherwise we'd have an incorrect value.
+                // Also re-set the published date in case it was SCHEDULED and they want
+                // to publish NOW.
+                if (postModel.status == PostStatus.SCHEDULED.toString()) {
+                    postModel.setDateCreated(dateTimeUtilsWrapper.currentTimeInIso8601())
+                }
+                if (uploadUtilsWrapper.userCanPublish(listener.getSiteModel())) {
+                    postModel.setStatus(PostStatus.PUBLISHED.toString())
+                } else {
+                    postModel.setStatus(PostStatus.PENDING.toString())
+                }
+                listener.getPostEditorAnalyticsSession()?.setOutcome(Outcome.PUBLISH)
+            } else {
+                listener.getPostEditorAnalyticsSession()?.setOutcome(Outcome.SAVE)
+            }
+            AppLog.d(
+                AppLog.T.POSTS,
+                "User explicitly confirmed changes. Post Title: " + postModel.title
+            )
+            // The user explicitly confirmed an intention to upload the post
+            postModel.setChangesConfirmedContentHashcode(postModel.contentHashcode())
+            true
+        }) { _: PostImmutableModel?, result: UpdatePostResult ->
+            if (result === Updated) {
+                val activityFinishState: ActivityFinishState =
+                    savePostOnline(isFirstTimePublish, listener)
+                storePostViewModel.finish(activityFinishState)
+            }
+        }
+    }
+
+    /**
+     * Saves the post to the server.
+     */
+    private fun savePostOnline(
+        isFirstTimePublish: Boolean,
+        listener: PublishingListener
+    ): ActivityFinishState {
+        val editorFragment = listener.getEditorFragment()
+        if (editorFragment is GutenbergEditorFragment) {
+            editorFragment.sendToJSPostSaveEvent()
+        }
+        return listener.provideStorePostViewModel().savePostOnline(
+            isFirstTimePublish,
+            listener.getContext(),
+            listener.getEditPostRepository(),
+            listener.getSiteModel()
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ShareContentHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ShareContentHandler.kt
@@ -1,0 +1,126 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Intent
+import android.net.Uri
+import dagger.Reusable
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult.Updated
+import org.wordpress.android.ui.posts.EditorUnitFunctions
+import org.wordpress.android.ui.posts.editor.media.EditorMedia
+import org.wordpress.android.util.AutolinkUtils
+import javax.inject.Inject
+
+/**
+ * Handles setting post content from share actions.
+ *
+ * This class extracts share content handling logic from EditPostActivity to improve
+ * testability and separation of concerns.
+ */
+@Reusable
+class ShareContentHandler @Inject constructor(
+    private val editorMedia: EditorMedia
+) {
+    /**
+     * Listener for share content events that require Activity-level handling.
+     */
+    interface ShareContentListener {
+        fun getIntent(): Intent
+        fun getEditPostRepository(): EditPostRepository
+        fun getEditorFragment(): EditorFragmentAbstract?
+        fun isShowGutenbergEditor(): Boolean
+        fun setHasSetPostContent(value: Boolean)
+    }
+
+    private var listener: ShareContentListener? = null
+
+    /**
+     * Initializes the handler with the required listener.
+     */
+    fun start(listener: ShareContentListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Sets the post content from a share action intent.
+     * This handles both text and media sharing.
+     */
+    fun setPostContentFromShareAction() {
+        val intent = listener?.getIntent() ?: return
+        val editPostRepository = listener?.getEditPostRepository() ?: return
+        val editorFragment = listener?.getEditorFragment()
+        val showGutenbergEditor = listener?.isShowGutenbergEditor() ?: false
+
+        // Check for shared text
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+        val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+
+        if (text != null) {
+            listener?.setHasSetPostContent(true)
+            editPostRepository.updateAsync({ postModel: PostModel ->
+                if (title != null) {
+                    postModel.setTitle(title)
+                }
+                // Create an <a href> element around links
+                var updatedContent: String = AutolinkUtils.autoCreateLinks(text)
+
+                // If editor is Gutenberg, add Gutenberg block around content
+                if (showGutenbergEditor) {
+                    updatedContent = EditorUnitFunctions.migrateToGutenbergEditor(updatedContent)
+                }
+
+                // update PostModel
+                postModel.setContent(updatedContent)
+                editPostRepository.updatePublishDateIfShouldBePublishedImmediately(postModel)
+                true
+            }) { postModel, result ->
+                if (result === Updated) {
+                    editorFragment?.setTitle(postModel.title)
+                    editorFragment?.setContent(postModel.content)
+                }
+            }
+        }
+        setPostMediaFromShareAction()
+    }
+
+    /**
+     * Adds media from a share action intent to the editor.
+     */
+    fun setPostMediaFromShareAction() {
+        val intent = listener?.getIntent() ?: return
+
+        // Short-circuit the method if Intent.EXTRA_STREAM is not found
+        if (!intent.hasExtra(Intent.EXTRA_STREAM)) {
+            return
+        }
+
+        // Check for shared media
+        val action = intent.action
+        val sharedUris: ArrayList<Uri> = ArrayList()
+
+        if (Intent.ACTION_SEND_MULTIPLE == action) {
+            val potentialUris: ArrayList<Uri>? = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
+            potentialUris?.forEach { uri ->
+                if (EditorUnitFunctions.isMediaTypeIntent(intent, uri)) {
+                    sharedUris.add(uri)
+                }
+            }
+        } else {
+            // For a single media share, we only allow images and video types
+            if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
+                intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.let {
+                    sharedUris.add(it)
+                }
+            }
+        }
+
+        if (sharedUris.isNotEmpty()) {
+            // removing this from the intent so it doesn't insert the media items again on each Activity re-creation
+            intent.removeExtra(Intent.EXTRA_STREAM)
+            editorMedia.addNewMediaItemsToEditorAsync(sharedUris, false)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinator.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadService.UploadMediaRetryEvent
 import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.helpers.MediaFile
 import javax.inject.Inject
 
 /**
@@ -192,9 +191,4 @@ class MediaUploadCoordinator @Inject constructor(
             }
         }
     }
-
-    /**
-     * Creates a MediaFile from a MediaModel for editor callbacks.
-     */
-    fun createMediaFile(media: MediaModel): MediaFile = FluxCUtils.mediaFileFromMediaModel(media)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinator.kt
@@ -1,0 +1,200 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import android.text.TextUtils
+import dagger.Reusable
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.editor.EditorMediaUploadListener
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
+import org.wordpress.android.ui.uploads.ProgressEvent
+import org.wordpress.android.ui.uploads.UploadService
+import org.wordpress.android.ui.uploads.UploadService.UploadMediaRetryEvent
+import org.wordpress.android.util.FluxCUtils
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.helpers.MediaFile
+import javax.inject.Inject
+
+/**
+ * Coordinates media upload events between FluxC and the editor.
+ *
+ * This class processes media upload events (progress, success, error, retry) and
+ * delegates to the appropriate handlers. It extracts upload coordination logic
+ * from EditPostActivity to improve testability.
+ */
+@Reusable
+class MediaUploadCoordinator @Inject constructor(
+    private val editorMedia: EditorMedia,
+    private val networkUtilsWrapper: NetworkUtilsWrapper
+) {
+    /**
+     * Listener interface for upload events that require Activity-level handling.
+     */
+    interface UploadEventListener {
+        /**
+         * Called when a featured image upload completes successfully.
+         * @param mediaId The remote media ID of the uploaded featured image.
+         */
+        fun onFeaturedImageUploaded(mediaId: Long)
+
+        /**
+         * @return true if the Activity is finishing and events should be ignored.
+         */
+        fun isFinishing(): Boolean
+
+        /**
+         * @return The local post ID associated with the current editor session.
+         */
+        fun getPostId(): Int
+
+        /**
+         * Shows a snackbar error message to the user.
+         * @param message The error message to display.
+         */
+        fun showUploadError(message: String)
+    }
+
+    private var listener: UploadEventListener? = null
+    private var editorMediaUploadListener: EditorMediaUploadListener? = null
+
+    /**
+     * Initializes the coordinator with the required listeners.
+     *
+     * @param listener Listener for Activity-level upload events.
+     * @param editorMediaUploadListener Listener for editor-level upload events.
+     */
+    fun start(listener: UploadEventListener, editorMediaUploadListener: EditorMediaUploadListener?) {
+        this.listener = listener
+        this.editorMediaUploadListener = editorMediaUploadListener
+    }
+
+    /**
+     * Updates the editor media upload listener. This may change during the Activity lifecycle.
+     */
+    fun setEditorMediaUploadListener(editorMediaUploadListener: EditorMediaUploadListener?) {
+        this.editorMediaUploadListener = editorMediaUploadListener
+    }
+
+    /**
+     * Processes a FluxC OnMediaUploaded event.
+     *
+     * @param event The media uploaded event from FluxC.
+     * @return true if the event was processed, false if it should be ignored.
+     */
+    @Suppress("ReturnCount")
+    fun processMediaUploadedEvent(event: OnMediaUploaded): Boolean {
+        if (listener?.isFinishing() == true) return false
+
+        if (event.isError && !networkUtilsWrapper.isNetworkAvailable()) {
+            handleUploadPausedDueToNetwork(event)
+            return true
+        }
+
+        val media = event.media ?: return false
+        when {
+            event.isError -> handleMediaUploadedError(media, event.error)
+            event.completed -> handleMediaUploadedCompleted(media)
+            else -> handleUploadProgress(media, event.progress)
+        }
+        return true
+    }
+
+    private fun handleUploadPausedDueToNetwork(event: OnMediaUploaded) {
+        val uploadListener = editorMediaUploadListener ?: return
+        val media = event.media ?: return
+        editorMedia.onMediaUploadPaused(uploadListener, media, event.error)
+    }
+
+    /**
+     * Processes a progress event from the upload service.
+     *
+     * @param event The progress event.
+     */
+    fun processProgressEvent(event: ProgressEvent) {
+        if (listener?.isFinishing() != true) {
+            // Use upload progress rather than optimizer progress since the former includes
+            // upload + optimization
+            val progress = UploadService.getUploadProgressForMedia(event.media)
+            handleUploadProgress(event.media, progress)
+        }
+    }
+
+    /**
+     * Processes an upload retry event.
+     *
+     * @param event The retry event containing media to retry.
+     */
+    @Suppress("ReturnCount")
+    fun processUploadRetryEvent(event: UploadMediaRetryEvent) {
+        if (listener?.isFinishing() == true) return
+        val mediaList = event.mediaModelList ?: return
+        val uploadListener = editorMediaUploadListener ?: return
+
+        mediaList.forEach { media ->
+            val localMediaId = media.id.toString()
+            val mediaType = if (media.isVideo) {
+                EditorFragmentAbstract.MediaType.VIDEO
+            } else {
+                EditorFragmentAbstract.MediaType.IMAGE
+            }
+            uploadListener.onMediaUploadRetry(localMediaId, mediaType)
+        }
+    }
+
+    /**
+     * Handles a successful media upload.
+     *
+     * @param media The uploaded media model.
+     */
+    fun handleUploadSuccess(media: MediaModel) {
+        val postId = listener?.getPostId() ?: return
+
+        if (!media.markedLocallyAsFeatured) {
+            editorMediaUploadListener?.onMediaUploadSucceeded(
+                media.id.toString(),
+                FluxCUtils.mediaFileFromMediaModel(media)
+            )
+        } else if (media.localPostId == postId) {
+            listener?.onFeaturedImageUploaded(media.mediaId)
+        }
+    }
+
+    /**
+     * Handles upload progress updates.
+     *
+     * @param media The media being uploaded (can be null).
+     * @param progress The upload progress (0.0 to 1.0).
+     */
+    fun handleUploadProgress(media: MediaModel?, progress: Float) {
+        val localMediaId = media?.id.toString()
+        editorMediaUploadListener?.onMediaUploadProgress(localMediaId, progress)
+    }
+
+    private fun handleMediaUploadedError(media: MediaModel, error: MediaError) {
+        editorMediaUploadListener?.let { uploadListener ->
+            editorMedia.onMediaUploadError(uploadListener, media, error)
+        }
+    }
+
+    private fun handleMediaUploadedCompleted(media: MediaModel) {
+        // If the remote URL on completion is null, we consider this upload unsuccessful
+        editorMediaUploadListener?.let { uploadListener ->
+            if (TextUtils.isEmpty(media.url)) {
+                val error = MediaError(MediaErrorType.GENERIC_ERROR)
+                if (!networkUtilsWrapper.isNetworkAvailable()) {
+                    editorMedia.onMediaUploadPaused(uploadListener, media, error)
+                } else {
+                    editorMedia.onMediaUploadError(uploadListener, media, error)
+                }
+            } else {
+                handleUploadSuccess(media)
+            }
+        }
+    }
+
+    /**
+     * Creates a MediaFile from a MediaModel for editor callbacks.
+     */
+    fun createMediaFile(media: MediaModel): MediaFile = FluxCUtils.mediaFileFromMediaModel(media)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorActivityResultHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorActivityResultHandlerTest.kt
@@ -1,0 +1,292 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Intent
+import android.net.Uri
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.media.MediaBrowserActivity
+import org.wordpress.android.ui.photopicker.MediaPickerConstants
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
+import org.wordpress.android.ui.posts.editor.media.EditorMedia
+import java.util.function.Consumer
+
+@RunWith(MockitoJUnitRunner::class)
+class EditorActivityResultHandlerTest {
+    @Mock
+    private lateinit var editorMedia: EditorMedia
+
+    @Mock
+    private lateinit var imageEditorTracker: ImageEditorTracker
+
+    @Mock
+    private lateinit var listener: EditorActivityResultHandler.ActivityResultListener
+
+    @Mock
+    private lateinit var editorFragment: EditorFragmentAbstract
+
+    private lateinit var handler: EditorActivityResultHandler
+
+    @Before
+    fun setUp() {
+        handler = EditorActivityResultHandler(editorMedia, imageEditorTracker)
+        whenever(listener.getEditorFragment()).thenReturn(editorFragment)
+        handler.start(listener)
+    }
+
+    // region handleNotOKResult tests
+    @Test
+    fun `handleNotOKResult cancels media selection for MULTI_SELECT_MEDIA_PICKER`() {
+        // Act
+        val handled = handler.handleNotOKResult(RequestCodes.MULTI_SELECT_MEDIA_PICKER)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorFragment).mediaSelectionCancelled()
+    }
+
+    @Test
+    fun `handleNotOKResult cancels media selection for SINGLE_SELECT_MEDIA_PICKER`() {
+        // Act
+        val handled = handler.handleNotOKResult(RequestCodes.SINGLE_SELECT_MEDIA_PICKER)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorFragment).mediaSelectionCancelled()
+    }
+
+    @Test
+    fun `handleNotOKResult cancels media selection for PHOTO_PICKER`() {
+        // Act
+        val handled = handler.handleNotOKResult(RequestCodes.PHOTO_PICKER)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorFragment).mediaSelectionCancelled()
+    }
+
+    @Test
+    fun `handleNotOKResult cancels media selection for TAKE_PHOTO`() {
+        // Act
+        val handled = handler.handleNotOKResult(RequestCodes.TAKE_PHOTO)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorFragment).mediaSelectionCancelled()
+    }
+
+    @Test
+    fun `handleNotOKResult cancels media selection for TAKE_VIDEO`() {
+        // Act
+        val handled = handler.handleNotOKResult(RequestCodes.TAKE_VIDEO)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorFragment).mediaSelectionCancelled()
+    }
+
+    @Test
+    fun `handleNotOKResult returns false for unknown request code`() {
+        // Act
+        val handled = handler.handleNotOKResult(999)
+
+        // Assert
+        assertThat(handled).isFalse()
+        verify(editorFragment, never()).mediaSelectionCancelled()
+    }
+    // endregion
+
+    // region handleOKResult tests
+    @Test
+    fun `handleOKResult handles MULTI_SELECT_MEDIA_PICKER`() {
+        // Arrange
+        val intent = createIntentWithMediaIds(longArrayOf(1L, 2L, 3L))
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.MULTI_SELECT_MEDIA_PICKER, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addExistingMediaToEditorAsync(
+            eq(AddExistingMediaSource.WP_MEDIA_LIBRARY),
+            eq(longArrayOf(1L, 2L, 3L))
+        )
+    }
+
+    @Test
+    fun `handleOKResult handles SINGLE_SELECT_MEDIA_PICKER`() {
+        // Arrange
+        val intent = createIntentWithMediaIds(longArrayOf(1L))
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.SINGLE_SELECT_MEDIA_PICKER, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addExistingMediaToEditorAsync(
+            eq(AddExistingMediaSource.WP_MEDIA_LIBRARY),
+            eq(longArrayOf(1L))
+        )
+    }
+
+    @Test
+    fun `handleOKResult handles TAKE_PHOTO by delegating to listener`() {
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.TAKE_PHOTO, null)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(listener).handleLastTakenPicture()
+    }
+
+    @Test
+    fun `handleOKResult handles TAKE_VIDEO with data`() {
+        // Arrange
+        val uri = mock<Uri>()
+        val intent = mock<Intent>()
+        whenever(intent.data).thenReturn(uri)
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.TAKE_VIDEO, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addNewMediaToEditorAsync(uri, true)
+    }
+
+    @Test
+    fun `handleOKResult handles STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK`() {
+        // Arrange
+        val intent = createIntentWithSingleMediaId(123L)
+
+        // Act
+        val handled = handler.handleOKResult(
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK,
+            intent
+        )
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addExistingMediaToEditorAsync(
+            eq(AddExistingMediaSource.STOCK_PHOTO_LIBRARY),
+            eq(longArrayOf(123L))
+        )
+    }
+
+    @Test
+    fun `handleOKResult handles STOCK_MEDIA_PICKER_MULTI_SELECT`() {
+        // Arrange
+        val intent = createIntentWithMediaIds(longArrayOf(1L, 2L))
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addExistingMediaToEditorAsync(
+            eq(AddExistingMediaSource.STOCK_PHOTO_LIBRARY),
+            eq(longArrayOf(1L, 2L))
+        )
+    }
+
+    @Test
+    fun `handleOKResult handles GIF_PICKER_SINGLE_SELECT`() {
+        // Arrange
+        val localIds = intArrayOf(1, 2, 3)
+        val intent = createIntentWithGifLocalIds(localIds)
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.GIF_PICKER_SINGLE_SELECT, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(editorMedia).addGifMediaToPostAsync(localIds)
+    }
+
+    @Test
+    fun `handleOKResult handles HISTORY_DETAIL when revision exists`() {
+        // Arrange
+        whenever(listener.getRevisionFromBundle()).thenReturn(mock<Any>())
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.HISTORY_DETAIL, null)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(listener).navigateToEditor()
+    }
+
+    @Test
+    fun `handleOKResult handles HISTORY_DETAIL when no revision`() {
+        // Arrange
+        whenever(listener.getRevisionFromBundle()).thenReturn(null)
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.HISTORY_DETAIL, null)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(listener, never()).navigateToEditor()
+    }
+
+    @Test
+    fun `handleOKResult handles SELECTED_USER_MENTION`() {
+        // Arrange
+        val callback = mock<Consumer<String?>>()
+        whenever(listener.getSuggestionCallback()).thenReturn(callback)
+        val intent = mock<Intent>()
+        whenever(intent.getStringExtra(any())).thenReturn("@username")
+
+        // Act
+        val handled = handler.handleOKResult(RequestCodes.SELECTED_USER_MENTION, intent)
+
+        // Assert
+        assertThat(handled).isTrue()
+        verify(callback).accept("@username")
+        verify(listener).clearSuggestionCallback()
+    }
+
+    @Test
+    fun `handleOKResult returns false for unknown request code`() {
+        // Act
+        val handled = handler.handleOKResult(999, null)
+
+        // Assert
+        assertThat(handled).isFalse()
+    }
+    // endregion
+
+    // region Helper methods
+    private fun createIntentWithMediaIds(ids: LongArray): Intent {
+        val intent = mock<Intent>()
+        whenever(intent.hasExtra(MediaBrowserActivity.RESULT_IDS)).thenReturn(true)
+        whenever(intent.getLongArrayExtra(MediaBrowserActivity.RESULT_IDS)).thenReturn(ids)
+        return intent
+    }
+
+    private fun createIntentWithSingleMediaId(mediaId: Long): Intent {
+        val intent = mock<Intent>()
+        whenever(intent.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)).thenReturn(true)
+        whenever(intent.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0)).thenReturn(mediaId)
+        return intent
+    }
+
+    private fun createIntentWithGifLocalIds(localIds: IntArray): Intent {
+        val intent = mock<Intent>()
+        whenever(intent.getIntArrayExtra(MediaPickerConstants.EXTRA_SAVED_MEDIA_MODEL_LOCAL_IDS))
+            .thenReturn(localIds)
+        return intent
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessorTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.util.ReblogUtils
-import org.wordpress.android.util.ShortcutUtils
 
 @RunWith(MockitoJUnitRunner::class)
 class EditorIntentProcessorTest {
@@ -28,16 +27,13 @@ class EditorIntentProcessorTest {
     private lateinit var reblogUtils: ReblogUtils
 
     @Mock
-    private lateinit var shortcutUtils: ShortcutUtils
-
-    @Mock
     private lateinit var siteModel: SiteModel
 
     private lateinit var processor: EditorIntentProcessor
 
     @Before
     fun setUp() {
-        processor = EditorIntentProcessor(siteStore, reblogUtils, shortcutUtils)
+        processor = EditorIntentProcessor(siteStore, reblogUtils)
     }
 
     // region processIntent - NewPost tests

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorIntentProcessorTest.kt
@@ -1,0 +1,299 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Intent
+import android.os.Bundle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.posts.EditorConstants
+import org.wordpress.android.util.ReblogUtils
+import org.wordpress.android.util.ShortcutUtils
+
+@RunWith(MockitoJUnitRunner::class)
+class EditorIntentProcessorTest {
+    @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
+    private lateinit var reblogUtils: ReblogUtils
+
+    @Mock
+    private lateinit var shortcutUtils: ShortcutUtils
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    private lateinit var processor: EditorIntentProcessor
+
+    @Before
+    fun setUp() {
+        processor = EditorIntentProcessor(siteStore, reblogUtils, shortcutUtils)
+    }
+
+    // region processIntent - NewPost tests
+    @Test
+    fun `processIntent returns NewPost for empty extras without post id`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val extras = createMockBundle()
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.NewPost::class.java)
+    }
+
+    @Test
+    fun `processIntent returns NewPost with isPage true when EXTRA_IS_PAGE is true`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val extras = createMockBundle(isPage = true)
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.NewPost::class.java)
+        assertThat((result as EditorIntentProcessor.IntentProcessResult.NewPost).isPage).isTrue()
+    }
+    // endregion
+
+    // region processIntent - ExistingPost tests
+    @Test
+    fun `processIntent returns ExistingPost when local post id is present`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val extras = createMockBundle(localPostId = 123)
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.ExistingPost::class.java)
+        assertThat((result as EditorIntentProcessor.IntentProcessResult.ExistingPost).localPostId).isEqualTo(123)
+    }
+
+    @Test
+    fun `processIntent returns ExistingPost with loadAutoSaveRevision when flag is set`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val extras = createMockBundle(localPostId = 123, loadAutoSaveRevision = true)
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.ExistingPost::class.java)
+        val existingPostResult = result as EditorIntentProcessor.IntentProcessResult.ExistingPost
+        assertThat(existingPostResult.localPostId).isEqualTo(123)
+        assertThat(existingPostResult.loadAutoSaveRevision).isTrue()
+    }
+    // endregion
+
+    // region processIntent - ShareAction tests
+    @Test
+    fun `processIntent returns ShareActionText for ACTION_SEND with text`() {
+        // Arrange
+        val intent = mock<Intent>()
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
+        whenever(intent.getStringExtra(Intent.EXTRA_SUBJECT)).thenReturn("Test Title")
+        whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("Test content")
+        val extras = createMockBundle()
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.ShareActionText::class.java)
+        val shareResult = result as EditorIntentProcessor.IntentProcessResult.ShareActionText
+        assertThat(shareResult.title).isEqualTo("Test Title")
+    }
+    // endregion
+
+    // region processIntent - Reblog tests
+    @Test
+    fun `processIntent returns Reblog for ACTION_REBLOG`() {
+        // Arrange
+        val intent = mock<Intent>()
+        whenever(intent.action).thenReturn(EditorConstants.ACTION_REBLOG)
+        whenever(intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_TITLE)).thenReturn("Reblog Title")
+        whenever(intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_QUOTE)).thenReturn("Quote")
+        whenever(reblogUtils.reblogContent(
+            imageUrl = anyOrNull(),
+            quote = any(),
+            citationTitle = anyOrNull(),
+            citationUrl = anyOrNull(),
+            isGutenberg = any()
+        )).thenReturn("Reblog content")
+        val extras = createMockBundle()
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.Reblog::class.java)
+        val reblogResult = result as EditorIntentProcessor.IntentProcessResult.Reblog
+        assertThat(reblogResult.title).isEqualTo("Reblog Title")
+        assertThat(reblogResult.content).isEqualTo("Reblog content")
+    }
+    // endregion
+
+    // region processIntent - PageFromLayout tests
+    @Test
+    fun `processIntent returns PageFromLayout when isPage with title and template`() {
+        // Arrange
+        val intent = mock<Intent>()
+        whenever(siteStore.getBlockLayoutContent(eq(siteModel), any())).thenReturn("Layout content")
+        val extras = createMockBundle(
+            isPage = true,
+            pageTitle = "Page Title",
+            pageTemplate = "template-slug"
+        )
+
+        // Act
+        val result = processor.processIntent(intent, extras, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(EditorIntentProcessor.IntentProcessResult.PageFromLayout::class.java)
+        val pageResult = result as EditorIntentProcessor.IntentProcessResult.PageFromLayout
+        assertThat(pageResult.title).isEqualTo("Page Title")
+        assertThat(pageResult.content).isEqualTo("Layout content")
+    }
+    // endregion
+
+    // region processIntent - InvalidIntent tests
+    @Test
+    fun `processIntent returns InvalidIntent when extras is null`() {
+        // Arrange
+        val intent = mock<Intent>()
+
+        // Act
+        val result = processor.processIntent(intent, null, siteModel, isRestarting = false)
+
+        // Assert
+        assertThat(result).isEqualTo(EditorIntentProcessor.IntentProcessResult.InvalidIntent)
+    }
+    // endregion
+
+    // region getSiteForQuickPress tests
+    @Test
+    fun `getSiteForQuickPress returns null when extras is null`() {
+        // Arrange
+        val intent = mock<Intent>()
+
+        // Act
+        val result = processor.getSiteForQuickPress(intent, null)
+
+        // Assert
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getSiteForQuickPress returns null when EXTRA_POST_LOCAL_ID is present`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val extras = createMockBundle(localPostId = 123)
+
+        // Act
+        val result = processor.getSiteForQuickPress(intent, extras)
+
+        // Assert
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getSiteForQuickPress returns site when quickpress blog id is present`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val expectedSite = mock<SiteModel>()
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
+        whenever(intent.getIntExtra(eq(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID), eq(-1))).thenReturn(456)
+        whenever(siteStore.getSiteByLocalId(456)).thenReturn(expectedSite)
+        val extras = createMockBundle(quickPressBlogId = 456)
+
+        // Act
+        val result = processor.getSiteForQuickPress(intent, extras)
+
+        // Assert
+        assertThat(result).isEqualTo(expectedSite)
+    }
+
+    @Test
+    fun `getSiteForQuickPress returns site when is quickpress flag is set`() {
+        // Arrange
+        val intent = mock<Intent>()
+        val expectedSite = mock<SiteModel>()
+        whenever(intent.getIntExtra(eq(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID), eq(-1))).thenReturn(456)
+        whenever(siteStore.getSiteByLocalId(456)).thenReturn(expectedSite)
+        val extras = createMockBundle(isQuickPress = true, quickPressBlogId = 456)
+
+        // Act
+        val result = processor.getSiteForQuickPress(intent, extras)
+
+        // Assert
+        assertThat(result).isEqualTo(expectedSite)
+    }
+    // endregion
+
+    // region extractMediaUrisFromShareIntent tests
+    @Test
+    fun `extractMediaUrisFromShareIntent returns empty list when no EXTRA_STREAM`() {
+        // Arrange
+        val intent = mock<Intent>()
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(false)
+
+        // Act
+        val result = processor.extractMediaUrisFromShareIntent(intent)
+
+        // Assert
+        assertThat(result).isEmpty()
+    }
+    // endregion
+
+    // region Helper methods
+    /**
+     * Creates a mocked Bundle with the specified values.
+     * This is necessary because Android's Bundle class doesn't work in unit tests.
+     */
+    private fun createMockBundle(
+        localPostId: Int? = null,
+        isPage: Boolean = false,
+        isQuickPress: Boolean = false,
+        quickPressBlogId: Int? = null,
+        loadAutoSaveRevision: Boolean = false,
+        pageTitle: String? = null,
+        pageTemplate: String? = null
+    ): Bundle {
+        val bundle = mock<Bundle>()
+
+        // Configure containsKey
+        whenever(bundle.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID)).thenReturn(localPostId != null)
+        whenever(bundle.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)).thenReturn(isQuickPress)
+        whenever(bundle.containsKey(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID)).thenReturn(quickPressBlogId != null)
+
+        // Configure getInt
+        whenever(bundle.getInt(EditorConstants.EXTRA_POST_LOCAL_ID)).thenReturn(localPostId ?: 0)
+
+        // Configure getBoolean
+        whenever(bundle.getBoolean(EditorConstants.EXTRA_IS_PAGE)).thenReturn(isPage)
+        whenever(bundle.getBoolean(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION)).thenReturn(loadAutoSaveRevision)
+
+        // Configure getString
+        whenever(bundle.getString(EditorConstants.EXTRA_PAGE_TITLE)).thenReturn(pageTitle)
+        whenever(bundle.getString(EditorConstants.EXTRA_PAGE_TEMPLATE)).thenReturn(pageTemplate)
+
+        return bundle
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorMediaPickerHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorMediaPickerHandlerTest.kt
@@ -1,0 +1,344 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.app.Activity
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.media.MediaBrowserType
+import org.wordpress.android.ui.photopicker.MediaPickerLauncher
+import org.wordpress.android.ui.posts.EditorCameraHelper
+import org.wordpress.android.ui.RequestCodes
+
+@RunWith(MockitoJUnitRunner::class)
+class EditorMediaPickerHandlerTest {
+    @Mock
+    private lateinit var mediaPickerLauncher: MediaPickerLauncher
+
+    @Mock
+    private lateinit var editorCameraHelper: EditorCameraHelper
+
+    @Mock
+    private lateinit var listener: EditorMediaPickerHandler.MediaPickerListener
+
+    @Mock
+    private lateinit var activity: Activity
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    @Mock
+    private lateinit var editorPhotoPicker: EditorPhotoPicker
+
+    private lateinit var handler: EditorMediaPickerHandler
+
+    @Before
+    fun setUp() {
+        handler = EditorMediaPickerHandler(mediaPickerLauncher, editorCameraHelper)
+        whenever(listener.getActivity()).thenReturn(activity)
+        whenever(listener.getSiteModel()).thenReturn(siteModel)
+        whenever(listener.getPostId()).thenReturn(TEST_POST_ID)
+        whenever(listener.getEditorPhotoPicker()).thenReturn(editorPhotoPicker)
+        handler.start(listener)
+    }
+
+    // region onAddMediaClicked tests
+    @Test
+    fun `onAddMediaClicked hides picker when already showing`() {
+        // Arrange
+        whenever(editorPhotoPicker.isPhotoPickerShowing()).thenReturn(true)
+
+        // Act
+        handler.onAddMediaClicked()
+
+        // Assert
+        verify(editorPhotoPicker).hidePhotoPicker()
+    }
+
+    @Test
+    fun `onAddMediaClicked attempts to show picker when not already showing`() {
+        // Arrange
+        whenever(editorPhotoPicker.isPhotoPickerShowing()).thenReturn(false)
+
+        // Act - method should process without throwing
+        // Note: The actual behavior depends on WPMediaUtils.currentUserCanUploadMedia which
+        // requires static mocking. This test verifies the method handles the case gracefully.
+        handler.onAddMediaClicked()
+
+        // Assert - verify isPhotoPickerShowing was checked
+        verify(editorPhotoPicker).isPhotoPickerShowing()
+    }
+    // endregion
+
+    // region onAddMediaImageClicked tests
+    @Test
+    fun `onAddMediaImageClicked launches WP media library with image picker`() {
+        // Arrange
+        val allowMultipleSelection = true
+
+        // Act
+        handler.onAddMediaImageClicked(allowMultipleSelection)
+
+        // Assert
+        verify(editorPhotoPicker).setAllowMultipleSelection(allowMultipleSelection)
+        verify(mediaPickerLauncher).viewWPMediaLibraryPickerForResult(
+            activity,
+            siteModel,
+            MediaBrowserType.GUTENBERG_IMAGE_PICKER
+        )
+    }
+
+    @Test
+    fun `onAddMediaImageClicked returns early when listener returns null activity`() {
+        // Arrange - create a new handler with a listener that returns null activity
+        val nullActivityListener = mock<EditorMediaPickerHandler.MediaPickerListener>()
+        whenever(nullActivityListener.getActivity()).thenReturn(null)
+        val testHandler = EditorMediaPickerHandler(mediaPickerLauncher, editorCameraHelper)
+        testHandler.start(nullActivityListener)
+
+        // Act - should return early without throwing
+        testHandler.onAddMediaImageClicked(true)
+
+        // Assert - no exception thrown (implicit verification that method handled null gracefully)
+    }
+    // endregion
+
+    // region onAddMediaVideoClicked tests
+    @Test
+    fun `onAddMediaVideoClicked launches WP media library with video picker`() {
+        // Arrange
+        val allowMultipleSelection = false
+
+        // Act
+        handler.onAddMediaVideoClicked(allowMultipleSelection)
+
+        // Assert
+        verify(editorPhotoPicker).setAllowMultipleSelection(allowMultipleSelection)
+        verify(mediaPickerLauncher).viewWPMediaLibraryPickerForResult(
+            activity,
+            siteModel,
+            MediaBrowserType.GUTENBERG_VIDEO_PICKER
+        )
+    }
+    // endregion
+
+    // region onAddLibraryMediaClicked tests
+    @Test
+    fun `onAddLibraryMediaClicked with multiselect launches editor picker`() {
+        // Act
+        handler.onAddLibraryMediaClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).viewWPMediaLibraryPickerForResult(
+            activity,
+            siteModel,
+            MediaBrowserType.EDITOR_PICKER
+        )
+    }
+
+    @Test
+    fun `onAddLibraryMediaClicked without multiselect launches single media picker`() {
+        // Act
+        handler.onAddLibraryMediaClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).viewWPMediaLibraryPickerForResult(
+            activity,
+            siteModel,
+            MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER
+        )
+    }
+    // endregion
+
+    // region onAddPhotoClicked tests
+    @Test
+    fun `onAddPhotoClicked with multiselect launches image picker`() {
+        // Act
+        handler.onAddPhotoClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_IMAGE_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+
+    @Test
+    fun `onAddPhotoClicked without multiselect launches single image picker`() {
+        // Act
+        handler.onAddPhotoClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+    // endregion
+
+    // region onAddVideoClicked tests
+    @Test
+    fun `onAddVideoClicked with multiselect launches video picker`() {
+        // Act
+        handler.onAddVideoClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_VIDEO_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+
+    @Test
+    fun `onAddVideoClicked without multiselect launches single video picker`() {
+        // Act
+        handler.onAddVideoClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+    // endregion
+
+    // region onAddDeviceMediaClicked tests
+    @Test
+    fun `onAddDeviceMediaClicked with multiselect launches media picker`() {
+        // Act
+        handler.onAddDeviceMediaClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_MEDIA_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+
+    @Test
+    fun `onAddDeviceMediaClicked without multiselect launches single media picker`() {
+        // Act
+        handler.onAddDeviceMediaClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).showPhotoPickerForResult(
+            activity,
+            MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER,
+            siteModel,
+            TEST_POST_ID
+        )
+    }
+    // endregion
+
+    // region onAddStockMediaClicked tests
+    @Test
+    fun `onAddStockMediaClicked with multiselect uses multi select request code`() {
+        // Act
+        handler.onAddStockMediaClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showStockMediaPickerForResult(
+            activity,
+            siteModel,
+            RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT,
+            true
+        )
+    }
+
+    @Test
+    fun `onAddStockMediaClicked without multiselect uses single select request code`() {
+        // Act
+        handler.onAddStockMediaClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).showStockMediaPickerForResult(
+            activity,
+            siteModel,
+            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK,
+            false
+        )
+    }
+    // endregion
+
+    // region onAddGifClicked tests
+    @Test
+    fun `onAddGifClicked launches gif picker`() {
+        // Act
+        handler.onAddGifClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showGifPickerForResult(activity, siteModel, true)
+    }
+    // endregion
+
+    // region onAddFileClicked tests
+    @Test
+    fun `onAddFileClicked launches file picker`() {
+        // Act
+        handler.onAddFileClicked(allowMultipleSelection = true)
+
+        // Assert
+        verify(mediaPickerLauncher).showFilePicker(activity, true, siteModel)
+    }
+    // endregion
+
+    // region onAddAudioFileClicked tests
+    @Test
+    fun `onAddAudioFileClicked launches audio file picker`() {
+        // Act
+        handler.onAddAudioFileClicked(allowMultipleSelection = false)
+
+        // Assert
+        verify(mediaPickerLauncher).showAudioFilePicker(activity, false, siteModel)
+    }
+    // endregion
+
+    // region onCapturePhotoClicked tests
+    @Test
+    fun `onCapturePhotoClicked delegates to editorCameraHelper`() {
+        // Act
+        handler.onCapturePhotoClicked()
+
+        // Assert
+        verify(editorCameraHelper).capturePhotoIfAllowed(
+            org.mockito.kotlin.eq(siteModel),
+            org.mockito.kotlin.any(),
+            org.mockito.kotlin.any()
+        )
+    }
+    // endregion
+
+    // region onCaptureVideoClicked tests
+    @Test
+    fun `onCaptureVideoClicked delegates to editorCameraHelper`() {
+        // Act
+        handler.onCaptureVideoClicked()
+
+        // Assert
+        verify(editorCameraHelper).captureVideoIfAllowed(
+            org.mockito.kotlin.eq(activity),
+            org.mockito.kotlin.eq(siteModel),
+            org.mockito.kotlin.any()
+        )
+    }
+    // endregion
+
+    companion object {
+        private const val TEST_POST_ID = 123
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorModeHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorModeHandlerTest.kt
@@ -1,0 +1,148 @@
+package org.wordpress.android.ui.posts.editor
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.R
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class EditorModeHandlerTest {
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+
+    @Mock
+    private lateinit var listener: EditorModeHandler.EditorModeListener
+
+    @Mock
+    private lateinit var editorFragment: EditorFragmentAbstract
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    @Mock
+    private lateinit var analyticsSession: PostEditorAnalyticsSession
+
+    private lateinit var handler: EditorModeHandler
+
+    @Before
+    fun setUp() {
+        handler = EditorModeHandler(dispatcher)
+        handler.start(listener)
+
+        whenever(listener.getEditorFragment()).thenReturn(editorFragment)
+        whenever(listener.getSiteModel()).thenReturn(siteModel)
+        whenever(listener.getPostEditorAnalyticsSession()).thenReturn(analyticsSession)
+    }
+
+    // region isHtmlModeOn tests
+    @Test
+    fun `initial htmlModeOn is false`() {
+        assertThat(handler.isHtmlModeOn()).isFalse()
+    }
+
+    @Test
+    fun `setHtmlModeOn updates state`() {
+        handler.setHtmlModeOn(true)
+        assertThat(handler.isHtmlModeOn()).isTrue()
+    }
+
+    @Test
+    fun `setHtmlModeOn to false updates state`() {
+        handler.setHtmlModeOn(true)
+        handler.setHtmlModeOn(false)
+        assertThat(handler.isHtmlModeOn()).isFalse()
+    }
+    // endregion
+
+    // region toggleHtmlMode tests
+    @Test
+    fun `toggleHtmlMode switches from false to true`() {
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML mode")
+
+        handler.toggleHtmlMode()
+
+        assertThat(handler.isHtmlModeOn()).isTrue()
+    }
+
+    @Test
+    fun `toggleHtmlMode switches from true to false`() {
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML mode")
+        whenever(listener.getString(R.string.menu_visual_mode_switched_notice)).thenReturn("Visual mode")
+
+        handler.setHtmlModeOn(true)
+        handler.toggleHtmlMode()
+
+        assertThat(handler.isHtmlModeOn()).isFalse()
+    }
+
+    @Test
+    fun `toggleHtmlMode invalidates options menu`() {
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML mode")
+
+        handler.toggleHtmlMode()
+
+        verify(listener).invalidateOptionsMenu()
+    }
+
+    @Test
+    fun `toggleHtmlMode shows notice on editor fragment`() {
+        val htmlMessage = "HTML mode enabled"
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn(htmlMessage)
+
+        handler.toggleHtmlMode()
+
+        verify(editorFragment).showNotice(htmlMessage)
+    }
+
+    @Test
+    fun `toggleHtmlMode shows visual notice when switching to visual`() {
+        val visualMessage = "Visual mode enabled"
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML")
+        whenever(listener.getString(R.string.menu_visual_mode_switched_notice)).thenReturn(visualMessage)
+
+        handler.setHtmlModeOn(true)
+        handler.toggleHtmlMode()
+
+        verify(editorFragment).showNotice(visualMessage)
+    }
+
+    @Test
+    fun `toggleHtmlMode tracks editor switch to HTML`() {
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML mode")
+
+        handler.toggleHtmlMode()
+
+        verify(analyticsSession).switchEditor(PostEditorAnalyticsSession.Editor.HTML)
+    }
+
+    @Test
+    fun `toggleHtmlMode tracks editor switch to classic when switching back from HTML`() {
+        whenever(listener.getString(R.string.menu_html_mode_switched_notice)).thenReturn("HTML")
+        whenever(listener.getString(R.string.menu_visual_mode_switched_notice)).thenReturn("Visual")
+
+        handler.setHtmlModeOn(true)
+        handler.toggleHtmlMode()
+
+        verify(analyticsSession).switchEditor(PostEditorAnalyticsSession.Editor.CLASSIC)
+    }
+    // endregion
+
+    // region start tests
+    @Test
+    fun `handler works without listener before start`() {
+        val newHandler = EditorModeHandler(dispatcher)
+        // Should not throw
+        newHandler.toggleHtmlMode()
+        assertThat(newHandler.isHtmlModeOn()).isTrue()
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorNavigationManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/EditorNavigationManagerTest.kt
@@ -1,0 +1,217 @@
+package org.wordpress.android.ui.posts.editor
+
+import androidx.appcompat.widget.Toolbar
+import com.google.android.material.appbar.AppBarLayout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.navigation.EditPostDestination
+import org.wordpress.android.widgets.WPViewPager
+
+@RunWith(MockitoJUnitRunner::class)
+class EditorNavigationManagerTest {
+    @Mock
+    private lateinit var listener: EditorNavigationManager.NavigationListener
+
+    @Mock
+    private lateinit var viewPager: WPViewPager
+
+    @Mock
+    private lateinit var appBarLayout: AppBarLayout
+
+    @Mock
+    private lateinit var toolbar: Toolbar
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    @Mock
+    private lateinit var editPostRepository: EditPostRepository
+
+    @Mock
+    private lateinit var editorPhotoPicker: EditorPhotoPicker
+
+    private lateinit var manager: EditorNavigationManager
+
+    @Before
+    fun setUp() {
+        manager = EditorNavigationManager()
+        manager.start(listener)
+
+        whenever(listener.provideViewPager()).thenReturn(viewPager)
+        whenever(listener.getAppBarLayout()).thenReturn(appBarLayout)
+        whenever(listener.getToolbar()).thenReturn(toolbar)
+        whenever(listener.getSiteModel()).thenReturn(siteModel)
+        whenever(listener.getEditPostRepository()).thenReturn(editPostRepository)
+        whenever(listener.getEditorPhotoPicker()).thenReturn(editorPhotoPicker)
+    }
+
+    // region getPageForDestination tests
+    @Test
+    fun `getPageForDestination returns 0 for Editor`() {
+        assertThat(manager.getPageForDestination(EditPostDestination.Editor))
+            .isEqualTo(EditorNavigationManager.VIEW_PAGER_PAGE_CONTENT)
+    }
+
+    @Test
+    fun `getPageForDestination returns 1 for Settings`() {
+        assertThat(manager.getPageForDestination(EditPostDestination.Settings))
+            .isEqualTo(EditorNavigationManager.VIEW_PAGER_PAGE_SETTINGS)
+    }
+
+    @Test
+    fun `getPageForDestination returns 2 for PublishSettings`() {
+        assertThat(manager.getPageForDestination(EditPostDestination.PublishSettings))
+            .isEqualTo(EditorNavigationManager.VIEW_PAGER_PAGE_PUBLISH_SETTINGS)
+    }
+
+    @Test
+    fun `getPageForDestination returns 3 for History`() {
+        assertThat(manager.getPageForDestination(EditPostDestination.History))
+            .isEqualTo(EditorNavigationManager.VIEW_PAGER_PAGE_HISTORY)
+    }
+    // endregion
+
+    // region updateViewPagerPosition tests
+    @Test
+    fun `updateViewPagerPosition navigates to Editor page`() {
+        whenever(viewPager.currentItem).thenReturn(1) // Currently on Settings
+
+        manager.updateViewPagerPosition(EditPostDestination.Editor)
+
+        verify(viewPager).currentItem = EditorNavigationManager.VIEW_PAGER_PAGE_CONTENT
+    }
+
+    @Test
+    fun `updateViewPagerPosition navigates to Settings page`() {
+        whenever(viewPager.currentItem).thenReturn(0) // Currently on Editor
+
+        manager.updateViewPagerPosition(EditPostDestination.Settings)
+
+        verify(viewPager).currentItem = EditorNavigationManager.VIEW_PAGER_PAGE_SETTINGS
+    }
+
+    @Test
+    fun `updateViewPagerPosition navigates to PublishSettings page`() {
+        whenever(viewPager.currentItem).thenReturn(0)
+
+        manager.updateViewPagerPosition(EditPostDestination.PublishSettings)
+
+        verify(viewPager).currentItem = EditorNavigationManager.VIEW_PAGER_PAGE_PUBLISH_SETTINGS
+    }
+
+    @Test
+    fun `updateViewPagerPosition navigates to History page`() {
+        whenever(viewPager.currentItem).thenReturn(0)
+
+        manager.updateViewPagerPosition(EditPostDestination.History)
+
+        verify(viewPager).currentItem = EditorNavigationManager.VIEW_PAGER_PAGE_HISTORY
+    }
+
+    @Test
+    fun `updateViewPagerPosition does not navigate when already on target page`() {
+        whenever(viewPager.currentItem).thenReturn(EditorNavigationManager.VIEW_PAGER_PAGE_CONTENT)
+
+        manager.updateViewPagerPosition(EditPostDestination.Editor)
+
+        verify(viewPager, never()).currentItem = any()
+    }
+
+    @Test
+    fun `updateViewPagerPosition handles null viewPager`() {
+        whenever(listener.provideViewPager()).thenReturn(null)
+
+        // Should not throw
+        manager.updateViewPagerPosition(EditPostDestination.Editor)
+    }
+    // endregion
+
+    // region updateUIForDestination tests
+    @Test
+    fun `updateUIForDestination sets title for Editor destination`() {
+        whenever(siteModel.name).thenReturn("Test Site")
+
+        manager.updateUIForDestination(EditPostDestination.Editor)
+
+        verify(listener).setTitle(any<CharSequence>())
+    }
+
+    @Test
+    fun `updateUIForDestination hides photo picker for Settings destination`() {
+        whenever(editPostRepository.isPage).thenReturn(false)
+
+        manager.updateUIForDestination(EditPostDestination.Settings)
+
+        verify(editorPhotoPicker).hidePhotoPicker()
+    }
+
+    @Test
+    fun `updateUIForDestination hides photo picker for PublishSettings destination`() {
+        manager.updateUIForDestination(EditPostDestination.PublishSettings)
+
+        verify(editorPhotoPicker).hidePhotoPicker()
+    }
+
+    @Test
+    fun `updateUIForDestination hides photo picker for History destination`() {
+        manager.updateUIForDestination(EditPostDestination.History)
+
+        verify(editorPhotoPicker).hidePhotoPicker()
+    }
+
+    @Test
+    fun `updateUIForDestination invalidates options menu`() {
+        manager.updateUIForDestination(EditPostDestination.Editor)
+
+        verify(listener).invalidateOptionsMenu()
+    }
+
+    @Test
+    fun `updateUIForDestination handles null appBarLayout`() {
+        whenever(listener.getAppBarLayout()).thenReturn(null)
+
+        // Should not throw
+        manager.updateUIForDestination(EditPostDestination.Editor)
+    }
+
+    @Test
+    fun `updateUIForDestination handles null toolbar`() {
+        whenever(listener.getToolbar()).thenReturn(null)
+
+        // Should not throw
+        manager.updateUIForDestination(EditPostDestination.Editor)
+    }
+    // endregion
+
+    // region start tests
+    @Test
+    fun `manager works without listener before start`() {
+        val newManager = EditorNavigationManager()
+
+        // Should not throw
+        newManager.updateViewPagerPosition(EditPostDestination.Editor)
+        newManager.updateUIForDestination(EditPostDestination.Editor)
+    }
+    // endregion
+
+    // region companion object tests
+    @Test
+    fun `companion object constants have correct values`() {
+        assertThat(EditorNavigationManager.VIEW_PAGER_PAGE_CONTENT).isEqualTo(0)
+        assertThat(EditorNavigationManager.VIEW_PAGER_PAGE_SETTINGS).isEqualTo(1)
+        assertThat(EditorNavigationManager.VIEW_PAGER_PAGE_PUBLISH_SETTINGS).isEqualTo(2)
+        assertThat(EditorNavigationManager.VIEW_PAGER_PAGE_HISTORY).isEqualTo(3)
+        assertThat(EditorNavigationManager.VIEW_PAGER_OFFSCREEN_PAGE_LIMIT).isEqualTo(4)
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostLoadingStateManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostLoadingStateManagerTest.kt
@@ -1,0 +1,253 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Context
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.ui.posts.ProgressDialogHelper
+import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
+import org.wordpress.android.ui.utils.UiHelpers
+
+@RunWith(MockitoJUnitRunner::class)
+class PostLoadingStateManagerTest {
+    @Mock
+    private lateinit var progressDialogHelper: ProgressDialogHelper
+
+    @Mock
+    private lateinit var uiHelpers: UiHelpers
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var listener: PostLoadingStateManager.StateChangeListener
+
+    @Mock
+    private lateinit var post: PostImmutableModel
+
+    private lateinit var manager: PostLoadingStateManager
+
+    @Before
+    fun setUp() {
+        manager = PostLoadingStateManager(progressDialogHelper, uiHelpers)
+        manager.setListener(listener)
+    }
+
+    // region state property tests
+    @Test
+    fun `initial state is NONE`() {
+        assertThat(manager.state).isEqualTo(PostLoadingState.NONE)
+    }
+    // endregion
+
+    // region isRemotePreviewingFromEditor tests
+    @Test
+    fun `isRemotePreviewingFromEditor is false for NONE state`() {
+        assertThat(manager.isRemotePreviewingFromEditor).isFalse()
+    }
+
+    @Test
+    fun `isRemotePreviewingFromEditor is true for UPLOADING_FOR_PREVIEW state`() {
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        assertThat(manager.isRemotePreviewingFromEditor).isTrue()
+    }
+
+    @Test
+    fun `isRemotePreviewingFromEditor is true for REMOTE_AUTO_SAVING_FOR_PREVIEW state`() {
+        manager.transitionTo(context, PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW)
+        assertThat(manager.isRemotePreviewingFromEditor).isTrue()
+    }
+
+    @Test
+    fun `isRemotePreviewingFromEditor is true for PREVIEWING state`() {
+        manager.transitionTo(context, PostLoadingState.PREVIEWING)
+        assertThat(manager.isRemotePreviewingFromEditor).isTrue()
+    }
+
+    @Test
+    fun `isRemotePreviewingFromEditor is true for REMOTE_AUTO_SAVE_PREVIEW_ERROR state`() {
+        manager.transitionTo(context, PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR)
+        assertThat(manager.isRemotePreviewingFromEditor).isTrue()
+    }
+
+    @Test
+    fun `isRemotePreviewingFromEditor is false for LOADING_REVISION state`() {
+        manager.transitionTo(context, PostLoadingState.LOADING_REVISION)
+        assertThat(manager.isRemotePreviewingFromEditor).isFalse()
+    }
+    // endregion
+
+    // region isUploadingPostForPreview tests
+    @Test
+    fun `isUploadingPostForPreview is false for NONE state`() {
+        assertThat(manager.isUploadingPostForPreview).isFalse()
+    }
+
+    @Test
+    fun `isUploadingPostForPreview is true for UPLOADING_FOR_PREVIEW state`() {
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        assertThat(manager.isUploadingPostForPreview).isTrue()
+    }
+
+    @Test
+    fun `isUploadingPostForPreview is true for REMOTE_AUTO_SAVING_FOR_PREVIEW state`() {
+        manager.transitionTo(context, PostLoadingState.REMOTE_AUTO_SAVING_FOR_PREVIEW)
+        assertThat(manager.isUploadingPostForPreview).isTrue()
+    }
+
+    @Test
+    fun `isUploadingPostForPreview is false for PREVIEWING state`() {
+        manager.transitionTo(context, PostLoadingState.PREVIEWING)
+        assertThat(manager.isUploadingPostForPreview).isFalse()
+    }
+    // endregion
+
+    // region isRemoteAutoSaveError tests
+    @Test
+    fun `isRemoteAutoSaveError is false for NONE state`() {
+        assertThat(manager.isRemoteAutoSaveError).isFalse()
+    }
+
+    @Test
+    fun `isRemoteAutoSaveError is true for REMOTE_AUTO_SAVE_PREVIEW_ERROR state`() {
+        manager.transitionTo(context, PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR)
+        assertThat(manager.isRemoteAutoSaveError).isTrue()
+    }
+
+    @Test
+    fun `isRemoteAutoSaveError is false for UPLOADING_FOR_PREVIEW state`() {
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        assertThat(manager.isRemoteAutoSaveError).isFalse()
+    }
+    // endregion
+
+    // region transitionTo tests
+    @Test
+    fun `transitionTo returns true for actual state change`() {
+        val result = manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `transitionTo returns false when already in requested state`() {
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        val result = manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `transitionTo updates state property`() {
+        manager.transitionTo(context, PostLoadingState.LOADING_REVISION)
+        assertThat(manager.state).isEqualTo(PostLoadingState.LOADING_REVISION)
+    }
+
+    @Test
+    fun `transitionTo notifies listener of dialog change`() {
+        manager.transitionTo(context, PostLoadingState.LOADING_REVISION)
+        verify(listener).onProgressDialogChanged(anyOrNull())
+    }
+    // endregion
+
+    // region handleRemotePreviewUploadResult tests
+    @Test
+    fun `handleRemotePreviewUploadResult launches preview on success when uploading`() {
+        // Set up uploading state first
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+
+        // Handle successful upload
+        val result = manager.handleRemotePreviewUploadResult(
+            context,
+            isError = false,
+            RemotePreviewType.REMOTE_PREVIEW,
+            post
+        )
+
+        assertThat(result).isEqualTo(PostLoadingStateManager.RemotePreviewResult.PREVIEW_LAUNCHED)
+        verify(listener).onPreviewUploadSuccess()
+        verify(listener).onLaunchPreview(RemotePreviewType.REMOTE_PREVIEW)
+        assertThat(manager.state).isEqualTo(PostLoadingState.PREVIEWING)
+    }
+
+    @Test
+    fun `handleRemotePreviewUploadResult shows error on upload failure`() {
+        manager.transitionTo(context, PostLoadingState.UPLOADING_FOR_PREVIEW)
+
+        val result = manager.handleRemotePreviewUploadResult(
+            context,
+            isError = true,
+            RemotePreviewType.REMOTE_PREVIEW,
+            post
+        )
+
+        assertThat(result).isEqualTo(PostLoadingStateManager.RemotePreviewResult.ERROR)
+        verify(listener).onPreviewUploadError()
+        assertThat(manager.state).isEqualTo(PostLoadingState.NONE)
+    }
+
+    @Test
+    fun `handleRemotePreviewUploadResult shows error on remote auto save error state`() {
+        manager.transitionTo(context, PostLoadingState.REMOTE_AUTO_SAVE_PREVIEW_ERROR)
+
+        val result = manager.handleRemotePreviewUploadResult(
+            context,
+            isError = false,
+            RemotePreviewType.REMOTE_PREVIEW,
+            post
+        )
+
+        assertThat(result).isEqualTo(PostLoadingStateManager.RemotePreviewResult.ERROR)
+        verify(listener).onPreviewUploadError()
+    }
+
+    @Test
+    fun `handleRemotePreviewUploadResult returns NO_ACTION when not in preview state`() {
+        // Manager is in NONE state
+        val result = manager.handleRemotePreviewUploadResult(
+            context,
+            isError = false,
+            RemotePreviewType.REMOTE_PREVIEW,
+            post
+        )
+
+        assertThat(result).isEqualTo(PostLoadingStateManager.RemotePreviewResult.NO_ACTION)
+        verify(listener, never()).onLaunchPreview(any())
+        verify(listener, never()).onPreviewUploadError()
+    }
+    // endregion
+
+    // region getStateValue tests
+    @Test
+    fun `getStateValue returns current state value`() {
+        manager.transitionTo(context, PostLoadingState.LOADING_REVISION)
+        assertThat(manager.getStateValue()).isEqualTo(PostLoadingState.LOADING_REVISION.value)
+    }
+    // endregion
+
+    // region clear tests
+    @Test
+    fun `clear resets state to NONE`() {
+        manager.transitionTo(context, PostLoadingState.PREVIEWING)
+        manager.clear()
+        assertThat(manager.state).isEqualTo(PostLoadingState.NONE)
+    }
+    // endregion
+
+    // region setListener tests
+    @Test
+    fun `setListener with null removes listener`() {
+        manager.setListener(null)
+        // Should not throw when transitioning without listener
+        manager.transitionTo(context, PostLoadingState.LOADING_REVISION)
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinatorTest.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.posts.EditPostRepository
-import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
 import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostPublishingCoordinatorTest.kt
@@ -1,0 +1,200 @@
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Context
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+import org.wordpress.android.ui.posts.PostUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class PostPublishingCoordinatorTest {
+    @Mock
+    private lateinit var accountStore: AccountStore
+
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+
+    @Mock
+    private lateinit var postUtilsWrapper: PostUtilsWrapper
+
+    @Mock
+    private lateinit var uploadUtilsWrapper: UploadUtilsWrapper
+
+    @Mock
+    private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
+    @Mock
+    private lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+
+    @Mock
+    private lateinit var listener: PostPublishingCoordinator.PublishingListener
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var storePostViewModel: StorePostViewModel
+
+    @Mock
+    private lateinit var editPostRepository: EditPostRepository
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    @Mock
+    private lateinit var analyticsSession: PostEditorAnalyticsSession
+
+    private lateinit var coordinator: PostPublishingCoordinator
+
+    @Before
+    fun setUp() {
+        coordinator = PostPublishingCoordinator(
+            accountStore,
+            dispatcher,
+            postUtilsWrapper,
+            uploadUtilsWrapper,
+            analyticsTrackerWrapper,
+            dateTimeUtilsWrapper
+        )
+        coordinator.start(listener)
+
+        whenever(listener.getContext()).thenReturn(context)
+        whenever(listener.provideStorePostViewModel()).thenReturn(storePostViewModel)
+        whenever(listener.getEditPostRepository()).thenReturn(editPostRepository)
+        whenever(listener.getSiteModel()).thenReturn(siteModel)
+        whenever(listener.getPostEditorAnalyticsSession()).thenReturn(analyticsSession)
+    }
+
+    // region performPrimaryAction tests
+    @Test
+    fun `performPrimaryAction tracks analytics and shows bottom sheet for PUBLISH_NOW`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.PUBLISH_NOW)
+
+        coordinator.performPrimaryAction()
+
+        verify(analyticsTrackerWrapper).track(Stat.EDITOR_POST_PUBLISH_TAPPED)
+        verify(listener).showPrepublishingNudgeBottomSheet()
+    }
+
+    @Test
+    fun `performPrimaryAction shows bottom sheet for UPDATE action`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.UPDATE)
+
+        coordinator.performPrimaryAction()
+
+        verify(listener).showPrepublishingNudgeBottomSheet()
+        verify(analyticsTrackerWrapper, never()).track(Stat.EDITOR_POST_PUBLISH_TAPPED)
+    }
+
+    @Test
+    fun `performPrimaryAction shows bottom sheet for SCHEDULE action`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.SCHEDULE)
+
+        coordinator.performPrimaryAction()
+
+        verify(listener).showPrepublishingNudgeBottomSheet()
+    }
+
+    @Test
+    fun `performPrimaryAction shows bottom sheet for SUBMIT_FOR_REVIEW action`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.SUBMIT_FOR_REVIEW)
+
+        coordinator.performPrimaryAction()
+
+        verify(listener).showPrepublishingNudgeBottomSheet()
+    }
+
+    @Test
+    fun `performPrimaryAction shows bottom sheet for CONTINUE action`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.CONTINUE)
+
+        coordinator.performPrimaryAction()
+
+        verify(listener).showPrepublishingNudgeBottomSheet()
+    }
+
+    @Test
+    fun `performPrimaryAction calls uploadPost for SAVE action`() {
+        whenever(listener.providePrimaryAction()).thenReturn(PrimaryEditorAction.SAVE)
+
+        coordinator.performPrimaryAction()
+
+        verify(listener).updateAndSavePostAsyncOnEditorExit(any())
+    }
+    // endregion
+
+    // region uploadPost tests
+    @Test
+    fun `uploadPost calls updateAndSavePostAsyncOnEditorExit`() {
+        coordinator.uploadPost(false)
+
+        verify(listener).updateAndSavePostAsyncOnEditorExit(any())
+    }
+    // endregion
+
+    // region shouldPerformPostUpdateAndPublish tests
+    @Test
+    fun `shouldPerformPostUpdateAndPublish returns true when email is verified and post is null`() {
+        val account = mock<AccountModel>()
+        whenever(account.emailVerified).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(editPostRepository.getPost()).thenReturn(null)
+
+        val result = coordinator.shouldPerformPostUpdateAndPublish()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `shouldPerformPostUpdateAndPublish returns false when no listener`() {
+        val newCoordinator = PostPublishingCoordinator(
+            accountStore,
+            dispatcher,
+            postUtilsWrapper,
+            uploadUtilsWrapper,
+            analyticsTrackerWrapper,
+            dateTimeUtilsWrapper
+        )
+        // Not started with listener
+
+        val result = newCoordinator.shouldPerformPostUpdateAndPublish()
+
+        assertThat(result).isFalse()
+    }
+    // endregion
+
+    // region start tests
+    @Test
+    fun `coordinator works without listener before start`() {
+        val newCoordinator = PostPublishingCoordinator(
+            accountStore,
+            dispatcher,
+            postUtilsWrapper,
+            uploadUtilsWrapper,
+            analyticsTrackerWrapper,
+            dateTimeUtilsWrapper
+        )
+        // Should not throw
+        newCoordinator.performPrimaryAction()
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/ShareContentHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/ShareContentHandlerTest.kt
@@ -1,0 +1,201 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.posts.editor
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.editor.EditorFragmentAbstract
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.editor.media.EditorMedia
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class ShareContentHandlerTest {
+    @Mock
+    private lateinit var editorMedia: EditorMedia
+
+    @Mock
+    private lateinit var listener: ShareContentHandler.ShareContentListener
+
+    @Mock
+    private lateinit var intent: Intent
+
+    @Mock
+    private lateinit var editPostRepository: EditPostRepository
+
+    @Mock
+    private lateinit var editorFragment: EditorFragmentAbstract
+
+    private lateinit var handler: ShareContentHandler
+
+    @Before
+    fun setUp() {
+        handler = ShareContentHandler(editorMedia)
+        whenever(listener.getIntent()).thenReturn(intent)
+        whenever(listener.getEditPostRepository()).thenReturn(editPostRepository)
+        whenever(listener.getEditorFragment()).thenReturn(editorFragment)
+        whenever(listener.isShowGutenbergEditor()).thenReturn(false)
+        handler.start(listener)
+    }
+
+    // region setPostContentFromShareAction tests
+    @Test
+    fun `setPostContentFromShareAction sets hasSetPostContent when text is shared`() {
+        // Arrange
+        whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn("Shared text content")
+        whenever(intent.getStringExtra(Intent.EXTRA_SUBJECT)).thenReturn(null)
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(false)
+
+        // Act
+        handler.setPostContentFromShareAction()
+
+        // Assert
+        verify(listener).setHasSetPostContent(true)
+        verify(editPostRepository).updateAsync(any(), any())
+    }
+
+    @Test
+    fun `setPostContentFromShareAction does not set content when text is null`() {
+        // Arrange
+        whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn(null)
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(false)
+
+        // Act
+        handler.setPostContentFromShareAction()
+
+        // Assert
+        verify(listener, never()).setHasSetPostContent(any())
+        verify(editPostRepository, never()).updateAsync(any(), any())
+    }
+
+    @Test
+    fun `setPostContentFromShareAction calls setPostMediaFromShareAction`() {
+        // Arrange
+        whenever(intent.getStringExtra(Intent.EXTRA_TEXT)).thenReturn(null)
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(false)
+
+        // Act
+        handler.setPostContentFromShareAction()
+
+        // Assert
+        // setPostMediaFromShareAction is called internally, verifies no media added when no EXTRA_STREAM
+        verify(editorMedia, never()).addNewMediaItemsToEditorAsync(any(), any())
+    }
+    // endregion
+
+    // region setPostMediaFromShareAction tests
+    @Test
+    fun `setPostMediaFromShareAction does nothing when EXTRA_STREAM is missing`() {
+        // Arrange
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(false)
+
+        // Act
+        handler.setPostMediaFromShareAction()
+
+        // Assert
+        verify(editorMedia, never()).addNewMediaItemsToEditorAsync(any(), any())
+    }
+
+    @Test
+    fun `setPostMediaFromShareAction removes EXTRA_STREAM after processing`() {
+        // Arrange
+        val uri = mock<Uri>()
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(true)
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
+        whenever(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)).thenReturn(uri)
+        // Mock that it's a media type
+        whenever(intent.type).thenReturn("image/jpeg")
+
+        // Act
+        handler.setPostMediaFromShareAction()
+
+        // Assert
+        verify(intent).removeExtra(Intent.EXTRA_STREAM)
+    }
+
+    @Test
+    fun `setPostMediaFromShareAction processes ACTION_SEND_MULTIPLE`() {
+        // Arrange
+        val uri1 = mock<Uri>()
+        val uri2 = mock<Uri>()
+        val uris = arrayListOf(uri1, uri2)
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(true)
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND_MULTIPLE)
+        whenever(intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)).thenReturn(uris)
+        whenever(intent.type).thenReturn("image/*")
+
+        // Act - method should process without throwing
+        handler.setPostMediaFromShareAction()
+
+        // Assert - verify the parcelable list was retrieved
+        verify(intent).getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+    }
+
+    @Test
+    fun `setPostMediaFromShareAction processes ACTION_SEND with single image`() {
+        // Arrange
+        val uri = mock<Uri>()
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(true)
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
+        whenever(intent.type).thenReturn("image/jpeg")
+        whenever(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)).thenReturn(uri)
+
+        // Act - method should process without throwing
+        handler.setPostMediaFromShareAction()
+
+        // Assert - verify getParcelableExtra was called for single send
+        verify(intent).getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+    }
+
+    @Test
+    fun `setPostMediaFromShareAction processes ACTION_SEND with single video`() {
+        // Arrange
+        val uri = mock<Uri>()
+        whenever(intent.hasExtra(Intent.EXTRA_STREAM)).thenReturn(true)
+        whenever(intent.action).thenReturn(Intent.ACTION_SEND)
+        whenever(intent.type).thenReturn("video/mp4")
+        whenever(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)).thenReturn(uri)
+
+        // Act - method should process without throwing
+        handler.setPostMediaFromShareAction()
+
+        // Assert - verify getParcelableExtra was called for single send
+        verify(intent).getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+    }
+    // endregion
+
+    // region Edge cases
+    @Test
+    fun `setPostContentFromShareAction does nothing when listener returns null intent`() {
+        // Arrange
+        whenever(listener.getIntent()).thenReturn(null)
+
+        // Act
+        handler.setPostContentFromShareAction()
+
+        // Assert
+        verify(listener, never()).setHasSetPostContent(any())
+    }
+
+    @Test
+    fun `setPostMediaFromShareAction does nothing when listener returns null intent`() {
+        // Arrange
+        whenever(listener.getIntent()).thenReturn(null)
+
+        // Act
+        handler.setPostMediaFromShareAction()
+
+        // Assert
+        verify(editorMedia, never()).addNewMediaItemsToEditorAsync(any(), any())
+    }
+    // endregion
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/MediaUploadCoordinatorTest.kt
@@ -1,0 +1,295 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.editor.EditorMediaUploadListener
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
+import org.wordpress.android.util.NetworkUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class MediaUploadCoordinatorTest {
+    @Mock
+    private lateinit var editorMedia: EditorMedia
+
+    @Mock
+    private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    @Mock
+    private lateinit var listener: MediaUploadCoordinator.UploadEventListener
+
+    @Mock
+    private lateinit var editorMediaUploadListener: EditorMediaUploadListener
+
+    private lateinit var coordinator: MediaUploadCoordinator
+
+    @Before
+    fun setUp() {
+        coordinator = MediaUploadCoordinator(editorMedia, networkUtilsWrapper)
+        whenever(listener.isFinishing()).thenReturn(false)
+        whenever(listener.getPostId()).thenReturn(TEST_POST_ID)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        coordinator.start(listener, editorMediaUploadListener)
+    }
+
+    // region processMediaUploadedEvent tests
+    @Test
+    fun `processMediaUploadedEvent returns false when Activity is finishing`() {
+        // Arrange
+        whenever(listener.isFinishing()).thenReturn(true)
+        val event = createMediaUploadedEvent(isError = false, completed = true)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `processMediaUploadedEvent pauses upload when error and no network`() {
+        // Arrange
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        val media = createMediaModel()
+        val error = MediaError(MediaErrorType.GENERIC_ERROR)
+        val event = createMediaUploadedEvent(media = media, isError = true, error = error)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isTrue()
+        verify(editorMedia).onMediaUploadPaused(eq(editorMediaUploadListener), eq(media), eq(error))
+    }
+
+    @Test
+    fun `processMediaUploadedEvent handles error when network available`() {
+        // Arrange
+        val media = createMediaModel()
+        val error = MediaError(MediaErrorType.GENERIC_ERROR)
+        val event = createMediaUploadedEvent(media = media, isError = true, error = error)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isTrue()
+        verify(editorMedia).onMediaUploadError(eq(editorMediaUploadListener), eq(media), eq(error))
+    }
+
+    @Test
+    fun `processMediaUploadedEvent handles successful completion with valid URL`() {
+        // Arrange
+        val media = createMediaModel(url = "https://example.com/image.jpg")
+        val event = createMediaUploadedEvent(media = media, completed = true)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isTrue()
+        verify(editorMediaUploadListener).onMediaUploadSucceeded(eq(media.id.toString()), any())
+    }
+
+    @Test
+    fun `processMediaUploadedEvent handles completion with empty URL as error`() {
+        // Arrange
+        val media = createMediaModel(url = "")
+        val event = createMediaUploadedEvent(media = media, completed = true)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isTrue()
+        verify(editorMedia).onMediaUploadError(eq(editorMediaUploadListener), eq(media), any())
+    }
+
+    @Test
+    fun `processMediaUploadedEvent handles progress update`() {
+        // Arrange
+        val media = createMediaModel()
+        val event = createMediaUploadedEvent(media = media, progress = 0.5f)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isTrue()
+        verify(editorMediaUploadListener).onMediaUploadProgress(eq(media.id.toString()), eq(0.5f))
+    }
+
+    @Test
+    fun `processMediaUploadedEvent returns false when media is null`() {
+        // Arrange
+        val event = createMediaUploadedEvent(media = null)
+
+        // Act
+        val result = coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `processMediaUploadedEvent calls onFeaturedImageUploaded for featured image`() {
+        // Arrange
+        val media = createMediaModel(
+            url = "https://example.com/image.jpg",
+            markedLocallyAsFeatured = true,
+            localPostId = TEST_POST_ID,
+            mediaId = TEST_MEDIA_ID
+        )
+        val event = createMediaUploadedEvent(media = media, completed = true)
+
+        // Act
+        coordinator.processMediaUploadedEvent(event)
+
+        // Assert
+        verify(listener).onFeaturedImageUploaded(TEST_MEDIA_ID)
+        verify(editorMediaUploadListener, never()).onMediaUploadSucceeded(any(), any())
+    }
+    // endregion
+
+    // region handleUploadSuccess tests
+    @Test
+    fun `handleUploadSuccess notifies listener for non-featured image`() {
+        // Arrange
+        val media = createMediaModel(
+            markedLocallyAsFeatured = false,
+            url = "https://example.com/image.jpg"
+        )
+
+        // Act
+        coordinator.handleUploadSuccess(media)
+
+        // Assert
+        verify(editorMediaUploadListener).onMediaUploadSucceeded(eq(media.id.toString()), any())
+    }
+
+    @Test
+    fun `handleUploadSuccess calls onFeaturedImageUploaded for featured image in current post`() {
+        // Arrange
+        val media = createMediaModel(
+            markedLocallyAsFeatured = true,
+            localPostId = TEST_POST_ID,
+            mediaId = TEST_MEDIA_ID
+        )
+
+        // Act
+        coordinator.handleUploadSuccess(media)
+
+        // Assert
+        verify(listener).onFeaturedImageUploaded(TEST_MEDIA_ID)
+    }
+
+    @Test
+    fun `handleUploadSuccess ignores featured image for different post`() {
+        // Arrange
+        val media = createMediaModel(
+            markedLocallyAsFeatured = true,
+            localPostId = 999, // Different post ID
+            mediaId = TEST_MEDIA_ID
+        )
+
+        // Act
+        coordinator.handleUploadSuccess(media)
+
+        // Assert
+        verify(listener, never()).onFeaturedImageUploaded(any())
+        verify(editorMediaUploadListener, never()).onMediaUploadSucceeded(any(), any())
+    }
+    // endregion
+
+    // region handleUploadProgress tests
+    @Test
+    fun `handleUploadProgress notifies editor listener`() {
+        // Arrange
+        val media = createMediaModel()
+
+        // Act
+        coordinator.handleUploadProgress(media, 0.75f)
+
+        // Assert
+        verify(editorMediaUploadListener).onMediaUploadProgress(eq(media.id.toString()), eq(0.75f))
+    }
+
+    @Test
+    fun `handleUploadProgress handles null media`() {
+        // Act
+        coordinator.handleUploadProgress(null, 0.5f)
+
+        // Assert
+        verify(editorMediaUploadListener).onMediaUploadProgress(eq("null"), eq(0.5f))
+    }
+    // endregion
+
+    // region setEditorMediaUploadListener tests
+    @Test
+    fun `setEditorMediaUploadListener updates listener for subsequent events`() {
+        // Arrange
+        val newListener = org.mockito.kotlin.mock<EditorMediaUploadListener>()
+        coordinator.setEditorMediaUploadListener(newListener)
+        val media = createMediaModel()
+
+        // Act
+        coordinator.handleUploadProgress(media, 0.5f)
+
+        // Assert
+        verify(newListener).onMediaUploadProgress(any(), any())
+        verify(editorMediaUploadListener, never()).onMediaUploadProgress(any(), any())
+    }
+    // endregion
+
+    // region Helper methods
+    private fun createMediaModel(
+        id: Int = TEST_MEDIA_LOCAL_ID,
+        mediaId: Long = TEST_MEDIA_ID,
+        url: String? = "https://example.com/image.jpg",
+        markedLocallyAsFeatured: Boolean = false,
+        localPostId: Int = TEST_POST_ID,
+        isVideo: Boolean = false
+    ): MediaModel {
+        return MediaModel(0, 0).apply {
+            this.id = id
+            this.mediaId = mediaId
+            url?.let { setUrl(it) }
+            this.markedLocallyAsFeatured = markedLocallyAsFeatured
+            this.localPostId = localPostId
+            // isVideo is determined by mime type
+            setMimeType(if (isVideo) "video/mp4" else "image/jpeg")
+        }
+    }
+
+    private fun createMediaUploadedEvent(
+        media: MediaModel? = createMediaModel(),
+        isError: Boolean = false,
+        completed: Boolean = false,
+        progress: Float = 0f,
+        error: MediaError = MediaError(MediaErrorType.GENERIC_ERROR)
+    ): OnMediaUploaded {
+        return OnMediaUploaded(media, progress, completed, false).apply {
+            if (isError) {
+                this.error = error
+            }
+        }
+    }
+    // endregion
+
+    companion object {
+        private const val TEST_POST_ID = 123
+        private const val TEST_MEDIA_LOCAL_ID = 456
+        private const val TEST_MEDIA_ID = 789L
+    }
+}


### PR DESCRIPTION
## Summary

Refactors EditPostActivity by extracting cohesive responsibilities into smaller, testable helper classes.

**Phase 1 (Initial commit):**
- `MediaUploadCoordinator` - Coordinates media upload events between FluxC and the editor
- `PostLoadingStateManager` - Manages post loading states and progress dialogs
- `EditorIntentProcessor` - Processes editor intents and determines post setup actions

**Phase 2:**
- `EditorMediaPickerHandler` - Handles media picker launching for the post editor
- `EditorActivityResultHandler` - Handles activity result processing
- `ShareContentHandler` - Handles setting post content from share intents

**Phase 3:**
- `EditorModeHandler` - Manages editor mode switching (HTML/Visual/Gutenberg)
- `EditorNavigationManager` - Manages ViewPager navigation and UI updates for destinations

**Phase 4:**
- `PostPublishingCoordinator` - Handles post publishing workflow, email verification, and upload validation

Each handler follows the existing `@Reusable` Dagger pattern with callback interfaces for Activity-level operations. This approach:
- Improves testability through dependency injection
- Reduces EditPostActivity complexity
- Creates clear separation of concerns
- Enables independent unit testing of each component

## Test plan

**Build verification:**
- [x] `./gradlew assembleWordPressVanillaDebug` passes
- [x] `./gradlew detekt` passes
- [x] `./gradlew checkstyle` passes
- [x] `./gradlew :WordPress:testWordPressVanillaDebugUnitTest` passes

**Manual testing:**

Media upload flow:
1. Create a new post
2. Add images/videos from device, WP media library, stock photos, and GIFs
- [ ] Verify upload progress shows correctly
- [ ] Verify uploads complete successfully
- [ ] Verify retry works on failed uploads

Activity result handling:
1. Add media from various sources (camera, gallery, stock media, GIFs)
- [ ] Verify media is added to post correctly
- [ ] Verify cancellation is handled properly

Share content:
1. Share text/images to WordPress from another app
- [ ] Verify shared content appears in new post

Editor mode switching:
1. Open a post in the editor
2. Toggle HTML mode via the menu
- [ ] Verify mode switches and notice appears
- [ ] Verify toggling back to visual mode works

Navigation:
1. Open post settings
- [ ] Verify title changes appropriately
- [ ] Verify navigation between Editor/Settings/PublishSettings/History works

Publishing flow:
1. Create a new post with content
2. Tap the publish button
- [ ] Verify prepublishing bottom sheet appears
- [ ] Verify publishing workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)