### PR TITLE
Distribute prototype builds via Firebase App Distribution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
+gem 'fastlane-plugin-firebase_app_distribution', '~> 0.10'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-plugin-firebase_app_distribution (0.10.1)
+      google-apis-firebaseappdistribution_v1 (~> 0.3.0)
+      google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
     fastlane-plugin-sentry (1.29.0)
       os (~> 1.1, >= 1.1.4)
     fastlane-plugin-wpmreleasetoolkit (13.8.1)
@@ -204,6 +207,10 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
       rexml
+    google-apis-firebaseappdistribution_v1 (0.3.0)
+      google-apis-core (>= 0.11.0, < 2.a)
+    google-apis-firebaseappdistribution_v1alpha (0.2.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-iamcredentials_v1 (0.17.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-playcustomapp_v1 (0.13.0)
@@ -358,6 +365,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.2)
   fastlane (~> 2)
+  fastlane-plugin-firebase_app_distribution (~> 0.10)
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
   nokogiri

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,11 @@ APP_SPECIFIC_VALUES = {
     package_name: 'org.wordpress.android',
     bundle_name_prefix: 'wpandroid',
     screenshots_test_class: 'org.wordpress.android.ui.screenshots.WPScreenshotTest',
-    screenshot_config_file: 'wordpress-config.json'
+    screenshot_config_file: 'wordpress-config.json',
+    firebase: {
+      app_id: '1:124902176124:android:4f9776805ebf421d1620f9',
+      testers_group: 'wordpress-android---prototype-builds'
+    }
   },
   jetpack: {
     display_name: 'Jetpack',
@@ -21,7 +25,11 @@ APP_SPECIFIC_VALUES = {
     package_name: 'com.jetpack.android',
     bundle_name_prefix: 'jpandroid',
     screenshots_test_class: 'org.wordpress.android.ui.screenshots.JPScreenshotTest',
-    screenshot_config_file: 'jetpack-config.json'
+    screenshot_config_file: 'jetpack-config.json',
+    firebase: {
+      app_id: '1:124902176124:android:97a4443a7dbfb7cc1620f9',
+      testers_group: 'jetpack-android---prototype-builds'
+    }
   }
 }.freeze
 
@@ -29,7 +37,6 @@ UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-and
 
 PROTOTYPE_BUILD_FLAVOR = 'Jalapeno'
 PROTOTYPE_BUILD_TYPE = 'Debug'
-PROTOTYPE_BUILD_DOMAIN = 'https://cdn.a8c-ci.services'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')


### PR DESCRIPTION
## Summary

Replace S3 upload with Firebase App Distribution (FAD) for WordPress and Jetpack prototype builds.

This aligns with other Android apps in the org (Day One, WooCommerce, Pocket Casts) and lets us delegate storage, distribution, and other management tasks to Firebase.

Ref: [AINFRA-1686](https://linear.app/a8c/issue/AINFRA-1686)

## Testing instructions

- [x] Verify prototype builds are uploaded to Firebase App Distribution
- [x] Verify PR comment contains FAD install link
- [x] Verify Buildkite annotation shows FAD link

See test PR https://github.com/wordpress-mobile/WordPress-Android/pull/22505 (as the files changed filter blocked this PR from generating the Firebase builds)


<img width="300" height="182" alt="image" src="https://github.com/user-attachments/assets/367178b3-4976-46a7-81a9-8221b13252e8" />

<img width="600" height="214" alt="image" src="https://github.com/user-attachments/assets/ebdea1a1-23cd-4a86-b220-6a787a9c0a72" />

<img width="600" height="214" alt="image" src="https://github.com/user-attachments/assets/bc478b32-468b-456e-84b1-6362cd7630cc" />

🤖 Generated with [Claude Code](https://claude.ai/code), in particular, I fed it the previous PRs I worked on adding FAD for reference.