### PR TITLE
My site fragment: no sites empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -496,7 +496,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             noSitesView.actionableEmptyView.setVisible(false)
         }
 
-        if(noSitesView.avatarAccountSettings.isVisible){
+        // TODO remove this
+        noSitesView.actionableEmptyView.setVisible(true)
+        recyclerView.setVisible(false)
+
+        if (noSitesView.avatarAccountSettings.isVisible){
             noSitesView.avatarAccountSettings.setVisible(false)
         }
     }

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -12,7 +12,6 @@
         android:layout_marginTop="@dimen/toolbar_height"
         android:visibility="gone"
         app:aevButton="@string/my_site_add_new_site"
-        app:aevImage="@drawable/img_illustration_site_wordpress_camera_pencils_226dp"
         app:aevSubtitle="@string/my_site_create_new_site"
         app:aevTitle="@string/my_site_create_new_site_title"
         app:layout_constraintBottom_toTopOf="@+id/avatar_account_settings"


### PR DESCRIPTION
As part of CMM-1037, this PR removes the image from the My Site fragment's empty view, which is shown when there are no sites.

**Note1:** I've added a `TODO` regarding test code which ensures that regardless of the account, the empty view appears. I'll remove this before merging. This is why the "Do not merge" label has been added.

**Note2:** I'm not convinced removing the image in this situation is the right thing to do. I know we're trying to get rid of outdated images in the various empty views, but not having any sites seems a special situation that may warrant keeping the image. Thoughts?

**To test**
Simply run the app and verify the empty view on the My Site page appears correctly.

**Before and After**
<img width="610" height="629" alt="before" src="https://github.com/user-attachments/assets/03e9ae05-cc9a-415d-90ef-9782ee611e19" />
