### PR TITLE
Add dark mode support for Zendesk tickets screen

### DIFF
--- a/WordPress/src/main/res/layout-night/zs_activity_request_list_scene_empty.xml
+++ b/WordPress/src/main/res/layout-night/zs_activity_request_list_scene_empty.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/request_list_swipe_refresh_layout_empty"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <include layout="@layout/zs_activity_request_list_empty_logo" />
+
+        <TextView
+            android:id="@+id/request_list_description_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginLeft="64dp"
+            android:layout_marginEnd="64dp"
+            android:layout_marginRight="64dp"
+            android:gravity="center"
+            android:text="@string/request_list_empty_text"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="16sp" />
+
+        <Button
+            android:id="@+id/request_list_empty_start_conversation"
+            style="@style/ZendeskRequestListButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="16dp"
+            android:paddingTop="10dp"
+            android:paddingRight="16dp"
+            android:paddingBottom="10dp"
+            android:text="@string/request_list_empty_start_conversation" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ImageView
+            android:id="@+id/request_list_zendesk_logo_empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:contentDescription="@string/zs_general_referrer_logo_label_accessibility"
+            android:padding="8dp"
+            app:srcCompat="@drawable/zs_zendesk_product_logo" />
+
+    </LinearLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -108,16 +108,16 @@
     <color name="gravatar_sync_info_banner">#2C2C2E</color>
 
     <!-- Zendesk Dark Mode Overrides -->
-    <color name="zendesk_background_color" tools:override="true">@color/background_dark</color>
-    <color name="zs_request_list_default_item_background" tools:override="true">@color/background_dark</color>
-    <color name="zs_request_list_empty_background" tools:override="true">@color/background_dark_elevated</color>
-    <color name="zs_request_agent_background_color" tools:override="true">@color/background_dark_elevated</color>
-    <color name="zs_request_user_background_color" tools:override="true">@color/colorPrimary</color>
-    <color name="zs_request_list_text_color" tools:override="true">@color/white</color>
-    <color name="zs_request_list_dark_text_color" tools:override="true">@color/white_translucent_80</color>
-    <color name="zs_request_list_light_text_color" tools:override="true">@color/white_translucent_50</color>
-    <color name="zs_request_cell_label_color" tools:override="true">@color/white_translucent_50</color>
-    <color name="zs_request_input_hint_color" tools:override="true">@color/white_translucent_50</color>
-    <color name="zs_request_attachment_indicator_color_inactive" tools:override="true">@color/white_translucent_50</color>
-    <color name="zs_request_message_composer_send_btn_color_inactive" tools:override="true">@color/white_translucent_10</color>
+    <color name="zendesk_background_color">@color/background_dark</color>
+    <color name="zs_request_list_default_item_background">@color/background_dark</color>
+    <color name="zs_request_list_empty_background">@color/background_dark_elevated</color>
+    <color name="zs_request_agent_background_color">@color/background_dark_elevated</color>
+    <color name="zs_request_user_background_color">@color/colorPrimary</color>
+    <color name="zs_request_list_text_color">@color/white</color>
+    <color name="zs_request_list_dark_text_color">@color/white_translucent_80</color>
+    <color name="zs_request_list_light_text_color">@color/white_translucent_50</color>
+    <color name="zs_request_cell_label_color">@color/white_translucent_50</color>
+    <color name="zs_request_input_hint_color">@color/white_translucent_50</color>
+    <color name="zs_request_attachment_indicator_color_inactive">@color/white_translucent_50</color>
+    <color name="zs_request_message_composer_send_btn_color_inactive">@color/white_translucent_10</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -107,17 +107,29 @@
     <color name="gravatar_info_banner">#1C1C1E</color>
     <color name="gravatar_sync_info_banner">#2C2C2E</color>
 
