### PR TITLE
Opt Zendesk screens out of edge-to-edge enforcement

### DIFF
--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">@color/primary_dark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>


### PR DESCRIPTION
## Description

Previously the Zendesk screens covered the Android system bar, like this:

<img width="297" height="629" alt="before" src="https://github.com/user-attachments/assets/03aec0e9-bee0-4d7c-8131-2026c5021190" />

This PR addresses this by changing the parent style from `WordPress.NoActionBar` to `WordPress.NoActionBar.NoEdgeToEdge`. This opts out of edge-to-edge enforcement introduced in Android 15 (API 35), ensuring the system status bar remains visible on Zendesk ticket screens.

<img width="297" height="629" alt="after" src="https://github.com/user-attachments/assets/bb9a327d-c2b9-4e16-a195-1cec92b54449" />


## Testing instructions

Navigate to Me → Help → My Tickets and verify the system status bar is visible and not covered by the Zendesk content

