### PR TITLE
Fix: Add ProGuard rules for jsoup's optional RE2J dependency to fix release build   

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -102,3 +102,9 @@
 -keep class * extends androidx.fragment.app.Fragment
 
 ###### Main resource class - end
+
+###### jsoup - begin
+# jsoup has optional support for Google's RE2J regex library which is not included
+-dontwarn com.google.re2j.Matcher
+-dontwarn com.google.re2j.Pattern
+###### jsoup - end


### PR DESCRIPTION
## Description

See the build issue: https://buildkite.com/automattic/wordpress-android/builds/24599                                                                                                    
                                                                                                                                        
  Fixes the beta release build failure caused by R8 detecting missing `com.google.re2j` classes referenced by jsoup's optional RE2J     
  regex support.                                                                                                                        
                                                                                                                                        
  jsoup 1.22.1 added optional support for Google's RE2J regex engine for CSS selectors. Since RE2J is not included as a dependency in   
  this project, R8 fails the release build when it encounters references to the missing classes.                                        
                                                                                                                                        
  The fix adds `-dontwarn` rules to `proguard.cfg` to suppress these warnings, which is the standard approach for optional dependencies.
                                                                                                                                        
  ### Why this won't break the app                                                                                                      
                                                                                                                                        
  RE2J is an **optional dependency** in jsoup. The library is designed to:                                                              
  - Detect at runtime whether RE2J is available on the classpath                                                                        
  - Gracefully fall back to Java's built-in regex engine if RE2J is not present                                                         
                                                                                                                                        
  The `-dontwarn` rules only tell R8 not to fail the build when it sees references to classes that might not exist at runtime. They     
  don't change any runtime behavior.                                                                                                    
                                                                                                                                        
  At runtime, jsoup checks if `com.google.re2j` classes are available. Since they're not included in the app, jsoup automatically uses  
  Java's standard `java.util.regex` engine instead - which is what the app was using before jsoup added RE2J support.    