-    <!-- Zendesk Dark Mode Overrides -->
-    <color name="zendesk_background_color">@color/background_dark</color>
-    <color name="zs_request_list_default_item_background">@color/background_dark</color>
-    <color name="zs_request_list_empty_background">@color/background_dark_elevated</color>
-    <color name="zs_request_agent_background_color">@color/background_dark_elevated</color>
-    <color name="zs_request_user_background_color">@color/colorPrimary</color>
-    <color name="zs_request_list_text_color">@color/white</color>
-    <color name="zs_request_list_dark_text_color">@color/white_translucent_80</color>
-    <color name="zs_request_list_light_text_color">@color/white_translucent_50</color>
-    <color name="zs_request_cell_label_color">@color/white_translucent_50</color>
-    <color name="zs_request_input_hint_color">@color/white_translucent_50</color>
-    <color name="zs_request_attachment_indicator_color_inactive">@color/white_translucent_50</color>
-    <color name="zs_request_message_composer_send_btn_color_inactive">@color/white_translucent_10</color>
+    <!-- Zendesk Dark Mode Overrides (base values provided by Zendesk SDK) -->
+    <color name="zendesk_background_color"
+        tools:ignore="MissingDefaultResource">@color/background_dark</color>
+    <color name="zs_request_list_default_item_background"
+        tools:ignore="MissingDefaultResource">@color/background_dark</color>
+    <color name="zs_request_list_empty_background"
+        tools:ignore="MissingDefaultResource">@color/background_dark_elevated</color>
+    <color name="zs_request_agent_background_color"
+        tools:ignore="MissingDefaultResource">@color/background_dark_elevated</color>
+    <color name="zs_request_user_background_color"
+        tools:ignore="MissingDefaultResource">@color/colorPrimary</color>
+    <color name="zs_request_list_text_color"
+        tools:ignore="MissingDefaultResource">@color/white</color>
+    <color name="zs_request_list_dark_text_color"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_80</color>
+    <color name="zs_request_list_light_text_color"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+    <color name="zs_request_cell_label_color"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+    <color name="zs_request_input_hint_color"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+    <color name="zs_request_attachment_indicator_color_inactive"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+    <color name="zs_request_message_composer_send_btn_color_inactive"
+        tools:ignore="MissingDefaultResource">@color/white_translucent_10</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -108,16 +108,16 @@
     <color name="gravatar_sync_info_banner">#2C2C2E</color>
 
     <!-- Zendesk Dark Mode Overrides -->
-    <color name="zendesk_background_color">@color/background_dark</color>
-    <color name="zs_request_list_default_item_background">@color/background_dark</color>
-    <color name="zs_request_list_empty_background">@color/background_dark_elevated</color>
-    <color name="zs_request_agent_background_color">@color/background_dark_elevated</color>
-    <color name="zs_request_user_background_color">@color/colorPrimary</color>
-    <color name="zs_request_list_text_color">@color/white</color>
-    <color name="zs_request_list_dark_text_color">@color/white_translucent_80</color>
-    <color name="zs_request_list_light_text_color">@color/white_translucent_50</color>
-    <color name="zs_request_cell_label_color">@color/white_translucent_50</color>
-    <color name="zs_request_input_hint_color">@color/white_translucent_50</color>
-    <color name="zs_request_attachment_indicator_color_inactive">@color/white_translucent_50</color>
-    <color name="zs_request_message_composer_send_btn_color_inactive">@color/white_translucent_10</color>
+    <color name="zendesk_background_color" tools:override="true">@color/background_dark</color>
+    <color name="zs_request_list_default_item_background" tools:override="true">@color/background_dark</color>
+    <color name="zs_request_list_empty_background" tools:override="true">@color/background_dark_elevated</color>
+    <color name="zs_request_agent_background_color" tools:override="true">@color/background_dark_elevated</color>
+    <color name="zs_request_user_background_color" tools:override="true">@color/colorPrimary</color>
+    <color name="zs_request_list_text_color" tools:override="true">@color/white</color>
+    <color name="zs_request_list_dark_text_color" tools:override="true">@color/white_translucent_80</color>
+    <color name="zs_request_list_light_text_color" tools:override="true">@color/white_translucent_50</color>
+    <color name="zs_request_cell_label_color" tools:override="true">@color/white_translucent_50</color>
+    <color name="zs_request_input_hint_color" tools:override="true">@color/white_translucent_50</color>
+    <color name="zs_request_attachment_indicator_color_inactive" tools:override="true">@color/white_translucent_50</color>
+    <color name="zs_request_message_composer_send_btn_color_inactive" tools:override="true">@color/white_translucent_10</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -109,27 +109,27 @@
 
     <!-- Zendesk Dark Mode Overrides (base values provided by Zendesk SDK) -->
     <color name="zendesk_background_color"
-        tools:ignore="MissingDefaultResource">@color/background_dark</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/background_dark</color>
     <color name="zs_request_list_default_item_background"
-        tools:ignore="MissingDefaultResource">@color/background_dark</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/background_dark</color>
     <color name="zs_request_list_empty_background"
