### PR TITLE
Instruct Claude Code GitHub Action to not comment on code formatting

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,6 +55,9 @@ jobs:
                - Verify README updates for new features
                - Check API documentation accuracy
 
+            6. **Scope limitation**
+               - Do NOT comment on code formatting (e.g., line length, indentation, spacing, brace style, naming style consistency, or other purely stylistic/formatting concerns). Assume a separate formatter/linter will handle those.
+
             Provide detailed feedback using inline comments for specific issues.
             Use top-level comments for general observations or praise.
 


### PR DESCRIPTION
Closes: [AINFRA-1807: Instruct Claude Code to not comment on code formatting](https://linear.app/a8c/issue/AINFRA-1807/instruct-claude-code-to-not-comment-on-code-formatting)

## Description

This PR adds a **Scope limitation** category that will, hopefully, filter out possible code formatting comments from Claude Code GitHub Review action.

### Testing

It's not really possible to test until this change lands on `trunk`. We'll have to work on this in iterations.
