### PR TITLE
CMM-1160: Fix WP Media Library search overlap

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -492,18 +492,6 @@ class MediaPickerFragment : Fragment(), MenuProvider {
                     )
                     actionableEmptyView.subtitle.movementMethod = WPLinkMovementMethod.getInstance()
                 }
-                actionableEmptyView.image.applyOrHide(uiModel.image) { image ->
-                    this.setImageResource(image)
-                }
-                actionableEmptyView.bottomImage.applyOrHide(uiModel.bottomImage) { bottomImage ->
-                    this.setImageResource(bottomImage)
-                    if (uiModel.bottomImageDescription != null) {
-                        this.contentDescription = uiHelpers.getTextOfUiString(
-                            requireContext(),
-                            uiModel.bottomImageDescription
-                        ).toString()
-                    }
-                }
                 actionableEmptyView.button.applyOrHide(uiModel.retryAction) { action ->
                     this.setText(R.string.retry)
                     this.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -434,7 +434,6 @@ class MediaPickerFragment : Fragment(), MenuProvider {
 
             override fun onQueryTextChange(query: String): Boolean {
                 if (!isExpanding) {
-                    binding?.actionableEmptyView?.visibility = View.GONE
                     viewModel.onSearch(query)
                 }
                 isExpanding = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -435,6 +435,7 @@ class MediaPickerFragment : Fragment(), MenuProvider {
 
             override fun onQueryTextChange(query: String): Boolean {
                 if (!isExpanding) {
+                    binding?.actionableEmptyView?.visibility = View.GONE
                     viewModel.onSearch(query)
                 }
                 isExpanding = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -69,7 +69,6 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
-import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPLinkMovementMethod
 import org.wordpress.android.util.WPMediaUtils
@@ -478,9 +477,6 @@ class MediaPickerFragment : Fragment(), MenuProvider {
             is PhotoListUiModel.Empty -> {
                 setupAdapter(listOf())
                 actionableEmptyView.updateLayoutForSearch(uiModel.isSearching, 0)
-                if (uiModel.isSearching) {
-                    ActivityUtils.hideKeyboardForced(actionableEmptyView)
-                }
                 actionableEmptyView.title.text = uiHelpers.getTextOfUiString(requireContext(), uiModel.title)
 
                 actionableEmptyView.subtitle.applyOrHide(uiModel.htmlSubtitle) { htmlSubtitle ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -193,9 +193,6 @@ class MediaPickerViewModel @Inject constructor(
             PhotoListUiModel.Empty(
                 title = domainModel.emptyState.title,
                 htmlSubtitle = domainModel.emptyState.htmlSubtitle,
-                image = domainModel.emptyState.image,
-                bottomImage = domainModel.emptyState.bottomImage,
-                bottomImageDescription = domainModel.emptyState.bottomImageDescription,
                 isSearching = isSearching == true,
                 retryAction = if (isSearching == true) null else this::retry
             )
@@ -733,9 +730,6 @@ class MediaPickerViewModel @Inject constructor(
         data class Empty(
             val title: UiString,
             val htmlSubtitle: UiString? = null,
-            val image: Int? = null,
-            val bottomImage: Int? = null,
-            val bottomImageDescription: UiString? = null,
             val isSearching: Boolean = false,
             val retryAction: (() -> Unit)? = null
         ) : PhotoListUiModel()

--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -47,6 +47,7 @@
                 android:visibility="gone"
                 app:aevButton="@string/retry"
                 app:aevTitle="@string/media_empty_list"
+                app:layout_constraintVertical_bias="0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## Description

**Fixes CMM-1160**

Previously, when creating a post and searching the WP Media Library with no results, the empty view is shown and the keyboard is hidden, but if the user tapped to continue typing, the keyboard would cover the empty view.

This PR fixes the problem by moving the empty view to the top so the keyboard won't cover it. I initially wasn't wild about this solution, but it turns out we already do this in the existing media search so it seemed like the right thing to do.

I also removed the image from the empty search results view as part of CMM-1037.

## Testing instructions

Media picker search empty state:

1. Create or edit a post 
2. Choose to add an image
3. Select the WP Media Library source
4. Search for something that returns no results and verify the empty view is shown


https://github.com/user-attachments/assets/39606512-d3dd-4378-bfe7-ecb0969e93cf


