### PR TITLE
CMM-150: Scroll to restored blog post after undoing block site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -236,6 +236,7 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
     private var postSearchAdapterPos = 0
     private var siteSearchAdapterPos = 0
     private var searchTabsPos = NO_POSITION
+    private var pendingScrollToBlogId: Long? = null
 
     private var isFilterableScreen = false
     private var isFiltered = false
@@ -536,6 +537,14 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             viewLifecycleOwner
         ) { readerData: FollowStatusChanged ->
             setFollowStatusForBlog(readerData)
+        }
+
+        postListViewModel.scrollToSiteId.observe(
+            viewLifecycleOwner
+        ) { event: Event<Long> ->
+            event.applyIfNotHandled {
+                pendingScrollToBlogId = this
+            }
         }
     }
 
@@ -1993,6 +2002,10 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
                     AppLog.d(AppLog.T.READER, "reader post list > restoring position")
                     recyclerView.scrollRecycleViewToPosition(restorePosition)
                 }
+                pendingScrollToBlogId?.let { blogId ->
+                    scrollToFirstPostFromBlog(blogId)
+                    pendingScrollToBlogId = null
+                }
                 if (isSearching && !isSearchTabsShowing()) {
                     showSearchTabs()
                 } else if (isSearching) {
@@ -2213,6 +2226,17 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
         hideNewPostsBar()
         if (hasPostAdapter()) {
             getPostAdapter().refresh()
+        }
+    }
+
+    /*
+     * scroll to the first post from the specified blog
+     */
+    private fun scrollToFirstPostFromBlog(blogId: Long) {
+        if (!hasPostAdapter()) return
+        val position = getPostAdapter().getPositionOfFirstPostFromBlog(blogId)
+        if (position > -1) {
+            recyclerView.scrollRecycleViewToPosition(position)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -28,9 +28,12 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.BundleCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.launch
 import com.google.android.material.R as MaterialR
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
@@ -539,11 +542,11 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
             setFollowStatusForBlog(readerData)
         }
 
-        postListViewModel.scrollToSiteId.observe(
-            viewLifecycleOwner
-        ) { event: Event<Long> ->
-            event.applyIfNotHandled {
-                pendingScrollToBlogId = this
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                postListViewModel.scrollToSiteId.collect { blogId ->
+                    pendingScrollToBlogId = blogId
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -755,6 +755,24 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return (mPosts == null || mPosts.size() == 0);
     }
 
+    /**
+     * Returns the adapter position of the first post from the specified blog, or -1 if not found.
+     */
+    public int getPositionOfFirstPostFromBlog(long blogId) {
+        if (mPosts == null) return -1;
+        for (int i = 0; i < mPosts.size(); i++) {
+            if (mPosts.get(i).blogId == blogId) {
+                int adapterPosition = i + getItemPositionOffset();
+                // Account for gap marker if it appears before this position
+                if (mGapMarkerPosition > -1 && adapterPosition >= mGapMarkerPosition) {
+                    adapterPosition++;
+                }
+                return adapterPosition;
+            }
+        }
+        return -1;
+    }
+
     private boolean isBookmarksList() {
         return (getPostListType() == ReaderPostListType.TAG_FOLLOWED
                 && (mCurrentTag != null && mCurrentTag.isBookmarked()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -125,7 +125,9 @@ class ReaderPostCardActionsHandler @Inject constructor(
     private val _refreshPosts = MediatorLiveData<Event<Unit>>()
     val refreshPosts: LiveData<Event<Unit>> = _refreshPosts
 
-    // Emits a blog ID to scroll to after undo block action
+    // Emits a blog ID to scroll to after undo block action. This provides visual feedback
+    // to the user that the undo was successful by scrolling to show the restored posts.
+    // The event is consumed by ReaderPostListFragment after posts are refreshed.
     private val _scrollToSiteId = MediatorLiveData<Event<Long>>()
     val scrollToSiteId: LiveData<Event<Long>> = _scrollToSiteId
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -125,6 +125,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
     private val _refreshPosts = MediatorLiveData<Event<Unit>>()
     val refreshPosts: LiveData<Event<Unit>> = _refreshPosts
 
+    // Emits a blog ID to scroll to after undo block action
+    private val _scrollToSiteId = MediatorLiveData<Event<Long>>()
+    val scrollToSiteId: LiveData<Event<Long>> = _scrollToSiteId
+
     init {
         dispatcher.register(siteNotificationsUseCase)
     }
@@ -437,8 +441,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
                                 UiStringRes(R.string.undo),
                                 {
                                     coroutineScope.launch {
+                                        val blogId = it.blockedBlogData.blogId
                                         undoBlockBlogUseCase.undoBlockBlog(it.blockedBlogData, source)
                                         _refreshPosts.postValue(Event(Unit))
+                                        _scrollToSiteId.postValue(Event(blogId))
                                         _snackbarEvents.postValue(
                                             Event(
                                                 SnackbarMessageHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -128,8 +131,8 @@ class ReaderPostCardActionsHandler @Inject constructor(
     // Emits a blog ID to scroll to after undo block action. This provides visual feedback
     // to the user that the undo was successful by scrolling to show the restored posts.
     // The event is consumed by ReaderPostListFragment after posts are refreshed.
-    private val _scrollToSiteId = MediatorLiveData<Event<Long>>()
-    val scrollToSiteId: LiveData<Event<Long>> = _scrollToSiteId
+    private val _scrollToSiteId = MutableSharedFlow<Long>()
+    val scrollToSiteId: SharedFlow<Long> = _scrollToSiteId.asSharedFlow()
 
     init {
         dispatcher.register(siteNotificationsUseCase)
@@ -446,7 +449,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
                                         val blogId = it.blockedBlogData.blogId
                                         undoBlockBlogUseCase.undoBlockBlog(it.blockedBlogData, source)
                                         _refreshPosts.postValue(Event(Unit))
-                                        _scrollToSiteId.postValue(Event(blogId))
+                                        _scrollToSiteId.emit(blogId)
                                         _snackbarEvents.postValue(
                                             Event(
                                                 SnackbarMessageHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -71,8 +71,7 @@ class ReaderPostListViewModel @Inject constructor(
     private val _updateFollowStatus = MediatorLiveData<FollowStatusChanged>()
     val updateFollowStatus: LiveData<FollowStatusChanged> = _updateFollowStatus
 
-    private val _scrollToSiteId = MediatorLiveData<Event<Long>>()
-    val scrollToSiteId: LiveData<Event<Long>> = _scrollToSiteId
+    val scrollToSiteId = readerPostCardActionsHandler.scrollToSiteId
 
     fun start(readerViewModel: ReaderViewModel?) {
         this.readerViewModel = readerViewModel
@@ -109,10 +108,6 @@ class ReaderPostListViewModel @Inject constructor(
 
         _updateFollowStatus.addSource(readerPostCardActionsHandler.followStatusUpdated) { data ->
             _updateFollowStatus.value = data
-        }
-
-        _scrollToSiteId.addSource(readerPostCardActionsHandler.scrollToSiteId) { event ->
-            _scrollToSiteId.value = event
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -71,6 +71,9 @@ class ReaderPostListViewModel @Inject constructor(
     private val _updateFollowStatus = MediatorLiveData<FollowStatusChanged>()
     val updateFollowStatus: LiveData<FollowStatusChanged> = _updateFollowStatus
 
+    private val _scrollToSiteId = MediatorLiveData<Event<Long>>()
+    val scrollToSiteId: LiveData<Event<Long>> = _scrollToSiteId
+
     fun start(readerViewModel: ReaderViewModel?) {
         this.readerViewModel = readerViewModel
 
@@ -106,6 +109,10 @@ class ReaderPostListViewModel @Inject constructor(
 
         _updateFollowStatus.addSource(readerPostCardActionsHandler.followStatusUpdated) { data ->
             _updateFollowStatus.value = data
+        }
+
+        _scrollToSiteId.addSource(readerPostCardActionsHandler.scrollToSiteId) { event ->
+            _scrollToSiteId.value = event
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.reader.discover
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -178,7 +180,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog())
             .thenReturn(true)
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -199,7 +201,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog())
             .thenReturn(false)
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -218,7 +220,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -237,7 +239,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         val isBookmarkList = true
         // Act
         actionHandler.onAction(
@@ -257,7 +259,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(false)))
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         val isBookmarkList = true
         // Act
         actionHandler.onAction(
@@ -277,7 +279,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -298,7 +300,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(mock<FollowStatusChanged>()))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -337,7 +339,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(
                 flowOf(FollowStatusChanged(-1, -1, following = true, showEnableNotification = true))
             )
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -383,7 +385,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(FollowStatusChanged(-1, -1, following = true, showEnableNotification = true)))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         actionHandler.onAction(
             dummyReaderPostModel(),
@@ -405,7 +407,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(NoNetwork))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -424,7 +426,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(RequestFailed))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -485,7 +487,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(null)
         whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
             .thenReturn(FetchSiteState.Failed.RequestFailed)
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -545,7 +547,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.NoNetwork)
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -564,7 +566,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.RequestFailed)
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -583,7 +585,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.AlreadyRunning)
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.onAction(
@@ -646,7 +648,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
                 .thenReturn(null)
             whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
                 .thenReturn(FetchSiteState.Failed.RequestFailed)
-            val observedValues = startObserving()
+            val observedValues = startObserving(backgroundScope)
 
             // Act
             actionHandler.onAction(
@@ -688,7 +690,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Share button opens share dialog`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -706,7 +708,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Visit Site button opens browser`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -726,7 +728,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -744,7 +746,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -762,7 +764,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.NoNetwork))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -780,7 +782,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.RequestFailed))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -798,7 +800,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.RequestFailed))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -816,7 +818,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         actionHandler.onAction(
             mock(),
             BLOCK_SITE,
@@ -834,7 +836,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         actionHandler.onAction(
             mock(),
             BLOCK_SITE,
@@ -857,7 +859,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             }
         whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(blockedBlogResult)))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         actionHandler.onAction(
             mock(),
             BLOCK_SITE,
@@ -878,7 +880,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -896,7 +898,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -914,7 +916,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         actionHandler.onAction(
             mock(),
             BLOCK_USER,
@@ -932,7 +934,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         actionHandler.onAction(
             mock(),
             BLOCK_USER,
@@ -1004,7 +1006,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikedInLocalDb))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1021,7 +1023,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.RequestFailed))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1038,7 +1040,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.NoNetwork))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1055,7 +1057,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.RequestFailed))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1072,7 +1074,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Success))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1093,7 +1095,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Unchanged))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1114,7 +1116,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Arrange
         whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.AlreadyRunning))
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1158,7 +1160,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(NoSite)
         whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull()))
             .thenCallRealMethod()
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1177,7 +1179,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(MultipleSites(mock(), mock()))
         whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull()))
             .thenCallRealMethod()
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1196,7 +1198,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(SingleSite(mock(), mock()))
         whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull()))
             .thenCallRealMethod()
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1215,7 +1217,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(Unknown)
         whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull()))
             .thenCallRealMethod()
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1232,7 +1234,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Comments screen shown when the user clicks on comments button`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1250,7 +1252,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Reading preferences screen shown when the user clicks on reading preferences button`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
         // Act
         actionHandler.onAction(
             mock(),
@@ -1265,7 +1267,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Clicking on a post opens post detail`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.handleOnItemClicked(mock(), any())
@@ -1277,7 +1279,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Clicking on a video overlay opens video viewer`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.handleVideoOverlayClicked("mock")
@@ -1289,7 +1291,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Clicking on a header opens blog preview`() = test {
         // Arrange
-        val observedValues = startObserving()
+        val observedValues = startObserving(backgroundScope)
 
         // Act
         actionHandler.handleHeaderClicked(0L, 0L, false)
@@ -1298,7 +1300,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         assertThat(observedValues.navigation[0]).isInstanceOf(ShowBlogPreview::class.java)
     }
 
-    private fun startObserving(): Observers {
+    private fun startObserving(scope: CoroutineScope): Observers {
         val navigation = mutableListOf<ReaderNavigationEvents>()
         actionHandler.navigationEvents.observeForever {
             navigation.add(it.peekContent())
@@ -1325,8 +1327,8 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         }
 
         val scrollToSiteId = mutableListOf<Long>()
-        actionHandler.scrollToSiteId.observeForever {
-            scrollToSiteId.add(it.peekContent())
+        scope.launch {
+            actionHandler.scrollToSiteId.collect { scrollToSiteId.add(it) }
         }
         return Observers(navigation, snackbarMsgs, preloadPost, followStatusUpdated, refreshPosts, scrollToSiteId)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -846,6 +846,30 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Assert
         assertThat(observedValues.refreshPosts.size).isEqualTo(2)
     }
+
+    @Test
+    fun `Scroll to site emitted when user clicks on undo action in snackbar`() = test {
+        // Arrange
+        val expectedBlogId = 123L
+        val blockedBlogResult =
+            org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResult().apply {
+                blogId = expectedBlogId
+            }
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
+            .thenReturn(flowOf(SiteBlockedInLocalDb(blockedBlogResult)))
+        val observedValues = startObserving()
+        actionHandler.onAction(
+            mock(),
+            BLOCK_SITE,
+            false,
+            SOURCE
+        )
+        // Act
+        observedValues.snackbarMsgs[0].buttonAction.invoke()
+        // Assert
+        assertThat(observedValues.scrollToSiteId.size).isEqualTo(1)
+        assertThat(observedValues.scrollToSiteId[0]).isEqualTo(expectedBlogId)
+    }
     /** BLOCK SITE ACTION end **/
 
     /** BLOCK USER ACTION begin **/
@@ -1299,7 +1323,12 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         actionHandler.refreshPosts.observeForever {
             refreshPosts.add(it.peekContent())
         }
-        return Observers(navigation, snackbarMsgs, preloadPost, followStatusUpdated, refreshPosts)
+
+        val scrollToSiteId = mutableListOf<Long>()
+        actionHandler.scrollToSiteId.observeForever {
+            scrollToSiteId.add(it.peekContent())
+        }
+        return Observers(navigation, snackbarMsgs, preloadPost, followStatusUpdated, refreshPosts, scrollToSiteId)
     }
 
     /** REPORT ACTIONS start **/
@@ -1346,6 +1375,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         val snackbarMsgs: List<SnackbarMessageHolder>,
         val preloadPost: List<PreLoadPostContent>,
         val followStatusUpdated: List<FollowStatusChanged>,
-        val refreshPosts: List<Unit>
+        val refreshPosts: List<Unit>,
+        val scrollToSiteId: List<Long>
     )
 }


### PR DESCRIPTION
## Description

Fixes CMM-150

When a user blocks a site in the Reader and then taps "Undo", the blog posts are restored but previously there was no visual indication that the action was undone. Now the list automatically scrolls to show the first post from the restored blog, providing a clear visual cue.

**Changes:**
- Add `scrollToSiteId` LiveData to `ReaderPostCardActionsHandler` that emits the blog ID after undo
- Forward the event through `ReaderPostListViewModel`
- Observe in `ReaderPostListFragment` and scroll to the restored blog after data loads
- Add `getPositionOfFirstPostFromBlog()` method to `ReaderPostAdapter`

## Testing instructions

Block site undo scroll:

1. Open the Reader
2. Find a post from a blog and tap the overflow menu (three dots)
3. Tap "Block this site"
- [ ] Verify the posts from that blog disappear and a snackbar appears with "Undo"
4. Tap "Undo" on the snackbar
- [ ] Verify the posts are restored
- [ ] Verify the list scrolls to show the first post from the restored blog


https://github.com/user-attachments/assets/eed2c59b-b7ac-4648-b8ed-852416a8ec70

