### PR TITLE
Bumping Vico to 2.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,7 +108,7 @@ automattic-ucrop = '2.2.11'
 zendesk = '5.5.2'
 turbine = '1.2.1'
 commonmark = '0.27.1'
-vico = '2.1.3'
+vico = '2.2.0'
 
 [libraries]
 airbnb-lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "airbnb-lottie" }


### PR DESCRIPTION
## Description                                                                                                                        
                                                                                                                                        
  Upgrades vico from 2.1.3 to 2.2.0.                                                                                                    
                                                                                                                                        
  Dependabot [attempted to upgrade to 2.4.1](https://github.com/wordpress-mobile/WordPress-Android/pull/22500), but that version (and anything 2.2.1+) is incompatible with our current build configuration.
   Starting from vico 2.2.1, the library declares a direct dependency on `androidx.core:core-ktx:1.17.0`, which requires:               
                                                                                                                                        
  - Android Gradle Plugin 8.9.1+ (we use 8.7.3)                                                                                         
  - compileSdk 36 (we use 35)                                                                                                           
                                                                                                                                        
  Version 2.2.0 is the latest compatible release, using `androidx.core:core-ktx:1.16.0`.                                                
                                                                                                                                        
  | vico version | core-ktx | Compatible |                                                                                              
  |--------------|----------|------------|                                                                                              
  | 2.1.3 | 1.16.0 | ✅ |                                                                                                               
  | 2.2.0 | 1.16.0 | ✅ |                                                                                                               
  | 2.2.1+ | 1.17.0 | ❌ |                                                                                                              
                                                                                                                                        
  Upgrading beyond 2.2.0 will require a separate PR to bump AGP and compileSdk.                                                         
                                                                                                                                        
  ## Testing instructions                                                                                                               
                                                                                                                                        
 Just check the CI is green