-        tools:ignore="MissingDefaultResource">@color/background_dark_elevated</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/background_dark_elevated</color>
     <color name="zs_request_agent_background_color"
-        tools:ignore="MissingDefaultResource">@color/background_dark_elevated</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/background_dark_elevated</color>
     <color name="zs_request_user_background_color"
-        tools:ignore="MissingDefaultResource">@color/colorPrimary</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/colorPrimary</color>
     <color name="zs_request_list_text_color"
-        tools:ignore="MissingDefaultResource">@color/white</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white</color>
     <color name="zs_request_list_dark_text_color"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_80</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_80</color>
     <color name="zs_request_list_light_text_color"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_50</color>
     <color name="zs_request_cell_label_color"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_50</color>
     <color name="zs_request_input_hint_color"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_50</color>
     <color name="zs_request_attachment_indicator_color_inactive"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_50</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_50</color>
     <color name="zs_request_message_composer_send_btn_color_inactive"
-        tools:ignore="MissingDefaultResource">@color/white_translucent_10</color>
+        tools:ignore="MissingDefaultResource,UnusedResources">@color/white_translucent_10</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -114,10 +114,10 @@
     <color name="zs_request_agent_background_color">@color/background_dark_elevated</color>
     <color name="zs_request_user_background_color">@color/colorPrimary</color>
     <color name="zs_request_list_text_color">@color/white</color>
-    <color name="zs_request_list_dark_text_color">#DEFFFFFF</color>
-    <color name="zs_request_list_light_text_color">#8AFFFFFF</color>
-    <color name="zs_request_cell_label_color">#8AFFFFFF</color>
-    <color name="zs_request_input_hint_color">#60FFFFFF</color>
-    <color name="zs_request_attachment_indicator_color_inactive">#89FFFFFF</color>
-    <color name="zs_request_message_composer_send_btn_color_inactive">#1EFFFFFF</color>
+    <color name="zs_request_list_dark_text_color">@color/white_translucent_80</color>
+    <color name="zs_request_list_light_text_color">@color/white_translucent_50</color>
+    <color name="zs_request_cell_label_color">@color/white_translucent_50</color>
+    <color name="zs_request_input_hint_color">@color/white_translucent_50</color>
+    <color name="zs_request_attachment_indicator_color_inactive">@color/white_translucent_50</color>
+    <color name="zs_request_message_composer_send_btn_color_inactive">@color/white_translucent_10</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -106,4 +106,18 @@
     <!-- Gravatar Info Banners -->
     <color name="gravatar_info_banner">#1C1C1E</color>
     <color name="gravatar_sync_info_banner">#2C2C2E</color>
+
+    <!-- Zendesk Dark Mode Overrides -->
+    <color name="zendesk_background_color">@color/background_dark</color>
+    <color name="zs_request_list_default_item_background">@color/background_dark</color>
+    <color name="zs_request_list_empty_background">@color/background_dark_elevated</color>
+    <color name="zs_request_agent_background_color">@color/background_dark_elevated</color>
+    <color name="zs_request_user_background_color">@color/colorPrimary</color>
+    <color name="zs_request_list_text_color">@color/white</color>
+    <color name="zs_request_list_dark_text_color">#DEFFFFFF</color>
+    <color name="zs_request_list_light_text_color">#8AFFFFFF</color>
+    <color name="zs_request_cell_label_color">#8AFFFFFF</color>
+    <color name="zs_request_input_hint_color">#60FFFFFF</color>
+    <color name="zs_request_attachment_indicator_color_inactive">#89FFFFFF</color>
+    <color name="zs_request_message_composer_send_btn_color_inactive">#1EFFFFFF</color>
 </resources>

--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">@color/primary_dark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -10,4 +10,13 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
+
+    <!-- Zendesk Styles Override -->
+
+    <style name="ZendeskRequestListButton" parent="@style/Widget.MaterialComponents.Button">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="backgroundTint">@null</item>
+        <item name="android:background">@color/colorPrimary</item>
+    </style>
 </resources>

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>


### PR DESCRIPTION
**Closes CMM-167**

Override Zendesk SDK colors in night resources to properly support dark mode:

- Background colors for list and empty states
- Text colors with appropriate alpha values
- Message bubble colors for agent and user messages
- Input hint and button inactive colors
- Night layout for empty state with theme-aware text color

<img width="297" height="629" alt="after" src="https://github.com/user-attachments/assets/5ec85f05-8986-43a6-81f9-91fb7482d4e4" />
