### PR TITLE
Add instruction for Claude to ask permission before committing or pushing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ WordPress/src/main/java/org/wordpress/android/
 - Fastlane used for release automation and testing
 - Secrets managed via `secrets.properties` file (not in repo)
 - Pre-commit hooks may modify files during commit
+- **IMPORTANT**: Never commit or push changes without explicitly asking permission each time
 
 ## Release Notes Compilation Process
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ WordPress/src/main/java/org/wordpress/android/
 - Pre-commit hooks may modify files during commit
 
 ### Git Operations Checklist
-Before performing ANY git commit or push:
+**IMPORTANT**: Claude must review and confirm ALL items in this checklist before performing any git commit or push operation.
 - [ ] Have you explicitly asked the user for permission for THIS specific operation?
 - [ ] Did the user respond affirmatively to THIS specific request (not a previous one)?
 - [ ] Are you committing only the changes the user approved?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,12 @@ WordPress/src/main/java/org/wordpress/android/
 - Fastlane used for release automation and testing
 - Secrets managed via `secrets.properties` file (not in repo)
 - Pre-commit hooks may modify files during commit
-- **IMPORTANT**: Never commit or push changes without explicitly asking permission each time
+
+### Git Operations Checklist
+Before performing ANY git commit or push:
+- [ ] Have you explicitly asked the user for permission for THIS specific operation?
+- [ ] Did the user respond affirmatively to THIS specific request (not a previous one)?
+- [ ] Are you committing only the changes the user approved?
 
 ## Release Notes Compilation Process
 


### PR DESCRIPTION
This small PR updates `claude.md` to include instructions to never commit or push changes without explicit permission. I'm not certain, but my guess is that this happened because I granted Claude permission to commit changes, so it assumed it should keep doing so without asking?

Note that I've updated this PR based on suggestions made by Claude when I asked for a review.