### PR TITLE
Issue/cmm 1037 media picker empty view take2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -501,6 +501,7 @@ class MediaPickerFragment : Fragment(), MenuProvider {
                     }
                 }
                 actionableEmptyView.button.applyOrHide(uiModel.retryAction) { action ->
+                    this.setText(R.string.retry)
                     this.setOnClickListener {
                         action()
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -69,6 +69,7 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPLinkMovementMethod
 import org.wordpress.android.util.WPMediaUtils
@@ -476,6 +477,9 @@ class MediaPickerFragment : Fragment(), MenuProvider {
             is PhotoListUiModel.Empty -> {
                 setupAdapter(listOf())
                 actionableEmptyView.updateLayoutForSearch(uiModel.isSearching, 0)
+                if (uiModel.isSearching) {
+                    ActivityUtils.hideKeyboardForced(actionableEmptyView)
+                }
                 actionableEmptyView.title.text = uiHelpers.getTextOfUiString(requireContext(), uiModel.title)
 
                 actionableEmptyView.subtitle.applyOrHide(uiModel.htmlSubtitle) { htmlSubtitle ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -193,7 +193,7 @@ class MediaPickerViewModel @Inject constructor(
                 bottomImage = domainModel.emptyState.bottomImage,
                 bottomImageDescription = domainModel.emptyState.bottomImageDescription,
                 isSearching = isSearching == true,
-                retryAction = this::retry
+                retryAction = if (isSearching == true) null else this::retry
             )
         } else if (domainModel?.isLoading == true) {
             PhotoListUiModel.Loading
@@ -209,7 +209,7 @@ class MediaPickerViewModel @Inject constructor(
             PhotoListUiModel.Empty(
                 UiStringRes(stringId),
                 isSearching = isSearching == true,
-                retryAction = this::retry
+                retryAction = if (isSearching == true) null else this::retry
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -182,17 +182,13 @@ class MediaPickerViewModel @Inject constructor(
             populateDomainItems(data, selectedIds, domainModel)
         } else if (domainModel?.emptyState != null) {
             PhotoListUiModel.Empty(
-                domainModel.emptyState.title,
-                domainModel.emptyState.htmlSubtitle,
-                domainModel.emptyState.image,
-                domainModel.emptyState.bottomImage,
-                domainModel.emptyState.bottomImageDescription,
-                isSearching == true,
-                retryAction = if (domainModel.emptyState.isError) {
-                    this::retry
-                } else {
-                    null
-                }
+                title = domainModel.emptyState.title,
+                htmlSubtitle = domainModel.emptyState.htmlSubtitle,
+                image = domainModel.emptyState.image,
+                bottomImage = domainModel.emptyState.bottomImage,
+                bottomImageDescription = domainModel.emptyState.bottomImageDescription,
+                isSearching = isSearching == true,
+                retryAction = this::retry
             )
         } else if (domainModel?.isLoading == true) {
             PhotoListUiModel.Loading
@@ -207,7 +203,6 @@ class MediaPickerViewModel @Inject constructor(
             }
             PhotoListUiModel.Empty(
                 UiStringRes(stringId),
-                image = R.drawable.img_illustration_media_105dp,
                 isSearching = isSearching == true
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -193,11 +193,7 @@ class MediaPickerViewModel @Inject constructor(
                 bottomImage = domainModel.emptyState.bottomImage,
                 bottomImageDescription = domainModel.emptyState.bottomImageDescription,
                 isSearching = isSearching == true,
-                retryAction = if (domainModel.emptyState.isError) {
-                    this::retry
-                } else {
-                    null
-                }
+                retryAction = this::retry
             )
         } else if (domainModel?.isLoading == true) {
             PhotoListUiModel.Loading
@@ -212,7 +208,8 @@ class MediaPickerViewModel @Inject constructor(
             }
             PhotoListUiModel.Empty(
                 UiStringRes(stringId),
-                isSearching = isSearching == true
+                isSearching = isSearching == true,
+                retryAction = this::retry
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -188,7 +188,11 @@ class MediaPickerViewModel @Inject constructor(
                 bottomImage = domainModel.emptyState.bottomImage,
                 bottomImageDescription = domainModel.emptyState.bottomImageDescription,
                 isSearching = isSearching == true,
-                retryAction = this::retry
+                retryAction = if (domainModel.emptyState.isError) {
+                    this::retry
+                } else {
+                    null
+                }
             )
         } else if (domainModel?.isLoading == true) {
             PhotoListUiModel.Loading

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -181,10 +181,14 @@ class MediaPickerViewModel @Inject constructor(
         isSearching: Boolean?
     ): PhotoListUiModel {
         val data = domainModel?.domainItems
+        // Hide empty view when search is expanded but no search term submitted yet
+        val isSearchExpandedWithoutFilter = isSearching == true && domainModel?.filter.isNullOrEmpty()
         return if (null != softAskRequest && softAskRequest.show) {
             PhotoListUiModel.Hidden
         } else if (data != null && data.isNotEmpty()) {
             populateDomainItems(data, selectedIds, domainModel)
+        } else if (isSearchExpandedWithoutFilter) {
+            PhotoListUiModel.Hidden
         } else if (domainModel?.emptyState != null) {
             PhotoListUiModel.Empty(
                 title = domainModel.emptyState.title,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -109,7 +109,12 @@ class MediaPickerViewModel @Inject constructor(
         _showPartialMediaAccessPrompt,
     ) { domainModel, selectedIds, softAskRequest, searchExpanded, progressDialogUiModel, showPartialAccessPrompt ->
         MediaPickerUiState(
-            buildUiModel(domainModel, selectedIds, softAskRequest, searchExpanded),
+            buildUiModel(
+                domainModel = domainModel,
+                selectedIds = selectedIds,
+                softAskRequest = softAskRequest,
+                isSearching = searchExpanded
+            ),
             buildSoftAskView(softAskRequest),
             FabUiModel(mediaPickerSetup.cameraSetup != HIDDEN && selectedIds.isNullOrEmpty(), this::clickOnCamera),
             buildActionModeUiModel(selectedIds, domainModel?.domainItems),

--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -45,7 +45,6 @@
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:visibility="gone"
-                app:aevImage="@drawable/img_illustration_media_105dp"
                 app:aevButton="@string/retry"
                 app:aevTitle="@string/media_empty_list"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
**Partially address CMM-1037**

Adds a Retry button to the MediaPickerFragment's empty view when the media list is empty and removes the empty view drawables. This allows users to refresh the media list without having to navigate away and back. The retry button is hidden during search operations to avoid confusion when the empty state is due to no search matches rather than a loading issue.

Changes include:
- Added Retry button to empty state that triggers a media list refresh
- Hide retry button when empty state is from search results (no matches)
- Hide empty view entirely when search field is expanded but no term submitted yet
- Removed default image from the empty view in the layout XML
- Added unit tests for the new retry logic

## Testing instructions

Test retry button on empty media library:

1. Open the Media Picker on a site with no media uploaded
2. Observe the empty state view appears
- [x] Verify a "Retry" button is displayed
3. Tap the Retry button
- [x] Verify the media list refreshes (loading indicator appears briefly)

Test retry button hidden during search:

1. Open the Media Picker with media items present
2. Tap the search icon to expand the search field
- [x] Verify the empty view is hidden while search is expanded but no term entered
3. Enter a search term that returns no results
- [x] Verify the empty state shows "No media matching your search" (or similar)
- [x] Verify NO Retry button is displayed

Test retry button on WP Media Library:

1. Open the WP Media Library picker (not device picker)
2. If the library is empty or fails to load, observe the empty state
- [x] Verify the Retry button appears and works to refresh the list

**Before and After**

<img width="610" height="629" alt="537693784-29d22a45-699f-4c03-aec0-1663b6c54b1b" src="https://github.com/user-attachments/assets/1f7c8472-8571-49c3-a1ee-2c6448f3ac48" />
