### PR TITLE
CMM-1142 stats create todays card

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -573,6 +573,9 @@ dependencies {
     // Cascade - Compose nested menu
     implementation(libs.cascade.compose)
 
+    // Vico - Charts for Compose
+    implementation(libs.vico.compose.m3)
+
     implementation(libs.automattic.encryptedlogging)
     implementation(libs.automattic.tracks.crashlogging)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -139,7 +139,6 @@ private fun TrafficTabContent(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp)
     ) {
         TodaysStatsCard(uiState = uiState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -17,11 +17,15 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -128,18 +132,36 @@ private fun StatsTabContent(tab: StatsTab) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TrafficTabContent(
     viewModel: TodaysStatsViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
+    val pullToRefreshState = rememberPullToRefreshState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+    PullToRefreshBox(
+        modifier = Modifier.fillMaxSize(),
+        isRefreshing = isRefreshing,
+        state = pullToRefreshState,
+        onRefresh = { viewModel.refresh() },
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                state = pullToRefreshState,
+                isRefreshing = isRefreshing,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
+        }
     ) {
-        TodaysStatsCard(uiState = uiState)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            TodaysStatsCard(uiState = uiState)
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -21,16 +23,22 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.newstats.todaysstat.TodaysStatsCard
+import org.wordpress.android.ui.newstats.todaysstat.TodaysStatsViewModel
 
 @AndroidEntryPoint
 class NewStatsActivity : BaseAppCompatActivity() {
@@ -115,6 +123,30 @@ private fun NewStatsScreen(
 
 @Composable
 private fun StatsTabContent(tab: StatsTab) {
+    when (tab) {
+        StatsTab.TRAFFIC -> TrafficTabContent()
+        else -> PlaceholderTabContent(tab)
+    }
+}
+
+@Composable
+private fun TrafficTabContent(
+    viewModel: TodaysStatsViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        TodaysStatsCard(uiState = uiState)
+    }
+}
+
+@Composable
+private fun PlaceholderTabContent(tab: StatsTab) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.newstats.todaysstat
 
+import android.graphics.DashPathEffect
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -238,15 +239,16 @@ private fun TitleSection() {
 @Composable
 private fun StatsChart(chartData: ChartData) {
     val modelProducer = remember { CartesianChartModelProducer() }
+    val hasPreviousPeriod = chartData.previousPeriod.isNotEmpty()
 
     LaunchedEffect(chartData) {
         if (chartData.currentPeriod.isNotEmpty()) {
             modelProducer.runTransaction {
                 lineSeries {
+                    // Today's data (solid line)
                     series(chartData.currentPeriod.map { it.views.toInt() })
-                }
-                if (chartData.previousPeriod.isNotEmpty()) {
-                    lineSeries {
+                    // Yesterday's data (dashed line) - only if available
+                    if (hasPreviousPeriod) {
                         series(chartData.previousPeriod.map { it.views.toInt() })
                     }
                 }
@@ -275,19 +277,25 @@ private fun StatsChart(chartData: ChartData) {
     val primaryColor = MaterialTheme.colorScheme.primary
     val secondaryColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
 
+    // Create fill for dashed line (yesterday's data)
+    val secondaryFill = fill(secondaryColor)
+    val dashedLine = remember(secondaryFill) {
+        DashedLine(LineCartesianLayer.LineFill.single(secondaryFill))
+    }
+
     CartesianChartHost(
         chart = rememberCartesianChart(
             rememberLineCartesianLayer(
                 lineProvider = LineCartesianLayer.LineProvider.series(
+                    // Today's line - solid with area fill
                     LineCartesianLayer.Line(
                         fill = LineCartesianLayer.LineFill.single(fill(primaryColor)),
                         areaFill = LineCartesianLayer.AreaFill.single(
                             fill(primaryColor.copy(alpha = 0.2f))
                         )
                     ),
-                    LineCartesianLayer.Line(
-                        fill = LineCartesianLayer.LineFill.single(fill(secondaryColor))
-                    )
+                    // Yesterday's line - dashed, no area fill
+                    dashedLine
                 )
             )
         ),
@@ -475,5 +483,20 @@ private fun TodaysStatsCardLoadedDarkPreview() {
                 onCardClick = {}
             )
         )
+    }
+}
+
+/**
+ * Custom Line implementation that draws a dashed line.
+ * Used for showing yesterday's stats comparison in the chart.
+ */
+private class DashedLine(
+    fill: LineCartesianLayer.LineFill
+) : LineCartesianLayer.Line(fill) {
+    init {
+        linePaint.apply {
+            strokeWidth = 4f
+            pathEffect = DashPathEffect(floatArrayOf(10f, 10f), 0f)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -89,30 +89,73 @@ private fun LoadingContent() {
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        CardHeader()
-        Spacer(modifier = Modifier.height(12.dp))
-        // Placeholder for chart
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(ChartHeight)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        // Placeholder for metrics
+        // Top section: Title + Chart placeholder
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            repeat(4) {
+            // Left: Title and date placeholder
+            Column(modifier = Modifier.weight(0.4f)) {
                 Box(
                     modifier = Modifier
-                        .width(60.dp)
-                        .height(40.dp)
+                        .width(80.dp)
+                        .height(24.dp)
                         .clip(RoundedCornerShape(4.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                 )
+                Spacer(modifier = Modifier.height(4.dp))
+                Box(
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(16.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                )
+            }
+            // Right: Chart placeholder
+            Box(
+                modifier = Modifier
+                    .weight(0.6f)
+                    .height(ChartHeight)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        // Bottom section: Metrics placeholder
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            // Views placeholder (larger)
+            Column {
+                Box(
+                    modifier = Modifier
+                        .width(60.dp)
+                        .height(12.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Box(
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(36.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                )
+            }
+            Spacer(modifier = Modifier.width(24.dp))
+            // Other metrics placeholder
+            repeat(3) {
+                Box(
+                    modifier = Modifier
+                        .width(50.dp)
+                        .height(24.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                )
+                Spacer(modifier = Modifier.width(16.dp))
             }
         }
     }
@@ -126,10 +169,21 @@ private fun LoadedContent(state: TodaysStatsCardUiState.Loaded) {
             .clickable(onClick = state.onCardClick)
             .padding(CardPadding)
     ) {
-        CardHeader()
+        // Top section: Title/Date on left, Chart on right
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top
+        ) {
+            // Left: Title and date
+            TitleSection()
+            Spacer(modifier = Modifier.width(16.dp))
+            // Right: Chart
+            Box(modifier = Modifier.weight(1f)) {
+                StatsChart(chartData = state.chartData)
+            }
+        }
         Spacer(modifier = Modifier.height(12.dp))
-        StatsChart(chartData = state.chartData)
-        Spacer(modifier = Modifier.height(16.dp))
+        // Bottom section: Metrics
         MetricsRow(
             views = state.views,
             visitors = state.visitors,
@@ -147,7 +201,7 @@ private fun ErrorContent(state: TodaysStatsCardUiState.Error) {
             .padding(CardPadding),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        CardHeader()
+        TitleSection()
         Spacer(modifier = Modifier.height(24.dp))
         Text(
             text = state.message,
@@ -162,20 +216,17 @@ private fun ErrorContent(state: TodaysStatsCardUiState.Error) {
 }
 
 @Composable
-private fun CardHeader() {
+private fun TitleSection() {
     val dateFormat = remember { SimpleDateFormat("EEEE, MMM d", Locale.getDefault()) }
     val formattedDate = remember { dateFormat.format(Date()) }
 
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
+    Column {
         Text(
-            text = stringResource(R.string.stats_insights_today),
+            text = stringResource(R.string.stats_insights_today_stats),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
+        Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = formattedDate,
             style = MaterialTheme.typography.bodySmall,
@@ -256,75 +307,76 @@ private fun MetricsRow(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
+        verticalAlignment = Alignment.Bottom
     ) {
-        MetricItem(
-            icon = Icons.Default.Visibility,
+        // Views - prominent on the left
+        PrimaryMetricItem(
             value = formatStatValue(views),
-            label = stringResource(R.string.stats_views),
-            isPrimary = true
+            label = stringResource(R.string.stats_views)
         )
-        MetricItem(
-            icon = Icons.Default.Person,
-            value = formatStatValue(visitors),
-            label = stringResource(R.string.stats_visitors)
+        Spacer(modifier = Modifier.weight(1f))
+        // Secondary metrics on the right
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SecondaryMetricItem(
+                icon = Icons.Default.Person,
+                value = formatStatValue(visitors)
+            )
+            SecondaryMetricItem(
+                icon = Icons.Default.FavoriteBorder,
+                value = formatStatValue(likes)
+            )
+            SecondaryMetricItem(
+                icon = Icons.Default.ChatBubbleOutline,
+                value = formatStatValue(comments)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PrimaryMetricItem(
+    value: String,
+    label: String
+) {
+    Column {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        MetricItem(
-            icon = Icons.Default.FavoriteBorder,
-            value = formatStatValue(likes),
-            label = stringResource(R.string.stats_likes)
-        )
-        MetricItem(
-            icon = Icons.Default.ChatBubbleOutline,
-            value = formatStatValue(comments),
-            label = stringResource(R.string.stats_comments)
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
         )
     }
 }
 
 @Composable
-private fun MetricItem(
+private fun SecondaryMetricItem(
     icon: ImageVector,
-    value: String,
-    label: String,
-    isPrimary: Boolean = false
+    value: String
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MetricSpacing)
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(MetricSpacing)
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = label,
-                modifier = Modifier.size(MetricIconSize),
-                tint = if (isPrimary) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                }
-            )
-            Text(
-                text = value,
-                style = if (isPrimary) {
-                    MaterialTheme.typography.titleLarge
-                } else {
-                    MaterialTheme.typography.titleMedium
-                },
-                fontWeight = FontWeight.Bold,
-                color = if (isPrimary) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurface
-                }
-            )
-        }
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(MetricIconSize),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -40,9 +40,13 @@ import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.common.fill
+import com.patrykandpatrick.vico.compose.common.shader.verticalGradient
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import java.text.SimpleDateFormat
@@ -277,26 +281,50 @@ private fun StatsChart(chartData: ChartData) {
     val primaryColor = MaterialTheme.colorScheme.primary
     val secondaryColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
 
+    // Create gradient shader for area fill (primary color fading to transparent)
+    val areaGradient = ShaderProvider.verticalGradient(
+        colors = arrayOf(
+            primaryColor.copy(alpha = 0.8f),
+            primaryColor.copy(alpha = 0f)
+        )
+    )
+
     // Create fill for dashed line (yesterday's data)
     val secondaryFill = fill(secondaryColor)
     val dashedLine = remember(secondaryFill) {
         DashedLine(LineCartesianLayer.LineFill.single(secondaryFill))
     }
 
+    // Custom range provider that fits data to chart height (no forced zero baseline)
+    val rangeProvider = remember {
+        object : CartesianLayerRangeProvider {
+            override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
+                // Use actual minimum with small padding below
+                val range = maxY - minY
+                return if (range > 0) minY - (range * 0.1) else 0.0
+            }
+
+            override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
+                // Use actual maximum with small padding above
+                val range = maxY - minY
+                return if (range > 0) maxY + (range * 0.1) else 1.0
+            }
+        }
+    }
+
     CartesianChartHost(
         chart = rememberCartesianChart(
             rememberLineCartesianLayer(
                 lineProvider = LineCartesianLayer.LineProvider.series(
-                    // Today's line - solid with area fill
+                    // Today's line - solid with gradient area fill
                     LineCartesianLayer.Line(
                         fill = LineCartesianLayer.LineFill.single(fill(primaryColor)),
-                        areaFill = LineCartesianLayer.AreaFill.single(
-                            fill(primaryColor.copy(alpha = 0.2f))
-                        )
+                        areaFill = LineCartesianLayer.AreaFill.single(fill(areaGradient))
                     ),
                     // Yesterday's line - dashed, no area fill
                     dashedLine
-                )
+                ),
+                rangeProvider = rangeProvider
             )
         ),
         modelProducer = modelProducer,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.newstats.todaysstat
 
-import android.graphics.DashPathEffect
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -37,15 +36,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.common.fill
 import com.patrykandpatrick.vico.compose.common.shader.verticalGradient
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
-import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
-import com.patrykandpatrick.vico.core.common.data.ExtraStore
 import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
@@ -289,45 +287,27 @@ private fun StatsChart(chartData: ChartData) {
         )
     )
 
-    // Create fill for dashed line (yesterday's data)
-    val secondaryFill = fill(secondaryColor)
-    val dashedLine = remember(secondaryFill) {
-        DashedLine(LineCartesianLayer.LineFill.single(secondaryFill))
-    }
-
-    // Custom range provider that fits data to chart height (no forced zero baseline)
-    val rangeProvider = remember {
-        object : CartesianLayerRangeProvider {
-            override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                // Use actual minimum with small padding below
-                val range = maxY - minY
-                return if (range > 0) minY - (range * 0.1) else 0.0
-            }
-
-            override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore): Double {
-                // Use actual maximum with small padding above
-                val range = maxY - minY
-                return if (range > 0) maxY + (range * 0.1) else 1.0
-            }
-        }
-    }
-
     CartesianChartHost(
         chart = rememberCartesianChart(
             rememberLineCartesianLayer(
                 lineProvider = LineCartesianLayer.LineProvider.series(
-                    // Today's line - solid with gradient area fill
+                    // Today's line - solid with gradient area fill, curved
                     LineCartesianLayer.Line(
                         fill = LineCartesianLayer.LineFill.single(fill(primaryColor)),
-                        areaFill = LineCartesianLayer.AreaFill.single(fill(areaGradient))
+                        areaFill = LineCartesianLayer.AreaFill.single(fill(areaGradient)),
+                        pointConnector = LineCartesianLayer.PointConnector.cubic()
                     ),
-                    // Yesterday's line - dashed, no area fill
-                    dashedLine
-                ),
-                rangeProvider = rangeProvider
+                    // Yesterday's line - dashed, no area fill, curved
+                    LineCartesianLayer.Line(
+                        fill = LineCartesianLayer.LineFill.single(fill(secondaryColor)),
+                        stroke = LineCartesianLayer.LineStroke.Dashed(),
+                        pointConnector = LineCartesianLayer.PointConnector.cubic()
+                    )
+                )
             )
         ),
         modelProducer = modelProducer,
+        scrollState = rememberVicoScrollState(scrollEnabled = false),
         modifier = Modifier
             .fillMaxWidth()
             .height(ChartHeight)
@@ -514,17 +494,4 @@ private fun TodaysStatsCardLoadedDarkPreview() {
     }
 }
 
-/**
- * Custom Line implementation that draws a dashed line.
- * Used for showing yesterday's stats comparison in the chart.
- */
-private class DashedLine(
-    fill: LineCartesianLayer.LineFill
-) : LineCartesianLayer.Line(fill) {
-    init {
-        linePaint.apply {
-            strokeWidth = 4f
-            pathEffect = DashPathEffect(floatArrayOf(10f, 10f), 0f)
-        }
-    }
-}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -1,5 +1,11 @@
 package org.wordpress.android.ui.newstats.todaysstat
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -24,10 +30,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -87,6 +96,29 @@ fun TodaysStatsCard(
 
 @Composable
 private fun LoadingContent() {
+    val shimmerColors = listOf(
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+    )
+
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateAnimation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmer_translate"
+    )
+
+    val shimmerBrush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset(translateAnimation - 500f, 0f),
+        end = Offset(translateAnimation, 0f)
+    )
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -104,7 +136,7 @@ private fun LoadingContent() {
                         .width(80.dp)
                         .height(24.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(shimmerBrush)
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Box(
@@ -112,7 +144,7 @@ private fun LoadingContent() {
                         .width(100.dp)
                         .height(16.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(shimmerBrush)
                 )
             }
             // Right: Chart placeholder
@@ -121,7 +153,7 @@ private fun LoadingContent() {
                     .weight(0.6f)
                     .height(ChartHeight)
                     .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .background(shimmerBrush)
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
@@ -137,7 +169,7 @@ private fun LoadingContent() {
                         .width(60.dp)
                         .height(12.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(shimmerBrush)
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Box(
@@ -145,7 +177,7 @@ private fun LoadingContent() {
                         .width(80.dp)
                         .height(36.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(shimmerBrush)
                 )
             }
             Spacer(modifier = Modifier.width(24.dp))
@@ -156,7 +188,7 @@ private fun LoadingContent() {
                         .width(50.dp)
                         .height(24.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .background(shimmerBrush)
                 )
                 Spacer(modifier = Modifier.width(16.dp))
             }
@@ -201,19 +233,47 @@ private fun ErrorContent(state: TodaysStatsCardUiState.Error) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(CardPadding),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(CardPadding)
     ) {
-        TitleSection()
-        Spacer(modifier = Modifier.height(24.dp))
-        Text(
-            text = state.message,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.error
-        )
+        // Top section: Title/Date on left, Empty chart placeholder on right
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top
+        ) {
+            // Left: Title and date
+            TitleSection()
+            Spacer(modifier = Modifier.width(16.dp))
+            // Right: Empty chart placeholder
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(ChartHeight)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.stats_no_data_yet),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = state.onRetry) {
-            Text(text = stringResource(R.string.retry))
+        // Error message and retry button centered
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = state.message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = state.onRetry) {
+                Text(text = stringResource(R.string.retry))
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -29,7 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -57,6 +55,8 @@ private val CardMargin = 16.dp
 private val ChartHeight = 80.dp
 private val MetricIconSize = 16.dp
 private val MetricSpacing = 4.dp
+private const val THOUSAND = 1_000
+private const val MILLION = 1_000_000
 
 @Composable
 fun TodaysStatsCard(
@@ -399,8 +399,8 @@ private fun SecondaryMetricItem(
 
 private fun formatStatValue(value: Int): String {
     return when {
-        value >= 1_000_000 -> String.format(Locale.getDefault(), "%.1fM", value / 1_000_000.0)
-        value >= 1_000 -> String.format(Locale.getDefault(), "%.1fK", value / 1_000.0)
+        value >= MILLION -> String.format(Locale.getDefault(), "%.1fM", value / MILLION.toDouble())
+        value >= THOUSAND -> String.format(Locale.getDefault(), "%.1fK", value / THOUSAND.toDouble())
         else -> value.toString()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -493,5 +493,3 @@ private fun TodaysStatsCardLoadedDarkPreview() {
         )
     }
 }
-
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -1,0 +1,396 @@
+package org.wordpress.android.ui.newstats.todaysstat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChatBubbleOutline
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.common.fill
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private val CardCornerRadius = 16.dp
+private val CardPadding = 16.dp
+private val ChartHeight = 80.dp
+private val MetricIconSize = 16.dp
+private val MetricSpacing = 4.dp
+
+@Composable
+fun TodaysStatsCard(
+    uiState: TodaysStatsCardUiState,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(CardCornerRadius)),
+        shape = RoundedCornerShape(CardCornerRadius),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        when (uiState) {
+            is TodaysStatsCardUiState.Loading -> LoadingContent()
+            is TodaysStatsCardUiState.Loaded -> LoadedContent(uiState)
+            is TodaysStatsCardUiState.Error -> ErrorContent(uiState)
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding)
+    ) {
+        CardHeader()
+        Spacer(modifier = Modifier.height(12.dp))
+        // Placeholder for chart
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ChartHeight)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        // Placeholder for metrics
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            repeat(4) {
+                Box(
+                    modifier = Modifier
+                        .width(60.dp)
+                        .height(40.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedContent(state: TodaysStatsCardUiState.Loaded) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = state.onCardClick)
+            .padding(CardPadding)
+    ) {
+        CardHeader()
+        Spacer(modifier = Modifier.height(12.dp))
+        StatsChart(chartData = state.chartData)
+        Spacer(modifier = Modifier.height(16.dp))
+        MetricsRow(
+            views = state.views,
+            visitors = state.visitors,
+            likes = state.likes,
+            comments = state.comments
+        )
+    }
+}
+
+@Composable
+private fun ErrorContent(state: TodaysStatsCardUiState.Error) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CardHeader()
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = state.message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = state.onRetry) {
+            Text(text = stringResource(R.string.retry))
+        }
+    }
+}
+
+@Composable
+private fun CardHeader() {
+    val dateFormat = remember { SimpleDateFormat("EEEE, MMM d", Locale.getDefault()) }
+    val formattedDate = remember { dateFormat.format(Date()) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(R.string.stats_insights_today),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = formattedDate,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun StatsChart(chartData: ChartData) {
+    val modelProducer = remember { CartesianChartModelProducer() }
+
+    LaunchedEffect(chartData) {
+        if (chartData.currentPeriod.isNotEmpty()) {
+            modelProducer.runTransaction {
+                lineSeries {
+                    series(chartData.currentPeriod.map { it.views.toInt() })
+                }
+                if (chartData.previousPeriod.isNotEmpty()) {
+                    lineSeries {
+                        series(chartData.previousPeriod.map { it.views.toInt() })
+                    }
+                }
+            }
+        }
+    }
+
+    if (chartData.currentPeriod.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ChartHeight)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.stats_no_data_yet),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val secondaryColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+
+    CartesianChartHost(
+        chart = rememberCartesianChart(
+            rememberLineCartesianLayer(
+                lineProvider = LineCartesianLayer.LineProvider.series(
+                    LineCartesianLayer.Line(
+                        fill = LineCartesianLayer.LineFill.single(fill(primaryColor)),
+                        areaFill = LineCartesianLayer.AreaFill.single(
+                            fill(primaryColor.copy(alpha = 0.2f))
+                        )
+                    ),
+                    LineCartesianLayer.Line(
+                        fill = LineCartesianLayer.LineFill.single(fill(secondaryColor))
+                    )
+                )
+            )
+        ),
+        modelProducer = modelProducer,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ChartHeight)
+    )
+}
+
+@Composable
+private fun MetricsRow(
+    views: Int,
+    visitors: Int,
+    likes: Int,
+    comments: Int
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        MetricItem(
+            icon = Icons.Default.Visibility,
+            value = formatStatValue(views),
+            label = stringResource(R.string.stats_views),
+            isPrimary = true
+        )
+        MetricItem(
+            icon = Icons.Default.Person,
+            value = formatStatValue(visitors),
+            label = stringResource(R.string.stats_visitors)
+        )
+        MetricItem(
+            icon = Icons.Default.FavoriteBorder,
+            value = formatStatValue(likes),
+            label = stringResource(R.string.stats_likes)
+        )
+        MetricItem(
+            icon = Icons.Default.ChatBubbleOutline,
+            value = formatStatValue(comments),
+            label = stringResource(R.string.stats_comments)
+        )
+    }
+}
+
+@Composable
+private fun MetricItem(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    isPrimary: Boolean = false
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MetricSpacing)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                modifier = Modifier.size(MetricIconSize),
+                tint = if (isPrimary) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+            Text(
+                text = value,
+                style = if (isPrimary) {
+                    MaterialTheme.typography.titleLarge
+                } else {
+                    MaterialTheme.typography.titleMedium
+                },
+                fontWeight = FontWeight.Bold,
+                color = if (isPrimary) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
+            )
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private fun formatStatValue(value: Int): String {
+    return when {
+        value >= 1_000_000 -> String.format(Locale.getDefault(), "%.1fM", value / 1_000_000.0)
+        value >= 1_000 -> String.format(Locale.getDefault(), "%.1fK", value / 1_000.0)
+        else -> value.toString()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TodaysStatsCardLoadingPreview() {
+    AppThemeM3 {
+        TodaysStatsCard(
+            uiState = TodaysStatsCardUiState.Loading,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TodaysStatsCardLoadedPreview() {
+    AppThemeM3 {
+        TodaysStatsCard(
+            uiState = TodaysStatsCardUiState.Loaded(
+                views = 1234,
+                visitors = 567,
+                likes = 89,
+                comments = 12,
+                chartData = ChartData(
+                    currentPeriod = listOf(
+                        ViewsDataPoint("Mon", 100),
+                        ViewsDataPoint("Tue", 150),
+                        ViewsDataPoint("Wed", 120),
+                        ViewsDataPoint("Thu", 200),
+                        ViewsDataPoint("Fri", 180),
+                        ViewsDataPoint("Sat", 250),
+                        ViewsDataPoint("Sun", 220)
+                    ),
+                    previousPeriod = listOf(
+                        ViewsDataPoint("Mon", 80),
+                        ViewsDataPoint("Tue", 120),
+                        ViewsDataPoint("Wed", 100),
+                        ViewsDataPoint("Thu", 160),
+                        ViewsDataPoint("Fri", 140),
+                        ViewsDataPoint("Sat", 200),
+                        ViewsDataPoint("Sun", 180)
+                    )
+                ),
+                onCardClick = {}
+            ),
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TodaysStatsCardErrorPreview() {
+    AppThemeM3 {
+        TodaysStatsCard(
+            uiState = TodaysStatsCardUiState.Error(
+                message = "Failed to load stats",
+                onRetry = {}
+            ),
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCard.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.newstats.todaysstat
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,8 +20,6 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -49,8 +48,9 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-private val CardCornerRadius = 16.dp
+private val CardCornerRadius = 10.dp
 private val CardPadding = 16.dp
+private val CardMargin = 16.dp
 private val ChartHeight = 80.dp
 private val MetricIconSize = 16.dp
 private val MetricSpacing = 4.dp
@@ -60,15 +60,19 @@ fun TodaysStatsCard(
     uiState: TodaysStatsCardUiState,
     modifier: Modifier = Modifier
 ) {
-    Card(
+    val borderColor = MaterialTheme.colorScheme.outlineVariant
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(CardCornerRadius)),
-        shape = RoundedCornerShape(CardCornerRadius),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            .padding(horizontal = CardMargin, vertical = 8.dp)
+            .clip(RoundedCornerShape(CardCornerRadius))
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(CardCornerRadius)
+            )
+            .background(MaterialTheme.colorScheme.surface)
     ) {
         when (uiState) {
             is TodaysStatsCardUiState.Loading -> LoadingContent()
@@ -337,10 +341,7 @@ private fun formatStatValue(value: Int): String {
 @Composable
 private fun TodaysStatsCardLoadingPreview() {
     AppThemeM3 {
-        TodaysStatsCard(
-            uiState = TodaysStatsCardUiState.Loading,
-            modifier = Modifier.padding(16.dp)
-        )
+        TodaysStatsCard(uiState = TodaysStatsCardUiState.Loading)
     }
 }
 
@@ -356,27 +357,24 @@ private fun TodaysStatsCardLoadedPreview() {
                 comments = 12,
                 chartData = ChartData(
                     currentPeriod = listOf(
-                        ViewsDataPoint("Mon", 100),
-                        ViewsDataPoint("Tue", 150),
-                        ViewsDataPoint("Wed", 120),
-                        ViewsDataPoint("Thu", 200),
-                        ViewsDataPoint("Fri", 180),
-                        ViewsDataPoint("Sat", 250),
-                        ViewsDataPoint("Sun", 220)
+                        ViewsDataPoint("12am", 100),
+                        ViewsDataPoint("4am", 50),
+                        ViewsDataPoint("8am", 150),
+                        ViewsDataPoint("12pm", 200),
+                        ViewsDataPoint("4pm", 180),
+                        ViewsDataPoint("8pm", 250)
                     ),
                     previousPeriod = listOf(
-                        ViewsDataPoint("Mon", 80),
-                        ViewsDataPoint("Tue", 120),
-                        ViewsDataPoint("Wed", 100),
-                        ViewsDataPoint("Thu", 160),
-                        ViewsDataPoint("Fri", 140),
-                        ViewsDataPoint("Sat", 200),
-                        ViewsDataPoint("Sun", 180)
+                        ViewsDataPoint("12am", 80),
+                        ViewsDataPoint("4am", 40),
+                        ViewsDataPoint("8am", 120),
+                        ViewsDataPoint("12pm", 160),
+                        ViewsDataPoint("4pm", 140),
+                        ViewsDataPoint("8pm", 200)
                     )
                 ),
                 onCardClick = {}
-            ),
-            modifier = Modifier.padding(16.dp)
+            )
         )
     }
 }
@@ -389,8 +387,41 @@ private fun TodaysStatsCardErrorPreview() {
             uiState = TodaysStatsCardUiState.Error(
                 message = "Failed to load stats",
                 onRetry = {}
-            ),
-            modifier = Modifier.padding(16.dp)
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun TodaysStatsCardLoadedDarkPreview() {
+    AppThemeM3 {
+        TodaysStatsCard(
+            uiState = TodaysStatsCardUiState.Loaded(
+                views = 1234,
+                visitors = 567,
+                likes = 89,
+                comments = 12,
+                chartData = ChartData(
+                    currentPeriod = listOf(
+                        ViewsDataPoint("12am", 100),
+                        ViewsDataPoint("4am", 50),
+                        ViewsDataPoint("8am", 150),
+                        ViewsDataPoint("12pm", 200),
+                        ViewsDataPoint("4pm", 180),
+                        ViewsDataPoint("8pm", 250)
+                    ),
+                    previousPeriod = listOf(
+                        ViewsDataPoint("12am", 80),
+                        ViewsDataPoint("4am", 40),
+                        ViewsDataPoint("8am", 120),
+                        ViewsDataPoint("12pm", 160),
+                        ViewsDataPoint("4pm", 140),
+                        ViewsDataPoint("8pm", 200)
+                    )
+                ),
+                onCardClick = {}
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsCardUiState.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.ui.newstats.todaysstat
+
+/**
+ * UI State for the Today's Stats card in the new stats screen.
+ */
+sealed class TodaysStatsCardUiState {
+    data object Loading : TodaysStatsCardUiState()
+
+    data class Loaded(
+        val views: Int,
+        val visitors: Int,
+        val likes: Int,
+        val comments: Int,
+        val chartData: ChartData,
+        val onCardClick: () -> Unit
+    ) : TodaysStatsCardUiState()
+
+    data class Error(
+        val message: String,
+        val onRetry: () -> Unit
+    ) : TodaysStatsCardUiState()
+}
+
+/**
+ * Data for the sparkline chart showing views over time.
+ * Contains both current period and previous period for comparison.
+ */
+data class ChartData(
+    val currentPeriod: List<ViewsDataPoint>,
+    val previousPeriod: List<ViewsDataPoint>
+)
+
+/**
+ * A single data point for the chart.
+ * @param label The label for this point (e.g., day name or date)
+ * @param views The number of views for this period
+ */
+data class ViewsDataPoint(
+    val label: String,
+    val views: Long
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
@@ -33,11 +33,21 @@ class TodaysStatsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<TodaysStatsCardUiState>(TodaysStatsCardUiState.Loading)
     val uiState: StateFlow<TodaysStatsCardUiState> = _uiState.asStateFlow()
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
     init {
         loadData()
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    fun refresh() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            loadDataInternal(forced = true)
+            _isRefreshing.value = false
+        }
+    }
+
     fun loadData(forced: Boolean = false) {
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
@@ -51,31 +61,45 @@ class TodaysStatsViewModel @Inject constructor(
         _uiState.value = TodaysStatsCardUiState.Loading
 
         viewModelScope.launch {
-            try {
-                val todayStats = fetchTodayStats(site, forced)
-                val chartData = fetchChartData(site, forced)
+            loadDataInternal(forced)
+        }
+    }
 
-                if (todayStats != null) {
-                    _uiState.value = TodaysStatsCardUiState.Loaded(
-                        views = todayStats.views,
-                        visitors = todayStats.visitors,
-                        likes = todayStats.likes,
-                        comments = todayStats.comments,
-                        chartData = chartData,
-                        onCardClick = { onCardClicked() }
-                    )
-                } else {
-                    _uiState.value = TodaysStatsCardUiState.Error(
-                        message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load),
-                        onRetry = { loadData(forced = true) }
-                    )
-                }
-            } catch (e: Exception) {
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun loadDataInternal(forced: Boolean) {
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            _uiState.value = TodaysStatsCardUiState.Error(
+                message = resourceProvider.getString(R.string.stats_todays_stats_no_site_selected),
+                onRetry = { loadData(forced = true) }
+            )
+            return
+        }
+
+        try {
+            val todayStats = fetchTodayStats(site, forced)
+            val chartData = fetchChartData(site, forced)
+
+            if (todayStats != null) {
+                _uiState.value = TodaysStatsCardUiState.Loaded(
+                    views = todayStats.views,
+                    visitors = todayStats.visitors,
+                    likes = todayStats.likes,
+                    comments = todayStats.comments,
+                    chartData = chartData,
+                    onCardClick = { onCardClicked() }
+                )
+            } else {
                 _uiState.value = TodaysStatsCardUiState.Error(
-                    message = e.message ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error),
+                    message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load),
                     onRetry = { loadData(forced = true) }
                 )
             }
+        } catch (e: Exception) {
+            _uiState.value = TodaysStatsCardUiState.Error(
+                message = e.message ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error),
+                onRetry = { loadData(forced = true) }
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
@@ -7,12 +7,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -25,7 +27,8 @@ private const val PREVIOUS_PERIOD_OFFSET_DAYS = 1
 class TodaysStatsViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val todayInsightsStore: TodayInsightsStore,
-    private val visitsAndViewsStore: VisitsAndViewsStore
+    private val visitsAndViewsStore: VisitsAndViewsStore,
+    private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<TodaysStatsCardUiState>(TodaysStatsCardUiState.Loading)
     val uiState: StateFlow<TodaysStatsCardUiState> = _uiState.asStateFlow()
@@ -39,7 +42,7 @@ class TodaysStatsViewModel @Inject constructor(
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
             _uiState.value = TodaysStatsCardUiState.Error(
-                message = "No site selected",
+                message = resourceProvider.getString(R.string.stats_todays_stats_no_site_selected),
                 onRetry = { loadData(forced = true) }
             )
             return
@@ -63,13 +66,13 @@ class TodaysStatsViewModel @Inject constructor(
                     )
                 } else {
                     _uiState.value = TodaysStatsCardUiState.Error(
-                        message = "Failed to load stats",
+                        message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load),
                         onRetry = { loadData(forced = true) }
                     )
                 }
             } catch (e: Exception) {
                 _uiState.value = TodaysStatsCardUiState.Error(
-                    message = e.message ?: "Unknown error",
+                    message = e.message ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error),
                     onRetry = { loadData(forced = true) }
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
@@ -18,8 +18,8 @@ import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
 
-private const val CHART_DATA_POINTS = 7
-private const val PREVIOUS_PERIOD_OFFSET_DAYS = 7
+private const val HOURLY_DATA_POINTS = 24
+private const val PREVIOUS_PERIOD_OFFSET_DAYS = 1
 
 @HiltViewModel
 class TodaysStatsViewModel @Inject constructor(
@@ -92,8 +92,8 @@ class TodaysStatsViewModel @Inject constructor(
     }
 
     private suspend fun fetchChartData(site: SiteModel, forced: Boolean): ChartData {
-        val currentPeriodData = fetchPeriodData(site, forced, offsetDays = 0)
-        val previousPeriodData = fetchPeriodData(site, forced, offsetDays = PREVIOUS_PERIOD_OFFSET_DAYS)
+        val currentPeriodData = fetchHourlyData(site, forced, offsetDays = 0)
+        val previousPeriodData = fetchHourlyData(site, forced, offsetDays = PREVIOUS_PERIOD_OFFSET_DAYS)
 
         return ChartData(
             currentPeriod = currentPeriodData,
@@ -101,7 +101,7 @@ class TodaysStatsViewModel @Inject constructor(
         )
     }
 
-    private suspend fun fetchPeriodData(
+    private suspend fun fetchHourlyData(
         site: SiteModel,
         forced: Boolean,
         offsetDays: Int
@@ -113,8 +113,8 @@ class TodaysStatsViewModel @Inject constructor(
 
         val response = visitsAndViewsStore.fetchVisits(
             site = site,
-            granularity = StatsGranularity.DAYS,
-            limitMode = LimitMode.Top(CHART_DATA_POINTS),
+            granularity = StatsGranularity.HOURS,
+            limitMode = LimitMode.Top(HOURLY_DATA_POINTS),
             date = calendar.time,
             forced = forced
         )
@@ -124,23 +124,31 @@ class TodaysStatsViewModel @Inject constructor(
             return emptyList()
         }
 
-        val dateFormat = SimpleDateFormat("EEE", Locale.getDefault())
-
         return model.dates.map { periodData ->
             ViewsDataPoint(
-                label = formatPeriodLabel(periodData.period, dateFormat),
+                label = formatHourlyLabel(periodData.period),
                 views = periodData.views
             )
         }
     }
 
-    private fun formatPeriodLabel(period: String, dateFormat: SimpleDateFormat): String {
+    private fun formatHourlyLabel(period: String): String {
         return try {
-            val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            // API returns period in format "2024-01-16 14:00:00" for hourly data
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+            val outputFormat = SimpleDateFormat("ha", Locale.getDefault())
             val date = inputFormat.parse(period)
-            date?.let { dateFormat.format(it) } ?: period
+            date?.let { outputFormat.format(it).lowercase() } ?: period
         } catch (e: Exception) {
-            period
+            // Fallback: try parsing just the hour if full format fails
+            try {
+                val inputFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                val outputFormat = SimpleDateFormat("ha", Locale.getDefault())
+                val date = inputFormat.parse(period)
+                date?.let { outputFormat.format(it).lowercase() } ?: period
+            } catch (e2: Exception) {
+                period
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
@@ -34,6 +34,7 @@ class TodaysStatsViewModel @Inject constructor(
         loadData()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun loadData(forced: Boolean = false) {
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
@@ -132,6 +133,7 @@ class TodaysStatsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun formatHourlyLabel(period: String): String {
         return try {
             // API returns period in format "2024-01-16 14:00:00" for hourly data

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModel.kt
@@ -1,0 +1,161 @@
+package org.wordpress.android.ui.newstats.todaysstat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import javax.inject.Inject
+
+private const val CHART_DATA_POINTS = 7
+private const val PREVIOUS_PERIOD_OFFSET_DAYS = 7
+
+@HiltViewModel
+class TodaysStatsViewModel @Inject constructor(
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val todayInsightsStore: TodayInsightsStore,
+    private val visitsAndViewsStore: VisitsAndViewsStore
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<TodaysStatsCardUiState>(TodaysStatsCardUiState.Loading)
+    val uiState: StateFlow<TodaysStatsCardUiState> = _uiState.asStateFlow()
+
+    init {
+        loadData()
+    }
+
+    fun loadData(forced: Boolean = false) {
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            _uiState.value = TodaysStatsCardUiState.Error(
+                message = "No site selected",
+                onRetry = { loadData(forced = true) }
+            )
+            return
+        }
+
+        _uiState.value = TodaysStatsCardUiState.Loading
+
+        viewModelScope.launch {
+            try {
+                val todayStats = fetchTodayStats(site, forced)
+                val chartData = fetchChartData(site, forced)
+
+                if (todayStats != null) {
+                    _uiState.value = TodaysStatsCardUiState.Loaded(
+                        views = todayStats.views,
+                        visitors = todayStats.visitors,
+                        likes = todayStats.likes,
+                        comments = todayStats.comments,
+                        chartData = chartData,
+                        onCardClick = { onCardClicked() }
+                    )
+                } else {
+                    _uiState.value = TodaysStatsCardUiState.Error(
+                        message = "Failed to load stats",
+                        onRetry = { loadData(forced = true) }
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = TodaysStatsCardUiState.Error(
+                    message = e.message ?: "Unknown error",
+                    onRetry = { loadData(forced = true) }
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchTodayStats(site: SiteModel, forced: Boolean): TodayStatsData? {
+        val response = todayInsightsStore.fetchTodayInsights(site, forced)
+        return if (response.isError) {
+            null
+        } else {
+            response.model?.let { model ->
+                TodayStatsData(
+                    views = model.views,
+                    visitors = model.visitors,
+                    likes = model.likes,
+                    comments = model.comments
+                )
+            }
+        }
+    }
+
+    private suspend fun fetchChartData(site: SiteModel, forced: Boolean): ChartData {
+        val currentPeriodData = fetchPeriodData(site, forced, offsetDays = 0)
+        val previousPeriodData = fetchPeriodData(site, forced, offsetDays = PREVIOUS_PERIOD_OFFSET_DAYS)
+
+        return ChartData(
+            currentPeriod = currentPeriodData,
+            previousPeriod = previousPeriodData
+        )
+    }
+
+    private suspend fun fetchPeriodData(
+        site: SiteModel,
+        forced: Boolean,
+        offsetDays: Int
+    ): List<ViewsDataPoint> {
+        val calendar = Calendar.getInstance()
+        if (offsetDays > 0) {
+            calendar.add(Calendar.DAY_OF_YEAR, -offsetDays)
+        }
+
+        val response = visitsAndViewsStore.fetchVisits(
+            site = site,
+            granularity = StatsGranularity.DAYS,
+            limitMode = LimitMode.Top(CHART_DATA_POINTS),
+            date = calendar.time,
+            forced = forced
+        )
+
+        val model = response.model
+        if (response.isError || model == null) {
+            return emptyList()
+        }
+
+        val dateFormat = SimpleDateFormat("EEE", Locale.getDefault())
+
+        return model.dates.map { periodData ->
+            ViewsDataPoint(
+                label = formatPeriodLabel(periodData.period, dateFormat),
+                views = periodData.views
+            )
+        }
+    }
+
+    private fun formatPeriodLabel(period: String, dateFormat: SimpleDateFormat): String {
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val date = inputFormat.parse(period)
+            date?.let { dateFormat.format(it) } ?: period
+        } catch (e: Exception) {
+            period
+        }
+    }
+
+    private fun onCardClicked() {
+        // Navigation will be handled by the parent
+    }
+
+    fun onRetry() {
+        loadData(forced = true)
+    }
+
+    private data class TodayStatsData(
+        val views: Int,
+        val visitors: Int,
+        val likes: Int,
+        val comments: Int
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 private const val TAP_SOURCE_PROPERTY = "tap_source"
 private const val GRANULARITY_PROPERTY = "granularity"
 private const val PERIOD_PROPERTY = "period"
+private const val HOURS_PROPERTY = "hours"
 private const val DAYS_PROPERTY = "days"
 private const val WEEKS_PROPERTY = "weeks"
 private const val MONTHS_PROPERTY = "months"
@@ -60,6 +61,7 @@ fun AnalyticsTrackerWrapper.trackWithGranularity(stat: Stat, granularity: StatsG
     track(stat, mapOf(PERIOD_PROPERTY to getPropertyByGranularity(granularity)))
 
 private fun getPropertyByGranularity(granularity: StatsGranularity) = when (granularity) {
+    StatsGranularity.HOURS -> HOURS_PROPERTY
     StatsGranularity.DAYS -> DAYS_PROPERTY
     StatsGranularity.WEEKS -> WEEKS_PROPERTY
     StatsGranularity.MONTHS -> MONTHS_PROPERTY

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.HOURS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
@@ -106,6 +107,7 @@ class StatsDateFormatter
      */
     fun printGranularDate(date: Date, granularity: StatsGranularity): String {
         return when (granularity) {
+            HOURS -> SimpleDateFormat("ha", localeManagerWrapper.getLocale()).format(date).lowercase()
             DAYS -> outputFormat.format(date)
             WEEKS -> {
                 val endCalendar = Calendar.getInstance()
@@ -136,6 +138,7 @@ class StatsDateFormatter
      */
     private fun printTrafficGranularDate(date: Date, granularity: StatsGranularity): String {
         return when (granularity) {
+            HOURS -> SimpleDateFormat("ha", localeManagerWrapper.getLocale()).format(date).lowercase()
             DAYS -> outputFormatTrafficDays.format(date)
             WEEKS -> {
                 val endCalendar = Calendar.getInstance()
@@ -243,6 +246,17 @@ class StatsDateFormatter
         date: String
     ): Date {
         return when (granularity) {
+            HOURS -> {
+                // Hourly data format: "yyyy-MM-dd HH:mm:ss" or "yyyy-MM-dd HH:mm"
+                val hourlyFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT)
+                val hourlyFormatAlt = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.ROOT)
+                try {
+                    hourlyFormat.parse(date) ?: hourlyFormatAlt.parse(date)
+                        ?: throw RuntimeException("Unexpected date format")
+                } catch (e: ParseException) {
+                    hourlyFormatAlt.parse(date) ?: throw RuntimeException("Unexpected date format")
+                }
+            }
             DAYS -> inputFormat.parse(date) ?: throw RuntimeException("Unexpected date format")
             WEEKS -> {
                 // first four digits are the year

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1549,6 +1549,9 @@
 
     <string name="stats_loading_error">Data not loaded</string>
     <string name="stats_loading_block_error">There was a problem loading your data, refresh your page to try again.</string>
+    <string name="stats_todays_stats_no_site_selected">No site selected</string>
+    <string name="stats_todays_stats_failed_to_load">Failed to load stats</string>
+    <string name="stats_todays_stats_unknown_error">Unknown error</string>
 
     <!-- stats referrer popup menu actions   -->
     <string name="stats_referrer_popup_menu_open_website">Open Website</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
@@ -19,9 +19,11 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.viewmodel.ResourceProvider
 
 @ExperimentalCoroutinesApi
 class TodaysStatsViewModelTest : BaseUnitTest() {
@@ -34,6 +36,9 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
     @Mock
     private lateinit var visitsAndViewsStore: VisitsAndViewsStore
 
+    @Mock
+    private lateinit var resourceProvider: ResourceProvider
+
     private lateinit var viewModel: TodaysStatsViewModel
 
     private val testSite = SiteModel().apply {
@@ -45,13 +50,20 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
+        whenever(resourceProvider.getString(R.string.stats_todays_stats_no_site_selected))
+            .thenReturn(NO_SITE_SELECTED_ERROR)
+        whenever(resourceProvider.getString(R.string.stats_todays_stats_failed_to_load))
+            .thenReturn(FAILED_TO_LOAD_ERROR)
+        whenever(resourceProvider.getString(R.string.stats_todays_stats_unknown_error))
+            .thenReturn(UNKNOWN_ERROR)
     }
 
     private fun initViewModel() {
         viewModel = TodaysStatsViewModel(
             selectedSiteRepository,
             todayInsightsStore,
-            visitsAndViewsStore
+            visitsAndViewsStore,
+            resourceProvider
         )
     }
 
@@ -64,7 +76,7 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.uiState.value
         assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
-        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("No site selected")
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo(NO_SITE_SELECTED_ERROR)
     }
 
     @Test
@@ -112,7 +124,7 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.uiState.value
         assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
-        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("Failed to load stats")
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo(FAILED_TO_LOAD_ERROR)
     }
 
     @Test
@@ -256,7 +268,7 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.uiState.value
         assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
-        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("Unknown error")
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo(UNKNOWN_ERROR)
     }
 
     @Test
@@ -344,5 +356,8 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
         private const val TEST_VISITORS = 100
         private const val TEST_LIKES = 50
         private const val TEST_COMMENTS = 25
+        private const val NO_SITE_SELECTED_ERROR = "No site selected"
+        private const val FAILED_TO_LOAD_ERROR = "Failed to load stats"
+        private const val UNKNOWN_ERROR = "Unknown error"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
@@ -1,0 +1,348 @@
+package org.wordpress.android.ui.newstats.todaysstat
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.VisitsModel
+import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType
+import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
+import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+
+@ExperimentalCoroutinesApi
+class TodaysStatsViewModelTest : BaseUnitTest() {
+    @Mock
+    private lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    private lateinit var todayInsightsStore: TodayInsightsStore
+
+    @Mock
+    private lateinit var visitsAndViewsStore: VisitsAndViewsStore
+
+    private lateinit var viewModel: TodaysStatsViewModel
+
+    private val testSite = SiteModel().apply {
+        id = 1
+        siteId = TEST_SITE_ID
+        name = "Test Site"
+    }
+
+    @Before
+    fun setUp() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
+    }
+
+    private fun initViewModel() {
+        viewModel = TodaysStatsViewModel(
+            selectedSiteRepository,
+            todayInsightsStore,
+            visitsAndViewsStore
+        )
+    }
+
+    @Test
+    fun `when no site selected, then error state is emitted`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("No site selected")
+    }
+
+    @Test
+    fun `when data loads successfully, then loaded state is emitted with correct values`() = test {
+        val visitsModel = VisitsModel(
+            period = "2024-01-16",
+            views = TEST_VIEWS,
+            visitors = TEST_VISITORS,
+            likes = TEST_LIKES,
+            reblogs = 0,
+            comments = TEST_COMMENTS,
+            posts = 0
+        )
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+        with(state as TodaysStatsCardUiState.Loaded) {
+            assertThat(views).isEqualTo(TEST_VIEWS)
+            assertThat(visitors).isEqualTo(TEST_VISITORS)
+            assertThat(likes).isEqualTo(TEST_LIKES)
+            assertThat(comments).isEqualTo(TEST_COMMENTS)
+        }
+    }
+
+    @Test
+    fun `when today insights fetch fails, then error state is emitted`() = test {
+        val error = StatsError(StatsErrorType.GENERIC_ERROR, "Network error")
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(error))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(createVisitsAndViewsModel()))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("Failed to load stats")
+    }
+
+    @Test
+    fun `when today insights returns null model, then error state is emitted`() = test {
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(model = null))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(createVisitsAndViewsModel()))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
+    }
+
+    @Test
+    fun `when visits and views fetch fails, then chart data is empty but state is loaded`() = test {
+        val visitsModel = createVisitsModel()
+        val error = StatsError(StatsErrorType.GENERIC_ERROR, "Network error")
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(error))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+        with(state as TodaysStatsCardUiState.Loaded) {
+            assertThat(chartData.currentPeriod).isEmpty()
+            assertThat(chartData.previousPeriod).isEmpty()
+        }
+    }
+
+    @Test
+    fun `when loadData is called with forced true, then stores are called with forced true`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.loadData(forced = true)
+        advanceUntilIdle()
+
+        verify(todayInsightsStore).fetchTodayInsights(eq(testSite), eq(true))
+    }
+
+    @Test
+    fun `when onRetry is called, then loadData is called with forced true`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.onRetry()
+        advanceUntilIdle()
+
+        verify(todayInsightsStore).fetchTodayInsights(eq(testSite), eq(true))
+    }
+
+    @Test
+    fun `when data loads, then chart data contains current and previous period data`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+        with(state as TodaysStatsCardUiState.Loaded) {
+            assertThat(chartData.currentPeriod).hasSize(2)
+            assertThat(chartData.previousPeriod).hasSize(2)
+        }
+    }
+
+    @Test
+    fun `when fetch visits is called, then hourly granularity is used for both periods`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // fetchVisits is called twice: once for current period, once for previous period
+        verify(visitsAndViewsStore, times(2)).fetchVisits(
+            site = eq(testSite),
+            granularity = eq(StatsGranularity.HOURS),
+            limitMode = any<LimitMode.Top>(),
+            date = any(),
+            forced = any(),
+            applySiteTimezone = any()
+        )
+    }
+
+    @Test
+    fun `when exception is thrown during fetch, then error state is emitted with exception message`() = test {
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenThrow(RuntimeException("Test exception"))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("Test exception")
+    }
+
+    @Test
+    fun `when exception with null message is thrown, then error state has unknown error message`() = test {
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenThrow(RuntimeException())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(TodaysStatsCardUiState.Error::class.java)
+        assertThat((state as TodaysStatsCardUiState.Error).message).isEqualTo("Unknown error")
+    }
+
+    @Test
+    fun `when loadData is called again, then state transitions through loading`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // Verify we're in Loaded state first
+        assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+
+        // Call loadData again and verify the final state is still Loaded
+        viewModel.loadData(forced = true)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+    }
+
+    @Test
+    fun `when error state retry is clicked, then data is reloaded`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val errorState = viewModel.uiState.value as TodaysStatsCardUiState.Error
+
+        // Now set up for successful reload
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(createVisitsModel()))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(createVisitsAndViewsModel()))
+
+        errorState.onRetry()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+    }
+
+    private fun createVisitsModel() = VisitsModel(
+        period = "2024-01-16",
+        views = TEST_VIEWS,
+        visitors = TEST_VISITORS,
+        likes = TEST_LIKES,
+        reblogs = 0,
+        comments = TEST_COMMENTS,
+        posts = 0
+    )
+
+    private fun createVisitsAndViewsModel() = VisitsAndViewsModel(
+        period = "hour",
+        dates = listOf(
+            VisitsAndViewsModel.PeriodData(
+                period = "2024-01-16 14:00:00",
+                views = 100L,
+                visitors = 50L,
+                likes = 10L,
+                reblogs = 0L,
+                comments = 5L,
+                posts = 0L
+            ),
+            VisitsAndViewsModel.PeriodData(
+                period = "2024-01-16 15:00:00",
+                views = 150L,
+                visitors = 75L,
+                likes = 15L,
+                reblogs = 0L,
+                comments = 8L,
+                posts = 0L
+            )
+        )
+    )
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+        private const val TEST_VIEWS = 500
+        private const val TEST_VISITORS = 100
+        private const val TEST_LIKES = 50
+        private const val TEST_COMMENTS = 25
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstat/TodaysStatsViewModelTest.kt
@@ -316,6 +316,74 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
     }
 
+    @Test
+    fun `when refresh is called, then isRefreshing becomes true then false`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // Verify initial state is not refreshing
+        assertThat(viewModel.isRefreshing.value).isFalse()
+
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        // After refresh completes, isRefreshing should be false
+        assertThat(viewModel.isRefreshing.value).isFalse()
+    }
+
+    @Test
+    fun `when refresh is called, then data is fetched with forced true`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        // Verify that fetchTodayInsights was called with forced = true during refresh
+        // (called twice: once during init, once during refresh)
+        verify(todayInsightsStore, times(2)).fetchTodayInsights(eq(testSite), any())
+        verify(todayInsightsStore).fetchTodayInsights(eq(testSite), eq(true))
+    }
+
+    @Test
+    fun `when refresh is called, then state remains loaded without showing loading state`() = test {
+        val visitsModel = createVisitsModel()
+        val visitsAndViewsModel = createVisitsAndViewsModel()
+
+        whenever(todayInsightsStore.fetchTodayInsights(any(), any()))
+            .thenReturn(OnStatsFetched(visitsModel))
+        whenever(visitsAndViewsStore.fetchVisits(any(), any(), any(), any(), any(), any()))
+            .thenReturn(OnStatsFetched(visitsAndViewsModel))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // Verify initial state is Loaded
+        assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        // State should still be Loaded after refresh (not showing Loading state)
+        assertThat(viewModel.uiState.value).isInstanceOf(TodaysStatsCardUiState.Loaded::class.java)
+    }
+
     private fun createVisitsModel() = VisitsModel(
         period = "2024-01-16",
         views = TEST_VIEWS,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,6 +108,7 @@ automattic-ucrop = '2.2.11'
 zendesk = '5.5.2'
 turbine = '1.2.1'
 commonmark = '0.27.1'
+vico = '2.1.3'
 
 [libraries]
 airbnb-lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "airbnb-lottie" }
@@ -267,6 +268,7 @@ automattic-ucrop = { group = "com.automattic", name = "ucrop", version.ref = "au
 zendesk-support = { group = "com.zendesk", name = "support", version.ref = "zendesk" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
+vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version.ref = "vico" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/StatsGranularity.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/utils/StatsGranularity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.utils
 
 enum class StatsGranularity(private val value: String) {
+    HOURS("hour"),
     DAYS("day"),
     WEEKS("week"),
     MONTHS("month"),

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -140,6 +140,7 @@ class StatsSqlUtils @Inject constructor() {
 
     enum class StatsType {
         INSIGHTS,
+        HOUR,
         DAY,
         WEEK,
         MONTH,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TimeStatsSqlUtils.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VideoPlaysRestC
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.time.VisitAndViewsRestClient.VisitsAndViewsResponse
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.HOURS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
@@ -239,6 +240,7 @@ open class TimeStatsSqlUtils<RESPONSE_TYPE>(
 
     private fun StatsGranularity.toStatsType(): StatsType {
         return when (this) {
+            HOURS -> StatsType.HOUR
             DAYS -> StatsType.DAY
             WEEKS -> StatsType.WEEK
             MONTHS -> StatsType.MONTH


### PR DESCRIPTION
## Description                                                                                                         
                                                                                                                         
  Implements the Today's Stats card for the new stats screen (CMM-1142). The card displays today's key metrics (views,   
  visitors, likes, comments) along with an hourly sparkline chart comparing today's views with yesterday's data. Built   
  using Jetpack Compose with the Vico charting library for the visualization.            

NOTE: the data might not be accurate. I'm getting the data from the current API, but I'll work in a new RUST endpoint to be used here. So, I'm not spending time on polishing the current data request as it will be replaced.
                                                                                                                         
  ## Testing instructions                                                                                                
                                                                                                                         
  Today's Stats card displays correctly:                                                                                 
                                                                                                                         
  1. Open the app, enable the new stats feature and navigate to the new Stats screen                                                                   
  2. Wait for the Today's Stats card to load                                                                             
  - [x] Verify the card shows today's date                                                                               
  - [x] Verify views, visitors, likes, and comments metrics are displayed                                                
  - [x] Verify the sparkline chart shows hourly data with a gradient fill                                                
  - [x] Verify yesterday's data appears as a secondary line on the chart                                                 

<img width="257" height="573" alt="Screenshot 2026-01-19 at 11 06 59" src="https://github.com/user-attachments/assets/0f647dd3-6731-4669-a9e0-c8430baee5e6" />
                                                                                                                         
  Loading state:                                                                                                         
                                                                                                                         
  1. Force refresh or navigate to the Stats screen with slow network                                                     
  - [ ] Verify shimmer/loading placeholders appear while data loads                                                      
                                                                                                                         
  Error state:                                                                                                           
                                                                                                                         
  1. Put device in airplane mode and navigate to Stats screen                                                            
  - [ ] Verify error message is displayed                                                                                
  2. Tap the retry button                                                                                                
  - [ ] Verify the card attempts to reload data                                                                          
                                                     
<img width="260" height="574" alt="Screenshot 2026-01-19 at 11 06 35" src="https://github.com/user-attachments/assets/bb3fda05-9b90-41a1-ae56-1bc9a0b006a2" />

                                                                    
Old stats:
1. Disable the new stats feature, and navigate to the stats screen
- [ ] Verify the old stats screen is shown      