### PR TITLE
CMM-1208  strange subscription notifications UI settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -336,7 +336,13 @@ public class ReaderSiteHeaderView extends LinearLayout {
                 return;
             }
             setFollowButtonLoading(false);
-            if (!succeeded) {
+            if (succeeded) {
+                // Update cached blog info and subscription settings button visibility
+                if (mBlogInfo != null) {
+                    mBlogInfo.isFollowing = isAskingToFollow;
+                    updateSubscriptionSettingsButtonVisibility(mBlogInfo);
+                }
+            } else {
                 int errResId = isAskingToFollow ? R.string.reader_toast_err_unable_to_follow_blog
                         : R.string.reader_toast_err_unable_to_unfollow_blog;
                 ToastUtils.showToast(getContext(), errResId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -317,6 +317,11 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         mFollowButton.setIsFollowed(isAskingToFollow);
 
+        // Disable subscription settings button while unsubscribing
+        if (!isAskingToFollow && mSubscriptionSettingsButton != null) {
+            mSubscriptionSettingsButton.setEnabled(false);
+        }
+
         OnFollowListener followListener =
                 mFollowListenerRef != null ? mFollowListenerRef.get() : null;
         if (followListener != null) {
@@ -347,6 +352,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
                         : R.string.reader_toast_err_unable_to_unfollow_blog;
                 ToastUtils.showToast(getContext(), errResId);
                 mFollowButton.setIsFollowed(!isAskingToFollow);
+                // Re-enable subscription settings button if unsubscribe failed
+                if (!isAskingToFollow && mSubscriptionSettingsButton != null) {
+                    mSubscriptionSettingsButton.setEnabled(true);
+                }
             }
         };
 
@@ -386,6 +395,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
         // Only show settings for followed WordPress.com blogs (not external feeds)
         boolean showSettings = blogInfo.isFollowing && !mIsFeed && mAccountStore.hasAccessToken();
         mSubscriptionSettingsButton.setVisibility(showSettings ? View.VISIBLE : View.GONE);
+        mSubscriptionSettingsButton.setEnabled(showSettings);
 
         if (showSettings) {
             mSubscriptionSettingsButton.setOnClickListener(v -> {


### PR DESCRIPTION
## Description                                                                                                                                                                  
                                                                                                                                                                                  
  Fixes UI inconsistencies in the Reader blog subscription settings button behavior.                                                                                              
                                                                                                                                                                                  
  **Problems:**                                                                                                                                                                   
  1. The subscription settings button was not visible after subscribing, but visible after unsubscribing (inverted behavior)                                                      
  2. The "notify via email" switch showed incorrect state because the settings were accessible when unsubscribed, displaying stale data                                           
  3. The settings button remained clickable during the unsubscribe operation                                                                                                      
                                                                                                                                                                                  
  **Root cause:**                                                                                                                                                                 
  In `ReaderSiteHeaderView.java`, after a successful follow/unfollow action, the cached `mBlogInfo.isFollowing` was never updated and                                             
  `updateSubscriptionSettingsButtonVisibility()` was never called, causing the button visibility to remain based on stale state.                                                  
                                                                                                                                                                                  
  **Fix:**                                                                                                                                                                        
  - Update `mBlogInfo.isFollowing` after successful follow/unfollow                                                                                                               
  - Call `updateSubscriptionSettingsButtonVisibility()` to refresh the button immediately                                                                                         
  - Disable the settings button while unsubscribing to prevent interaction during the operation                                                                                   
  - Re-enable the button if unsubscribe fails                                                                                                                                     
                                                                                                                                                                                  
  ## Testing instructions                                                                                                                                                         
                                                                                                                                                                                  
  Test subscription settings button visibility:                                                                                                                                   
                                                                                                                                                                                  
  1. Open the Reader and navigate to a blog you are NOT subscribed to                                                                                                             
  2. Tap the Subscribe button                                                                                                                                                     
  - [x] Verify the subscription settings icon appears after subscribing                                                                                                           
  3. Tap the subscription settings icon                                                                                                                                           
  - [x] Verify the settings bottom sheet opens with correct toggle states                                                                                                         
  4. Close the settings and tap the Subscribed button to unsubscribe                                                                                                              
  - [x] Verify the settings icon becomes disabled while unsubscribing                                                                                                             
  - [x] Verify the settings icon disappears after unsubscribing                                                                                                                   
                                                                                                                                                                                  
 

https://github.com/user-attachments/assets/2bf61601-e935-44a6-b0a2-c227a5b4eda9

