### PR TITLE
CMM-1146 stats create cards handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -268,6 +268,22 @@ private fun TrafficTabContent(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
+            if (visibleCards.isEmpty()) {
+                // Empty state message
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(R.string.stats_no_cards_message),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
             // Dynamic card rendering based on configuration
             visibleCards.forEach { cardType ->
                 when (cardType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.newstats.countries.CountriesCard
 import org.wordpress.android.ui.newstats.countries.CountriesDetailActivity
 import org.wordpress.android.ui.newstats.countries.CountriesViewModel
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedCard
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedDetailActivity
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedViewModel
 import org.wordpress.android.ui.newstats.todaysstats.TodaysStatsCard
@@ -210,7 +211,8 @@ private fun TrafficTabContent(
     val context = LocalContext.current
     val todaysStatsUiState by todaysStatsViewModel.uiState.collectAsState()
     val viewsStatsUiState by viewsStatsViewModel.uiState.collectAsState()
-    val mostViewedUiState by mostViewedViewModel.uiState.collectAsState()
+    val postsUiState by mostViewedViewModel.postsUiState.collectAsState()
+    val referrersUiState by mostViewedViewModel.referrersUiState.collectAsState()
     val countriesUiState by countriesViewModel.uiState.collectAsState()
     val selectedPeriod by viewsStatsViewModel.selectedPeriod.collectAsState()
     val isTodaysStatsRefreshing by todaysStatsViewModel.isRefreshing.collectAsState()
@@ -224,6 +226,8 @@ private fun TrafficTabContent(
     // Card configuration state
     val visibleCards by newStatsViewModel.visibleCards.collectAsState()
     val hiddenCards by newStatsViewModel.hiddenCards.collectAsState()
+    val mostViewedDataSources by newStatsViewModel.mostViewedDataSources.collectAsState()
+    val hiddenMostViewedDataSources by newStatsViewModel.hiddenMostViewedDataSources.collectAsState()
     var showAddCardSheet by remember { mutableStateOf(false) }
     val addCardSheetState = rememberModalBottomSheetState()
 
@@ -237,9 +241,13 @@ private fun TrafficTabContent(
         AddStatsCardBottomSheet(
             sheetState = addCardSheetState,
             availableCards = hiddenCards,
+            availableMostViewedDataSources = hiddenMostViewedDataSources,
             onDismiss = { showAddCardSheet = false },
             onCardSelected = { cardType ->
                 newStatsViewModel.addCard(cardType)
+            },
+            onMostViewedDataSourceSelected = { dataSource ->
+                newStatsViewModel.addMostViewedCard(dataSource)
             }
         )
     }
@@ -285,7 +293,9 @@ private fun TrafficTabContent(
             }
 
             // Dynamic card rendering based on configuration
-            visibleCards.forEach { cardType ->
+            // Count Most Viewed cards up to each position
+            var mostViewedIndex = 0
+            visibleCards.forEachIndexed { _, cardType ->
                 when (cardType) {
                     StatsCardType.TODAYS_STATS -> TodaysStatsCard(
                         uiState = todaysStatsUiState,
@@ -297,24 +307,49 @@ private fun TrafficTabContent(
                         onRetry = viewsStatsViewModel::onRetry,
                         onRemoveCard = { newStatsViewModel.removeCard(cardType) }
                     )
-                    StatsCardType.MOST_VIEWED -> MostViewedCard(
-                        uiState = mostViewedUiState,
-                        onDataSourceChanged = mostViewedViewModel::onDataSourceChanged,
-                        onShowAllClick = {
-                            val detailData = mostViewedViewModel.getDetailData()
-                            MostViewedDetailActivity.start(
-                                context = context,
-                                dataSource = detailData.dataSource,
-                                items = detailData.items,
-                                totalViews = detailData.totalViews,
-                                totalViewsChange = detailData.totalViewsChange,
-                                totalViewsChangePercent = detailData.totalViewsChangePercent,
-                                dateRange = detailData.dateRange
-                            )
-                        },
-                        onRetry = mostViewedViewModel::onRetry,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
-                    )
+                    StatsCardType.MOST_VIEWED -> {
+                        val index = mostViewedIndex
+                        mostViewedIndex++
+                        val dataSource = mostViewedDataSources.getOrNull(index)
+                            ?: MostViewedDataSource.POSTS_AND_PAGES
+                        val uiState = when (dataSource) {
+                            MostViewedDataSource.POSTS_AND_PAGES -> postsUiState
+                            MostViewedDataSource.REFERRERS -> referrersUiState
+                        }
+                        MostViewedCard(
+                            uiState = uiState,
+                            dataSource = dataSource,
+                            onDataSourceChanged = { newDataSource ->
+                                newStatsViewModel.updateMostViewedDataSource(index, newDataSource)
+                            },
+                            onShowAllClick = {
+                                val detailData = when (dataSource) {
+                                    MostViewedDataSource.POSTS_AND_PAGES ->
+                                        mostViewedViewModel.getPostsDetailData()
+                                    MostViewedDataSource.REFERRERS ->
+                                        mostViewedViewModel.getReferrersDetailData()
+                                }
+                                MostViewedDetailActivity.start(
+                                    context = context,
+                                    dataSource = detailData.dataSource,
+                                    items = detailData.items,
+                                    totalViews = detailData.totalViews,
+                                    totalViewsChange = detailData.totalViewsChange,
+                                    totalViewsChangePercent = detailData.totalViewsChangePercent,
+                                    dateRange = detailData.dateRange
+                                )
+                            },
+                            onRetry = {
+                                when (dataSource) {
+                                    MostViewedDataSource.POSTS_AND_PAGES ->
+                                        mostViewedViewModel.onRetryPosts()
+                                    MostViewedDataSource.REFERRERS ->
+                                        mostViewedViewModel.onRetryReferrers()
+                                }
+                            },
+                            onRemoveCard = { newStatsViewModel.removeMostViewedCard(index) }
+                        )
+                    }
                     StatsCardType.COUNTRIES -> CountriesCard(
                         uiState = countriesUiState,
                         onShowAllClick = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -295,7 +296,7 @@ private fun TrafficTabContent(
             // Dynamic card rendering based on configuration
             // Count Most Viewed cards up to each position
             var mostViewedIndex = 0
-            visibleCards.forEachIndexed { _, cardType ->
+            visibleCards.forEach { cardType ->
                 when (cardType) {
                     StatsCardType.TODAYS_STATS -> TodaysStatsCard(
                         uiState = todaysStatsUiState,
@@ -395,7 +396,7 @@ private fun AddCardButton(
             contentDescription = null,
             modifier = Modifier.size(18.dp)
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.width(8.dp))
         Text(stringResource(R.string.stats_add_card_title))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -274,19 +275,16 @@ private fun TrafficTabContent(
             if (visibleCards.isEmpty()) {
                 // Empty state message
                 val emptyStateMessage = stringResource(R.string.stats_no_cards_message)
-                Box(
+                Text(
+                    text = emptyStateMessage,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(32.dp)
                         .semantics { contentDescription = emptyStateMessage },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = emptyStateMessage,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                    textAlign = TextAlign.Center
+                )
             }
 
             // Dynamic card rendering based on configuration

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -48,6 +48,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -271,14 +273,16 @@ private fun TrafficTabContent(
         ) {
             if (visibleCards.isEmpty()) {
                 // Empty state message
+                val emptyStateMessage = stringResource(R.string.stats_no_cards_message)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(32.dp),
+                        .padding(32.dp)
+                        .semantics { contentDescription = emptyStateMessage },
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = stringResource(R.string.stats_no_cards_message),
+                        text = emptyStateMessage,
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -6,14 +6,19 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.DropdownMenu
@@ -22,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
@@ -30,6 +36,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -43,12 +50,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.newstats.components.AddStatsCardBottomSheet
 import org.wordpress.android.ui.newstats.countries.CountriesCard
 import org.wordpress.android.ui.newstats.countries.CountriesDetailActivity
 import org.wordpress.android.ui.newstats.countries.CountriesViewModel
@@ -195,7 +204,8 @@ private fun TrafficTabContent(
     viewsStatsViewModel: ViewsStatsViewModel,
     todaysStatsViewModel: TodaysStatsViewModel = viewModel(),
     mostViewedViewModel: MostViewedViewModel = viewModel(),
-    countriesViewModel: CountriesViewModel = viewModel()
+    countriesViewModel: CountriesViewModel = viewModel(),
+    newStatsViewModel: NewStatsViewModel = viewModel()
 ) {
     val context = LocalContext.current
     val todaysStatsUiState by todaysStatsViewModel.uiState.collectAsState()
@@ -211,10 +221,27 @@ private fun TrafficTabContent(
         isMostViewedRefreshing || isCountriesRefreshing
     val pullToRefreshState = rememberPullToRefreshState()
 
+    // Card configuration state
+    val visibleCards by newStatsViewModel.visibleCards.collectAsState()
+    val hiddenCards by newStatsViewModel.hiddenCards.collectAsState()
+    var showAddCardSheet by remember { mutableStateOf(false) }
+    val addCardSheetState = rememberModalBottomSheetState()
+
     // Propagate period changes to the MostViewedViewModel and CountriesViewModel
     LaunchedEffect(selectedPeriod) {
         mostViewedViewModel.onPeriodChanged(selectedPeriod)
         countriesViewModel.onPeriodChanged(selectedPeriod)
+    }
+
+    if (showAddCardSheet) {
+        AddStatsCardBottomSheet(
+            sheetState = addCardSheetState,
+            availableCards = hiddenCards,
+            onDismiss = { showAddCardSheet = false },
+            onCardSelected = { cardType ->
+                newStatsViewModel.addCard(cardType)
+            }
+        )
     }
 
     PullToRefreshBox(
@@ -241,48 +268,84 @@ private fun TrafficTabContent(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
-            TodaysStatsCard(uiState = todaysStatsUiState)
-            ViewsStatsCard(
-                uiState = viewsStatsUiState,
-                onChartTypeChanged = viewsStatsViewModel::onChartTypeChanged,
-                onRetry = viewsStatsViewModel::onRetry
-            )
-            MostViewedCard(
-                uiState = mostViewedUiState,
-                onDataSourceChanged = mostViewedViewModel::onDataSourceChanged,
-                onShowAllClick = {
-                    val detailData = mostViewedViewModel.getDetailData()
-                    MostViewedDetailActivity.start(
-                        context = context,
-                        dataSource = detailData.dataSource,
-                        items = detailData.items,
-                        totalViews = detailData.totalViews,
-                        totalViewsChange = detailData.totalViewsChange,
-                        totalViewsChangePercent = detailData.totalViewsChangePercent,
-                        dateRange = detailData.dateRange
+            // Dynamic card rendering based on configuration
+            visibleCards.forEach { cardType ->
+                when (cardType) {
+                    StatsCardType.TODAYS_STATS -> TodaysStatsCard(
+                        uiState = todaysStatsUiState,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
                     )
-                },
-                onRetry = mostViewedViewModel::onRetry
-            )
-            CountriesCard(
-                uiState = countriesUiState,
-                onShowAllClick = {
-                    val detailData = countriesViewModel.getDetailData()
-                    CountriesDetailActivity.start(
-                        context = context,
-                        countries = detailData.countries,
-                        mapData = detailData.mapData,
-                        minViews = detailData.minViews,
-                        maxViews = detailData.maxViews,
-                        totalViews = detailData.totalViews,
-                        totalViewsChange = detailData.totalViewsChange,
-                        totalViewsChangePercent = detailData.totalViewsChangePercent,
-                        dateRange = detailData.dateRange
+                    StatsCardType.VIEWS_STATS -> ViewsStatsCard(
+                        uiState = viewsStatsUiState,
+                        onChartTypeChanged = viewsStatsViewModel::onChartTypeChanged,
+                        onRetry = viewsStatsViewModel::onRetry,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
                     )
-                },
-                onRetry = countriesViewModel::onRetry
+                    StatsCardType.MOST_VIEWED -> MostViewedCard(
+                        uiState = mostViewedUiState,
+                        onDataSourceChanged = mostViewedViewModel::onDataSourceChanged,
+                        onShowAllClick = {
+                            val detailData = mostViewedViewModel.getDetailData()
+                            MostViewedDetailActivity.start(
+                                context = context,
+                                dataSource = detailData.dataSource,
+                                items = detailData.items,
+                                totalViews = detailData.totalViews,
+                                totalViewsChange = detailData.totalViewsChange,
+                                totalViewsChangePercent = detailData.totalViewsChangePercent,
+                                dateRange = detailData.dateRange
+                            )
+                        },
+                        onRetry = mostViewedViewModel::onRetry,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                    )
+                    StatsCardType.COUNTRIES -> CountriesCard(
+                        uiState = countriesUiState,
+                        onShowAllClick = {
+                            val detailData = countriesViewModel.getDetailData()
+                            CountriesDetailActivity.start(
+                                context = context,
+                                countries = detailData.countries,
+                                mapData = detailData.mapData,
+                                minViews = detailData.minViews,
+                                maxViews = detailData.maxViews,
+                                totalViews = detailData.totalViews,
+                                totalViewsChange = detailData.totalViewsChange,
+                                totalViewsChangePercent = detailData.totalViewsChangePercent,
+                                dateRange = detailData.dateRange
+                            )
+                        },
+                        onRetry = countriesViewModel::onRetry,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                    )
+                }
+            }
+
+            // Add Card Button
+            AddCardButton(
+                onClick = { showAddCardSheet = true },
+                modifier = Modifier.padding(16.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun AddCardButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(stringResource(R.string.stats_add_card_title))
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -62,7 +62,6 @@ import org.wordpress.android.ui.newstats.countries.CountriesCard
 import org.wordpress.android.ui.newstats.countries.CountriesDetailActivity
 import org.wordpress.android.ui.newstats.countries.CountriesViewModel
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedCard
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedDetailActivity
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedViewModel
 import org.wordpress.android.ui.newstats.todaysstats.TodaysStatsCard
@@ -226,8 +225,6 @@ private fun TrafficTabContent(
     // Card configuration state
     val visibleCards by newStatsViewModel.visibleCards.collectAsState()
     val hiddenCards by newStatsViewModel.hiddenCards.collectAsState()
-    val mostViewedDataSources by newStatsViewModel.mostViewedDataSources.collectAsState()
-    val hiddenMostViewedDataSources by newStatsViewModel.hiddenMostViewedDataSources.collectAsState()
     var showAddCardSheet by remember { mutableStateOf(false) }
     val addCardSheetState = rememberModalBottomSheetState()
 
@@ -241,13 +238,9 @@ private fun TrafficTabContent(
         AddStatsCardBottomSheet(
             sheetState = addCardSheetState,
             availableCards = hiddenCards,
-            availableMostViewedDataSources = hiddenMostViewedDataSources,
             onDismiss = { showAddCardSheet = false },
             onCardSelected = { cardType ->
                 newStatsViewModel.addCard(cardType)
-            },
-            onMostViewedDataSourceSelected = { dataSource ->
-                newStatsViewModel.addMostViewedCard(dataSource)
             }
         )
     }
@@ -293,8 +286,6 @@ private fun TrafficTabContent(
             }
 
             // Dynamic card rendering based on configuration
-            // Count Most Viewed cards up to each position
-            var mostViewedIndex = 0
             visibleCards.forEach { cardType ->
                 when (cardType) {
                     StatsCardType.TODAYS_STATS -> TodaysStatsCard(
@@ -307,49 +298,42 @@ private fun TrafficTabContent(
                         onRetry = viewsStatsViewModel::onRetry,
                         onRemoveCard = { newStatsViewModel.removeCard(cardType) }
                     )
-                    StatsCardType.MOST_VIEWED -> {
-                        val index = mostViewedIndex
-                        mostViewedIndex++
-                        val dataSource = mostViewedDataSources.getOrNull(index)
-                            ?: MostViewedDataSource.POSTS_AND_PAGES
-                        val uiState = when (dataSource) {
-                            MostViewedDataSource.POSTS_AND_PAGES -> postsUiState
-                            MostViewedDataSource.REFERRERS -> referrersUiState
-                        }
-                        MostViewedCard(
-                            uiState = uiState,
-                            dataSource = dataSource,
-                            onDataSourceChanged = { newDataSource ->
-                                newStatsViewModel.updateMostViewedDataSource(index, newDataSource)
-                            },
-                            onShowAllClick = {
-                                val detailData = when (dataSource) {
-                                    MostViewedDataSource.POSTS_AND_PAGES ->
-                                        mostViewedViewModel.getPostsDetailData()
-                                    MostViewedDataSource.REFERRERS ->
-                                        mostViewedViewModel.getReferrersDetailData()
-                                }
-                                MostViewedDetailActivity.start(
-                                    context = context,
-                                    dataSource = detailData.dataSource,
-                                    items = detailData.items,
-                                    totalViews = detailData.totalViews,
-                                    totalViewsChange = detailData.totalViewsChange,
-                                    totalViewsChangePercent = detailData.totalViewsChangePercent,
-                                    dateRange = detailData.dateRange
-                                )
-                            },
-                            onRetry = {
-                                when (dataSource) {
-                                    MostViewedDataSource.POSTS_AND_PAGES ->
-                                        mostViewedViewModel.onRetryPosts()
-                                    MostViewedDataSource.REFERRERS ->
-                                        mostViewedViewModel.onRetryReferrers()
-                                }
-                            },
-                            onRemoveCard = { newStatsViewModel.removeMostViewedCard(index) }
-                        )
-                    }
+                    StatsCardType.MOST_VIEWED_POSTS_AND_PAGES -> MostViewedCard(
+                        uiState = postsUiState,
+                        cardType = cardType,
+                        onShowAllClick = {
+                            val detailData = mostViewedViewModel.getPostsDetailData()
+                            MostViewedDetailActivity.start(
+                                context = context,
+                                cardType = detailData.cardType,
+                                items = detailData.items,
+                                totalViews = detailData.totalViews,
+                                totalViewsChange = detailData.totalViewsChange,
+                                totalViewsChangePercent = detailData.totalViewsChangePercent,
+                                dateRange = detailData.dateRange
+                            )
+                        },
+                        onRetry = mostViewedViewModel::onRetryPosts,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                    )
+                    StatsCardType.MOST_VIEWED_REFERRERS -> MostViewedCard(
+                        uiState = referrersUiState,
+                        cardType = cardType,
+                        onShowAllClick = {
+                            val detailData = mostViewedViewModel.getReferrersDetailData()
+                            MostViewedDetailActivity.start(
+                                context = context,
+                                cardType = detailData.cardType,
+                                items = detailData.items,
+                                totalViews = detailData.totalViews,
+                                totalViewsChange = detailData.totalViewsChange,
+                                totalViewsChangePercent = detailData.totalViewsChangePercent,
+                                dateRange = detailData.dateRange
+                            )
+                        },
+                        onRetry = mostViewedViewModel::onRetryReferrers,
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                    )
                     StatsCardType.COUNTRIES -> CountriesCard(
                         uiState = countriesUiState,
                         onShowAllClick = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -21,7 +21,6 @@ class NewStatsViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardConfigurationRepository: StatsCardsConfigurationRepository
 ) : ViewModel() {
-
     private val _visibleCards = MutableStateFlow<List<StatsCardType>>(StatsCardType.defaultCards())
     val visibleCards: StateFlow<List<StatsCardType>> = _visibleCards.asStateFlow()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
 import javax.inject.Inject
 
@@ -27,6 +28,17 @@ class NewStatsViewModel @Inject constructor(
     private val _hiddenCards = MutableStateFlow<List<StatsCardType>>(emptyList())
     val hiddenCards: StateFlow<List<StatsCardType>> = _hiddenCards.asStateFlow()
 
+    // Data sources for visible Most Viewed cards (in order)
+    private val _mostViewedDataSources = MutableStateFlow<List<MostViewedDataSource>>(
+        listOf(MostViewedDataSource.POSTS_AND_PAGES, MostViewedDataSource.REFERRERS)
+    )
+    val mostViewedDataSources: StateFlow<List<MostViewedDataSource>> = _mostViewedDataSources.asStateFlow()
+
+    // Hidden Most Viewed data sources (available to add)
+    private val _hiddenMostViewedDataSources = MutableStateFlow<List<MostViewedDataSource>>(emptyList())
+    val hiddenMostViewedDataSources: StateFlow<List<MostViewedDataSource>> =
+        _hiddenMostViewedDataSources.asStateFlow()
+
     private val siteId: Long
         get() = selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
 
@@ -38,8 +50,7 @@ class NewStatsViewModel @Inject constructor(
     private fun loadConfiguration() {
         viewModelScope.launch {
             val config = cardConfigurationRepository.getConfiguration(siteId)
-            _visibleCards.value = config.visibleCards
-            _hiddenCards.value = config.hiddenCards()
+            updateFromConfiguration(config)
         }
     }
 
@@ -47,11 +58,19 @@ class NewStatsViewModel @Inject constructor(
         viewModelScope.launch {
             cardConfigurationRepository.configurationFlow.collect { pair ->
                 if (pair != null && pair.first == siteId) {
-                    _visibleCards.value = pair.second.visibleCards
-                    _hiddenCards.value = pair.second.hiddenCards()
+                    updateFromConfiguration(pair.second)
                 }
             }
         }
+    }
+
+    private fun updateFromConfiguration(config: StatsCardsConfiguration) {
+        _visibleCards.value = config.visibleCards
+        _hiddenCards.value = config.hiddenCards()
+        _mostViewedDataSources.value = config.mostViewedDataSources.mapNotNull { name ->
+            runCatching { MostViewedDataSource.valueOf(name) }.getOrNull()
+        }
+        _hiddenMostViewedDataSources.value = config.hiddenMostViewedDataSources()
     }
 
     fun removeCard(cardType: StatsCardType) {
@@ -63,6 +82,44 @@ class NewStatsViewModel @Inject constructor(
     fun addCard(cardType: StatsCardType) {
         viewModelScope.launch {
             cardConfigurationRepository.addCard(siteId, cardType)
+        }
+    }
+
+    /**
+     * Removes a Most Viewed card at the given index.
+     */
+    fun removeMostViewedCard(index: Int) {
+        viewModelScope.launch {
+            cardConfigurationRepository.removeMostViewedCard(siteId, index)
+        }
+    }
+
+    /**
+     * Adds a Most Viewed card with the given data source.
+     */
+    fun addMostViewedCard(dataSource: MostViewedDataSource) {
+        viewModelScope.launch {
+            cardConfigurationRepository.addMostViewedCard(siteId, dataSource.name)
+        }
+    }
+
+    /**
+     * Updates the data source for a Most Viewed card at the given index.
+     */
+    fun updateMostViewedDataSource(index: Int, dataSource: MostViewedDataSource) {
+        // Update locally immediately for responsiveness
+        val currentSources = _mostViewedDataSources.value.toMutableList()
+        if (index in currentSources.indices) {
+            currentSources[index] = dataSource
+            _mostViewedDataSources.value = currentSources
+            // Update hidden data sources
+            _hiddenMostViewedDataSources.value = MostViewedDataSource.entries.filter {
+                it !in currentSources
+            }
+        }
+        // Persist
+        viewModelScope.launch {
+            cardConfigurationRepository.updateMostViewedDataSource(siteId, index, dataSource.name)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -37,9 +37,10 @@ class NewStatsViewModel @Inject constructor(
 
     @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration() {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
         viewModelScope.launch {
             try {
-                val config = cardConfigurationRepository.getConfiguration(siteId)
+                val config = cardConfigurationRepository.getConfiguration(currentSiteId)
                 updateFromConfiguration(config)
             } catch (e: Exception) {
                 AppLog.e(AppLog.T.STATS, "Failed to load card configuration", e)
@@ -64,14 +65,16 @@ class NewStatsViewModel @Inject constructor(
     }
 
     fun removeCard(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
         viewModelScope.launch {
-            cardConfigurationRepository.removeCard(siteId, cardType)
+            cardConfigurationRepository.removeCard(currentSiteId, cardType)
         }
     }
 
     fun addCard(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
         viewModelScope.launch {
-            cardConfigurationRepository.addCard(siteId, cardType)
+            cardConfigurationRepository.addCard(currentSiteId, cardType)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 /**
@@ -34,10 +35,16 @@ class NewStatsViewModel @Inject constructor(
         observeConfigurationChanges()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration() {
         viewModelScope.launch {
-            val config = cardConfigurationRepository.getConfiguration(siteId)
-            updateFromConfiguration(config)
+            try {
+                val config = cardConfigurationRepository.getConfiguration(siteId)
+                updateFromConfiguration(config)
+            } catch (e: Exception) {
+                AppLog.e(AppLog.T.STATS, "Failed to load card configuration", e)
+                updateFromConfiguration(StatsCardsConfiguration())
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
 import javax.inject.Inject
 
@@ -26,17 +25,6 @@ class NewStatsViewModel @Inject constructor(
 
     private val _hiddenCards = MutableStateFlow<List<StatsCardType>>(emptyList())
     val hiddenCards: StateFlow<List<StatsCardType>> = _hiddenCards.asStateFlow()
-
-    // Data sources for visible Most Viewed cards (in order)
-    private val _mostViewedDataSources = MutableStateFlow<List<MostViewedDataSource>>(
-        listOf(MostViewedDataSource.POSTS_AND_PAGES, MostViewedDataSource.REFERRERS)
-    )
-    val mostViewedDataSources: StateFlow<List<MostViewedDataSource>> = _mostViewedDataSources.asStateFlow()
-
-    // Hidden Most Viewed data sources (available to add)
-    private val _hiddenMostViewedDataSources = MutableStateFlow<List<MostViewedDataSource>>(emptyList())
-    val hiddenMostViewedDataSources: StateFlow<List<MostViewedDataSource>> =
-        _hiddenMostViewedDataSources.asStateFlow()
 
     private val siteId: Long
         get() = selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
@@ -66,10 +54,6 @@ class NewStatsViewModel @Inject constructor(
     private fun updateFromConfiguration(config: StatsCardsConfiguration) {
         _visibleCards.value = config.visibleCards
         _hiddenCards.value = config.hiddenCards()
-        _mostViewedDataSources.value = config.mostViewedDataSources.mapNotNull { name ->
-            runCatching { MostViewedDataSource.valueOf(name) }.getOrNull()
-        }
-        _hiddenMostViewedDataSources.value = config.hiddenMostViewedDataSources()
     }
 
     fun removeCard(cardType: StatsCardType) {
@@ -81,44 +65,6 @@ class NewStatsViewModel @Inject constructor(
     fun addCard(cardType: StatsCardType) {
         viewModelScope.launch {
             cardConfigurationRepository.addCard(siteId, cardType)
-        }
-    }
-
-    /**
-     * Removes a Most Viewed card at the given index.
-     */
-    fun removeMostViewedCard(index: Int) {
-        viewModelScope.launch {
-            cardConfigurationRepository.removeMostViewedCard(siteId, index)
-        }
-    }
-
-    /**
-     * Adds a Most Viewed card with the given data source.
-     */
-    fun addMostViewedCard(dataSource: MostViewedDataSource) {
-        viewModelScope.launch {
-            cardConfigurationRepository.addMostViewedCard(siteId, dataSource.name)
-        }
-    }
-
-    /**
-     * Updates the data source for a Most Viewed card at the given index.
-     */
-    fun updateMostViewedDataSource(index: Int, dataSource: MostViewedDataSource) {
-        // Update locally immediately for responsiveness
-        val currentSources = _mostViewedDataSources.value.toMutableList()
-        if (index in currentSources.indices) {
-            currentSources[index] = dataSource
-            _mostViewedDataSources.value = currentSources
-            // Update hidden data sources
-            _hiddenMostViewedDataSources.value = MostViewedDataSource.entries.filter {
-                it !in currentSources
-            }
-        }
-        // Persist
-        viewModelScope.launch {
-            cardConfigurationRepository.updateMostViewedDataSource(siteId, index, dataSource.name)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.ui.newstats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
+import javax.inject.Inject
+
+/**
+ * ViewModel for managing stats cards configuration.
+ * Handles visible/hidden cards state and card add/remove operations.
+ */
+@HiltViewModel
+class NewStatsViewModel @Inject constructor(
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val cardConfigurationRepository: StatsCardsConfigurationRepository
+) : ViewModel() {
+
+    private val _visibleCards = MutableStateFlow<List<StatsCardType>>(StatsCardType.defaultCards())
+    val visibleCards: StateFlow<List<StatsCardType>> = _visibleCards.asStateFlow()
+
+    private val _hiddenCards = MutableStateFlow<List<StatsCardType>>(emptyList())
+    val hiddenCards: StateFlow<List<StatsCardType>> = _hiddenCards.asStateFlow()
+
+    private val siteId: Long
+        get() = selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
+
+    init {
+        loadConfiguration()
+        observeConfigurationChanges()
+    }
+
+    private fun loadConfiguration() {
+        viewModelScope.launch {
+            val config = cardConfigurationRepository.getConfiguration(siteId)
+            _visibleCards.value = config.visibleCards
+            _hiddenCards.value = config.hiddenCards()
+        }
+    }
+
+    private fun observeConfigurationChanges() {
+        viewModelScope.launch {
+            cardConfigurationRepository.configurationFlow.collect { pair ->
+                if (pair != null && pair.first == siteId) {
+                    _visibleCards.value = pair.second.visibleCards
+                    _hiddenCards.value = pair.second.hiddenCards()
+                }
+            }
+        }
+    }
+
+    fun removeCard(cardType: StatsCardType) {
+        viewModelScope.launch {
+            cardConfigurationRepository.removeCard(siteId, cardType)
+        }
+    }
+
+    fun addCard(cardType: StatsCardType) {
+        viewModelScope.launch {
+            cardConfigurationRepository.addCard(siteId, cardType)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
-import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 /**
@@ -35,17 +34,12 @@ class NewStatsViewModel @Inject constructor(
         observeConfigurationChanges()
     }
 
-    @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration() {
         val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
         viewModelScope.launch {
-            try {
-                val config = cardConfigurationRepository.getConfiguration(currentSiteId)
-                updateFromConfiguration(config)
-            } catch (e: Exception) {
-                AppLog.e(AppLog.T.STATS, "Failed to load card configuration", e)
-                updateFromConfiguration(StatsCardsConfiguration())
-            }
+            // Repository handles errors internally and returns default config on failure
+            val config = cardConfigurationRepository.getConfiguration(currentSiteId)
+            updateFromConfiguration(config)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.newstats
+
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+/**
+ * Defines the available card types for the new stats screen.
+ * Each card has a unique identifier, display name resource, and default order.
+ */
+enum class StatsCardType(
+    @StringRes val displayNameResId: Int,
+    val defaultOrder: Int
+) {
+    TODAYS_STATS(R.string.stats_insights_today, 0),
+    VIEWS_STATS(R.string.stats_views, 1),
+    MOST_VIEWED(R.string.stats_most_viewed_title, 2),
+    COUNTRIES(R.string.stats_countries_title, 3);
+
+    companion object {
+        /**
+         * Returns the default list of visible cards in their default order.
+         */
+        fun defaultCards(): List<StatsCardType> = entries.sortedBy { it.defaultOrder }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
@@ -13,19 +13,19 @@ enum class StatsCardType(
 ) {
     TODAYS_STATS(R.string.stats_insights_today, 0),
     VIEWS_STATS(R.string.stats_views, 1),
-    MOST_VIEWED(R.string.stats_most_viewed_title, 2),
-    COUNTRIES(R.string.stats_countries_title, 3);
+    MOST_VIEWED_POSTS_AND_PAGES(R.string.stats_most_viewed_posts_and_pages, 2),
+    MOST_VIEWED_REFERRERS(R.string.stats_most_viewed_referrers, 3),
+    COUNTRIES(R.string.stats_countries_title, 4);
 
     companion object {
         /**
          * Returns the default list of visible cards in their default order.
-         * Note: MOST_VIEWED appears twice by default (one for each data source).
          */
         fun defaultCards(): List<StatsCardType> = listOf(
             TODAYS_STATS,
             VIEWS_STATS,
-            MOST_VIEWED,
-            MOST_VIEWED,
+            MOST_VIEWED_POSTS_AND_PAGES,
+            MOST_VIEWED_REFERRERS,
             COUNTRIES
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
@@ -19,7 +19,14 @@ enum class StatsCardType(
     companion object {
         /**
          * Returns the default list of visible cards in their default order.
+         * Note: MOST_VIEWED appears twice by default (one for each data source).
          */
-        fun defaultCards(): List<StatsCardType> = entries.sortedBy { it.defaultOrder }
+        fun defaultCards(): List<StatsCardType> = listOf(
+            TODAYS_STATS,
+            VIEWS_STATS,
+            MOST_VIEWED,
+            MOST_VIEWED,
+            COUNTRIES
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.newstats
 
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
-
 /**
  * Represents the configuration for stats cards on a per-site basis.
  * This is serialized to JSON for persistence.
@@ -10,32 +8,13 @@ data class StatsCardsConfiguration(
     val visibleCards: List<StatsCardType> = StatsCardType.defaultCards(),
     val selectedPeriodType: String? = null,
     val customPeriodStartDate: Long? = null,
-    val customPeriodEndDate: Long? = null,
-    // Data sources for each MOST_VIEWED card instance (in order)
-    // Default: one for Posts, one for Referrers
-    val mostViewedDataSources: List<String> = listOf(
-        MostViewedDataSource.POSTS_AND_PAGES.name,
-        MostViewedDataSource.REFERRERS.name
-    )
+    val customPeriodEndDate: Long? = null
 ) {
     /**
      * Returns card types that are not currently visible (available to add).
-     * For MOST_VIEWED, this is handled separately via hiddenMostViewedDataSources().
      */
     fun hiddenCards(): List<StatsCardType> {
-        return StatsCardType.entries.filter { cardType ->
-            cardType != StatsCardType.MOST_VIEWED && cardType !in visibleCards
-        }
-    }
-
-    /**
-     * Returns Most Viewed data sources that are not currently visible.
-     */
-    fun hiddenMostViewedDataSources(): List<MostViewedDataSource> {
-        val visibleDataSources = mostViewedDataSources.mapNotNull { name ->
-            runCatching { MostViewedDataSource.valueOf(name) }.getOrNull()
-        }.toSet()
-        return MostViewedDataSource.entries.filter { it !in visibleDataSources }
+        return StatsCardType.entries.filter { it !in visibleCards }
     }
 
     /**
@@ -43,12 +22,5 @@ data class StatsCardsConfiguration(
      */
     fun isCardVisible(cardType: StatsCardType): Boolean {
         return cardType in visibleCards
-    }
-
-    /**
-     * Returns the number of MOST_VIEWED cards currently visible.
-     */
-    fun mostViewedCardCount(): Int {
-        return visibleCards.count { it == StatsCardType.MOST_VIEWED }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.newstats
 
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
+
 /**
  * Represents the configuration for stats cards on a per-site basis.
  * This is serialized to JSON for persistence.
@@ -8,13 +10,32 @@ data class StatsCardsConfiguration(
     val visibleCards: List<StatsCardType> = StatsCardType.defaultCards(),
     val selectedPeriodType: String? = null,
     val customPeriodStartDate: Long? = null,
-    val customPeriodEndDate: Long? = null
+    val customPeriodEndDate: Long? = null,
+    // Data sources for each MOST_VIEWED card instance (in order)
+    // Default: one for Posts, one for Referrers
+    val mostViewedDataSources: List<String> = listOf(
+        MostViewedDataSource.POSTS_AND_PAGES.name,
+        MostViewedDataSource.REFERRERS.name
+    )
 ) {
     /**
-     * Returns cards that are not currently visible (available to add).
+     * Returns card types that are not currently visible (available to add).
+     * For MOST_VIEWED, this is handled separately via hiddenMostViewedDataSources().
      */
     fun hiddenCards(): List<StatsCardType> {
-        return StatsCardType.entries.filter { it !in visibleCards }
+        return StatsCardType.entries.filter { cardType ->
+            cardType != StatsCardType.MOST_VIEWED && cardType !in visibleCards
+        }
+    }
+
+    /**
+     * Returns Most Viewed data sources that are not currently visible.
+     */
+    fun hiddenMostViewedDataSources(): List<MostViewedDataSource> {
+        val visibleDataSources = mostViewedDataSources.mapNotNull { name ->
+            runCatching { MostViewedDataSource.valueOf(name) }.getOrNull()
+        }.toSet()
+        return MostViewedDataSource.entries.filter { it !in visibleDataSources }
     }
 
     /**
@@ -22,5 +43,12 @@ data class StatsCardsConfiguration(
      */
     fun isCardVisible(cardType: StatsCardType): Boolean {
         return cardType in visibleCards
+    }
+
+    /**
+     * Returns the number of MOST_VIEWED cards currently visible.
+     */
+    fun mostViewedCardCount(): Int {
+        return visibleCards.count { it == StatsCardType.MOST_VIEWED }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardsConfiguration.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.newstats
+
+/**
+ * Represents the configuration for stats cards on a per-site basis.
+ * This is serialized to JSON for persistence.
+ */
+data class StatsCardsConfiguration(
+    val visibleCards: List<StatsCardType> = StatsCardType.defaultCards(),
+    val selectedPeriodType: String? = null,
+    val customPeriodStartDate: Long? = null,
+    val customPeriodEndDate: Long? = null
+) {
+    /**
+     * Returns cards that are not currently visible (available to add).
+     */
+    fun hiddenCards(): List<StatsCardType> {
+        return StatsCardType.entries.filter { it !in visibleCards }
+    }
+
+    /**
+     * Returns true if the given card type is currently visible.
+     */
+    fun isCardVisible(cardType: StatsCardType): Boolean {
+        return cardType in visibleCards
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
@@ -24,23 +24,28 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.newstats.StatsCardType
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 
 /**
  * Bottom sheet for adding stats cards.
- * Shows a list of available (hidden) cards that can be added.
+ * Shows a list of available (hidden) cards that can be added, including Most Viewed data sources.
  *
  * @param sheetState The state of the bottom sheet
- * @param availableCards List of card types that can be added (currently hidden)
+ * @param availableCards List of card types that can be added (currently hidden, excluding MOST_VIEWED)
+ * @param availableMostViewedDataSources List of Most Viewed data sources that can be added
  * @param onDismiss Callback invoked when the sheet is dismissed
  * @param onCardSelected Callback invoked when a card is selected to be added
+ * @param onMostViewedDataSourceSelected Callback invoked when a Most Viewed data source is selected
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddStatsCardBottomSheet(
     sheetState: SheetState,
     availableCards: List<StatsCardType>,
+    availableMostViewedDataSources: List<MostViewedDataSource>,
     onDismiss: () -> Unit,
-    onCardSelected: (StatsCardType) -> Unit
+    onCardSelected: (StatsCardType) -> Unit,
+    onMostViewedDataSourceSelected: (MostViewedDataSource) -> Unit
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -59,7 +64,10 @@ fun AddStatsCardBottomSheet(
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            if (availableCards.isEmpty()) {
+            val hasAvailableItems = availableCards.isNotEmpty() ||
+                availableMostViewedDataSources.isNotEmpty()
+
+            if (!hasAvailableItems) {
                 Text(
                     text = stringResource(R.string.stats_all_cards_visible),
                     style = MaterialTheme.typography.bodyMedium,
@@ -67,11 +75,23 @@ fun AddStatsCardBottomSheet(
                     modifier = Modifier.padding(vertical = 24.dp)
                 )
             } else {
+                // Regular cards (excluding MOST_VIEWED which is handled separately)
                 availableCards.forEach { cardType ->
                     AddCardItem(
-                        cardType = cardType,
+                        label = stringResource(cardType.displayNameResId),
                         onClick = {
                             onCardSelected(cardType)
+                            onDismiss()
+                        }
+                    )
+                }
+
+                // Most Viewed data sources
+                availableMostViewedDataSources.forEach { dataSource ->
+                    AddCardItem(
+                        label = stringResource(dataSource.labelResId),
+                        onClick = {
+                            onMostViewedDataSourceSelected(dataSource)
                             onDismiss()
                         }
                     )
@@ -83,7 +103,7 @@ fun AddStatsCardBottomSheet(
 
 @Composable
 private fun AddCardItem(
-    cardType: StatsCardType,
+    label: String,
     onClick: () -> Unit
 ) {
     Row(
@@ -101,7 +121,7 @@ private fun AddCardItem(
         )
         Spacer(modifier = Modifier.width(16.dp))
         Text(
-            text = stringResource(cardType.displayNameResId),
+            text = label,
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
@@ -1,0 +1,109 @@
+package org.wordpress.android.ui.newstats.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.newstats.StatsCardType
+
+/**
+ * Bottom sheet for adding stats cards.
+ * Shows a list of available (hidden) cards that can be added.
+ *
+ * @param sheetState The state of the bottom sheet
+ * @param availableCards List of card types that can be added (currently hidden)
+ * @param onDismiss Callback invoked when the sheet is dismissed
+ * @param onCardSelected Callback invoked when a card is selected to be added
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddStatsCardBottomSheet(
+    sheetState: SheetState,
+    availableCards: List<StatsCardType>,
+    onDismiss: () -> Unit,
+    onCardSelected: (StatsCardType) -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.stats_add_card_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            if (availableCards.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.stats_all_cards_visible),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 24.dp)
+                )
+            } else {
+                availableCards.forEach { cardType ->
+                    AddCardItem(
+                        cardType = cardType,
+                        onClick = {
+                            onCardSelected(cardType)
+                            onDismiss()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddCardItem(
+    cardType: StatsCardType,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = stringResource(cardType.displayNameResId),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/AddStatsCardBottomSheet.kt
@@ -24,28 +24,23 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.newstats.StatsCardType
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 
 /**
  * Bottom sheet for adding stats cards.
- * Shows a list of available (hidden) cards that can be added, including Most Viewed data sources.
+ * Shows a list of available (hidden) cards that can be added.
  *
  * @param sheetState The state of the bottom sheet
- * @param availableCards List of card types that can be added (currently hidden, excluding MOST_VIEWED)
- * @param availableMostViewedDataSources List of Most Viewed data sources that can be added
+ * @param availableCards List of card types that can be added (currently hidden)
  * @param onDismiss Callback invoked when the sheet is dismissed
  * @param onCardSelected Callback invoked when a card is selected to be added
- * @param onMostViewedDataSourceSelected Callback invoked when a Most Viewed data source is selected
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddStatsCardBottomSheet(
     sheetState: SheetState,
     availableCards: List<StatsCardType>,
-    availableMostViewedDataSources: List<MostViewedDataSource>,
     onDismiss: () -> Unit,
-    onCardSelected: (StatsCardType) -> Unit,
-    onMostViewedDataSourceSelected: (MostViewedDataSource) -> Unit
+    onCardSelected: (StatsCardType) -> Unit
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -64,10 +59,7 @@ fun AddStatsCardBottomSheet(
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            val hasAvailableItems = availableCards.isNotEmpty() ||
-                availableMostViewedDataSources.isNotEmpty()
-
-            if (!hasAvailableItems) {
+            if (availableCards.isEmpty()) {
                 Text(
                     text = stringResource(R.string.stats_all_cards_visible),
                     style = MaterialTheme.typography.bodyMedium,
@@ -75,23 +67,11 @@ fun AddStatsCardBottomSheet(
                     modifier = Modifier.padding(vertical = 24.dp)
                 )
             } else {
-                // Regular cards (excluding MOST_VIEWED which is handled separately)
                 availableCards.forEach { cardType ->
                     AddCardItem(
                         label = stringResource(cardType.displayNameResId),
                         onClick = {
                             onCardSelected(cardType)
-                            onDismiss()
-                        }
-                    )
-                }
-
-                // Most Viewed data sources
-                availableMostViewedDataSources.forEach { dataSource ->
-                    AddCardItem(
-                        label = stringResource(dataSource.labelResId),
-                        onClick = {
-                            onMostViewedDataSourceSelected(dataSource)
                             onDismiss()
                         }
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.ui.newstats.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.wordpress.android.R
+
+/**
+ * Standard three-dots menu for stats cards.
+ * Includes card-specific options (via additionalContent) and a "Remove" option.
+ *
+ * @param onRemoveClick Callback invoked when user clicks "Remove"
+ * @param modifier Modifier for the menu
+ * @param additionalContent Optional composable content for card-specific menu items,
+ *                          called within the DropdownMenu. Should contain DropdownMenuItem(s).
+ */
+@Composable
+fun StatsCardMenu(
+    onRemoveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    additionalContent: @Composable (() -> Unit)? = null
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.more_options),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            // Card-specific options (e.g., chart type for ViewsStatsCard)
+            additionalContent?.invoke()
+
+            // Common "Remove" option
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.stats_card_remove)) },
+                onClick = {
+                    expanded = false
+                    onRemoveClick()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = null
+                    )
+                }
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/countries/CountriesCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/countries/CountriesCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 import org.wordpress.android.ui.newstats.util.formatStatValue
 
@@ -49,6 +50,7 @@ fun CountriesCard(
     uiState: CountriesCardUiState,
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
+    onRemoveCard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
@@ -63,8 +65,8 @@ fun CountriesCard(
     ) {
         when (uiState) {
             is CountriesCardUiState.Loading -> LoadingContent()
-            is CountriesCardUiState.Loaded -> LoadedContent(uiState, onShowAllClick)
-            is CountriesCardUiState.Error -> ErrorContent(uiState, onRetry)
+            is CountriesCardUiState.Loaded -> LoadedContent(uiState, onShowAllClick, onRemoveCard)
+            is CountriesCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
         }
     }
 }
@@ -126,16 +128,27 @@ private fun LoadingContent() {
 }
 
 @Composable
-private fun LoadedContent(state: CountriesCardUiState.Loaded, onShowAllClick: () -> Unit) {
+private fun LoadedContent(
+    state: CountriesCardUiState.Loaded,
+    onShowAllClick: () -> Unit,
+    onRemoveCard: () -> Unit
+) {
     Column(modifier = Modifier.padding(CardPadding)) {
-        // Title
-        Text(
-            text = stringResource(R.string.stats_countries_title),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+        // Header with menu
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.stats_countries_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            StatsCardMenu(onRemoveClick = onRemoveCard)
+        }
+        Spacer(modifier = Modifier.height(8.dp))
 
         if (state.countries.isEmpty()) {
             EmptyContent()
@@ -319,15 +332,24 @@ private fun ShowAllFooter(onClick: () -> Unit) {
 @Composable
 private fun ErrorContent(
     state: CountriesCardUiState.Error,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     Column(modifier = Modifier.padding(CardPadding)) {
-        Text(
-            text = stringResource(R.string.stats_countries_title),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
+        // Header with menu
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.stats_countries_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            StatsCardMenu(onRemoveClick = onRemoveCard)
+        }
         Spacer(modifier = Modifier.height(24.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -355,7 +377,8 @@ private fun CountriesCardLoadingPreview() {
         CountriesCard(
             uiState = CountriesCardUiState.Loading,
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -379,7 +402,8 @@ private fun CountriesCardLoadedPreview() {
                 hasMoreItems = true
             ),
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -391,7 +415,8 @@ private fun CountriesCardErrorPreview() {
         CountriesCard(
             uiState = CountriesCardUiState.Error("Failed to load country data"),
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -20,12 +20,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -58,6 +56,7 @@ private const val LOADING_SHIMMER_ITEM_COUNT = 5
 @Composable
 fun MostViewedCard(
     uiState: MostViewedCardUiState,
+    dataSource: MostViewedDataSource,
     onDataSourceChanged: (MostViewedDataSource) -> Unit,
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
@@ -82,11 +81,12 @@ fun MostViewedCard(
             is MostViewedCardUiState.Loading -> LoadingContent()
             is MostViewedCardUiState.Loaded -> LoadedContent(
                 uiState,
+                dataSource,
                 onDataSourceChanged,
                 onShowAllClick,
                 onRemoveCard
             )
-            is MostViewedCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
+            is MostViewedCardUiState.Error -> ErrorContent(uiState, dataSource, onRetry, onRemoveCard)
         }
     }
 }
@@ -166,6 +166,7 @@ private fun LoadingContent() {
 @Composable
 private fun LoadedContent(
     state: MostViewedCardUiState.Loaded,
+    dataSource: MostViewedDataSource,
     onDataSourceChanged: (MostViewedDataSource) -> Unit,
     onShowAllClick: () -> Unit,
     onRemoveCard: () -> Unit
@@ -175,10 +176,10 @@ private fun LoadedContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(onRemoveCard = onRemoveCard)
+        HeaderSection(dataSource = dataSource, onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(12.dp))
         ColumnHeadersRow(
-            selectedDataSource = state.selectedDataSource,
+            selectedDataSource = dataSource,
             onDataSourceChanged = onDataSourceChanged
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -200,14 +201,14 @@ private fun LoadedContent(
 }
 
 @Composable
-private fun HeaderSection(onRemoveCard: () -> Unit) {
+private fun HeaderSection(dataSource: MostViewedDataSource, onRemoveCard: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = stringResource(R.string.stats_most_viewed_title),
+            text = stringResource(dataSource.labelResId),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
@@ -235,7 +236,7 @@ private fun ColumnHeadersRow(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = stringResource(selectedDataSource.labelResId),
+                    text = stringResource(selectedDataSource.columnHeaderResId),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -410,6 +411,7 @@ private fun ShowAllFooter(onClick: () -> Unit) {
 @Composable
 private fun ErrorContent(
     state: MostViewedCardUiState.Error,
+    dataSource: MostViewedDataSource,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit
 ) {
@@ -418,7 +420,7 @@ private fun ErrorContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(onRemoveCard = onRemoveCard)
+        HeaderSection(dataSource = dataSource, onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(16.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -443,6 +445,7 @@ private fun MostViewedCardLoadingPreview() {
     AppThemeM3 {
         MostViewedCard(
             uiState = MostViewedCardUiState.Loading,
+            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
             onDataSourceChanged = {},
             onShowAllClick = {},
             onRetry = {},
@@ -497,6 +500,7 @@ private fun MostViewedCardLoadedPreview() {
                 ),
                 maxViewsForBar = 417
             ),
+            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
             onDataSourceChanged = {},
             onShowAllClick = {},
             onRetry = {},
@@ -513,6 +517,7 @@ private fun MostViewedCardErrorPreview() {
             uiState = MostViewedCardUiState.Error(
                 message = "Failed to load data"
             ),
+            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
             onDataSourceChanged = {},
             onShowAllClick = {},
             onRetry = {},
@@ -546,6 +551,7 @@ private fun MostViewedCardLoadedDarkPreview() {
                 ),
                 maxViewsForBar = 417
             ),
+            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
             onDataSourceChanged = {},
             onShowAllClick = {},
             onRetry = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -17,20 +17,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsColors
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
@@ -56,8 +49,7 @@ private const val LOADING_SHIMMER_ITEM_COUNT = 5
 @Composable
 fun MostViewedCard(
     uiState: MostViewedCardUiState,
-    dataSource: MostViewedDataSource,
-    onDataSourceChanged: (MostViewedDataSource) -> Unit,
+    cardType: StatsCardType,
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit,
@@ -81,12 +73,11 @@ fun MostViewedCard(
             is MostViewedCardUiState.Loading -> LoadingContent()
             is MostViewedCardUiState.Loaded -> LoadedContent(
                 uiState,
-                dataSource,
-                onDataSourceChanged,
+                cardType,
                 onShowAllClick,
                 onRemoveCard
             )
-            is MostViewedCardUiState.Error -> ErrorContent(uiState, dataSource, onRetry, onRemoveCard)
+            is MostViewedCardUiState.Error -> ErrorContent(uiState, cardType, onRetry, onRemoveCard)
         }
     }
 }
@@ -166,8 +157,7 @@ private fun LoadingContent() {
 @Composable
 private fun LoadedContent(
     state: MostViewedCardUiState.Loaded,
-    dataSource: MostViewedDataSource,
-    onDataSourceChanged: (MostViewedDataSource) -> Unit,
+    cardType: StatsCardType,
     onShowAllClick: () -> Unit,
     onRemoveCard: () -> Unit
 ) {
@@ -176,12 +166,9 @@ private fun LoadedContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(dataSource = dataSource, onRemoveCard = onRemoveCard)
+        HeaderSection(cardType = cardType, onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(12.dp))
-        ColumnHeadersRow(
-            selectedDataSource = dataSource,
-            onDataSourceChanged = onDataSourceChanged
-        )
+        ColumnHeadersRow(cardType = cardType)
         Spacer(modifier = Modifier.height(8.dp))
         state.items.forEachIndexed { index, item ->
             val percentage = if (state.maxViewsForBar > 0) {
@@ -201,14 +188,14 @@ private fun LoadedContent(
 }
 
 @Composable
-private fun HeaderSection(dataSource: MostViewedDataSource, onRemoveCard: () -> Unit) {
+private fun HeaderSection(cardType: StatsCardType, onRemoveCard: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = stringResource(dataSource.labelResId),
+            text = stringResource(cardType.displayNameResId),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
@@ -217,57 +204,17 @@ private fun HeaderSection(dataSource: MostViewedDataSource, onRemoveCard: () -> 
 }
 
 @Composable
-private fun ColumnHeadersRow(
-    selectedDataSource: MostViewedDataSource,
-    onDataSourceChanged: (MostViewedDataSource) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-
+private fun ColumnHeadersRow(cardType: StatsCardType) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box {
-            Row(
-                modifier = Modifier
-                    .clickable { expanded = true }
-                    .padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(selectedDataSource.labelResId),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Icon(
-                    imageVector = Icons.Default.KeyboardArrowDown,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false }
-            ) {
-                MostViewedDataSource.entries.forEach { dataSource ->
-                    DropdownMenuItem(
-                        text = { Text(stringResource(dataSource.labelResId)) },
-                        onClick = {
-                            onDataSourceChanged(dataSource)
-                            expanded = false
-                        },
-                        trailingIcon = if (dataSource == selectedDataSource) {
-                            { Icon(Icons.Default.Check, contentDescription = null) }
-                        } else {
-                            null
-                        }
-                    )
-                }
-            }
-        }
+        Text(
+            text = stringResource(cardType.displayNameResId),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
 
         Text(
             text = stringResource(R.string.stats_views),
@@ -411,7 +358,7 @@ private fun ShowAllFooter(onClick: () -> Unit) {
 @Composable
 private fun ErrorContent(
     state: MostViewedCardUiState.Error,
-    dataSource: MostViewedDataSource,
+    cardType: StatsCardType,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit
 ) {
@@ -420,7 +367,7 @@ private fun ErrorContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(dataSource = dataSource, onRemoveCard = onRemoveCard)
+        HeaderSection(cardType = cardType, onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(16.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -445,8 +392,7 @@ private fun MostViewedCardLoadingPreview() {
     AppThemeM3 {
         MostViewedCard(
             uiState = MostViewedCardUiState.Loading,
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
-            onDataSourceChanged = {},
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             onShowAllClick = {},
             onRetry = {},
             onRemoveCard = {}
@@ -499,8 +445,7 @@ private fun MostViewedCardLoadedPreview() {
                 ),
                 maxViewsForBar = 417
             ),
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
-            onDataSourceChanged = {},
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             onShowAllClick = {},
             onRetry = {},
             onRemoveCard = {}
@@ -516,8 +461,7 @@ private fun MostViewedCardErrorPreview() {
             uiState = MostViewedCardUiState.Error(
                 message = "Failed to load data"
             ),
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
-            onDataSourceChanged = {},
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             onShowAllClick = {},
             onRetry = {},
             onRemoveCard = {}
@@ -549,8 +493,7 @@ private fun MostViewedCardLoadedDarkPreview() {
                 ),
                 maxViewsForBar = 417
             ),
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
-            onDataSourceChanged = {},
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             onShowAllClick = {},
             onRetry = {},
             onRemoveCard = {}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.newstats.StatsColors
+import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.util.Locale
@@ -60,6 +61,7 @@ fun MostViewedCard(
     onDataSourceChanged: (MostViewedDataSource) -> Unit,
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
+    onRemoveCard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
@@ -78,8 +80,13 @@ fun MostViewedCard(
     ) {
         when (uiState) {
             is MostViewedCardUiState.Loading -> LoadingContent()
-            is MostViewedCardUiState.Loaded -> LoadedContent(uiState, onDataSourceChanged, onShowAllClick)
-            is MostViewedCardUiState.Error -> ErrorContent(uiState, onRetry)
+            is MostViewedCardUiState.Loaded -> LoadedContent(
+                uiState,
+                onDataSourceChanged,
+                onShowAllClick,
+                onRemoveCard
+            )
+            is MostViewedCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
         }
     }
 }
@@ -160,14 +167,15 @@ private fun LoadingContent() {
 private fun LoadedContent(
     state: MostViewedCardUiState.Loaded,
     onDataSourceChanged: (MostViewedDataSource) -> Unit,
-    onShowAllClick: () -> Unit
+    onShowAllClick: () -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection()
+        HeaderSection(onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(12.dp))
         ColumnHeadersRow(
             selectedDataSource = state.selectedDataSource,
@@ -192,7 +200,7 @@ private fun LoadedContent(
 }
 
 @Composable
-private fun HeaderSection() {
+private fun HeaderSection(onRemoveCard: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -203,13 +211,7 @@ private fun HeaderSection() {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
-        IconButton(onClick = { /* Future menu actions */ }) {
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = stringResource(R.string.more_options),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+        StatsCardMenu(onRemoveClick = onRemoveCard)
     }
 }
 
@@ -408,18 +410,15 @@ private fun ShowAllFooter(onClick: () -> Unit) {
 @Composable
 private fun ErrorContent(
     state: MostViewedCardUiState.Error,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        Text(
-            text = stringResource(R.string.stats_most_viewed_title),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold
-        )
+        HeaderSection(onRemoveCard = onRemoveCard)
         Spacer(modifier = Modifier.height(16.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -446,7 +445,8 @@ private fun MostViewedCardLoadingPreview() {
             uiState = MostViewedCardUiState.Loading,
             onDataSourceChanged = {},
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -499,7 +499,8 @@ private fun MostViewedCardLoadedPreview() {
             ),
             onDataSourceChanged = {},
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -514,7 +515,8 @@ private fun MostViewedCardErrorPreview() {
             ),
             onDataSourceChanged = {},
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -546,7 +548,8 @@ private fun MostViewedCardLoadedDarkPreview() {
             ),
             onDataSourceChanged = {},
             onShowAllClick = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -460,7 +460,6 @@ private fun MostViewedCardLoadedPreview() {
     AppThemeM3 {
         MostViewedCard(
             uiState = MostViewedCardUiState.Loaded(
-                selectedDataSource = MostViewedDataSource.POSTS_AND_PAGES,
                 items = listOf(
                     MostViewedItem(
                         id = 1,
@@ -532,7 +531,6 @@ private fun MostViewedCardLoadedDarkPreview() {
     AppThemeM3 {
         MostViewedCard(
             uiState = MostViewedCardUiState.Loaded(
-                selectedDataSource = MostViewedDataSource.POSTS_AND_PAGES,
                 items = listOf(
                     MostViewedItem(
                         id = 1,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -236,7 +236,7 @@ private fun ColumnHeadersRow(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = stringResource(selectedDataSource.columnHeaderResId),
+                    text = stringResource(selectedDataSource.labelResId),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
@@ -20,7 +20,6 @@ sealed class MostViewedCardUiState {
     data object Loading : MostViewedCardUiState()
 
     data class Loaded(
-        val selectedDataSource: MostViewedDataSource,
         val items: List<MostViewedItem>,
         val maxViewsForBar: Long
     ) : MostViewedCardUiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
@@ -8,9 +8,9 @@ import org.wordpress.android.R
  * Represents the available data source types for the Most Viewed card.
  * Extensible for future additional data sources.
  */
-enum class MostViewedDataSource(val labelResId: Int, val columnHeaderResId: Int) {
-    POSTS_AND_PAGES(R.string.stats_most_viewed_posts_and_pages, R.string.stats_most_viewed_column_title),
-    REFERRERS(R.string.stats_most_viewed_referrers, R.string.stats_most_viewed_column_referrer)
+enum class MostViewedDataSource(val labelResId: Int) {
+    POSTS_AND_PAGES(R.string.stats_most_viewed_posts_and_pages),
+    REFERRERS(R.string.stats_most_viewed_referrers)
 }
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
@@ -8,9 +8,9 @@ import org.wordpress.android.R
  * Represents the available data source types for the Most Viewed card.
  * Extensible for future additional data sources.
  */
-enum class MostViewedDataSource(val labelResId: Int) {
-    POSTS_AND_PAGES(R.string.stats_most_viewed_posts_and_pages),
-    REFERRERS(R.string.stats_most_viewed_referrers)
+enum class MostViewedDataSource(val labelResId: Int, val columnHeaderResId: Int) {
+    POSTS_AND_PAGES(R.string.stats_most_viewed_posts_and_pages, R.string.stats_most_viewed_column_title),
+    REFERRERS(R.string.stats_most_viewed_referrers, R.string.stats_most_viewed_column_referrer)
 }
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
@@ -44,6 +44,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsColors
 import org.wordpress.android.ui.newstats.components.StatsSummaryCard
 import org.wordpress.android.ui.newstats.util.formatStatValue
@@ -51,7 +52,7 @@ import org.wordpress.android.util.extensions.getParcelableArrayListCompat
 import org.wordpress.android.util.extensions.getSerializableCompat
 import java.util.Locale
 
-private const val EXTRA_DATA_SOURCE = "extra_data_source"
+private const val EXTRA_CARD_TYPE = "extra_card_type"
 private const val EXTRA_ITEMS = "extra_items"
 private const val EXTRA_TOTAL_VIEWS = "extra_total_views"
 private const val EXTRA_TOTAL_VIEWS_CHANGE = "extra_total_views_change"
@@ -63,8 +64,8 @@ class MostViewedDetailActivity : BaseAppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val dataSource = intent.extras?.getSerializableCompat<MostViewedDataSource>(EXTRA_DATA_SOURCE)
-            ?: MostViewedDataSource.POSTS_AND_PAGES
+        val cardType = intent.extras?.getSerializableCompat<StatsCardType>(EXTRA_CARD_TYPE)
+            ?: StatsCardType.MOST_VIEWED_POSTS_AND_PAGES
         val items = intent.extras?.getParcelableArrayListCompat<MostViewedDetailItem>(EXTRA_ITEMS)
             ?: arrayListOf()
         val totalViews = intent.getLongExtra(EXTRA_TOTAL_VIEWS, 0L)
@@ -77,7 +78,7 @@ class MostViewedDetailActivity : BaseAppCompatActivity() {
         setContent {
             AppThemeM3 {
                 MostViewedDetailScreen(
-                    dataSource = dataSource,
+                    cardType = cardType,
                     items = items,
                     maxViewsForBar = maxViewsForBar,
                     totalViews = totalViews,
@@ -94,7 +95,7 @@ class MostViewedDetailActivity : BaseAppCompatActivity() {
         @Suppress("LongParameterList")
         fun start(
             context: Context,
-            dataSource: MostViewedDataSource,
+            cardType: StatsCardType,
             items: List<MostViewedDetailItem>,
             totalViews: Long,
             totalViewsChange: Long,
@@ -102,7 +103,7 @@ class MostViewedDetailActivity : BaseAppCompatActivity() {
             dateRange: String
         ) {
             val intent = Intent(context, MostViewedDetailActivity::class.java).apply {
-                putExtra(EXTRA_DATA_SOURCE, dataSource)
+                putExtra(EXTRA_CARD_TYPE, cardType)
                 putExtra(EXTRA_ITEMS, ArrayList(items))
                 putExtra(EXTRA_TOTAL_VIEWS, totalViews)
                 putExtra(EXTRA_TOTAL_VIEWS_CHANGE, totalViewsChange)
@@ -117,7 +118,7 @@ class MostViewedDetailActivity : BaseAppCompatActivity() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MostViewedDetailScreen(
-    dataSource: MostViewedDataSource,
+    cardType: StatsCardType,
     items: List<MostViewedDetailItem>,
     maxViewsForBar: Long,
     totalViews: Long,
@@ -126,7 +127,7 @@ private fun MostViewedDetailScreen(
     dateRange: String,
     onBackPressed: () -> Unit
 ) {
-    val title = stringResource(dataSource.labelResId)
+    val title = stringResource(cardType.displayNameResId)
 
     Scaffold(
         topBar = {
@@ -303,7 +304,7 @@ private fun ChangeIndicator(change: MostViewedChange) {
 private fun MostViewedDetailScreenPreview() {
     AppThemeM3 {
         MostViewedDetailScreen(
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             items = listOf(
                 MostViewedDetailItem(1, "Welcome to Automattic", 998,
                     MostViewedChange.Positive(41, 4.3)),

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
@@ -198,7 +198,6 @@ class MostViewedViewModel @Inject constructor(
                     val maxViewsForBar = cardItems.firstOrNull()?.views ?: 1L
 
                     val loadedState = MostViewedCardUiState.Loaded(
-                        selectedDataSource = dataSource,
                         items = cardItems.mapIndexed { index, item ->
                             MostViewedItem(
                                 id = item.id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
@@ -26,27 +26,30 @@ class MostViewedViewModel @Inject constructor(
     private val statsRepository: StatsRepository,
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow<MostViewedCardUiState>(MostViewedCardUiState.Loading)
-    val uiState: StateFlow<MostViewedCardUiState> = _uiState.asStateFlow()
+    // Separate state flows for each data source
+    private val _postsUiState = MutableStateFlow<MostViewedCardUiState>(MostViewedCardUiState.Loading)
+    val postsUiState: StateFlow<MostViewedCardUiState> = _postsUiState.asStateFlow()
+
+    private val _referrersUiState = MutableStateFlow<MostViewedCardUiState>(MostViewedCardUiState.Loading)
+    val referrersUiState: StateFlow<MostViewedCardUiState> = _referrersUiState.asStateFlow()
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private var currentDataSource: MostViewedDataSource = MostViewedDataSource.POSTS_AND_PAGES
     private var currentPeriod: StatsPeriod = StatsPeriod.Last7Days
 
-    private var allItems: List<MostViewedDetailItem> = emptyList()
-    private var cachedTotalViews: Long = 0L
-    private var cachedTotalViewsChange: Long = 0L
-    private var cachedTotalViewsChangePercent: Double = 0.0
+    // Cache for detail data - separate for each data source
+    private var postsAllItems: List<MostViewedDetailItem> = emptyList()
+    private var postsCachedTotalViews: Long = 0L
+    private var postsCachedTotalViewsChange: Long = 0L
+    private var postsCachedTotalViewsChangePercent: Double = 0.0
+
+    private var referrersAllItems: List<MostViewedDetailItem> = emptyList()
+    private var referrersCachedTotalViews: Long = 0L
+    private var referrersCachedTotalViewsChange: Long = 0L
+    private var referrersCachedTotalViewsChangePercent: Double = 0.0
 
     init {
-        loadData()
-    }
-
-    fun onDataSourceChanged(dataSource: MostViewedDataSource) {
-        if (dataSource == currentDataSource) return
-        currentDataSource = dataSource
         loadData()
     }
 
@@ -69,17 +72,32 @@ class MostViewedViewModel @Inject constructor(
         }
     }
 
-    fun onRetry() {
-        loadData()
+    fun onRetryPosts() {
+        loadDataForSource(MostViewedDataSource.POSTS_AND_PAGES)
     }
 
-    fun getDetailData(): MostViewedDetailData {
+    fun onRetryReferrers() {
+        loadDataForSource(MostViewedDataSource.REFERRERS)
+    }
+
+    fun getPostsDetailData(): MostViewedDetailData {
         return MostViewedDetailData(
-            dataSource = currentDataSource,
-            items = allItems,
-            totalViews = cachedTotalViews,
-            totalViewsChange = cachedTotalViewsChange,
-            totalViewsChangePercent = cachedTotalViewsChangePercent,
+            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
+            items = postsAllItems,
+            totalViews = postsCachedTotalViews,
+            totalViewsChange = postsCachedTotalViewsChange,
+            totalViewsChangePercent = postsCachedTotalViewsChangePercent,
+            dateRange = currentPeriod.toDateRangeString(resourceProvider)
+        )
+    }
+
+    fun getReferrersDetailData(): MostViewedDetailData {
+        return MostViewedDetailData(
+            dataSource = MostViewedDataSource.REFERRERS,
+            items = referrersAllItems,
+            totalViews = referrersCachedTotalViews,
+            totalViewsChange = referrersCachedTotalViewsChange,
+            totalViewsChangePercent = referrersCachedTotalViewsChangePercent,
             dateRange = currentPeriod.toDateRangeString(resourceProvider)
         )
     }
@@ -87,40 +105,88 @@ class MostViewedViewModel @Inject constructor(
     private fun loadData() {
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
-            _uiState.value = MostViewedCardUiState.Error(
+            val errorState = MostViewedCardUiState.Error(
                 message = resourceProvider.getString(R.string.stats_todays_stats_no_site_selected)
             )
+            _postsUiState.value = errorState
+            _referrersUiState.value = errorState
             return
         }
 
         val accessToken = accountStore.accessToken
         if (accessToken.isNullOrEmpty()) {
-            _uiState.value = MostViewedCardUiState.Error(
+            val errorState = MostViewedCardUiState.Error(
                 message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load)
             )
+            _postsUiState.value = errorState
+            _referrersUiState.value = errorState
             return
         }
 
         statsRepository.init(accessToken)
-        _uiState.value = MostViewedCardUiState.Loading
+        _postsUiState.value = MostViewedCardUiState.Loading
+        _referrersUiState.value = MostViewedCardUiState.Loading
 
         viewModelScope.launch {
             loadDataInternal(site.siteId)
         }
     }
 
+    private fun loadDataForSource(dataSource: MostViewedDataSource) {
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            val errorState = MostViewedCardUiState.Error(
+                message = resourceProvider.getString(R.string.stats_todays_stats_no_site_selected)
+            )
+            when (dataSource) {
+                MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
+                MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
+            }
+            return
+        }
+
+        val accessToken = accountStore.accessToken
+        if (accessToken.isNullOrEmpty()) {
+            val errorState = MostViewedCardUiState.Error(
+                message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load)
+            )
+            when (dataSource) {
+                MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
+                MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
+            }
+            return
+        }
+
+        statsRepository.init(accessToken)
+        when (dataSource) {
+            MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = MostViewedCardUiState.Loading
+            MostViewedDataSource.REFERRERS -> _referrersUiState.value = MostViewedCardUiState.Loading
+        }
+
+        viewModelScope.launch {
+            loadDataForSourceInternal(site.siteId, dataSource)
+        }
+    }
+
     @Suppress("TooGenericExceptionCaught")
     private suspend fun loadDataInternal(siteId: Long) {
+        // Load both data sources in parallel
+        viewModelScope.launch {
+            loadDataForSourceInternal(siteId, MostViewedDataSource.POSTS_AND_PAGES)
+        }
+        viewModelScope.launch {
+            loadDataForSourceInternal(siteId, MostViewedDataSource.REFERRERS)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun loadDataForSourceInternal(siteId: Long, dataSource: MostViewedDataSource) {
         try {
-            val result = statsRepository.fetchMostViewed(siteId, currentPeriod, currentDataSource)
+            val result = statsRepository.fetchMostViewed(siteId, currentPeriod, dataSource)
 
             when (result) {
                 is MostViewedResult.Success -> {
-                    cachedTotalViews = result.totalViews
-                    cachedTotalViewsChange = result.totalViewsChange
-                    cachedTotalViewsChangePercent = result.totalViewsChangePercent
-
-                    allItems = result.items.map { item ->
+                    val allItems = result.items.map { item ->
                         MostViewedDetailItem(
                             id = item.id,
                             title = item.title,
@@ -129,11 +195,10 @@ class MostViewedViewModel @Inject constructor(
                         )
                     }
                     val cardItems = allItems.take(CARD_MAX_ITEMS)
-                    // For bar percentage, use first item's views (list is sorted by views descending)
                     val maxViewsForBar = cardItems.firstOrNull()?.views ?: 1L
 
-                    _uiState.value = MostViewedCardUiState.Loaded(
-                        selectedDataSource = currentDataSource,
+                    val loadedState = MostViewedCardUiState.Loaded(
+                        selectedDataSource = dataSource,
                         items = cardItems.mapIndexed { index, item ->
                             MostViewedItem(
                                 id = item.id,
@@ -145,18 +210,43 @@ class MostViewedViewModel @Inject constructor(
                         },
                         maxViewsForBar = maxViewsForBar
                     )
+
+                    when (dataSource) {
+                        MostViewedDataSource.POSTS_AND_PAGES -> {
+                            postsAllItems = allItems
+                            postsCachedTotalViews = result.totalViews
+                            postsCachedTotalViewsChange = result.totalViewsChange
+                            postsCachedTotalViewsChangePercent = result.totalViewsChangePercent
+                            _postsUiState.value = loadedState
+                        }
+                        MostViewedDataSource.REFERRERS -> {
+                            referrersAllItems = allItems
+                            referrersCachedTotalViews = result.totalViews
+                            referrersCachedTotalViewsChange = result.totalViewsChange
+                            referrersCachedTotalViewsChangePercent = result.totalViewsChangePercent
+                            _referrersUiState.value = loadedState
+                        }
+                    }
                 }
                 is MostViewedResult.Error -> {
-                    _uiState.value = MostViewedCardUiState.Error(
+                    val errorState = MostViewedCardUiState.Error(
                         message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load)
                     )
+                    when (dataSource) {
+                        MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
+                        MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
+                    }
                 }
             }
         } catch (e: Exception) {
-            _uiState.value = MostViewedCardUiState.Error(
+            val errorState = MostViewedCardUiState.Error(
                 message = e.message
                     ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error)
             )
+            when (dataSource) {
+                MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
+                MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
@@ -183,69 +183,68 @@ class MostViewedViewModel @Inject constructor(
     private suspend fun loadDataForSourceInternal(siteId: Long, dataSource: MostViewedDataSource) {
         try {
             val result = statsRepository.fetchMostViewed(siteId, currentPeriod, dataSource)
-
             when (result) {
-                is MostViewedResult.Success -> {
-                    val allItems = result.items.map { item ->
-                        MostViewedDetailItem(
-                            id = item.id,
-                            title = item.title,
-                            views = item.views,
-                            change = item.toMostViewedChange()
-                        )
-                    }
-                    val cardItems = allItems.take(CARD_MAX_ITEMS)
-                    val maxViewsForBar = cardItems.firstOrNull()?.views ?: 1L
-
-                    val loadedState = MostViewedCardUiState.Loaded(
-                        items = cardItems.mapIndexed { index, item ->
-                            MostViewedItem(
-                                id = item.id,
-                                title = item.title,
-                                views = item.views,
-                                change = item.change,
-                                isHighlighted = index == 0
-                            )
-                        },
-                        maxViewsForBar = maxViewsForBar
-                    )
-
-                    when (dataSource) {
-                        MostViewedDataSource.POSTS_AND_PAGES -> {
-                            postsAllItems = allItems
-                            postsCachedTotalViews = result.totalViews
-                            postsCachedTotalViewsChange = result.totalViewsChange
-                            postsCachedTotalViewsChangePercent = result.totalViewsChangePercent
-                            _postsUiState.value = loadedState
-                        }
-                        MostViewedDataSource.REFERRERS -> {
-                            referrersAllItems = allItems
-                            referrersCachedTotalViews = result.totalViews
-                            referrersCachedTotalViewsChange = result.totalViewsChange
-                            referrersCachedTotalViewsChangePercent = result.totalViewsChangePercent
-                            _referrersUiState.value = loadedState
-                        }
-                    }
-                }
-                is MostViewedResult.Error -> {
-                    val errorState = MostViewedCardUiState.Error(
-                        message = resourceProvider.getString(R.string.stats_todays_stats_failed_to_load)
-                    )
-                    when (dataSource) {
-                        MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
-                        MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
-                    }
-                }
+                is MostViewedResult.Success -> handleSuccessResult(result, dataSource)
+                is MostViewedResult.Error -> setErrorState(
+                    dataSource,
+                    resourceProvider.getString(R.string.stats_todays_stats_failed_to_load)
+                )
             }
         } catch (e: Exception) {
-            val errorState = MostViewedCardUiState.Error(
-                message = e.message
-                    ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error)
+            setErrorState(
+                dataSource,
+                e.message ?: resourceProvider.getString(R.string.stats_todays_stats_unknown_error)
             )
-            when (dataSource) {
-                MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
-                MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
+        }
+    }
+
+    private fun handleSuccessResult(result: MostViewedResult.Success, dataSource: MostViewedDataSource) {
+        val allItems = result.items.map { it.toDetailItem() }
+        val cardItems = allItems.take(CARD_MAX_ITEMS)
+        val loadedState = MostViewedCardUiState.Loaded(
+            items = cardItems.mapIndexed { index, item ->
+                MostViewedItem(
+                    id = item.id,
+                    title = item.title,
+                    views = item.views,
+                    change = item.change,
+                    isHighlighted = index == 0
+                )
+            },
+            maxViewsForBar = cardItems.firstOrNull()?.views ?: 1L
+        )
+        updateCacheAndState(dataSource, allItems, result, loadedState)
+    }
+
+    private fun updateCacheAndState(
+        dataSource: MostViewedDataSource,
+        allItems: List<MostViewedDetailItem>,
+        result: MostViewedResult.Success,
+        loadedState: MostViewedCardUiState.Loaded
+    ) {
+        when (dataSource) {
+            MostViewedDataSource.POSTS_AND_PAGES -> {
+                postsAllItems = allItems
+                postsCachedTotalViews = result.totalViews
+                postsCachedTotalViewsChange = result.totalViewsChange
+                postsCachedTotalViewsChangePercent = result.totalViewsChangePercent
+                _postsUiState.value = loadedState
             }
+            MostViewedDataSource.REFERRERS -> {
+                referrersAllItems = allItems
+                referrersCachedTotalViews = result.totalViews
+                referrersCachedTotalViewsChange = result.totalViewsChange
+                referrersCachedTotalViewsChangePercent = result.totalViewsChangePercent
+                _referrersUiState.value = loadedState
+            }
+        }
+    }
+
+    private fun setErrorState(dataSource: MostViewedDataSource, message: String) {
+        val errorState = MostViewedCardUiState.Error(message = message)
+        when (dataSource) {
+            MostViewedDataSource.POSTS_AND_PAGES -> _postsUiState.value = errorState
+            MostViewedDataSource.REFERRERS -> _referrersUiState.value = errorState
         }
     }
 
@@ -263,10 +262,11 @@ data class MostViewedDetailData(
     val dateRange: String
 )
 
-private fun MostViewedItemData.toMostViewedChange(): MostViewedChange {
-    return when {
+private fun MostViewedItemData.toDetailItem(): MostViewedDetailItem {
+    val change = when {
         viewsChange > 0 -> MostViewedChange.Positive(viewsChange, abs(viewsChangePercent))
         viewsChange < 0 -> MostViewedChange.Negative(abs(viewsChange), abs(viewsChangePercent))
         else -> MostViewedChange.NoChange
     }
+    return MostViewedDetailItem(id = id, title = title, views = views, change = change)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.repository.MostViewedItemData
 import org.wordpress.android.ui.newstats.repository.MostViewedResult
@@ -82,7 +83,7 @@ class MostViewedViewModel @Inject constructor(
 
     fun getPostsDetailData(): MostViewedDetailData {
         return MostViewedDetailData(
-            dataSource = MostViewedDataSource.POSTS_AND_PAGES,
+            cardType = StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
             items = postsAllItems,
             totalViews = postsCachedTotalViews,
             totalViewsChange = postsCachedTotalViewsChange,
@@ -93,7 +94,7 @@ class MostViewedViewModel @Inject constructor(
 
     fun getReferrersDetailData(): MostViewedDetailData {
         return MostViewedDetailData(
-            dataSource = MostViewedDataSource.REFERRERS,
+            cardType = StatsCardType.MOST_VIEWED_REFERRERS,
             items = referrersAllItems,
             totalViews = referrersCachedTotalViews,
             totalViewsChange = referrersCachedTotalViewsChange,
@@ -254,7 +255,7 @@ class MostViewedViewModel @Inject constructor(
 }
 
 data class MostViewedDetailData(
-    val dataSource: MostViewedDataSource,
+    val cardType: StatsCardType,
     val items: List<MostViewedDetailItem>,
     val totalViews: Long,
     val totalViewsChange: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.ui.newstats.repository
+
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.ui.newstats.StatsCardType
+import org.wordpress.android.ui.newstats.StatsCardsConfiguration
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.EnumWithFallbackValueTypeAdapterFactory
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class StatsCardsConfigurationRepository @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+) {
+    private val gson = GsonBuilder()
+        .registerTypeAdapterFactory(EnumWithFallbackValueTypeAdapterFactory())
+        .create()
+
+    // Cache per site to avoid repeated disk reads
+    private val configurationCache = mutableMapOf<Long, StatsCardsConfiguration>()
+
+    // StateFlow to notify observers of configuration changes
+    private val _configurationFlow = MutableStateFlow<Pair<Long, StatsCardsConfiguration>?>(null)
+    val configurationFlow: StateFlow<Pair<Long, StatsCardsConfiguration>?> =
+        _configurationFlow.asStateFlow()
+
+    suspend fun getConfiguration(siteId: Long): StatsCardsConfiguration = withContext(ioDispatcher) {
+        configurationCache[siteId] ?: loadConfiguration(siteId).also {
+            configurationCache[siteId] = it
+        }
+    }
+
+    fun getConfigurationSync(siteId: Long): StatsCardsConfiguration {
+        return configurationCache[siteId] ?: loadConfiguration(siteId).also {
+            configurationCache[siteId] = it
+        }
+    }
+
+    suspend fun saveConfiguration(
+        siteId: Long,
+        configuration: StatsCardsConfiguration
+    ): Unit = withContext(ioDispatcher) {
+        appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(configuration))
+        configurationCache[siteId] = configuration
+        _configurationFlow.value = siteId to configuration
+    }
+
+    suspend fun removeCard(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newVisibleCards = current.visibleCards.filter { it != cardType }
+        saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+    }
+
+    suspend fun addCard(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        if (cardType !in current.visibleCards) {
+            val newVisibleCards = current.visibleCards + cardType
+            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        }
+    }
+
+    private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {
+        return appPrefsWrapper.getStatsCardsConfigurationJson(siteId)?.let {
+            try {
+                gson.fromJson(it, StatsCardsConfiguration::class.java)
+            } catch (e: Exception) {
+                StatsCardsConfiguration()
+            }
+        } ?: StatsCardsConfiguration()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -55,16 +55,90 @@ class StatsCardsConfigurationRepository @Inject constructor(
 
     suspend fun removeCard(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        val newVisibleCards = current.visibleCards.filter { it != cardType }
+        // For non-MOST_VIEWED cards, remove from visibleCards
+        val newVisibleCards = current.visibleCards.toMutableList()
+        newVisibleCards.remove(cardType)
         saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
     }
 
     suspend fun addCard(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        if (cardType !in current.visibleCards) {
-            val newVisibleCards = current.visibleCards + cardType
-            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        val newVisibleCards = current.visibleCards + cardType
+        saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+    }
+
+    /**
+     * Removes a Most Viewed card at the given index.
+     */
+    suspend fun removeMostViewedCard(siteId: Long, index: Int): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        // Remove one MOST_VIEWED from visibleCards
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val mostViewedIndex = newVisibleCards.indexOfFirst { it == StatsCardType.MOST_VIEWED }
+        if (mostViewedIndex >= 0) {
+            // Find the nth MOST_VIEWED occurrence
+            var count = 0
+            val indexToRemove = newVisibleCards.indexOfFirst {
+                if (it == StatsCardType.MOST_VIEWED) {
+                    if (count == index) true else { count++; false }
+                } else false
+            }
+            if (indexToRemove >= 0) {
+                newVisibleCards.removeAt(indexToRemove)
+            }
         }
+        // Remove the corresponding data source
+        val newDataSources = current.mostViewedDataSources.toMutableList()
+        if (index in newDataSources.indices) {
+            newDataSources.removeAt(index)
+        }
+        saveConfiguration(siteId, current.copy(
+            visibleCards = newVisibleCards,
+            mostViewedDataSources = newDataSources
+        ))
+    }
+
+    /**
+     * Adds a Most Viewed card with the given data source.
+     */
+    suspend fun addMostViewedCard(siteId: Long, dataSourceName: String): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        // Add MOST_VIEWED to visibleCards (after the last MOST_VIEWED or at default position)
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val lastMostViewedIndex = newVisibleCards.indexOfLast { it == StatsCardType.MOST_VIEWED }
+        if (lastMostViewedIndex >= 0) {
+            newVisibleCards.add(lastMostViewedIndex + 1, StatsCardType.MOST_VIEWED)
+        } else {
+            // Add at default position (after VIEWS_STATS)
+            val viewsIndex = newVisibleCards.indexOfFirst { it == StatsCardType.VIEWS_STATS }
+            if (viewsIndex >= 0) {
+                newVisibleCards.add(viewsIndex + 1, StatsCardType.MOST_VIEWED)
+            } else {
+                newVisibleCards.add(StatsCardType.MOST_VIEWED)
+            }
+        }
+        // Add the data source
+        val newDataSources = current.mostViewedDataSources + dataSourceName
+        saveConfiguration(siteId, current.copy(
+            visibleCards = newVisibleCards,
+            mostViewedDataSources = newDataSources
+        ))
+    }
+
+    /**
+     * Updates the data source for a Most Viewed card at the given index.
+     */
+    suspend fun updateMostViewedDataSource(
+        siteId: Long,
+        index: Int,
+        dataSourceName: String
+    ): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newDataSources = current.mostViewedDataSources.toMutableList()
+        if (index in newDataSources.indices) {
+            newDataSources[index] = dataSourceName
+        }
+        saveConfiguration(siteId, current.copy(mostViewedDataSources = newDataSources))
     }
 
     private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -62,68 +62,6 @@ class StatsCardsConfigurationRepository @Inject constructor(
         saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
     }
 
-    /**
-     * Removes a Most Viewed card at the given index.
-     */
-    suspend fun removeMostViewedCard(siteId: Long, index: Int): Unit = withContext(ioDispatcher) {
-        val current = getConfiguration(siteId)
-        // Remove one MOST_VIEWED from visibleCards
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val mostViewedIndex = newVisibleCards.indexOfFirst { it == StatsCardType.MOST_VIEWED }
-        if (mostViewedIndex >= 0) {
-            // Find the nth MOST_VIEWED occurrence
-            var count = 0
-            val indexToRemove = newVisibleCards.indexOfFirst {
-                if (it == StatsCardType.MOST_VIEWED) {
-                    if (count == index) true else { count++; false }
-                } else false
-            }
-            if (indexToRemove >= 0) {
-                newVisibleCards.removeAt(indexToRemove)
-            }
-        }
-        // Remove the corresponding data source
-        val newDataSources = current.mostViewedDataSources.toMutableList()
-        if (index in newDataSources.indices) {
-            newDataSources.removeAt(index)
-        }
-        saveConfiguration(siteId, current.copy(
-            visibleCards = newVisibleCards,
-            mostViewedDataSources = newDataSources
-        ))
-    }
-
-    /**
-     * Adds a Most Viewed card with the given data source.
-     */
-    suspend fun addMostViewedCard(siteId: Long, dataSourceName: String): Unit = withContext(ioDispatcher) {
-        val current = getConfiguration(siteId)
-        // Add MOST_VIEWED to the end of visibleCards
-        val newVisibleCards = current.visibleCards + StatsCardType.MOST_VIEWED
-        // Add the data source
-        val newDataSources = current.mostViewedDataSources + dataSourceName
-        saveConfiguration(siteId, current.copy(
-            visibleCards = newVisibleCards,
-            mostViewedDataSources = newDataSources
-        ))
-    }
-
-    /**
-     * Updates the data source for a Most Viewed card at the given index.
-     */
-    suspend fun updateMostViewedDataSource(
-        siteId: Long,
-        index: Int,
-        dataSourceName: String
-    ): Unit = withContext(ioDispatcher) {
-        val current = getConfiguration(siteId)
-        val newDataSources = current.mostViewedDataSources.toMutableList()
-        if (index in newDataSources.indices) {
-            newDataSources[index] = dataSourceName
-        }
-        saveConfiguration(siteId, current.copy(mostViewedDataSources = newDataSources))
-    }
-
     @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {
         val json = appPrefsWrapper.getStatsCardsConfigurationJson(siteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -25,18 +25,13 @@ class StatsCardsConfigurationRepository @Inject constructor(
         .registerTypeAdapterFactory(EnumWithFallbackValueTypeAdapterFactory())
         .create()
 
-    // Cache per site to avoid repeated disk reads
-    private val configurationCache = mutableMapOf<Long, StatsCardsConfiguration>()
-
     // StateFlow to notify observers of configuration changes
     private val _configurationFlow = MutableStateFlow<Pair<Long, StatsCardsConfiguration>?>(null)
     val configurationFlow: StateFlow<Pair<Long, StatsCardsConfiguration>?> =
         _configurationFlow.asStateFlow()
 
     suspend fun getConfiguration(siteId: Long): StatsCardsConfiguration = withContext(ioDispatcher) {
-        configurationCache[siteId] ?: loadConfiguration(siteId).also {
-            configurationCache[siteId] = it
-        }
+        loadConfiguration(siteId)
     }
 
     suspend fun saveConfiguration(
@@ -44,7 +39,6 @@ class StatsCardsConfigurationRepository @Inject constructor(
         configuration: StatsCardsConfiguration
     ): Unit = withContext(ioDispatcher) {
         appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(configuration))
-        configurationCache[siteId] = configuration
         _configurationFlow.value = siteId to configuration
     }
 
@@ -84,14 +78,17 @@ class StatsCardsConfigurationRepository @Inject constructor(
 
     /**
      * Validates that the configuration contains only valid card types.
-     * Returns false if any card type is null (which happens when EnumWithFallbackValueTypeAdapterFactory
+     * Returns false if any card type is null (which happens when Gson's default enum deserializer
      * encounters an unknown enum value like the old "MOST_VIEWED").
+     *
+     * Note: Since StatsCardType doesn't have a @FallbackValue annotation, unknown enum values
+     * are deserialized as null by Gson and can sneak into the List<StatsCardType> at runtime,
+     * bypassing Kotlin's null-safety. We use filterIsInstance to safely count valid entries.
      */
     private fun isValidConfiguration(config: StatsCardsConfiguration): Boolean {
-        // Check if visibleCards contains any null values (invalid enum values are deserialized as null)
-        @Suppress("USELESS_CAST")
-        val hasInvalidCards = config.visibleCards.any { (it as StatsCardType?) == null }
-        return !hasInvalidCards
+        // filterIsInstance safely handles nulls that may have snuck into the list from Gson
+        val validCards = config.visibleCards.filterIsInstance<StatsCardType>()
+        return validCards.size == config.visibleCards.size
     }
 
     private fun resetToDefault(siteId: Long): StatsCardsConfiguration {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsCardsConfiguration
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.EnumWithFallbackValueTypeAdapterFactory
 import javax.inject.Inject
 import javax.inject.Named
@@ -34,12 +35,6 @@ class StatsCardsConfigurationRepository @Inject constructor(
 
     suspend fun getConfiguration(siteId: Long): StatsCardsConfiguration = withContext(ioDispatcher) {
         configurationCache[siteId] ?: loadConfiguration(siteId).also {
-            configurationCache[siteId] = it
-        }
-    }
-
-    fun getConfigurationSync(siteId: Long): StatsCardsConfiguration {
-        return configurationCache[siteId] ?: loadConfiguration(siteId).also {
             configurationCache[siteId] = it
         }
     }
@@ -137,6 +132,7 @@ class StatsCardsConfigurationRepository @Inject constructor(
         return try {
             gson.fromJson(json, StatsCardsConfiguration::class.java)
         } catch (e: Exception) {
+            AppLog.e(AppLog.T.STATS, "Failed to parse stats cards configuration, resetting to default", e)
             // Wipe corrupted data and save default configuration
             val defaultConfig = StatsCardsConfiguration()
             appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(defaultConfig))

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -69,13 +69,34 @@ class StatsCardsConfigurationRepository @Inject constructor(
             return StatsCardsConfiguration()
         }
         return try {
-            gson.fromJson(json, StatsCardsConfiguration::class.java)
+            val config = gson.fromJson(json, StatsCardsConfiguration::class.java)
+            if (isValidConfiguration(config)) {
+                config
+            } else {
+                AppLog.w(AppLog.T.STATS, "Stats cards configuration contains invalid card types, resetting to default")
+                resetToDefault(siteId)
+            }
         } catch (e: Exception) {
             AppLog.e(AppLog.T.STATS, "Failed to parse stats cards configuration, resetting to default", e)
-            // Wipe corrupted data and save default configuration
-            val defaultConfig = StatsCardsConfiguration()
-            appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(defaultConfig))
-            defaultConfig
+            resetToDefault(siteId)
         }
+    }
+
+    /**
+     * Validates that the configuration contains only valid card types.
+     * Returns false if any card type is null (which happens when EnumWithFallbackValueTypeAdapterFactory
+     * encounters an unknown enum value like the old "MOST_VIEWED").
+     */
+    private fun isValidConfiguration(config: StatsCardsConfiguration): Boolean {
+        // Check if visibleCards contains any null values (invalid enum values are deserialized as null)
+        @Suppress("USELESS_CAST")
+        val hasInvalidCards = config.visibleCards.any { (it as StatsCardType?) == null }
+        return !hasInvalidCards
+    }
+
+    private fun resetToDefault(siteId: Long): StatsCardsConfiguration {
+        val defaultConfig = StatsCardsConfiguration()
+        appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(defaultConfig))
+        return defaultConfig
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -103,20 +103,8 @@ class StatsCardsConfigurationRepository @Inject constructor(
      */
     suspend fun addMostViewedCard(siteId: Long, dataSourceName: String): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        // Add MOST_VIEWED to visibleCards (after the last MOST_VIEWED or at default position)
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val lastMostViewedIndex = newVisibleCards.indexOfLast { it == StatsCardType.MOST_VIEWED }
-        if (lastMostViewedIndex >= 0) {
-            newVisibleCards.add(lastMostViewedIndex + 1, StatsCardType.MOST_VIEWED)
-        } else {
-            // Add at default position (after VIEWS_STATS)
-            val viewsIndex = newVisibleCards.indexOfFirst { it == StatsCardType.VIEWS_STATS }
-            if (viewsIndex >= 0) {
-                newVisibleCards.add(viewsIndex + 1, StatsCardType.MOST_VIEWED)
-            } else {
-                newVisibleCards.add(StatsCardType.MOST_VIEWED)
-            }
-        }
+        // Add MOST_VIEWED to the end of visibleCards
+        val newVisibleCards = current.visibleCards + StatsCardType.MOST_VIEWED
         // Add the data source
         val newDataSources = current.mostViewedDataSources + dataSourceName
         saveConfiguration(siteId, current.copy(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -124,6 +124,7 @@ class StatsCardsConfigurationRepository @Inject constructor(
         saveConfiguration(siteId, current.copy(mostViewedDataSources = newDataSources))
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {
         val json = appPrefsWrapper.getStatsCardsConfigurationJson(siteId)
         if (json == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -142,12 +142,17 @@ class StatsCardsConfigurationRepository @Inject constructor(
     }
 
     private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {
-        return appPrefsWrapper.getStatsCardsConfigurationJson(siteId)?.let {
-            try {
-                gson.fromJson(it, StatsCardsConfiguration::class.java)
-            } catch (e: Exception) {
-                StatsCardsConfiguration()
-            }
-        } ?: StatsCardsConfiguration()
+        val json = appPrefsWrapper.getStatsCardsConfigurationJson(siteId)
+        if (json == null) {
+            return StatsCardsConfiguration()
+        }
+        return try {
+            gson.fromJson(json, StatsCardsConfiguration::class.java)
+        } catch (e: Exception) {
+            // Wipe corrupted data and save default configuration
+            val defaultConfig = StatsCardsConfiguration()
+            appPrefsWrapper.setStatsCardsConfigurationJson(siteId, gson.toJson(defaultConfig))
+            defaultConfig
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
@@ -54,6 +54,7 @@ import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -69,6 +70,7 @@ private val MetricSpacing = 4.dp
 @Composable
 fun TodaysStatsCard(
     uiState: TodaysStatsCardUiState,
+    onRemoveCard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
@@ -87,8 +89,8 @@ fun TodaysStatsCard(
     ) {
         when (uiState) {
             is TodaysStatsCardUiState.Loading -> LoadingContent()
-            is TodaysStatsCardUiState.Loaded -> LoadedContent(uiState)
-            is TodaysStatsCardUiState.Error -> ErrorContent(uiState)
+            is TodaysStatsCardUiState.Loaded -> LoadedContent(uiState, onRemoveCard)
+            is TodaysStatsCardUiState.Error -> ErrorContent(uiState, onRemoveCard)
         }
     }
 }
@@ -196,26 +198,28 @@ private fun LoadingContent() {
 }
 
 @Composable
-private fun LoadedContent(state: TodaysStatsCardUiState.Loaded) {
+private fun LoadedContent(
+    state: TodaysStatsCardUiState.Loaded,
+    onRemoveCard: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = state.onCardClick)
             .padding(CardPadding)
     ) {
-        // Top section: Title/Date on left, Chart on right
+        // Header with menu
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            // Left: Title and date
             TitleSection()
-            Spacer(modifier = Modifier.width(16.dp))
-            // Right: Chart
-            Box(modifier = Modifier.weight(1f)) {
-                StatsChart(chartData = state.chartData)
-            }
+            StatsCardMenu(onRemoveClick = onRemoveCard)
         }
+        Spacer(modifier = Modifier.height(8.dp))
+        // Chart
+        StatsChart(chartData = state.chartData)
         Spacer(modifier = Modifier.height(12.dp))
         // Bottom section: Metrics
         MetricsRow(
@@ -228,35 +232,39 @@ private fun LoadedContent(state: TodaysStatsCardUiState.Loaded) {
 }
 
 @Composable
-private fun ErrorContent(state: TodaysStatsCardUiState.Error) {
+private fun ErrorContent(
+    state: TodaysStatsCardUiState.Error,
+    onRemoveCard: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        // Top section: Title/Date on left, Empty chart placeholder on right
+        // Header with menu
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            // Left: Title and date
             TitleSection()
-            Spacer(modifier = Modifier.width(16.dp))
-            // Right: Empty chart placeholder
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(ChartHeight)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(R.string.stats_no_data_yet),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            StatsCardMenu(onRemoveClick = onRemoveCard)
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        // Empty chart placeholder
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(ChartHeight)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.stats_no_data_yet),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
         Spacer(modifier = Modifier.height(16.dp))
         // Error message and retry button centered
@@ -464,7 +472,7 @@ private fun SecondaryMetricItem(
 @Composable
 private fun TodaysStatsCardLoadingPreview() {
     AppThemeM3 {
-        TodaysStatsCard(uiState = TodaysStatsCardUiState.Loading)
+        TodaysStatsCard(uiState = TodaysStatsCardUiState.Loading, onRemoveCard = {})
     }
 }
 
@@ -497,7 +505,8 @@ private fun TodaysStatsCardLoadedPreview() {
                     )
                 ),
                 onCardClick = {}
-            )
+            ),
+            onRemoveCard = {}
         )
     }
 }
@@ -510,7 +519,8 @@ private fun TodaysStatsCardErrorPreview() {
             uiState = TodaysStatsCardUiState.Error(
                 message = "Failed to load stats",
                 onRetry = {}
-            )
+            ),
+            onRemoveCard = {}
         )
     }
 }
@@ -544,7 +554,8 @@ private fun TodaysStatsCardLoadedDarkPreview() {
                     )
                 ),
                 onCardClick = {}
-            )
+            ),
+            onRemoveCard = {}
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -29,23 +29,16 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -87,6 +80,7 @@ import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.util.Locale
 import kotlin.math.abs
@@ -283,8 +277,6 @@ private fun HeaderSection(
     onChartTypeChanged: (ChartType) -> Unit,
     onRemoveCard: () -> Unit
 ) {
-    var showMenu by remember { mutableStateOf(false) }
-
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -296,28 +288,15 @@ private fun HeaderSection(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
-            Box {
-                IconButton(onClick = { showMenu = true }) {
-                    Icon(
-                        imageVector = Icons.Default.MoreVert,
-                        contentDescription = stringResource(R.string.more_options),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                additionalContent = {
+                    ChartTypeMenuItems(
+                        currentChartType = state.chartType,
+                        onChartTypeSelected = onChartTypeChanged
                     )
                 }
-                ChartTypeMenu(
-                    expanded = showMenu,
-                    currentChartType = state.chartType,
-                    onDismiss = { showMenu = false },
-                    onChartTypeSelected = { chartType ->
-                        onChartTypeChanged(chartType)
-                        showMenu = false
-                    },
-                    onRemoveCard = {
-                        showMenu = false
-                        onRemoveCard()
-                    }
-                )
-            }
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         Row(
@@ -367,63 +346,36 @@ private fun HeaderSection(
     }
 }
 
+/**
+ * Menu items for chart type selection. Used as additionalContent in StatsCardMenu.
+ */
 @Composable
-private fun ChartTypeMenu(
-    expanded: Boolean,
+private fun ChartTypeMenuItems(
     currentChartType: ChartType,
-    onDismiss: () -> Unit,
-    onChartTypeSelected: (ChartType) -> Unit,
-    onRemoveCard: () -> Unit
+    onChartTypeSelected: (ChartType) -> Unit
 ) {
-    DropdownMenu(
-        expanded = expanded,
-        onDismissRequest = onDismiss
-    ) {
-        DropdownMenuItem(
-            text = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ShowChart,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = stringResource(R.string.stats_chart_type_lines))
-                }
-            },
-            onClick = { onChartTypeSelected(ChartType.LINE) },
-            enabled = currentChartType != ChartType.LINE
-        )
-        DropdownMenuItem(
-            text = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.BarChart,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = stringResource(R.string.stats_chart_type_bars))
-                }
-            },
-            onClick = { onChartTypeSelected(ChartType.BAR) },
-            enabled = currentChartType != ChartType.BAR
-        )
-        DropdownMenuItem(
-            text = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = stringResource(R.string.stats_card_remove))
-                }
-            },
-            onClick = onRemoveCard
-        )
-    }
+    DropdownMenuItem(
+        text = { Text(text = stringResource(R.string.stats_chart_type_lines)) },
+        onClick = { onChartTypeSelected(ChartType.LINE) },
+        enabled = currentChartType != ChartType.LINE,
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ShowChart,
+                contentDescription = null
+            )
+        }
+    )
+    DropdownMenuItem(
+        text = { Text(text = stringResource(R.string.stats_chart_type_bars)) },
+        onClick = { onChartTypeSelected(ChartType.BAR) },
+        enabled = currentChartType != ChartType.BAR,
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.BarChart,
+                contentDescription = null
+            )
+        }
+    )
 }
 
 @Composable
@@ -785,38 +737,7 @@ private fun ErrorContent(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
-            Box {
-                var showMenu by remember { mutableStateOf(false) }
-                IconButton(onClick = { showMenu = true }) {
-                    Icon(
-                        imageVector = Icons.Default.MoreVert,
-                        contentDescription = stringResource(R.string.more_options),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                DropdownMenu(
-                    expanded = showMenu,
-                    onDismissRequest = { showMenu = false }
-                ) {
-                    DropdownMenuItem(
-                        text = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector = Icons.Default.Delete,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(text = stringResource(R.string.stats_card_remove))
-                            }
-                        },
-                        onClick = {
-                            showMenu = false
-                            onRemoveCard()
-                        }
-                    )
-                }
-            }
+            StatsCardMenu(onRemoveClick = onRemoveCard)
         }
         Spacer(modifier = Modifier.height(16.dp))
         Box(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
@@ -117,6 +118,7 @@ fun ViewsStatsCard(
     uiState: ViewsStatsCardUiState,
     onChartTypeChanged: (ChartType) -> Unit,
     onRetry: () -> Unit,
+    onRemoveCard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
@@ -135,8 +137,8 @@ fun ViewsStatsCard(
     ) {
         when (uiState) {
             is ViewsStatsCardUiState.Loading -> LoadingContent()
-            is ViewsStatsCardUiState.Loaded -> LoadedContent(uiState, onChartTypeChanged)
-            is ViewsStatsCardUiState.Error -> ErrorContent(uiState, onRetry)
+            is ViewsStatsCardUiState.Loaded -> LoadedContent(uiState, onChartTypeChanged, onRemoveCard)
+            is ViewsStatsCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
         }
     }
 }
@@ -248,7 +250,8 @@ private fun LoadingContent() {
 @Composable
 private fun LoadedContent(
     state: ViewsStatsCardUiState.Loaded,
-    onChartTypeChanged: (ChartType) -> Unit
+    onChartTypeChanged: (ChartType) -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -258,7 +261,8 @@ private fun LoadedContent(
         // Header Section
         HeaderSection(
             state = state,
-            onChartTypeChanged = onChartTypeChanged
+            onChartTypeChanged = onChartTypeChanged,
+            onRemoveCard = onRemoveCard
         )
         Spacer(modifier = Modifier.height(16.dp))
         // Chart Section
@@ -276,7 +280,8 @@ private fun LoadedContent(
 @Composable
 private fun HeaderSection(
     state: ViewsStatsCardUiState.Loaded,
-    onChartTypeChanged: (ChartType) -> Unit
+    onChartTypeChanged: (ChartType) -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
@@ -306,6 +311,10 @@ private fun HeaderSection(
                     onChartTypeSelected = { chartType ->
                         onChartTypeChanged(chartType)
                         showMenu = false
+                    },
+                    onRemoveCard = {
+                        showMenu = false
+                        onRemoveCard()
                     }
                 )
             }
@@ -363,7 +372,8 @@ private fun ChartTypeMenu(
     expanded: Boolean,
     currentChartType: ChartType,
     onDismiss: () -> Unit,
-    onChartTypeSelected: (ChartType) -> Unit
+    onChartTypeSelected: (ChartType) -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     DropdownMenu(
         expanded = expanded,
@@ -398,6 +408,20 @@ private fun ChartTypeMenu(
             },
             onClick = { onChartTypeSelected(ChartType.BAR) },
             enabled = currentChartType != ChartType.BAR
+        )
+        DropdownMenuItem(
+            text = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = stringResource(R.string.stats_card_remove))
+                }
+            },
+            onClick = onRemoveCard
         )
     }
 }
@@ -743,18 +767,57 @@ private fun ChangeBadge(change: StatChange) {
 @Composable
 private fun ErrorContent(
     state: ViewsStatsCardUiState.Error,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onRemoveCard: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        Text(
-            text = stringResource(R.string.stats_views),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.stats_views),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Box {
+                var showMenu by remember { mutableStateOf(false) }
+                IconButton(onClick = { showMenu = true }) {
+                    Icon(
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = stringResource(R.string.more_options),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false }
+                ) {
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Default.Delete,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(text = stringResource(R.string.stats_card_remove))
+                            }
+                        },
+                        onClick = {
+                            showMenu = false
+                            onRemoveCard()
+                        }
+                    )
+                }
+            }
+        }
         Spacer(modifier = Modifier.height(16.dp))
         Box(
             modifier = Modifier
@@ -800,7 +863,8 @@ private fun ViewsStatsCardLoadingPreview() {
         ViewsStatsCard(
             uiState = ViewsStatsCardUiState.Loading,
             onChartTypeChanged = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -839,7 +903,12 @@ private fun sampleLoadedState(): ViewsStatsCardUiState.Loaded {
 @Composable
 private fun ViewsStatsCardLoadedPreview() {
     AppThemeM3 {
-        ViewsStatsCard(uiState = sampleLoadedState(), onChartTypeChanged = {}, onRetry = {})
+        ViewsStatsCard(
+            uiState = sampleLoadedState(),
+            onChartTypeChanged = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
     }
 }
 
@@ -852,7 +921,8 @@ private fun ViewsStatsCardErrorPreview() {
                 message = stringResource(R.string.stats_todays_stats_failed_to_load)
             ),
             onChartTypeChanged = {},
-            onRetry = {}
+            onRetry = {},
+            onRemoveCard = {}
         )
     }
 }
@@ -861,7 +931,12 @@ private fun ViewsStatsCardErrorPreview() {
 @Composable
 private fun ViewsStatsCardLoadedDarkPreview() {
     AppThemeM3 {
-        ViewsStatsCard(uiState = sampleLoadedState(), onChartTypeChanged = {}, onRetry = {})
+        ViewsStatsCard(
+            uiState = sampleLoadedState(),
+            onChartTypeChanged = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
@@ -60,14 +60,33 @@ class ViewsStatsViewModel @Inject constructor(
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
-    private val _selectedPeriod = MutableStateFlow(restorePeriod())
+    private val _selectedPeriod = MutableStateFlow(restorePeriodFromSavedState())
     val selectedPeriod: StateFlow<StatsPeriod> = _selectedPeriod.asStateFlow()
 
     private var currentChartType: ChartType = ChartType.LINE
     private var currentPeriod: StatsPeriod = _selectedPeriod.value
 
     init {
-        loadData()
+        initializeWithPersistedPeriod()
+    }
+
+    /**
+     * Initializes the ViewModel by restoring the period from persisted preferences asynchronously,
+     * then loading data. This avoids blocking the main thread with disk I/O.
+     */
+    private fun initializeWithPersistedPeriod() {
+        viewModelScope.launch {
+            // Try to restore from persisted preferences if SavedStateHandle didn't have a value
+            val savedPeriodType = savedStateHandle.get<String>(KEY_PERIOD_TYPE)
+            if (savedPeriodType == null) {
+                val restoredPeriod = restorePeriodFromPreferences()
+                if (restoredPeriod != null) {
+                    currentPeriod = restoredPeriod
+                    _selectedPeriod.value = restoredPeriod
+                }
+            }
+            loadData()
+        }
     }
 
     fun onPeriodChanged(period: StatsPeriod) {
@@ -118,35 +137,41 @@ class ViewsStatsViewModel @Inject constructor(
         }
     }
 
-    private fun restorePeriod(): StatsPeriod {
-        // First try to restore from SavedStateHandle (for configuration changes)
-        val savedPeriodType = savedStateHandle.get<String>(KEY_PERIOD_TYPE)
-        if (savedPeriodType != null) {
-            return when (savedPeriodType) {
-                PERIOD_TODAY -> StatsPeriod.Today
-                PERIOD_LAST_7_DAYS -> StatsPeriod.Last7Days
-                PERIOD_LAST_30_DAYS -> StatsPeriod.Last30Days
-                PERIOD_LAST_6_MONTHS -> StatsPeriod.Last6Months
-                PERIOD_LAST_12_MONTHS -> StatsPeriod.Last12Months
-                PERIOD_CUSTOM -> {
-                    val startEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_START_DATE)
-                    val endEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_END_DATE)
-                    if (startEpochDay != null && endEpochDay != null) {
-                        StatsPeriod.Custom(
-                            LocalDate.ofEpochDay(startEpochDay),
-                            LocalDate.ofEpochDay(endEpochDay)
-                        )
-                    } else {
-                        StatsPeriod.Last7Days
-                    }
+    /**
+     * Restores period from SavedStateHandle only (fast, no disk I/O).
+     * Used for property initialization.
+     */
+    private fun restorePeriodFromSavedState(): StatsPeriod {
+        val savedPeriodType = savedStateHandle.get<String>(KEY_PERIOD_TYPE) ?: return StatsPeriod.Last7Days
+        return when (savedPeriodType) {
+            PERIOD_TODAY -> StatsPeriod.Today
+            PERIOD_LAST_7_DAYS -> StatsPeriod.Last7Days
+            PERIOD_LAST_30_DAYS -> StatsPeriod.Last30Days
+            PERIOD_LAST_6_MONTHS -> StatsPeriod.Last6Months
+            PERIOD_LAST_12_MONTHS -> StatsPeriod.Last12Months
+            PERIOD_CUSTOM -> {
+                val startEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_START_DATE)
+                val endEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_END_DATE)
+                if (startEpochDay != null && endEpochDay != null) {
+                    StatsPeriod.Custom(
+                        LocalDate.ofEpochDay(startEpochDay),
+                        LocalDate.ofEpochDay(endEpochDay)
+                    )
+                } else {
+                    StatsPeriod.Last7Days
                 }
-                else -> StatsPeriod.Last7Days
             }
+            else -> StatsPeriod.Last7Days
         }
+    }
 
-        // Fall back to persisted preferences (for app restarts)
-        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return StatsPeriod.Last7Days
-        val config = cardsConfigurationRepository.getConfigurationSync(siteId)
+    /**
+     * Restores period from persisted preferences asynchronously.
+     * Used for app restarts when SavedStateHandle doesn't have the value.
+     */
+    private suspend fun restorePeriodFromPreferences(): StatsPeriod? {
+        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return null
+        val config = cardsConfigurationRepository.getConfiguration(siteId)
         return when (config.selectedPeriodType) {
             PERIOD_TODAY -> StatsPeriod.Today
             PERIOD_LAST_7_DAYS -> StatsPeriod.Last7Days
@@ -162,10 +187,10 @@ class ViewsStatsViewModel @Inject constructor(
                         LocalDate.ofEpochDay(endEpochDay)
                     )
                 } else {
-                    StatsPeriod.Last7Days
+                    null
                 }
             }
-            else -> StatsPeriod.Last7Days
+            else -> null
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.repository.PeriodStatsResult
+import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
 import org.wordpress.android.ui.newstats.repository.StatsRepository
 import org.wordpress.android.ui.newstats.repository.PeriodAggregates
 import org.wordpress.android.util.AppLog
@@ -50,7 +51,8 @@ class ViewsStatsViewModel @Inject constructor(
     private val accountStore: AccountStore,
     private val statsRepository: StatsRepository,
     private val resourceProvider: ResourceProvider,
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val cardsConfigurationRepository: StatsCardsConfigurationRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<ViewsStatsCardUiState>(ViewsStatsCardUiState.Loading)
     val uiState: StateFlow<ViewsStatsCardUiState> = _uiState.asStateFlow()
@@ -77,6 +79,7 @@ class ViewsStatsViewModel @Inject constructor(
     }
 
     private fun savePeriod(period: StatsPeriod) {
+        // Save to SavedStateHandle for immediate restoration
         when (period) {
             is StatsPeriod.Today -> savedStateHandle[KEY_PERIOD_TYPE] = PERIOD_TODAY
             is StatsPeriod.Last7Days -> savedStateHandle[KEY_PERIOD_TYPE] = PERIOD_LAST_7_DAYS
@@ -89,18 +92,70 @@ class ViewsStatsViewModel @Inject constructor(
                 savedStateHandle[KEY_CUSTOM_END_DATE] = period.endDate.toEpochDay()
             }
         }
+
+        // Persist to preferences for cross-session restoration
+        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return
+        viewModelScope.launch {
+            val config = cardsConfigurationRepository.getConfiguration(siteId)
+            val periodType = when (period) {
+                is StatsPeriod.Today -> PERIOD_TODAY
+                is StatsPeriod.Last7Days -> PERIOD_LAST_7_DAYS
+                is StatsPeriod.Last30Days -> PERIOD_LAST_30_DAYS
+                is StatsPeriod.Last6Months -> PERIOD_LAST_6_MONTHS
+                is StatsPeriod.Last12Months -> PERIOD_LAST_12_MONTHS
+                is StatsPeriod.Custom -> PERIOD_CUSTOM
+            }
+            val customStart = (period as? StatsPeriod.Custom)?.startDate?.toEpochDay()
+            val customEnd = (period as? StatsPeriod.Custom)?.endDate?.toEpochDay()
+            cardsConfigurationRepository.saveConfiguration(
+                siteId,
+                config.copy(
+                    selectedPeriodType = periodType,
+                    customPeriodStartDate = customStart,
+                    customPeriodEndDate = customEnd
+                )
+            )
+        }
     }
 
     private fun restorePeriod(): StatsPeriod {
-        return when (savedStateHandle.get<String>(KEY_PERIOD_TYPE)) {
+        // First try to restore from SavedStateHandle (for configuration changes)
+        val savedPeriodType = savedStateHandle.get<String>(KEY_PERIOD_TYPE)
+        if (savedPeriodType != null) {
+            return when (savedPeriodType) {
+                PERIOD_TODAY -> StatsPeriod.Today
+                PERIOD_LAST_7_DAYS -> StatsPeriod.Last7Days
+                PERIOD_LAST_30_DAYS -> StatsPeriod.Last30Days
+                PERIOD_LAST_6_MONTHS -> StatsPeriod.Last6Months
+                PERIOD_LAST_12_MONTHS -> StatsPeriod.Last12Months
+                PERIOD_CUSTOM -> {
+                    val startEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_START_DATE)
+                    val endEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_END_DATE)
+                    if (startEpochDay != null && endEpochDay != null) {
+                        StatsPeriod.Custom(
+                            LocalDate.ofEpochDay(startEpochDay),
+                            LocalDate.ofEpochDay(endEpochDay)
+                        )
+                    } else {
+                        StatsPeriod.Last7Days
+                    }
+                }
+                else -> StatsPeriod.Last7Days
+            }
+        }
+
+        // Fall back to persisted preferences (for app restarts)
+        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return StatsPeriod.Last7Days
+        val config = cardsConfigurationRepository.getConfigurationSync(siteId)
+        return when (config.selectedPeriodType) {
             PERIOD_TODAY -> StatsPeriod.Today
             PERIOD_LAST_7_DAYS -> StatsPeriod.Last7Days
             PERIOD_LAST_30_DAYS -> StatsPeriod.Last30Days
             PERIOD_LAST_6_MONTHS -> StatsPeriod.Last6Months
             PERIOD_LAST_12_MONTHS -> StatsPeriod.Last12Months
             PERIOD_CUSTOM -> {
-                val startEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_START_DATE)
-                val endEpochDay = savedStateHandle.get<Long>(KEY_CUSTOM_END_DATE)
+                val startEpochDay = config.customPeriodStartDate
+                val endEpochDay = config.customPeriodEndDate
                 if (startEpochDay != null && endEpochDay != null) {
                     StatsPeriod.Custom(
                         LocalDate.ofEpochDay(startEpochDay),

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -195,6 +195,7 @@ public class AppPrefs {
         PINNED_SITE_IDS,
         READER_READING_PREFERENCES_JSON,
         SHOULD_SHOW_READER_ANNOUNCEMENT_CARD,
+        STATS_CARDS_CONFIGURATION_JSON,
     }
 
     /**
@@ -1769,6 +1770,26 @@ public class AppPrefs {
         } else {
             setString(DeletablePrefKey.READER_READING_PREFERENCES_JSON, json);
         }
+    }
+
+    @Nullable
+    public static String getStatsCardsConfigurationJson(long siteId) {
+        return prefs().getString(getStatsCardsConfigurationKey(siteId), null);
+    }
+
+    public static void setStatsCardsConfigurationJson(long siteId, @Nullable String json) {
+        SharedPreferences.Editor editor = prefs().edit();
+        if (json == null) {
+            editor.remove(getStatsCardsConfigurationKey(siteId));
+        } else {
+            editor.putString(getStatsCardsConfigurationKey(siteId), json);
+        }
+        editor.apply();
+    }
+
+    @NonNull
+    private static String getStatsCardsConfigurationKey(long siteId) {
+        return DeletablePrefKey.STATS_CARDS_CONFIGURATION_JSON.name() + siteId;
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -99,6 +99,12 @@ class AppPrefsWrapper @Inject constructor(val buildConfigWrapper: BuildConfigWra
         get() = AppPrefs.getReaderReadingPreferencesJson()
         set(json) = AppPrefs.setReaderReadingPreferencesJson(json)
 
+    fun getStatsCardsConfigurationJson(siteId: Long): String? =
+        AppPrefs.getStatsCardsConfigurationJson(siteId)
+
+    fun setStatsCardsConfigurationJson(siteId: Long, json: String?) =
+        AppPrefs.setStatsCardsConfigurationJson(siteId, json)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1580,6 +1580,11 @@
     <string name="stats_countries_location_header">Locations</string>
     <string name="stats_countries_views_header">Views</string>
 
+    <!-- Stats Card Configuration -->
+    <string name="stats_card_remove">Remove Card</string>
+    <string name="stats_add_card_title">Add Card</string>
+    <string name="stats_all_cards_visible">All cards are currently visible</string>
+
     <!-- stats referrer popup menu actions   -->
     <string name="stats_referrer_popup_menu_open_website">Open Website</string>
     <string name="stats_referrer_popup_menu_mark_as_spam">Mark as Spam</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1584,6 +1584,7 @@
     <string name="stats_card_remove">Remove Card</string>
     <string name="stats_add_card_title">Add Card</string>
     <string name="stats_all_cards_visible">All cards are currently visible</string>
+    <string name="stats_no_cards_message">No cards to display. Tap the button below to add cards.</string>
 
     <!-- stats referrer popup menu actions   -->
     <string name="stats_referrer_popup_menu_open_website">Open Website</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1584,7 +1584,7 @@
     <string name="stats_card_remove">Remove Card</string>
     <string name="stats_add_card_title">Add Card</string>
     <string name="stats_all_cards_visible">All cards are currently visible</string>
-    <string name="stats_no_cards_message">No cards to display. Tap the button below to add cards.</string>
+    <string name="stats_no_cards_message">No cards to display.</string>
 
     <!-- stats referrer popup menu actions   -->
     <string name="stats_referrer_popup_menu_open_website">Open Website</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
@@ -8,13 +8,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
 
 @ExperimentalCoroutinesApi
@@ -95,64 +93,6 @@ class NewStatsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when removeMostViewedCard is called, then repository removeMostViewedCard is invoked`() = test {
-        initViewModel()
-        advanceUntilIdle()
-
-        viewModel.removeMostViewedCard(0)
-        advanceUntilIdle()
-
-        verify(cardConfigurationRepository).removeMostViewedCard(TEST_SITE_ID, 0)
-    }
-
-    @Test
-    fun `when addMostViewedCard is called, then repository addMostViewedCard is invoked`() = test {
-        initViewModel()
-        advanceUntilIdle()
-
-        viewModel.addMostViewedCard(MostViewedDataSource.REFERRERS)
-        advanceUntilIdle()
-
-        verify(cardConfigurationRepository).addMostViewedCard(TEST_SITE_ID, MostViewedDataSource.REFERRERS.name)
-    }
-
-    @Test
-    fun `when updateMostViewedDataSource is called, then state is updated immediately`() = test {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.MOST_VIEWED, StatsCardType.MOST_VIEWED),
-            mostViewedDataSources = listOf(
-                MostViewedDataSource.POSTS_AND_PAGES.name,
-                MostViewedDataSource.REFERRERS.name
-            )
-        )
-        initViewModel(config)
-        advanceUntilIdle()
-
-        viewModel.updateMostViewedDataSource(0, MostViewedDataSource.REFERRERS)
-
-        assertThat(viewModel.mostViewedDataSources.value[0]).isEqualTo(MostViewedDataSource.REFERRERS)
-    }
-
-    @Test
-    fun `when updateMostViewedDataSource is called, then repository is updated`() = test {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.MOST_VIEWED),
-            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
-        )
-        initViewModel(config)
-        advanceUntilIdle()
-
-        viewModel.updateMostViewedDataSource(0, MostViewedDataSource.REFERRERS)
-        advanceUntilIdle()
-
-        verify(cardConfigurationRepository).updateMostViewedDataSource(
-            eq(TEST_SITE_ID),
-            eq(0),
-            eq(MostViewedDataSource.REFERRERS.name)
-        )
-    }
-
-    @Test
     fun `when configuration changes via flow, then state is updated`() = test {
         initViewModel()
         advanceUntilIdle()
@@ -182,17 +122,24 @@ class NewStatsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when hiddenCards is calculated, then it excludes visible cards except MOST_VIEWED`() = test {
+    fun `when hiddenCards is calculated, then it excludes visible cards`() = test {
         val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED_POSTS_AND_PAGES)
         )
         initViewModel(config)
         advanceUntilIdle()
 
         val hiddenCards = viewModel.hiddenCards.value
 
-        assertThat(hiddenCards).contains(StatsCardType.VIEWS_STATS, StatsCardType.COUNTRIES)
-        assertThat(hiddenCards).doesNotContain(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+        assertThat(hiddenCards).contains(
+            StatsCardType.VIEWS_STATS,
+            StatsCardType.MOST_VIEWED_REFERRERS,
+            StatsCardType.COUNTRIES
+        )
+        assertThat(hiddenCards).doesNotContain(
+            StatsCardType.TODAYS_STATS,
+            StatsCardType.MOST_VIEWED_POSTS_AND_PAGES
+        )
     }
 
     @Test
@@ -204,38 +151,6 @@ class NewStatsViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         verify(cardConfigurationRepository).getConfiguration(0L)
-    }
-
-    @Test
-    fun `when mostViewedDataSources has valid values, then they are parsed correctly`() = test {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.MOST_VIEWED, StatsCardType.MOST_VIEWED),
-            mostViewedDataSources = listOf(
-                MostViewedDataSource.POSTS_AND_PAGES.name,
-                MostViewedDataSource.REFERRERS.name
-            )
-        )
-        initViewModel(config)
-        advanceUntilIdle()
-
-        assertThat(viewModel.mostViewedDataSources.value).containsExactly(
-            MostViewedDataSource.POSTS_AND_PAGES,
-            MostViewedDataSource.REFERRERS
-        )
-    }
-
-    @Test
-    fun `when hiddenMostViewedDataSources is calculated, then it excludes visible data sources`() = test {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.MOST_VIEWED),
-            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
-        )
-        initViewModel(config)
-        advanceUntilIdle()
-
-        val hiddenDataSources = viewModel.hiddenMostViewedDataSources.value
-
-        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
     }
 
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
@@ -1,0 +1,246 @@
+package org.wordpress.android.ui.newstats
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
+import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner.Silent::class)
+class NewStatsViewModelTest : BaseUnitTest() {
+    @Mock
+    private lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    private lateinit var cardConfigurationRepository: StatsCardsConfigurationRepository
+
+    private lateinit var viewModel: NewStatsViewModel
+
+    private val testSite = SiteModel().apply {
+        id = 1
+        siteId = TEST_SITE_ID
+        name = "Test Site"
+    }
+
+    private val configurationFlow = MutableStateFlow<Pair<Long, StatsCardsConfiguration>?>(null)
+
+    @Before
+    fun setUp() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
+        whenever(cardConfigurationRepository.configurationFlow).thenReturn(configurationFlow)
+    }
+
+    private suspend fun initViewModel(config: StatsCardsConfiguration = StatsCardsConfiguration()) {
+        whenever(cardConfigurationRepository.getConfiguration(TEST_SITE_ID)).thenReturn(config)
+        viewModel = NewStatsViewModel(selectedSiteRepository, cardConfigurationRepository)
+    }
+
+    @Test
+    fun `when initialized with default config, then default cards are visible`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.visibleCards.value).isEqualTo(StatsCardType.defaultCards())
+    }
+
+    @Test
+    fun `when initialized with custom config, then custom cards are visible`() = test {
+        val customConfig = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.VIEWS_STATS)
+        )
+        initViewModel(customConfig)
+        advanceUntilIdle()
+
+        assertThat(viewModel.visibleCards.value).containsExactly(
+            StatsCardType.TODAYS_STATS,
+            StatsCardType.VIEWS_STATS
+        )
+    }
+
+    @Test
+    fun `when removeCard is called, then repository removeCard is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.removeCard(StatsCardType.TODAYS_STATS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).removeCard(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+    }
+
+    @Test
+    fun `when addCard is called, then repository addCard is invoked`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS)
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        viewModel.addCard(StatsCardType.COUNTRIES)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).addCard(TEST_SITE_ID, StatsCardType.COUNTRIES)
+    }
+
+    @Test
+    fun `when removeMostViewedCard is called, then repository removeMostViewedCard is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.removeMostViewedCard(0)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).removeMostViewedCard(TEST_SITE_ID, 0)
+    }
+
+    @Test
+    fun `when addMostViewedCard is called, then repository addMostViewedCard is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.addMostViewedCard(MostViewedDataSource.REFERRERS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).addMostViewedCard(TEST_SITE_ID, MostViewedDataSource.REFERRERS.name)
+    }
+
+    @Test
+    fun `when updateMostViewedDataSource is called, then state is updated immediately`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.MOST_VIEWED, StatsCardType.MOST_VIEWED),
+            mostViewedDataSources = listOf(
+                MostViewedDataSource.POSTS_AND_PAGES.name,
+                MostViewedDataSource.REFERRERS.name
+            )
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        viewModel.updateMostViewedDataSource(0, MostViewedDataSource.REFERRERS)
+
+        assertThat(viewModel.mostViewedDataSources.value[0]).isEqualTo(MostViewedDataSource.REFERRERS)
+    }
+
+    @Test
+    fun `when updateMostViewedDataSource is called, then repository is updated`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.MOST_VIEWED),
+            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        viewModel.updateMostViewedDataSource(0, MostViewedDataSource.REFERRERS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).updateMostViewedDataSource(
+            eq(TEST_SITE_ID),
+            eq(0),
+            eq(MostViewedDataSource.REFERRERS.name)
+        )
+    }
+
+    @Test
+    fun `when configuration changes via flow, then state is updated`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        val newConfig = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.COUNTRIES)
+        )
+        configurationFlow.value = TEST_SITE_ID to newConfig
+        advanceUntilIdle()
+
+        assertThat(viewModel.visibleCards.value).containsExactly(StatsCardType.COUNTRIES)
+    }
+
+    @Test
+    fun `when configuration changes for different site, then state is not updated`() = test {
+        initViewModel()
+        advanceUntilIdle()
+        val initialCards = viewModel.visibleCards.value
+
+        val newConfig = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.COUNTRIES)
+        )
+        configurationFlow.value = OTHER_SITE_ID to newConfig
+        advanceUntilIdle()
+
+        assertThat(viewModel.visibleCards.value).isEqualTo(initialCards)
+    }
+
+    @Test
+    fun `when hiddenCards is calculated, then it excludes visible cards except MOST_VIEWED`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        val hiddenCards = viewModel.hiddenCards.value
+
+        assertThat(hiddenCards).contains(StatsCardType.VIEWS_STATS, StatsCardType.COUNTRIES)
+        assertThat(hiddenCards).doesNotContain(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+    }
+
+    @Test
+    fun `when no site selected, then siteId defaults to 0`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        whenever(cardConfigurationRepository.getConfiguration(0L)).thenReturn(StatsCardsConfiguration())
+
+        viewModel = NewStatsViewModel(selectedSiteRepository, cardConfigurationRepository)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).getConfiguration(0L)
+    }
+
+    @Test
+    fun `when mostViewedDataSources has valid values, then they are parsed correctly`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.MOST_VIEWED, StatsCardType.MOST_VIEWED),
+            mostViewedDataSources = listOf(
+                MostViewedDataSource.POSTS_AND_PAGES.name,
+                MostViewedDataSource.REFERRERS.name
+            )
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        assertThat(viewModel.mostViewedDataSources.value).containsExactly(
+            MostViewedDataSource.POSTS_AND_PAGES,
+            MostViewedDataSource.REFERRERS
+        )
+    }
+
+    @Test
+    fun `when hiddenMostViewedDataSources is calculated, then it excludes visible data sources`() = test {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.MOST_VIEWED),
+            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
+        )
+        initViewModel(config)
+        advanceUntilIdle()
+
+        val hiddenDataSources = viewModel.hiddenMostViewedDataSources.value
+
+        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
+    }
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+        private const val OTHER_SITE_ID = 456L
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
@@ -1,0 +1,176 @@
+package org.wordpress.android.ui.newstats
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
+
+class StatsCardsConfigurationTest {
+
+    @Test
+    fun `when default configuration, then all default cards are visible`() {
+        val config = StatsCardsConfiguration()
+
+        assertThat(config.visibleCards).isEqualTo(StatsCardType.defaultCards())
+    }
+
+    @Test
+    fun `when default configuration, then default most viewed data sources are set`() {
+        val config = StatsCardsConfiguration()
+
+        assertThat(config.mostViewedDataSources).containsExactly(
+            MostViewedDataSource.POSTS_AND_PAGES.name,
+            MostViewedDataSource.REFERRERS.name
+        )
+    }
+
+    @Test
+    fun `when hiddenCards is called, then non-visible cards are returned excluding MOST_VIEWED`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+        )
+
+        val hiddenCards = config.hiddenCards()
+
+        assertThat(hiddenCards).containsExactlyInAnyOrder(
+            StatsCardType.VIEWS_STATS,
+            StatsCardType.COUNTRIES
+        )
+        assertThat(hiddenCards).doesNotContain(StatsCardType.MOST_VIEWED)
+    }
+
+    @Test
+    fun `when all cards visible, then hiddenCards returns empty list`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(
+                StatsCardType.TODAYS_STATS,
+                StatsCardType.VIEWS_STATS,
+                StatsCardType.MOST_VIEWED,
+                StatsCardType.COUNTRIES
+            )
+        )
+
+        val hiddenCards = config.hiddenCards()
+
+        assertThat(hiddenCards).isEmpty()
+    }
+
+    @Test
+    fun `when no cards visible, then hiddenCards returns all except MOST_VIEWED`() {
+        val config = StatsCardsConfiguration(visibleCards = emptyList())
+
+        val hiddenCards = config.hiddenCards()
+
+        assertThat(hiddenCards).containsExactlyInAnyOrder(
+            StatsCardType.TODAYS_STATS,
+            StatsCardType.VIEWS_STATS,
+            StatsCardType.COUNTRIES
+        )
+    }
+
+    @Test
+    fun `when hiddenMostViewedDataSources is called, then non-visible data sources are returned`() {
+        val config = StatsCardsConfiguration(
+            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
+        )
+
+        val hiddenDataSources = config.hiddenMostViewedDataSources()
+
+        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
+    }
+
+    @Test
+    fun `when all data sources visible, then hiddenMostViewedDataSources returns empty`() {
+        val config = StatsCardsConfiguration(
+            mostViewedDataSources = listOf(
+                MostViewedDataSource.POSTS_AND_PAGES.name,
+                MostViewedDataSource.REFERRERS.name
+            )
+        )
+
+        val hiddenDataSources = config.hiddenMostViewedDataSources()
+
+        assertThat(hiddenDataSources).isEmpty()
+    }
+
+    @Test
+    fun `when no data sources visible, then hiddenMostViewedDataSources returns all`() {
+        val config = StatsCardsConfiguration(mostViewedDataSources = emptyList())
+
+        val hiddenDataSources = config.hiddenMostViewedDataSources()
+
+        assertThat(hiddenDataSources).containsExactlyInAnyOrder(
+            MostViewedDataSource.POSTS_AND_PAGES,
+            MostViewedDataSource.REFERRERS
+        )
+    }
+
+    @Test
+    fun `when invalid data source name in list, then it is ignored`() {
+        val config = StatsCardsConfiguration(
+            mostViewedDataSources = listOf(
+                MostViewedDataSource.POSTS_AND_PAGES.name,
+                "INVALID_DATA_SOURCE"
+            )
+        )
+
+        val hiddenDataSources = config.hiddenMostViewedDataSources()
+
+        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
+    }
+
+    @Test
+    fun `when isCardVisible is called for visible card, then returns true`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.VIEWS_STATS)
+        )
+
+        assertThat(config.isCardVisible(StatsCardType.TODAYS_STATS)).isTrue()
+        assertThat(config.isCardVisible(StatsCardType.VIEWS_STATS)).isTrue()
+    }
+
+    @Test
+    fun `when isCardVisible is called for hidden card, then returns false`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS)
+        )
+
+        assertThat(config.isCardVisible(StatsCardType.VIEWS_STATS)).isFalse()
+        assertThat(config.isCardVisible(StatsCardType.COUNTRIES)).isFalse()
+    }
+
+    @Test
+    fun `when mostViewedCardCount is called, then returns count of MOST_VIEWED cards`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(
+                StatsCardType.TODAYS_STATS,
+                StatsCardType.MOST_VIEWED,
+                StatsCardType.MOST_VIEWED,
+                StatsCardType.COUNTRIES
+            )
+        )
+
+        assertThat(config.mostViewedCardCount()).isEqualTo(2)
+    }
+
+    @Test
+    fun `when no MOST_VIEWED cards, then mostViewedCardCount returns zero`() {
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.COUNTRIES)
+        )
+
+        assertThat(config.mostViewedCardCount()).isEqualTo(0)
+    }
+
+    @Test
+    fun `when custom period dates are set, then they are stored correctly`() {
+        val config = StatsCardsConfiguration(
+            selectedPeriodType = "custom",
+            customPeriodStartDate = 19000L,
+            customPeriodEndDate = 19007L
+        )
+
+        assertThat(config.selectedPeriodType).isEqualTo("custom")
+        assertThat(config.customPeriodStartDate).isEqualTo(19000L)
+        assertThat(config.customPeriodEndDate).isEqualTo(19007L)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.newstats
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 
 class StatsCardsConfigurationTest {
     @Test
@@ -13,28 +12,18 @@ class StatsCardsConfigurationTest {
     }
 
     @Test
-    fun `when default configuration, then default most viewed data sources are set`() {
-        val config = StatsCardsConfiguration()
-
-        assertThat(config.mostViewedDataSources).containsExactly(
-            MostViewedDataSource.POSTS_AND_PAGES.name,
-            MostViewedDataSource.REFERRERS.name
-        )
-    }
-
-    @Test
-    fun `when hiddenCards is called, then non-visible cards are returned excluding MOST_VIEWED`() {
+    fun `when hiddenCards is called, then non-visible cards are returned`() {
         val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.MOST_VIEWED)
+            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.VIEWS_STATS)
         )
 
         val hiddenCards = config.hiddenCards()
 
         assertThat(hiddenCards).containsExactlyInAnyOrder(
-            StatsCardType.VIEWS_STATS,
+            StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
+            StatsCardType.MOST_VIEWED_REFERRERS,
             StatsCardType.COUNTRIES
         )
-        assertThat(hiddenCards).doesNotContain(StatsCardType.MOST_VIEWED)
     }
 
     @Test
@@ -43,7 +32,8 @@ class StatsCardsConfigurationTest {
             visibleCards = listOf(
                 StatsCardType.TODAYS_STATS,
                 StatsCardType.VIEWS_STATS,
-                StatsCardType.MOST_VIEWED,
+                StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
+                StatsCardType.MOST_VIEWED_REFERRERS,
                 StatsCardType.COUNTRIES
             )
         )
@@ -54,7 +44,7 @@ class StatsCardsConfigurationTest {
     }
 
     @Test
-    fun `when no cards visible, then hiddenCards returns all except MOST_VIEWED`() {
+    fun `when no cards visible, then hiddenCards returns all cards`() {
         val config = StatsCardsConfiguration(visibleCards = emptyList())
 
         val hiddenCards = config.hiddenCards()
@@ -62,59 +52,10 @@ class StatsCardsConfigurationTest {
         assertThat(hiddenCards).containsExactlyInAnyOrder(
             StatsCardType.TODAYS_STATS,
             StatsCardType.VIEWS_STATS,
+            StatsCardType.MOST_VIEWED_POSTS_AND_PAGES,
+            StatsCardType.MOST_VIEWED_REFERRERS,
             StatsCardType.COUNTRIES
         )
-    }
-
-    @Test
-    fun `when hiddenMostViewedDataSources is called, then non-visible data sources are returned`() {
-        val config = StatsCardsConfiguration(
-            mostViewedDataSources = listOf(MostViewedDataSource.POSTS_AND_PAGES.name)
-        )
-
-        val hiddenDataSources = config.hiddenMostViewedDataSources()
-
-        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
-    }
-
-    @Test
-    fun `when all data sources visible, then hiddenMostViewedDataSources returns empty`() {
-        val config = StatsCardsConfiguration(
-            mostViewedDataSources = listOf(
-                MostViewedDataSource.POSTS_AND_PAGES.name,
-                MostViewedDataSource.REFERRERS.name
-            )
-        )
-
-        val hiddenDataSources = config.hiddenMostViewedDataSources()
-
-        assertThat(hiddenDataSources).isEmpty()
-    }
-
-    @Test
-    fun `when no data sources visible, then hiddenMostViewedDataSources returns all`() {
-        val config = StatsCardsConfiguration(mostViewedDataSources = emptyList())
-
-        val hiddenDataSources = config.hiddenMostViewedDataSources()
-
-        assertThat(hiddenDataSources).containsExactlyInAnyOrder(
-            MostViewedDataSource.POSTS_AND_PAGES,
-            MostViewedDataSource.REFERRERS
-        )
-    }
-
-    @Test
-    fun `when invalid data source name in list, then it is ignored`() {
-        val config = StatsCardsConfiguration(
-            mostViewedDataSources = listOf(
-                MostViewedDataSource.POSTS_AND_PAGES.name,
-                "INVALID_DATA_SOURCE"
-            )
-        )
-
-        val hiddenDataSources = config.hiddenMostViewedDataSources()
-
-        assertThat(hiddenDataSources).containsExactly(MostViewedDataSource.REFERRERS)
     }
 
     @Test
@@ -135,29 +76,6 @@ class StatsCardsConfigurationTest {
 
         assertThat(config.isCardVisible(StatsCardType.VIEWS_STATS)).isFalse()
         assertThat(config.isCardVisible(StatsCardType.COUNTRIES)).isFalse()
-    }
-
-    @Test
-    fun `when mostViewedCardCount is called, then returns count of MOST_VIEWED cards`() {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(
-                StatsCardType.TODAYS_STATS,
-                StatsCardType.MOST_VIEWED,
-                StatsCardType.MOST_VIEWED,
-                StatsCardType.COUNTRIES
-            )
-        )
-
-        assertThat(config.mostViewedCardCount()).isEqualTo(2)
-    }
-
-    @Test
-    fun `when no MOST_VIEWED cards, then mostViewedCardCount returns zero`() {
-        val config = StatsCardsConfiguration(
-            visibleCards = listOf(StatsCardType.TODAYS_STATS, StatsCardType.COUNTRIES)
-        )
-
-        assertThat(config.mostViewedCardCount()).isEqualTo(0)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
@@ -5,7 +5,6 @@ import org.junit.Test
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 
 class StatsCardsConfigurationTest {
-
     @Test
     fun `when default configuration, then all default cards are visible`() {
         val config = StatsCardsConfiguration()

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
@@ -70,29 +70,32 @@ class MostViewedViewModelTest : BaseUnitTest() {
 
     // region Error states
     @Test
-    fun `when no site selected, then error state is emitted`() = test {
+    fun `when no site selected, then error state is emitted for both data sources`() = test {
         stubNoSiteSelectedError()
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Error::class.java)
-        assertThat((state as MostViewedCardUiState.Error).message).isEqualTo(NO_SITE_SELECTED_ERROR)
+        val postsState = viewModel.postsUiState.value
+        val referrersState = viewModel.referrersUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat(referrersState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat((postsState as MostViewedCardUiState.Error).message).isEqualTo(NO_SITE_SELECTED_ERROR)
     }
 
     @Test
-    fun `when access token is null, then error state is emitted`() = test {
+    fun `when access token is null, then error state is emitted for both data sources`() = test {
         stubFailedToLoadError()
         whenever(accountStore.accessToken).thenReturn(null)
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Error::class.java)
-        assertThat((state as MostViewedCardUiState.Error).message).isEqualTo(FAILED_TO_LOAD_ERROR)
+        val postsState = viewModel.postsUiState.value
+        val referrersState = viewModel.referrersUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat(referrersState).isInstanceOf(MostViewedCardUiState.Error::class.java)
     }
 
     @Test
@@ -103,50 +106,70 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Error::class.java)
-        assertThat((state as MostViewedCardUiState.Error).message).isEqualTo(FAILED_TO_LOAD_ERROR)
+        val postsState = viewModel.postsUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat((postsState as MostViewedCardUiState.Error).message).isEqualTo(FAILED_TO_LOAD_ERROR)
     }
 
     @Test
-    fun `when fetch fails, then error state is emitted`() = test {
+    fun `when posts fetch fails, then posts error state is emitted`() = test {
         stubFailedToLoadError()
-        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.POSTS_AND_PAGES)))
+            .thenReturn(MostViewedResult.Error("Network error"))
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.REFERRERS)))
+            .thenReturn(createSuccessResult())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val postsState = viewModel.postsUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+    }
+
+    @Test
+    fun `when referrers fetch fails, then referrers error state is emitted`() = test {
+        stubFailedToLoadError()
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.POSTS_AND_PAGES)))
+            .thenReturn(createSuccessResult())
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.REFERRERS)))
             .thenReturn(MostViewedResult.Error("Network error"))
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Error::class.java)
-        assertThat((state as MostViewedCardUiState.Error).message).isEqualTo(FAILED_TO_LOAD_ERROR)
+        val referrersState = viewModel.referrersUiState.value
+        assertThat(referrersState).isInstanceOf(MostViewedCardUiState.Error::class.java)
     }
 
     @Test
     fun `when exception is thrown, then error state with exception message is emitted`() = test {
-        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.POSTS_AND_PAGES)))
             .thenThrow(RuntimeException("Test exception"))
+        whenever(statsRepository.fetchMostViewed(any(), any(), eq(MostViewedDataSource.REFERRERS)))
+            .thenReturn(createSuccessResult())
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Error::class.java)
-        assertThat((state as MostViewedCardUiState.Error).message).isEqualTo("Test exception")
+        val postsState = viewModel.postsUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat((postsState as MostViewedCardUiState.Error).message).isEqualTo("Test exception")
     }
     // endregion
 
     // region Success states
     @Test
-    fun `when data loads successfully, then loaded state is emitted`() = test {
+    fun `when data loads successfully, then loaded state is emitted for both data sources`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+        val postsState = viewModel.postsUiState.value
+        val referrersState = viewModel.referrersUiState.value
+        assertThat(postsState).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+        assertThat(referrersState).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
     }
 
     @Test
@@ -157,7 +180,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items).hasSize(2)
         assertThat(state.items[0].title).isEqualTo(TEST_POST_TITLE_1)
         assertThat(state.items[0].views).isEqualTo(TEST_POST_VIEWS_1)
@@ -173,7 +196,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items[0].isHighlighted).isTrue()
         assertThat(state.items[1].isHighlighted).isFalse()
     }
@@ -202,62 +225,26 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items).hasSize(10)
     }
 
     @Test
-    fun `when data loads, then selected data source is correct`() = test {
+    fun `when init, then both data sources are fetched in parallel`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
 
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
-        assertThat(state.selectedDataSource).isEqualTo(MostViewedDataSource.POSTS_AND_PAGES)
-    }
-    // endregion
-
-    // region Data source changes
-    @Test
-    fun `when data source changes, then data is reloaded`() = test {
-        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
-            .thenReturn(createSuccessResult())
-
-        initViewModel()
-        advanceUntilIdle()
-
-        viewModel.onDataSourceChanged(MostViewedDataSource.REFERRERS)
-        advanceUntilIdle()
-
-        verify(statsRepository, times(2)).fetchMostViewed(any(), any(), any())
-        verify(statsRepository).fetchMostViewed(
-            eq(TEST_SITE_ID),
-            any(),
-            eq(MostViewedDataSource.REFERRERS)
-        )
-    }
-
-    @Test
-    fun `when same data source is selected, then data is not reloaded`() = test {
-        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
-            .thenReturn(createSuccessResult())
-
-        initViewModel()
-        advanceUntilIdle()
-
-        viewModel.onDataSourceChanged(MostViewedDataSource.POSTS_AND_PAGES)
-        advanceUntilIdle()
-
-        // Should only be called once during init
-        verify(statsRepository, times(1)).fetchMostViewed(any(), any(), any())
+        verify(statsRepository).fetchMostViewed(eq(TEST_SITE_ID), any(), eq(MostViewedDataSource.POSTS_AND_PAGES))
+        verify(statsRepository).fetchMostViewed(eq(TEST_SITE_ID), any(), eq(MostViewedDataSource.REFERRERS))
     }
     // endregion
 
     // region Period changes
     @Test
-    fun `when period changes, then data is reloaded`() = test {
+    fun `when period changes, then both data sources are reloaded`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
 
@@ -267,8 +254,12 @@ class MostViewedViewModelTest : BaseUnitTest() {
         viewModel.onPeriodChanged(StatsPeriod.Last30Days)
         advanceUntilIdle()
 
-        verify(statsRepository, times(2)).fetchMostViewed(any(), any(), any())
-        verify(statsRepository).fetchMostViewed(eq(TEST_SITE_ID), eq(StatsPeriod.Last30Days), any())
+        // Called 4 times: twice during init (posts + referrers), twice during period change
+        verify(statsRepository, times(2)).fetchMostViewed(
+            eq(TEST_SITE_ID),
+            eq(StatsPeriod.Last30Days),
+            any()
+        )
     }
 
     @Test
@@ -282,8 +273,8 @@ class MostViewedViewModelTest : BaseUnitTest() {
         viewModel.onPeriodChanged(StatsPeriod.Last7Days)
         advanceUntilIdle()
 
-        // Should only be called once during init
-        verify(statsRepository, times(1)).fetchMostViewed(any(), any(), any())
+        // Should only be called twice during init (once per data source)
+        verify(statsRepository, times(2)).fetchMostViewed(any(), any(), any())
     }
     // endregion
 
@@ -305,7 +296,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when refresh is called, then data is fetched`() = test {
+    fun `when refresh is called, then both data sources are fetched`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
 
@@ -315,31 +306,54 @@ class MostViewedViewModelTest : BaseUnitTest() {
         viewModel.refresh()
         advanceUntilIdle()
 
-        // Called twice: once during init, once during refresh
-        verify(statsRepository, times(2)).fetchMostViewed(eq(TEST_SITE_ID), any(), any())
+        // Called 4 times: twice during init, twice during refresh
+        verify(statsRepository, times(4)).fetchMostViewed(eq(TEST_SITE_ID), any(), any())
     }
     // endregion
 
     // region Retry
     @Test
-    fun `when onRetry is called, then data is reloaded`() = test {
+    fun `when onRetryPosts is called, then posts data is reloaded`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
 
         initViewModel()
         advanceUntilIdle()
 
-        viewModel.onRetry()
+        viewModel.onRetryPosts()
         advanceUntilIdle()
 
-        // Called twice: once during init, once during retry
-        verify(statsRepository, times(2)).fetchMostViewed(any(), any(), any())
+        // Called 3 times for posts: once during init, once during retry
+        // Plus 1 time for referrers during init
+        verify(statsRepository, times(2)).fetchMostViewed(
+            any(),
+            any(),
+            eq(MostViewedDataSource.POSTS_AND_PAGES)
+        )
+    }
+
+    @Test
+    fun `when onRetryReferrers is called, then referrers data is reloaded`() = test {
+        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+            .thenReturn(createSuccessResult())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.onRetryReferrers()
+        advanceUntilIdle()
+
+        verify(statsRepository, times(2)).fetchMostViewed(
+            any(),
+            any(),
+            eq(MostViewedDataSource.REFERRERS)
+        )
     }
     // endregion
 
     // region getDetailData
     @Test
-    fun `when getDetailData is called, then returns cached data`() = test {
+    fun `when getPostsDetailData is called, then returns cached posts data`() = test {
         whenever(statsRepository.fetchMostViewed(any(), any(), any()))
             .thenReturn(createSuccessResult())
         whenever(resourceProvider.getString(R.string.stats_period_last_7_days))
@@ -348,7 +362,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val detailData = viewModel.getDetailData()
+        val detailData = viewModel.getPostsDetailData()
 
         assertThat(detailData.dataSource).isEqualTo(MostViewedDataSource.POSTS_AND_PAGES)
         assertThat(detailData.items).hasSize(2)
@@ -358,7 +372,23 @@ class MostViewedViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when getDetailData is called, then all items are returned not just card items`() = test {
+    fun `when getReferrersDetailData is called, then returns cached referrers data`() = test {
+        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+            .thenReturn(createSuccessResult())
+        whenever(resourceProvider.getString(R.string.stats_period_last_7_days))
+            .thenReturn("Last 7 days")
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val detailData = viewModel.getReferrersDetailData()
+
+        assertThat(detailData.dataSource).isEqualTo(MostViewedDataSource.REFERRERS)
+        assertThat(detailData.items).hasSize(2)
+    }
+
+    @Test
+    fun `when getPostsDetailData is called, then all items are returned not just card items`() = test {
         val manyItems = (1..15).mapIndexed { idx, index ->
             MostViewedItemData(
                 id = index.toLong(),
@@ -383,7 +413,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val detailData = viewModel.getDetailData()
+        val detailData = viewModel.getPostsDetailData()
         // Card shows max 10, but detail data should have all 15
         assertThat(detailData.items).hasSize(15)
     }
@@ -414,7 +444,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items[0].change).isInstanceOf(MostViewedChange.Positive::class.java)
         val change = state.items[0].change as MostViewedChange.Positive
         assertThat(change.value).isEqualTo(50)
@@ -445,7 +475,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items[0].change).isInstanceOf(MostViewedChange.Negative::class.java)
         val change = state.items[0].change as MostViewedChange.Negative
         assertThat(change.value).isEqualTo(50)
@@ -476,7 +506,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value as MostViewedCardUiState.Loaded
+        val state = viewModel.postsUiState.value as MostViewedCardUiState.Loaded
         assertThat(state.items[0].change).isEqualTo(MostViewedChange.NoChange)
     }
     // endregion

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.repository.MostViewedItemData
 import org.wordpress.android.ui.newstats.repository.MostViewedResult
@@ -364,7 +365,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
 
         val detailData = viewModel.getPostsDetailData()
 
-        assertThat(detailData.dataSource).isEqualTo(MostViewedDataSource.POSTS_AND_PAGES)
+        assertThat(detailData.cardType).isEqualTo(StatsCardType.MOST_VIEWED_POSTS_AND_PAGES)
         assertThat(detailData.items).hasSize(2)
         assertThat(detailData.totalViews).isEqualTo(TEST_TOTAL_VIEWS)
         assertThat(detailData.totalViewsChange).isEqualTo(TEST_TOTAL_VIEWS_CHANGE)
@@ -383,7 +384,7 @@ class MostViewedViewModelTest : BaseUnitTest() {
 
         val detailData = viewModel.getReferrersDetailData()
 
-        assertThat(detailData.dataSource).isEqualTo(MostViewedDataSource.REFERRERS)
+        assertThat(detailData.cardType).isEqualTo(StatsCardType.MOST_VIEWED_REFERRERS)
         assertThat(detailData.items).hasSize(2)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsCardsConfiguration
-import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 @ExperimentalCoroutinesApi
@@ -47,8 +46,7 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
     fun `when valid json is saved, then configuration is parsed correctly`() = test {
         val json = """
             {
-                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS"],
-                "mostViewedDataSources": ["POSTS_AND_PAGES"]
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS"]
             }
         """.trimIndent()
         whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(json)
@@ -56,7 +54,6 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
         val config = repository.getConfiguration(TEST_SITE_ID)
 
         assertThat(config.visibleCards).containsExactly(StatsCardType.TODAYS_STATS, StatsCardType.VIEWS_STATS)
-        assertThat(config.mostViewedDataSources).containsExactly("POSTS_AND_PAGES")
     }
 
     @Test
@@ -85,8 +82,7 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
     fun `when removeCard is called, then card is removed from visible cards`() = test {
         val initialJson = """
             {
-                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"],
-                "mostViewedDataSources": []
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
             }
         """.trimIndent()
         whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
@@ -101,8 +97,7 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
     fun `when addCard is called, then card is added to visible cards`() = test {
         val initialJson = """
             {
-                "visibleCards": ["TODAYS_STATS"],
-                "mostViewedDataSources": []
+                "visibleCards": ["TODAYS_STATS"]
             }
         """.trimIndent()
         whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
@@ -114,61 +109,10 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when removeMostViewedCard is called, then most viewed card and data source are removed`() = test {
-        val initialJson = """
-            {
-                "visibleCards": ["TODAYS_STATS", "MOST_VIEWED", "MOST_VIEWED"],
-                "mostViewedDataSources": ["POSTS_AND_PAGES", "REFERRERS"]
-            }
-        """.trimIndent()
-        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
-
-        repository.removeMostViewedCard(TEST_SITE_ID, 0)
-
-        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
-        assertThat(savedConfig.visibleCards.count { it == StatsCardType.MOST_VIEWED }).isEqualTo(1)
-        assertThat(savedConfig.mostViewedDataSources).containsExactly("REFERRERS")
-    }
-
-    @Test
-    fun `when addMostViewedCard is called, then most viewed card and data source are added`() = test {
-        val initialJson = """
-            {
-                "visibleCards": ["TODAYS_STATS", "MOST_VIEWED"],
-                "mostViewedDataSources": ["POSTS_AND_PAGES"]
-            }
-        """.trimIndent()
-        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
-
-        repository.addMostViewedCard(TEST_SITE_ID, MostViewedDataSource.REFERRERS.name)
-
-        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
-        assertThat(savedConfig.visibleCards.count { it == StatsCardType.MOST_VIEWED }).isEqualTo(2)
-        assertThat(savedConfig.mostViewedDataSources).containsExactly("POSTS_AND_PAGES", "REFERRERS")
-    }
-
-    @Test
-    fun `when updateMostViewedDataSource is called, then data source is updated`() = test {
-        val initialJson = """
-            {
-                "visibleCards": ["MOST_VIEWED", "MOST_VIEWED"],
-                "mostViewedDataSources": ["POSTS_AND_PAGES", "REFERRERS"]
-            }
-        """.trimIndent()
-        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
-
-        repository.updateMostViewedDataSource(TEST_SITE_ID, 0, MostViewedDataSource.REFERRERS.name)
-
-        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
-        assertThat(savedConfig.mostViewedDataSources).containsExactly("REFERRERS", "REFERRERS")
-    }
-
-    @Test
     fun `when configuration is cached, then subsequent calls use cache`() = test {
         val json = """
             {
-                "visibleCards": ["TODAYS_STATS"],
-                "mostViewedDataSources": []
+                "visibleCards": ["TODAYS_STATS"]
             }
         """.trimIndent()
         whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(json)

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -89,8 +90,11 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
 
         repository.removeCard(TEST_SITE_ID, StatsCardType.VIEWS_STATS)
 
-        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
-        assertThat(savedConfig.visibleCards).containsExactly(StatsCardType.TODAYS_STATS, StatsCardType.COUNTRIES)
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        assertThat(jsonCaptor.firstValue).contains("TODAYS_STATS")
+        assertThat(jsonCaptor.firstValue).contains("COUNTRIES")
+        assertThat(jsonCaptor.firstValue).doesNotContain("VIEWS_STATS")
     }
 
     @Test
@@ -104,26 +108,10 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
 
         repository.addCard(TEST_SITE_ID, StatsCardType.COUNTRIES)
 
-        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
-        assertThat(savedConfig.visibleCards).contains(StatsCardType.COUNTRIES)
-    }
-
-    @Test
-    fun `when configuration is cached, then subsequent calls use cache`() = test {
-        val json = """
-            {
-                "visibleCards": ["TODAYS_STATS"]
-            }
-        """.trimIndent()
-        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(json)
-
-        // First call
-        repository.getConfiguration(TEST_SITE_ID)
-        // Second call should use cache
-        repository.getConfiguration(TEST_SITE_ID)
-
-        // getStatsCardsConfigurationJson should only be called once due to caching
-        verify(appPrefsWrapper).getStatsCardsConfigurationJson(TEST_SITE_ID)
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        assertThat(jsonCaptor.firstValue).contains("TODAYS_STATS")
+        assertThat(jsonCaptor.firstValue).contains("COUNTRIES")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
@@ -139,6 +139,22 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
         assertThat(flowValue?.second?.visibleCards).containsExactly(StatsCardType.TODAYS_STATS)
     }
 
+    @Test
+    fun `when config contains invalid card type, then default configuration is returned and json is reset`() = test {
+        // JSON with old "MOST_VIEWED" card type that no longer exists
+        val jsonWithInvalidCardType = """
+            {
+                "visibleCards": ["TODAYS_STATS", "MOST_VIEWED", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(jsonWithInvalidCardType)
+
+        val config = repository.getConfiguration(TEST_SITE_ID)
+
+        assertThat(config.visibleCards).isEqualTo(StatsCardType.defaultCards())
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), any())
+    }
+
     companion object {
         private const val TEST_SITE_ID = 123L
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
@@ -1,0 +1,201 @@
+package org.wordpress.android.ui.newstats.repository
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.newstats.StatsCardType
+import org.wordpress.android.ui.newstats.StatsCardsConfiguration
+import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner.Silent::class)
+class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
+    @Mock
+    private lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    private lateinit var repository: StatsCardsConfigurationRepository
+
+    @Before
+    fun setUp() {
+        repository = StatsCardsConfigurationRepository(
+            appPrefsWrapper,
+            UnconfinedTestDispatcher()
+        )
+    }
+
+    @Test
+    fun `when no saved configuration, then default configuration is returned`() = test {
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(null)
+
+        val config = repository.getConfiguration(TEST_SITE_ID)
+
+        assertThat(config.visibleCards).isEqualTo(StatsCardType.defaultCards())
+    }
+
+    @Test
+    fun `when valid json is saved, then configuration is parsed correctly`() = test {
+        val json = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS"],
+                "mostViewedDataSources": ["POSTS_AND_PAGES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(json)
+
+        val config = repository.getConfiguration(TEST_SITE_ID)
+
+        assertThat(config.visibleCards).containsExactly(StatsCardType.TODAYS_STATS, StatsCardType.VIEWS_STATS)
+        assertThat(config.mostViewedDataSources).containsExactly("POSTS_AND_PAGES")
+    }
+
+    @Test
+    fun `when invalid json is saved, then default configuration is returned and json is reset`() = test {
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn("invalid json")
+
+        val config = repository.getConfiguration(TEST_SITE_ID)
+
+        assertThat(config.visibleCards).isEqualTo(StatsCardType.defaultCards())
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), any())
+    }
+
+    @Test
+    fun `when saveConfiguration is called, then json is saved to prefs`() = test {
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(null)
+        val config = StatsCardsConfiguration(
+            visibleCards = listOf(StatsCardType.TODAYS_STATS)
+        )
+
+        repository.saveConfiguration(TEST_SITE_ID, config)
+
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), any())
+    }
+
+    @Test
+    fun `when removeCard is called, then card is removed from visible cards`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"],
+                "mostViewedDataSources": []
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.removeCard(TEST_SITE_ID, StatsCardType.VIEWS_STATS)
+
+        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
+        assertThat(savedConfig.visibleCards).containsExactly(StatsCardType.TODAYS_STATS, StatsCardType.COUNTRIES)
+    }
+
+    @Test
+    fun `when addCard is called, then card is added to visible cards`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS"],
+                "mostViewedDataSources": []
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.addCard(TEST_SITE_ID, StatsCardType.COUNTRIES)
+
+        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
+        assertThat(savedConfig.visibleCards).contains(StatsCardType.COUNTRIES)
+    }
+
+    @Test
+    fun `when removeMostViewedCard is called, then most viewed card and data source are removed`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "MOST_VIEWED", "MOST_VIEWED"],
+                "mostViewedDataSources": ["POSTS_AND_PAGES", "REFERRERS"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.removeMostViewedCard(TEST_SITE_ID, 0)
+
+        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
+        assertThat(savedConfig.visibleCards.count { it == StatsCardType.MOST_VIEWED }).isEqualTo(1)
+        assertThat(savedConfig.mostViewedDataSources).containsExactly("REFERRERS")
+    }
+
+    @Test
+    fun `when addMostViewedCard is called, then most viewed card and data source are added`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "MOST_VIEWED"],
+                "mostViewedDataSources": ["POSTS_AND_PAGES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.addMostViewedCard(TEST_SITE_ID, MostViewedDataSource.REFERRERS.name)
+
+        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
+        assertThat(savedConfig.visibleCards.count { it == StatsCardType.MOST_VIEWED }).isEqualTo(2)
+        assertThat(savedConfig.mostViewedDataSources).containsExactly("POSTS_AND_PAGES", "REFERRERS")
+    }
+
+    @Test
+    fun `when updateMostViewedDataSource is called, then data source is updated`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["MOST_VIEWED", "MOST_VIEWED"],
+                "mostViewedDataSources": ["POSTS_AND_PAGES", "REFERRERS"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.updateMostViewedDataSource(TEST_SITE_ID, 0, MostViewedDataSource.REFERRERS.name)
+
+        val savedConfig = repository.getConfiguration(TEST_SITE_ID)
+        assertThat(savedConfig.mostViewedDataSources).containsExactly("REFERRERS", "REFERRERS")
+    }
+
+    @Test
+    fun `when configuration is cached, then subsequent calls use cache`() = test {
+        val json = """
+            {
+                "visibleCards": ["TODAYS_STATS"],
+                "mostViewedDataSources": []
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(json)
+
+        // First call
+        repository.getConfiguration(TEST_SITE_ID)
+        // Second call should use cache
+        repository.getConfiguration(TEST_SITE_ID)
+
+        // getStatsCardsConfigurationJson should only be called once due to caching
+        verify(appPrefsWrapper).getStatsCardsConfigurationJson(TEST_SITE_ID)
+    }
+
+    @Test
+    fun `when configurationFlow emits, then it contains site id and configuration`() = test {
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(null)
+        val config = StatsCardsConfiguration(visibleCards = listOf(StatsCardType.TODAYS_STATS))
+
+        repository.saveConfiguration(TEST_SITE_ID, config)
+
+        val flowValue = repository.configurationFlow.value
+        assertThat(flowValue).isNotNull
+        assertThat(flowValue?.first).isEqualTo(TEST_SITE_ID)
+        assertThat(flowValue?.second?.visibleCards).containsExactly(StatsCardType.TODAYS_STATS)
+    }
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModelTest.kt
@@ -18,8 +18,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.StatsPeriod
+import org.wordpress.android.ui.newstats.StatsCardsConfiguration
 import org.wordpress.android.ui.newstats.repository.ViewsDataPoint
 import org.wordpress.android.ui.newstats.repository.StatsRepository
+import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
 import org.wordpress.android.ui.newstats.repository.PeriodAggregates
 import org.wordpress.android.ui.newstats.repository.PeriodStatsResult
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -40,6 +42,9 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var resourceProvider: ResourceProvider
+
+    @Mock
+    private lateinit var cardsConfigurationRepository: StatsCardsConfigurationRepository
 
     private lateinit var viewModel: ViewsStatsViewModel
 
@@ -71,13 +76,16 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
             .thenReturn("Posts")
     }
 
-    private fun initViewModel() {
+    private suspend fun initViewModel() {
+        whenever(cardsConfigurationRepository.getConfiguration(any()))
+            .thenReturn(StatsCardsConfiguration())
         viewModel = ViewsStatsViewModel(
             selectedSiteRepository,
             accountStore,
             statsRepository,
             resourceProvider,
-            SavedStateHandle()
+            SavedStateHandle(),
+            cardsConfigurationRepository
         )
     }
 


### PR DESCRIPTION
## Description                                                                                                                                                              
                                                                                                                                                                              
  Implements stats cards configuration handling for the new stats screen. Users can now customize which                                                                       
  stats cards are visible by removing cards via menu and adding them back through a bottom sheet.                                                                             
  Configuration is persisted per-site using SharedPreferences.                    

NEXT: allow user to move cards and fix the individual "Retry" button                                                                                            
                                                                                                                                                                              
  Key changes:                                                                                                                                                                
  - Added `StatsCardsConfigurationRepository` to manage per-site card visibility preferences                                                                                  
  - Created explicit card types (`MOST_VIEWED_POSTS_AND_PAGES`, `MOST_VIEWED_REFERRERS`) instead of                                                                           
    using a single `MOST_VIEWED` type with subtypes, simplifying the architecture                                                                                             
  - Added `AddStatsCardBottomSheet` for re-adding hidden cards                                                                                                                
  - Added configuration validation to handle migration from old saved configurations containing                                                                               
    invalid/removed card types                                                                                                                                                
  - Added card menu with "Remove card" option to all stats cards                                                                                                              
                                                                                                                                                                              
  ## Testing instructions                        

                           

https://github.com/user-attachments/assets/1f2bc462-6331-4da5-9b0c-3237dd99c6bd

                                                                                                  
                                                                                                                                                                              
  Card removal:                                                                                                                                                               
                                                                                                                                                                              
  1. Open the new stats screen on any site                                                                                                                                    
  2. Tap the menu icon on any stats card (e.g., "Today's Stats")                                                                                                
  3. Tap "Remove card"                                                                                                                                                        
  - [ ] Verify the card is removed from the screen                                                                                                                            
  - [ ] Verify the change persists after navigating away and returning                                                                                                        
                                                                                                                                                                              
  Adding cards back:                                                                                                                                                          
                                                                                                                                                                              
  1. Remove at least one card using the steps above                                                                                                                           
  2. Scroll to the bottom of the stats screen                                                                                                                                 
  3. Tap the "Add card" button                                                                                                                                                
  - [ ] Verify a bottom sheet appears showing the removed card(s)                                                                                                             
  4. Tap on a card to add it back                                                                                                                                             
  - [ ] Verify the card reappears on the stats screen                                                                                                                         
                                                                                                                                                                              
  Empty state:                                                                                                                                                                
                                                                                                                                                                              
  1. Remove all cards from the stats screen                                                                                                                                   
  - [ ] Verify an empty state message is displayed                                                                                                                            
  - [ ] Verify the "Add card" option is still available                                                                                                                       
                                                                                                                                                                              
  Configuration persistence:                                                                                                                                                  
                                                                                                                                                                              
  1. Customize the visible cards (remove some, keep others)                                                                                                                   
  2. Force close the app completely                                                                                                                                           
  3. Reopen the app and navigate to the stats screen                                                                                                                          
  - [ ] Verify the card configuration is preserved                                                                                                                            
                                                                                                                                                                              
  Multi-site configuration:                                                                                                                                                   
                                                                                                                                                                              
  1. On Site A, remove some cards                                                                                                                                             
  2. Switch to Site B                                                                                                                                                         
  - [ ] Verify Site B shows its own card configuration (default if not customized)                                                                                            
  3. Customize Site B's cards differently                                                                                                                                     
  4. Switch back to Site A                                                                                                                                                    
  - [ ] Verify Site A still has its original customization                                                                                                                    
                                                                                                                                                                                                                                                            
                                                                                                