### PR TITLE
Remove unused illustrationResId from ReaderDiscoverViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -132,7 +132,6 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
                 is DiscoverUiState.EmptyUiState -> {
                     uiHelpers.setTextOrHide(actionableEmptyView.title, it.titleResId)
                     uiHelpers.setTextOrHide(actionableEmptyView.subtitle, it.subTitleRes)
-                    uiHelpers.setImageOrHide(actionableEmptyView.image, it.illustrationResId)
                     uiHelpers.setTextOrHide(actionableEmptyView.button, it.buttonResId)
                     actionableEmptyView.button.setOnClickListener { _ -> it.action.invoke() }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -539,7 +539,6 @@ class ReaderDiscoverViewModel @Inject constructor(
             abstract val buttonResId: Int
             open val subTitleRes: Int? = null
             abstract val action: () -> Unit
-            open val illustrationResId: Int? = null
 
             data class RequestFailedUiState(override val action: () -> Unit) : EmptyUiState() {
                 override val titleResId = R.string.connection_error


### PR DESCRIPTION
As part of CMM-1037, this small PR updates `ReaderDiscoverFragment` by removing the unused `illustrationResId` property in `EmptyUiState`. This property was never overridden by any subclass, so the image view was always hidden. 

So, there are no user-facing changes in this PR - it simply removes an unused property.

**To test**

Clear CI should be all that's necessary to approve this.