### PR TITLE
CMM-1146 stats cards handling i2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -4,23 +4,28 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
@@ -229,6 +235,7 @@ private fun TrafficTabContent(
     // Card configuration state
     val visibleCards by newStatsViewModel.visibleCards.collectAsState()
     val hiddenCards by newStatsViewModel.hiddenCards.collectAsState()
+    val isNetworkAvailable by newStatsViewModel.isNetworkAvailable.collectAsState()
     var showAddCardSheet by remember { mutableStateOf(false) }
     val addCardSheetState = rememberModalBottomSheetState()
 
@@ -249,11 +256,29 @@ private fun TrafficTabContent(
         )
     }
 
+    // Show no connection state when network is unavailable
+    if (!isNetworkAvailable) {
+        NoConnectionContent(
+            onRetry = {
+                newStatsViewModel.checkNetworkStatus()
+                if (newStatsViewModel.isNetworkAvailable.value) {
+                    // Use loadData() to show loading state on cards
+                    todaysStatsViewModel.loadData()
+                    viewsStatsViewModel.loadData()
+                    mostViewedViewModel.loadData()
+                    countriesViewModel.loadData()
+                }
+            }
+        )
+        return
+    }
+
     PullToRefreshBox(
         modifier = Modifier.fillMaxSize(),
         isRefreshing = isRefreshing,
         state = pullToRefreshState,
         onRefresh = {
+            newStatsViewModel.checkNetworkStatus()
             todaysStatsViewModel.refresh()
             viewsStatsViewModel.refresh()
             mostViewedViewModel.refresh()
@@ -410,6 +435,55 @@ private fun AddCardButton(
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(stringResource(R.string.stats_add_card_title))
+    }
+}
+
+@Composable
+private fun NoConnectionContent(
+    onRetry: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 60.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_wifi_off_24px),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = CircleShape
+                    )
+                    .padding(12.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(R.string.no_connection_error_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.no_connection_error_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onRetry) {
+                Text(stringResource(R.string.retry))
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -340,9 +340,16 @@ private fun TrafficTabContent(
                 )
             }
 
+            // Memoize card positions to avoid recalculation on every recomposition
+            val cardPositions = remember(visibleCards) {
+                visibleCards.mapIndexed { index, _ ->
+                    CardPosition(index = index, totalCards = visibleCards.size)
+                }
+            }
+
             // Dynamic card rendering based on configuration
             visibleCards.forEachIndexed { index, cardType ->
-                val cardPosition = CardPosition(index = index, totalCards = visibleCards.size)
+                val cardPosition = cardPositions[index]
                 when (cardType) {
                     StatsCardType.TODAYS_STATS -> TodaysStatsCard(
                         uiState = todaysStatsUiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -292,9 +292,14 @@ private fun TrafficTabContent(
     if (showNoConnectionScreen) {
         NoConnectionContent(
             onRetry = {
-                newStatsViewModel.checkNetworkStatus()
-                // Only show cards if network is now available
-                // The LaunchedEffect will handle loading data when isNetworkAvailable becomes true
+                val isAvailable = newStatsViewModel.checkNetworkStatus()
+                if (isAvailable) {
+                    showNoConnectionScreen = false
+                    todaysStatsViewModel.loadData()
+                    viewsStatsViewModel.loadData()
+                    mostViewedViewModel.loadData()
+                    countriesViewModel.loadData()
+                }
             }
         )
         return

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -274,13 +274,11 @@ private fun TrafficTabContent(
         NoConnectionContent(
             onRetry = {
                 newStatsViewModel.checkNetworkStatus()
-                if (newStatsViewModel.isNetworkAvailable.value) {
-                    // Use loadData() to show loading state on cards
-                    todaysStatsViewModel.loadData()
-                    viewsStatsViewModel.loadData()
-                    mostViewedViewModel.loadData()
-                    countriesViewModel.loadData()
-                }
+                // Always load data on retry - ViewModels will handle errors if still offline
+                todaysStatsViewModel.loadData()
+                viewsStatsViewModel.loadData()
+                mostViewedViewModel.loadData()
+                countriesViewModel.loadData()
             }
         )
         return

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,6 +21,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -145,12 +147,23 @@ private fun NewStatsScreen(
                 },
                 actions = {
                     Box {
-                        IconButton(onClick = { showPeriodMenu = true }) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .clickable { showPeriodMenu = true }
+                                .padding(horizontal = 8.dp)
+                        ) {
+                            Text(
+                                text = selectedPeriod.getDisplayLabel(),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
                             Icon(
                                 imageVector = Icons.Default.DateRange,
                                 contentDescription = stringResource(
                                     R.string.stats_period_selector_content_description
-                                )
+                                ),
+                                modifier = Modifier.padding(start = 4.dp)
                             )
                         }
                         StatsPeriodMenu(
@@ -533,6 +546,17 @@ private fun StatsPeriodMenu(
                 null
             }
         )
+    }
+}
+
+@Composable
+private fun StatsPeriod.getDisplayLabel(): String {
+    return when (this) {
+        is StatsPeriod.Custom -> {
+            val formatter = java.time.format.DateTimeFormatter.ofPattern("MMM d")
+            "${startDate.format(formatter)} - ${endDate.format(formatter)}"
+        }
+        else -> stringResource(id = labelResId)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -61,6 +61,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.newstats.components.AddStatsCardBottomSheet
+import org.wordpress.android.ui.newstats.components.CardPosition
 import org.wordpress.android.ui.newstats.countries.CountriesCard
 import org.wordpress.android.ui.newstats.countries.CountriesDetailActivity
 import org.wordpress.android.ui.newstats.countries.CountriesViewModel
@@ -288,17 +289,28 @@ private fun TrafficTabContent(
             }
 
             // Dynamic card rendering based on configuration
-            visibleCards.forEach { cardType ->
+            visibleCards.forEachIndexed { index, cardType ->
+                val cardPosition = CardPosition(index = index, totalCards = visibleCards.size)
                 when (cardType) {
                     StatsCardType.TODAYS_STATS -> TodaysStatsCard(
                         uiState = todaysStatsUiState,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) },
+                        cardPosition = cardPosition,
+                        onMoveUp = { newStatsViewModel.moveCardUp(cardType) },
+                        onMoveToTop = { newStatsViewModel.moveCardToTop(cardType) },
+                        onMoveDown = { newStatsViewModel.moveCardDown(cardType) },
+                        onMoveToBottom = { newStatsViewModel.moveCardToBottom(cardType) }
                     )
                     StatsCardType.VIEWS_STATS -> ViewsStatsCard(
                         uiState = viewsStatsUiState,
                         onChartTypeChanged = viewsStatsViewModel::onChartTypeChanged,
                         onRetry = viewsStatsViewModel::onRetry,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) },
+                        cardPosition = cardPosition,
+                        onMoveUp = { newStatsViewModel.moveCardUp(cardType) },
+                        onMoveToTop = { newStatsViewModel.moveCardToTop(cardType) },
+                        onMoveDown = { newStatsViewModel.moveCardDown(cardType) },
+                        onMoveToBottom = { newStatsViewModel.moveCardToBottom(cardType) }
                     )
                     StatsCardType.MOST_VIEWED_POSTS_AND_PAGES -> MostViewedCard(
                         uiState = postsUiState,
@@ -316,7 +328,12 @@ private fun TrafficTabContent(
                             )
                         },
                         onRetry = mostViewedViewModel::onRetryPosts,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) },
+                        cardPosition = cardPosition,
+                        onMoveUp = { newStatsViewModel.moveCardUp(cardType) },
+                        onMoveToTop = { newStatsViewModel.moveCardToTop(cardType) },
+                        onMoveDown = { newStatsViewModel.moveCardDown(cardType) },
+                        onMoveToBottom = { newStatsViewModel.moveCardToBottom(cardType) }
                     )
                     StatsCardType.MOST_VIEWED_REFERRERS -> MostViewedCard(
                         uiState = referrersUiState,
@@ -334,7 +351,12 @@ private fun TrafficTabContent(
                             )
                         },
                         onRetry = mostViewedViewModel::onRetryReferrers,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) },
+                        cardPosition = cardPosition,
+                        onMoveUp = { newStatsViewModel.moveCardUp(cardType) },
+                        onMoveToTop = { newStatsViewModel.moveCardToTop(cardType) },
+                        onMoveDown = { newStatsViewModel.moveCardDown(cardType) },
+                        onMoveToBottom = { newStatsViewModel.moveCardToBottom(cardType) }
                     )
                     StatsCardType.COUNTRIES -> CountriesCard(
                         uiState = countriesUiState,
@@ -353,7 +375,12 @@ private fun TrafficTabContent(
                             )
                         },
                         onRetry = countriesViewModel::onRetry,
-                        onRemoveCard = { newStatsViewModel.removeCard(cardType) }
+                        onRemoveCard = { newStatsViewModel.removeCard(cardType) },
+                        cardPosition = cardPosition,
+                        onMoveUp = { newStatsViewModel.moveCardUp(cardType) },
+                        onMoveToTop = { newStatsViewModel.moveCardToTop(cardType) },
+                        onMoveDown = { newStatsViewModel.moveCardDown(cardType) },
+                        onMoveToBottom = { newStatsViewModel.moveCardToBottom(cardType) }
                     )
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -269,16 +269,32 @@ private fun TrafficTabContent(
         )
     }
 
-    // Show no connection state when network is unavailable
-    if (!isNetworkAvailable) {
+    // Track whether to show the no-connection screen
+    // Once user retries or network becomes available, show cards instead
+    var showNoConnectionScreen by remember { mutableStateOf(!isNetworkAvailable) }
+
+    // React to network availability changes
+    LaunchedEffect(isNetworkAvailable) {
+        if (isNetworkAvailable && showNoConnectionScreen) {
+            // Network became available while on no-connection screen - auto-load
+            showNoConnectionScreen = false
+            todaysStatsViewModel.loadData()
+            viewsStatsViewModel.loadData()
+            mostViewedViewModel.loadData()
+            countriesViewModel.loadData()
+        } else if (!isNetworkAvailable && !showNoConnectionScreen) {
+            // Network became unavailable while viewing cards - show no-connection screen
+            showNoConnectionScreen = true
+        }
+    }
+
+    // Show no connection screen only when network is unavailable
+    if (showNoConnectionScreen) {
         NoConnectionContent(
             onRetry = {
                 newStatsViewModel.checkNetworkStatus()
-                // Always load data on retry - ViewModels will handle errors if still offline
-                todaysStatsViewModel.loadData()
-                viewsStatsViewModel.loadData()
-                mostViewedViewModel.loadData()
-                countriesViewModel.loadData()
+                // Only show cards if network is now available
+                // The LaunchedEffect will handle loading data when isNetworkAvailable becomes true
             }
         )
         return

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -40,8 +40,10 @@ class NewStatsViewModel @Inject constructor(
         observeConfigurationChanges()
     }
 
-    fun checkNetworkStatus() {
-        _isNetworkAvailable.value = networkUtilsWrapper.isNetworkAvailable()
+    fun checkNetworkStatus(): Boolean {
+        val isAvailable = networkUtilsWrapper.isNetworkAvailable()
+        _isNetworkAvailable.value = isAvailable
+        return isAvailable
     }
 
     private fun loadConfiguration() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -71,4 +71,32 @@ class NewStatsViewModel @Inject constructor(
             cardConfigurationRepository.addCard(currentSiteId, cardType)
         }
     }
+
+    fun moveCardUp(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
+        viewModelScope.launch {
+            cardConfigurationRepository.moveCardUp(currentSiteId, cardType)
+        }
+    }
+
+    fun moveCardToTop(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
+        viewModelScope.launch {
+            cardConfigurationRepository.moveCardToTop(currentSiteId, cardType)
+        }
+    }
+
+    fun moveCardDown(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
+        viewModelScope.launch {
+            cardConfigurationRepository.moveCardDown(currentSiteId, cardType)
+        }
+    }
+
+    fun moveCardToBottom(cardType: StatsCardType) {
+        val currentSiteId = siteId // Capture siteId to avoid race conditions during site switching
+        viewModelScope.launch {
+            cardConfigurationRepository.moveCardToBottom(currentSiteId, cardType)
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
+import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 
 /**
@@ -18,7 +19,8 @@ import javax.inject.Inject
 @HiltViewModel
 class NewStatsViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val cardConfigurationRepository: StatsCardsConfigurationRepository
+    private val cardConfigurationRepository: StatsCardsConfigurationRepository,
+    private val networkUtilsWrapper: NetworkUtilsWrapper
 ) : ViewModel() {
     private val _visibleCards = MutableStateFlow<List<StatsCardType>>(StatsCardType.defaultCards())
     val visibleCards: StateFlow<List<StatsCardType>> = _visibleCards.asStateFlow()
@@ -26,12 +28,20 @@ class NewStatsViewModel @Inject constructor(
     private val _hiddenCards = MutableStateFlow<List<StatsCardType>>(emptyList())
     val hiddenCards: StateFlow<List<StatsCardType>> = _hiddenCards.asStateFlow()
 
+    private val _isNetworkAvailable = MutableStateFlow(true)
+    val isNetworkAvailable: StateFlow<Boolean> = _isNetworkAvailable.asStateFlow()
+
     private val siteId: Long
         get() = selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
 
     init {
+        checkNetworkStatus()
         loadConfiguration()
         observeConfigurationChanges()
+    }
+
+    fun checkNetworkStatus() {
+        _isNetworkAvailable.value = networkUtilsWrapper.isNetworkAvailable()
     }
 
     private fun loadConfiguration() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -2,15 +2,16 @@ package org.wordpress.android.ui.newstats.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.VerticalAlignBottom
 import androidx.compose.material.icons.filled.VerticalAlignTop
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -40,7 +41,7 @@ data class CardPosition(
 
 /**
  * Standard three-dots menu for stats cards.
- * Includes card-specific options (via additionalContent), move options, and a "Remove" option.
+ * Includes card-specific options (via additionalContent), a "Move Card" sub-menu, and a "Remove" option.
  *
  * @param onRemoveClick Callback invoked when user clicks "Remove"
  * @param modifier Modifier for the menu
@@ -64,6 +65,7 @@ fun StatsCardMenu(
     additionalContent: @Composable (() -> Unit)? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var moveSubMenuExpanded by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         IconButton(onClick = { expanded = true }) {
@@ -81,78 +83,105 @@ fun StatsCardMenu(
             // Card-specific options (e.g., chart type for ViewsStatsCard)
             additionalContent?.invoke()
 
-            // Move options (shown only when cardPosition is provided and there are multiple cards)
-            if (cardPosition != null && cardPosition.totalCards > 1) {
-                // Move Up (hidden for first card)
-                if (cardPosition.canMoveUp && onMoveUp != null) {
+            // Move Card sub-menu (shown only when cardPosition is provided and there are multiple cards)
+            val showMoveOption = cardPosition != null && cardPosition.totalCards > 1
+            if (showMoveOption) {
+                Box {
                     DropdownMenuItem(
-                        text = { Text(stringResource(R.string.stats_card_move_up)) },
-                        onClick = {
-                            expanded = false
-                            onMoveUp()
-                        },
+                        text = { Text(stringResource(R.string.stats_card_move)) },
+                        onClick = { moveSubMenuExpanded = true },
                         leadingIcon = {
                             Icon(
-                                imageVector = Icons.Default.KeyboardArrowUp,
+                                imageVector = Icons.Default.SwapVert,
+                                contentDescription = null
+                            )
+                        },
+                        trailingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.ChevronRight,
                                 contentDescription = null
                             )
                         }
                     )
-                }
 
-                // Move to Top (hidden for first card)
-                if (cardPosition.canMoveUp && onMoveToTop != null) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.stats_card_move_to_top)) },
-                        onClick = {
-                            expanded = false
-                            onMoveToTop()
-                        },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.VerticalAlignTop,
-                                contentDescription = null
+                    // Move sub-menu
+                    DropdownMenu(
+                        expanded = moveSubMenuExpanded,
+                        onDismissRequest = { moveSubMenuExpanded = false }
+                    ) {
+                        // Move Up (hidden for first card)
+                        if (cardPosition?.canMoveUp == true && onMoveUp != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.stats_card_move_up)) },
+                                onClick = {
+                                    moveSubMenuExpanded = false
+                                    expanded = false
+                                    onMoveUp()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.KeyboardArrowUp,
+                                        contentDescription = null
+                                    )
+                                }
                             )
                         }
-                    )
-                }
 
-                // Move Down (hidden for last card)
-                if (cardPosition.canMoveDown && onMoveDown != null) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.stats_card_move_down)) },
-                        onClick = {
-                            expanded = false
-                            onMoveDown()
-                        },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.KeyboardArrowDown,
-                                contentDescription = null
+                        // Move to Top (hidden for first card)
+                        if (cardPosition?.canMoveUp == true && onMoveToTop != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.stats_card_move_to_top)) },
+                                onClick = {
+                                    moveSubMenuExpanded = false
+                                    expanded = false
+                                    onMoveToTop()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.VerticalAlignTop,
+                                        contentDescription = null
+                                    )
+                                }
                             )
                         }
-                    )
-                }
 
-                // Move to Bottom (hidden for last card)
-                if (cardPosition.canMoveDown && onMoveToBottom != null) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.stats_card_move_to_bottom)) },
-                        onClick = {
-                            expanded = false
-                            onMoveToBottom()
-                        },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.VerticalAlignBottom,
-                                contentDescription = null
+                        // Move Down (hidden for last card)
+                        if (cardPosition?.canMoveDown == true && onMoveDown != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.stats_card_move_down)) },
+                                onClick = {
+                                    moveSubMenuExpanded = false
+                                    expanded = false
+                                    onMoveDown()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.KeyboardArrowDown,
+                                        contentDescription = null
+                                    )
+                                }
                             )
                         }
-                    )
-                }
 
-                // Divider before Remove option
-                HorizontalDivider()
+                        // Move to Bottom (hidden for last card)
+                        if (cardPosition?.canMoveDown == true && onMoveToBottom != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.stats_card_move_to_bottom)) },
+                                onClick = {
+                                    moveSubMenuExpanded = false
+                                    expanded = false
+                                    onMoveToBottom()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.VerticalAlignBottom,
+                                        contentDescription = null
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
             }
 
             // Common "Remove" option

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -3,9 +3,14 @@ package org.wordpress.android.ui.newstats.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.VerticalAlignBottom
+import androidx.compose.material.icons.filled.VerticalAlignTop
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -20,11 +25,30 @@ import androidx.compose.ui.res.stringResource
 import org.wordpress.android.R
 
 /**
+ * Represents the position of a card in the stats card list.
+ * Used to determine which move options should be shown.
+ */
+data class CardPosition(
+    val index: Int,
+    val totalCards: Int
+) {
+    val isFirst: Boolean get() = index == 0
+    val isLast: Boolean get() = index == totalCards - 1
+    val canMoveUp: Boolean get() = !isFirst
+    val canMoveDown: Boolean get() = !isLast
+}
+
+/**
  * Standard three-dots menu for stats cards.
- * Includes card-specific options (via additionalContent) and a "Remove" option.
+ * Includes card-specific options (via additionalContent), move options, and a "Remove" option.
  *
  * @param onRemoveClick Callback invoked when user clicks "Remove"
  * @param modifier Modifier for the menu
+ * @param cardPosition Optional position info to show move options. If null, move options are hidden.
+ * @param onMoveUp Callback invoked when user clicks "Move Up"
+ * @param onMoveToTop Callback invoked when user clicks "Move to Top"
+ * @param onMoveDown Callback invoked when user clicks "Move Down"
+ * @param onMoveToBottom Callback invoked when user clicks "Move to Bottom"
  * @param additionalContent Optional composable content for card-specific menu items,
  *                          called within the DropdownMenu. Should contain DropdownMenuItem(s).
  */
@@ -32,6 +56,11 @@ import org.wordpress.android.R
 fun StatsCardMenu(
     onRemoveClick: () -> Unit,
     modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null,
     additionalContent: @Composable (() -> Unit)? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -51,6 +80,80 @@ fun StatsCardMenu(
         ) {
             // Card-specific options (e.g., chart type for ViewsStatsCard)
             additionalContent?.invoke()
+
+            // Move options (shown only when cardPosition is provided and there are multiple cards)
+            if (cardPosition != null && cardPosition.totalCards > 1) {
+                // Move Up (hidden for first card)
+                if (cardPosition.canMoveUp && onMoveUp != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.stats_card_move_up)) },
+                        onClick = {
+                            expanded = false
+                            onMoveUp()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowUp,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                }
+
+                // Move to Top (hidden for first card)
+                if (cardPosition.canMoveUp && onMoveToTop != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.stats_card_move_to_top)) },
+                        onClick = {
+                            expanded = false
+                            onMoveToTop()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.VerticalAlignTop,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                }
+
+                // Move Down (hidden for last card)
+                if (cardPosition.canMoveDown && onMoveDown != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.stats_card_move_down)) },
+                        onClick = {
+                            expanded = false
+                            onMoveDown()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowDown,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                }
+
+                // Move to Bottom (hidden for last card)
+                if (cardPosition.canMoveDown && onMoveToBottom != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.stats_card_move_to_bottom)) },
+                        onClick = {
+                            expanded = false
+                            onMoveToBottom()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.VerticalAlignBottom,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                }
+
+                // Divider before Remove option
+                HorizontalDivider()
+            }
 
             // Common "Remove" option
             DropdownMenuItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -113,8 +113,10 @@ fun StatsCardMenu(
                             )
                         }
 
-                        // Move to Top (hidden for first card)
-                        if (cardPosition?.canMoveUp == true && onMoveToTop != null) {
+                        // Move to Top (hidden for first card or when only 2 cards)
+                        if (cardPosition?.canMoveUp == true &&
+                            cardPosition.showMoveToTopBottom &&
+                            onMoveToTop != null) {
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.stats_card_move_to_top)) },
                                 onClick = {
@@ -149,8 +151,10 @@ fun StatsCardMenu(
                             )
                         }
 
-                        // Move to Bottom (hidden for last card)
-                        if (cardPosition?.canMoveDown == true && onMoveToBottom != null) {
+                        // Move to Bottom (hidden for last card or when only 2 cards)
+                        if (cardPosition?.canMoveDown == true &&
+                            cardPosition.showMoveToTopBottom &&
+                            onMoveToBottom != null) {
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.stats_card_move_to_bottom)) },
                                 onClick = {
@@ -200,5 +204,8 @@ data class CardPosition(
     val isLast: Boolean get() = index == totalCards - 1
     val canMoveUp: Boolean get() = !isFirst
     val canMoveDown: Boolean get() = !isLast
+    // Show "Move to Top/Bottom" only when there are more than 2 cards
+    // (with 2 cards, "Move Up" and "Move to Top" are equivalent)
+    val showMoveToTopBottom: Boolean get() = totalCards > 2
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -79,13 +79,13 @@ fun StatsCardMenu(
                         leadingIcon = {
                             Icon(
                                 imageVector = Icons.Default.SwapVert,
-                                contentDescription = null
+                                contentDescription = stringResource(R.string.stats_card_move)
                             )
                         },
                         trailingIcon = {
                             Icon(
                                 imageVector = Icons.Default.ChevronRight,
-                                contentDescription = null
+                                contentDescription = stringResource(R.string.stats_card_move_submenu)
                             )
                         }
                     )
@@ -107,7 +107,7 @@ fun StatsCardMenu(
                                 leadingIcon = {
                                     Icon(
                                         imageVector = Icons.Default.KeyboardArrowUp,
-                                        contentDescription = null
+                                        contentDescription = stringResource(R.string.stats_card_move_up)
                                     )
                                 }
                             )
@@ -125,7 +125,7 @@ fun StatsCardMenu(
                                 leadingIcon = {
                                     Icon(
                                         imageVector = Icons.Default.VerticalAlignTop,
-                                        contentDescription = null
+                                        contentDescription = stringResource(R.string.stats_card_move_to_top)
                                     )
                                 }
                             )
@@ -143,7 +143,7 @@ fun StatsCardMenu(
                                 leadingIcon = {
                                     Icon(
                                         imageVector = Icons.Default.KeyboardArrowDown,
-                                        contentDescription = null
+                                        contentDescription = stringResource(R.string.stats_card_move_down)
                                     )
                                 }
                             )
@@ -161,7 +161,7 @@ fun StatsCardMenu(
                                 leadingIcon = {
                                     Icon(
                                         imageVector = Icons.Default.VerticalAlignBottom,
-                                        contentDescription = null
+                                        contentDescription = stringResource(R.string.stats_card_move_to_bottom)
                                     )
                                 }
                             )
@@ -180,7 +180,7 @@ fun StatsCardMenu(
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Default.Delete,
-                        contentDescription = null
+                        contentDescription = stringResource(R.string.stats_card_remove)
                     )
                 }
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardMenu.kt
@@ -26,20 +26,6 @@ import androidx.compose.ui.res.stringResource
 import org.wordpress.android.R
 
 /**
- * Represents the position of a card in the stats card list.
- * Used to determine which move options should be shown.
- */
-data class CardPosition(
-    val index: Int,
-    val totalCards: Int
-) {
-    val isFirst: Boolean get() = index == 0
-    val isLast: Boolean get() = index == totalCards - 1
-    val canMoveUp: Boolean get() = !isFirst
-    val canMoveDown: Boolean get() = !isLast
-}
-
-/**
  * Standard three-dots menu for stats cards.
  * Includes card-specific options (via additionalContent), a "Move Card" sub-menu, and a "Remove" option.
  *
@@ -201,3 +187,18 @@ fun StatsCardMenu(
         }
     }
 }
+
+/**
+ * Represents the position of a card in the stats card list.
+ * Used to determine which move options should be shown.
+ */
+data class CardPosition(
+    val index: Int,
+    val totalCards: Int
+) {
+    val isFirst: Boolean get() = index == 0
+    val isLast: Boolean get() = index == totalCards - 1
+    val canMoveUp: Boolean get() = !isFirst
+    val canMoveDown: Boolean get() = !isLast
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/countries/CountriesCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/countries/CountriesCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.CardPosition
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 import org.wordpress.android.ui.newstats.util.formatStatValue
@@ -51,7 +52,12 @@ fun CountriesCard(
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
 
@@ -65,8 +71,14 @@ fun CountriesCard(
     ) {
         when (uiState) {
             is CountriesCardUiState.Loading -> LoadingContent()
-            is CountriesCardUiState.Loaded -> LoadedContent(uiState, onShowAllClick, onRemoveCard)
-            is CountriesCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
+            is CountriesCardUiState.Loaded -> LoadedContent(
+                uiState, onShowAllClick, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
+            is CountriesCardUiState.Error -> ErrorContent(
+                uiState, onRetry, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
         }
     }
 }
@@ -131,7 +143,12 @@ private fun LoadingContent() {
 private fun LoadedContent(
     state: CountriesCardUiState.Loaded,
     onShowAllClick: () -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(modifier = Modifier.padding(CardPadding)) {
         // Header with menu
@@ -146,7 +163,14 @@ private fun LoadedContent(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            StatsCardMenu(onRemoveClick = onRemoveCard)
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -333,7 +357,12 @@ private fun ShowAllFooter(onClick: () -> Unit) {
 private fun ErrorContent(
     state: CountriesCardUiState.Error,
     onRetry: () -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(modifier = Modifier.padding(CardPadding)) {
         // Header with menu
@@ -348,7 +377,14 @@ private fun ErrorContent(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            StatsCardMenu(onRemoveClick = onRemoveCard)
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
         }
         Spacer(modifier = Modifier.height(24.dp))
         Column(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsColors
+import org.wordpress.android.ui.newstats.components.CardPosition
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 import org.wordpress.android.ui.newstats.util.formatStatValue
@@ -53,7 +54,12 @@ fun MostViewedCard(
     onShowAllClick: () -> Unit,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
 
@@ -72,12 +78,13 @@ fun MostViewedCard(
         when (uiState) {
             is MostViewedCardUiState.Loading -> LoadingContent()
             is MostViewedCardUiState.Loaded -> LoadedContent(
-                uiState,
-                cardType,
-                onShowAllClick,
-                onRemoveCard
+                uiState, cardType, onShowAllClick, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
             )
-            is MostViewedCardUiState.Error -> ErrorContent(uiState, cardType, onRetry, onRemoveCard)
+            is MostViewedCardUiState.Error -> ErrorContent(
+                uiState, cardType, onRetry, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
         }
     }
 }
@@ -159,14 +166,27 @@ private fun LoadedContent(
     state: MostViewedCardUiState.Loaded,
     cardType: StatsCardType,
     onShowAllClick: () -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(cardType = cardType, onRemoveCard = onRemoveCard)
+        HeaderSection(
+            cardType = cardType,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
         Spacer(modifier = Modifier.height(12.dp))
         ColumnHeadersRow(cardType = cardType)
         Spacer(modifier = Modifier.height(8.dp))
@@ -188,7 +208,15 @@ private fun LoadedContent(
 }
 
 @Composable
-private fun HeaderSection(cardType: StatsCardType, onRemoveCard: () -> Unit) {
+private fun HeaderSection(
+    cardType: StatsCardType,
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -199,7 +227,14 @@ private fun HeaderSection(cardType: StatsCardType, onRemoveCard: () -> Unit) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
-        StatsCardMenu(onRemoveClick = onRemoveCard)
+        StatsCardMenu(
+            onRemoveClick = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
     }
 }
 
@@ -360,14 +395,27 @@ private fun ErrorContent(
     state: MostViewedCardUiState.Error,
     cardType: StatsCardType,
     onRetry: () -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        HeaderSection(cardType = cardType, onRemoveCard = onRemoveCard)
+        HeaderSection(
+            cardType = cardType,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
         Spacer(modifier = Modifier.height(16.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModel.kt
@@ -103,7 +103,7 @@ class MostViewedViewModel @Inject constructor(
         )
     }
 
-    private fun loadData() {
+    fun loadData() {
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
             val errorState = MostViewedCardUiState.Error(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -56,6 +56,50 @@ class StatsCardsConfigurationRepository @Inject constructor(
         saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
     }
 
+    suspend fun moveCardUp(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val index = newVisibleCards.indexOf(cardType)
+        if (index > 0) {
+            newVisibleCards.removeAt(index)
+            newVisibleCards.add(index - 1, cardType)
+            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        }
+    }
+
+    suspend fun moveCardToTop(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val index = newVisibleCards.indexOf(cardType)
+        if (index > 0) {
+            newVisibleCards.removeAt(index)
+            newVisibleCards.add(0, cardType)
+            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        }
+    }
+
+    suspend fun moveCardDown(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val index = newVisibleCards.indexOf(cardType)
+        if (index >= 0 && index < newVisibleCards.size - 1) {
+            newVisibleCards.removeAt(index)
+            newVisibleCards.add(index + 1, cardType)
+            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        }
+    }
+
+    suspend fun moveCardToBottom(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
+        val current = getConfiguration(siteId)
+        val newVisibleCards = current.visibleCards.toMutableList()
+        val index = newVisibleCards.indexOf(cardType)
+        if (index >= 0 && index < newVisibleCards.size - 1) {
+            newVisibleCards.removeAt(index)
+            newVisibleCards.add(cardType)
+            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        }
+    }
+
     @Suppress("TooGenericExceptionCaught")
     private fun loadConfiguration(siteId: Long): StatsCardsConfiguration {
         val json = appPrefsWrapper.getStatsCardsConfigurationJson(siteId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepository.kt
@@ -58,46 +58,46 @@ class StatsCardsConfigurationRepository @Inject constructor(
 
     suspend fun moveCardUp(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val index = newVisibleCards.indexOf(cardType)
+        val index = current.visibleCards.indexOf(cardType)
         if (index > 0) {
-            newVisibleCards.removeAt(index)
-            newVisibleCards.add(index - 1, cardType)
-            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+            moveCardToIndex(siteId, current, cardType, index - 1)
         }
     }
 
     suspend fun moveCardToTop(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val index = newVisibleCards.indexOf(cardType)
+        val index = current.visibleCards.indexOf(cardType)
         if (index > 0) {
-            newVisibleCards.removeAt(index)
-            newVisibleCards.add(0, cardType)
-            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+            moveCardToIndex(siteId, current, cardType, 0)
         }
     }
 
     suspend fun moveCardDown(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val index = newVisibleCards.indexOf(cardType)
-        if (index >= 0 && index < newVisibleCards.size - 1) {
-            newVisibleCards.removeAt(index)
-            newVisibleCards.add(index + 1, cardType)
-            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        val index = current.visibleCards.indexOf(cardType)
+        if (index >= 0 && index < current.visibleCards.size - 1) {
+            moveCardToIndex(siteId, current, cardType, index + 1)
         }
     }
 
     suspend fun moveCardToBottom(siteId: Long, cardType: StatsCardType): Unit = withContext(ioDispatcher) {
         val current = getConfiguration(siteId)
-        val newVisibleCards = current.visibleCards.toMutableList()
-        val index = newVisibleCards.indexOf(cardType)
-        if (index >= 0 && index < newVisibleCards.size - 1) {
-            newVisibleCards.removeAt(index)
-            newVisibleCards.add(cardType)
-            saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
+        val index = current.visibleCards.indexOf(cardType)
+        if (index >= 0 && index < current.visibleCards.size - 1) {
+            moveCardToIndex(siteId, current, cardType, current.visibleCards.size - 1)
         }
+    }
+
+    private suspend fun moveCardToIndex(
+        siteId: Long,
+        current: StatsCardsConfiguration,
+        cardType: StatsCardType,
+        newIndex: Int
+    ) {
+        val newVisibleCards = current.visibleCards.toMutableList()
+        newVisibleCards.remove(cardType)
+        newVisibleCards.add(newIndex, cardType)
+        saveConfiguration(siteId, current.copy(visibleCards = newVisibleCards))
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
@@ -54,6 +54,7 @@ import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.CardPosition
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.text.SimpleDateFormat
@@ -71,7 +72,12 @@ private val MetricSpacing = 4.dp
 fun TodaysStatsCard(
     uiState: TodaysStatsCardUiState,
     onRemoveCard: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
 
@@ -89,8 +95,12 @@ fun TodaysStatsCard(
     ) {
         when (uiState) {
             is TodaysStatsCardUiState.Loading -> LoadingContent()
-            is TodaysStatsCardUiState.Loaded -> LoadedContent(uiState, onRemoveCard)
-            is TodaysStatsCardUiState.Error -> ErrorContent(uiState, onRemoveCard)
+            is TodaysStatsCardUiState.Loaded -> LoadedContent(
+                uiState, onRemoveCard, cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
+            is TodaysStatsCardUiState.Error -> ErrorContent(
+                uiState, onRemoveCard, cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
         }
     }
 }
@@ -200,7 +210,12 @@ private fun LoadingContent() {
 @Composable
 private fun LoadedContent(
     state: TodaysStatsCardUiState.Loaded,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
@@ -215,7 +230,14 @@ private fun LoadedContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleSection()
-            StatsCardMenu(onRemoveClick = onRemoveCard)
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         // Chart
@@ -234,7 +256,12 @@ private fun LoadedContent(
 @Composable
 private fun ErrorContent(
     state: TodaysStatsCardUiState.Error,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
@@ -248,7 +275,14 @@ private fun ErrorContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleSection()
-            StatsCardMenu(onRemoveClick = onRemoveCard)
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         // Empty chart placeholder

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -80,6 +80,7 @@ import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.CardPosition
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.util.Locale
@@ -113,7 +114,12 @@ fun ViewsStatsCard(
     onChartTypeChanged: (ChartType) -> Unit,
     onRetry: () -> Unit,
     onRemoveCard: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null
 ) {
     val borderColor = MaterialTheme.colorScheme.outlineVariant
 
@@ -131,8 +137,14 @@ fun ViewsStatsCard(
     ) {
         when (uiState) {
             is ViewsStatsCardUiState.Loading -> LoadingContent()
-            is ViewsStatsCardUiState.Loaded -> LoadedContent(uiState, onChartTypeChanged, onRemoveCard)
-            is ViewsStatsCardUiState.Error -> ErrorContent(uiState, onRetry, onRemoveCard)
+            is ViewsStatsCardUiState.Loaded -> LoadedContent(
+                uiState, onChartTypeChanged, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
+            is ViewsStatsCardUiState.Error -> ErrorContent(
+                uiState, onRetry, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop, onMoveDown, onMoveToBottom
+            )
         }
     }
 }
@@ -245,7 +257,12 @@ private fun LoadingContent() {
 private fun LoadedContent(
     state: ViewsStatsCardUiState.Loaded,
     onChartTypeChanged: (ChartType) -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
@@ -256,7 +273,12 @@ private fun LoadedContent(
         HeaderSection(
             state = state,
             onChartTypeChanged = onChartTypeChanged,
-            onRemoveCard = onRemoveCard
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
         )
         Spacer(modifier = Modifier.height(16.dp))
         // Chart Section
@@ -275,7 +297,12 @@ private fun LoadedContent(
 private fun HeaderSection(
     state: ViewsStatsCardUiState.Loaded,
     onChartTypeChanged: (ChartType) -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(
@@ -290,6 +317,11 @@ private fun HeaderSection(
             )
             StatsCardMenu(
                 onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom,
                 additionalContent = {
                     ChartTypeMenuItems(
                         currentChartType = state.chartType,
@@ -720,7 +752,12 @@ private fun ChangeBadge(change: StatChange) {
 private fun ErrorContent(
     state: ViewsStatsCardUiState.Error,
     onRetry: () -> Unit,
-    onRemoveCard: () -> Unit
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
 ) {
     Column(
         modifier = Modifier
@@ -737,7 +774,14 @@ private fun ErrorContent(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
-            StatsCardMenu(onRemoveClick = onRemoveCard)
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
         }
         Spacer(modifier = Modifier.height(16.dp))
         Box(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1583,6 +1583,7 @@
     <!-- Stats Card Configuration -->
     <string name="stats_card_remove">Remove Card</string>
     <string name="stats_card_move">Move Card</string>
+    <string name="stats_card_move_submenu">Open move options</string>
     <string name="stats_card_move_up">Move Up</string>
     <string name="stats_card_move_to_top">Move to Top</string>
     <string name="stats_card_move_down">Move Down</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1582,6 +1582,10 @@
 
     <!-- Stats Card Configuration -->
     <string name="stats_card_remove">Remove Card</string>
+    <string name="stats_card_move_up">Move Up</string>
+    <string name="stats_card_move_to_top">Move to Top</string>
+    <string name="stats_card_move_down">Move Down</string>
+    <string name="stats_card_move_to_bottom">Move to Bottom</string>
     <string name="stats_add_card_title">Add Card</string>
     <string name="stats_all_cards_visible">All cards are currently visible</string>
     <string name="stats_no_cards_message">No cards to display.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1582,6 +1582,7 @@
 
     <!-- Stats Card Configuration -->
     <string name="stats_card_remove">Remove Card</string>
+    <string name="stats_card_move">Move Card</string>
     <string name="stats_card_move_up">Move Up</string>
     <string name="stats_card_move_to_top">Move to Top</string>
     <string name="stats_card_move_down">Move Down</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/NewStatsViewModelTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.StatsCardsConfigurationRepository
+import org.wordpress.android.util.NetworkUtilsWrapper
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner.Silent::class)
@@ -23,6 +24,9 @@ class NewStatsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var cardConfigurationRepository: StatsCardsConfigurationRepository
+
+    @Mock
+    private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
     private lateinit var viewModel: NewStatsViewModel
 
@@ -38,11 +42,16 @@ class NewStatsViewModelTest : BaseUnitTest() {
     fun setUp() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
         whenever(cardConfigurationRepository.configurationFlow).thenReturn(configurationFlow)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
     }
 
     private suspend fun initViewModel(config: StatsCardsConfiguration = StatsCardsConfiguration()) {
         whenever(cardConfigurationRepository.getConfiguration(TEST_SITE_ID)).thenReturn(config)
-        viewModel = NewStatsViewModel(selectedSiteRepository, cardConfigurationRepository)
+        viewModel = NewStatsViewModel(
+            selectedSiteRepository,
+            cardConfigurationRepository,
+            networkUtilsWrapper
+        )
     }
 
     @Test
@@ -147,11 +156,97 @@ class NewStatsViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
         whenever(cardConfigurationRepository.getConfiguration(0L)).thenReturn(StatsCardsConfiguration())
 
-        viewModel = NewStatsViewModel(selectedSiteRepository, cardConfigurationRepository)
+        viewModel = NewStatsViewModel(
+            selectedSiteRepository,
+            cardConfigurationRepository,
+            networkUtilsWrapper
+        )
         advanceUntilIdle()
 
         verify(cardConfigurationRepository).getConfiguration(0L)
     }
+
+    // region Move card tests
+    @Test
+    fun `when moveCardUp is called, then repository moveCardUp is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.moveCardUp(StatsCardType.VIEWS_STATS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).moveCardUp(TEST_SITE_ID, StatsCardType.VIEWS_STATS)
+    }
+
+    @Test
+    fun `when moveCardToTop is called, then repository moveCardToTop is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.moveCardToTop(StatsCardType.COUNTRIES)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).moveCardToTop(TEST_SITE_ID, StatsCardType.COUNTRIES)
+    }
+
+    @Test
+    fun `when moveCardDown is called, then repository moveCardDown is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.moveCardDown(StatsCardType.TODAYS_STATS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).moveCardDown(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+    }
+
+    @Test
+    fun `when moveCardToBottom is called, then repository moveCardToBottom is invoked`() = test {
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.moveCardToBottom(StatsCardType.TODAYS_STATS)
+        advanceUntilIdle()
+
+        verify(cardConfigurationRepository).moveCardToBottom(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+    }
+    // endregion
+
+    // region Network availability tests
+    @Test
+    fun `when initialized with network available, then isNetworkAvailable is true`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        initViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.isNetworkAvailable.value).isTrue()
+    }
+
+    @Test
+    fun `when initialized without network, then isNetworkAvailable is false`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        initViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.isNetworkAvailable.value).isFalse()
+    }
+
+    @Test
+    fun `when checkNetworkStatus is called, then network status is updated`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        initViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.isNetworkAvailable.value).isFalse()
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        viewModel.checkNetworkStatus()
+
+        assertThat(viewModel.isNetworkAvailable.value).isTrue()
+    }
+    // endregion
 
     companion object {
         private const val TEST_SITE_ID = 123L

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/components/CardPositionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/components/CardPositionTest.kt
@@ -1,0 +1,78 @@
+package org.wordpress.android.ui.newstats.components
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CardPositionTest {
+    @Test
+    fun `when card is at index 0, then isFirst is true`() {
+        val position = CardPosition(index = 0, totalCards = 3)
+
+        assertThat(position.isFirst).isTrue()
+    }
+
+    @Test
+    fun `when card is not at index 0, then isFirst is false`() {
+        val position = CardPosition(index = 1, totalCards = 3)
+
+        assertThat(position.isFirst).isFalse()
+    }
+
+    @Test
+    fun `when card is at last index, then isLast is true`() {
+        val position = CardPosition(index = 2, totalCards = 3)
+
+        assertThat(position.isLast).isTrue()
+    }
+
+    @Test
+    fun `when card is not at last index, then isLast is false`() {
+        val position = CardPosition(index = 1, totalCards = 3)
+
+        assertThat(position.isLast).isFalse()
+    }
+
+    @Test
+    fun `when card is first, then canMoveUp is false`() {
+        val position = CardPosition(index = 0, totalCards = 3)
+
+        assertThat(position.canMoveUp).isFalse()
+    }
+
+    @Test
+    fun `when card is not first, then canMoveUp is true`() {
+        val position = CardPosition(index = 1, totalCards = 3)
+
+        assertThat(position.canMoveUp).isTrue()
+    }
+
+    @Test
+    fun `when card is last, then canMoveDown is false`() {
+        val position = CardPosition(index = 2, totalCards = 3)
+
+        assertThat(position.canMoveDown).isFalse()
+    }
+
+    @Test
+    fun `when card is not last, then canMoveDown is true`() {
+        val position = CardPosition(index = 1, totalCards = 3)
+
+        assertThat(position.canMoveDown).isTrue()
+    }
+
+    @Test
+    fun `when only one card exists, then both canMoveUp and canMoveDown are false`() {
+        val position = CardPosition(index = 0, totalCards = 1)
+
+        assertThat(position.canMoveUp).isFalse()
+        assertThat(position.canMoveDown).isFalse()
+    }
+
+    @Test
+    fun `when middle card in list of 3, then can move both up and down`() {
+        val position = CardPosition(index = 1, totalCards = 3)
+
+        assertThat(position.canMoveUp).isTrue()
+        assertThat(position.canMoveDown).isTrue()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/components/CardPositionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/components/CardPositionTest.kt
@@ -75,4 +75,18 @@ class CardPositionTest {
         assertThat(position.canMoveUp).isTrue()
         assertThat(position.canMoveDown).isTrue()
     }
+
+    @Test
+    fun `when only 2 cards exist, then showMoveToTopBottom is false`() {
+        val position = CardPosition(index = 0, totalCards = 2)
+
+        assertThat(position.showMoveToTopBottom).isFalse()
+    }
+
+    @Test
+    fun `when 3 or more cards exist, then showMoveToTopBottom is true`() {
+        val position = CardPosition(index = 0, totalCards = 3)
+
+        assertThat(position.showMoveToTopBottom).isTrue()
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedViewModelTest.kt
@@ -352,6 +352,56 @@ class MostViewedViewModelTest : BaseUnitTest() {
     }
     // endregion
 
+    // region loadData
+    @Test
+    fun `when loadData is called, then data is fetched and states are updated`() = test {
+        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+            .thenReturn(createSuccessResult())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // Data was fetched during init
+        verify(statsRepository, times(2)).fetchMostViewed(any(), any(), any())
+
+        // Call loadData again
+        viewModel.loadData()
+        advanceUntilIdle()
+
+        // Data should be fetched again (4 times total: 2 init + 2 loadData)
+        verify(statsRepository, times(4)).fetchMostViewed(any(), any(), any())
+
+        // States should be Loaded
+        assertThat(viewModel.postsUiState.value).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+        assertThat(viewModel.referrersUiState.value).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+    }
+
+    @Test
+    fun `when loadData is called after error, then states recover to Loaded`() = test {
+        stubFailedToLoadError()
+        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+            .thenReturn(MostViewedResult.Error("Network error"))
+
+        initViewModel()
+        advanceUntilIdle()
+
+        // States should be Error after init with failed network
+        assertThat(viewModel.postsUiState.value).isInstanceOf(MostViewedCardUiState.Error::class.java)
+        assertThat(viewModel.referrersUiState.value).isInstanceOf(MostViewedCardUiState.Error::class.java)
+
+        // Now configure success and call loadData
+        whenever(statsRepository.fetchMostViewed(any(), any(), any()))
+            .thenReturn(createSuccessResult())
+
+        viewModel.loadData()
+        advanceUntilIdle()
+
+        // After loadData, should be Loaded
+        assertThat(viewModel.postsUiState.value).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+        assertThat(viewModel.referrersUiState.value).isInstanceOf(MostViewedCardUiState.Loaded::class.java)
+    }
+    // endregion
+
     // region getDetailData
     @Test
     fun `when getPostsDetailData is called, then returns cached posts data`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsCardsConfigurationRepositoryTest.kt
@@ -143,6 +143,142 @@ class StatsCardsConfigurationRepositoryTest : BaseUnitTest() {
         verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), any())
     }
 
+    // region Move card tests
+    @Test
+    fun `when moveCardUp is called, then card is moved up one position`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardUp(TEST_SITE_ID, StatsCardType.VIEWS_STATS)
+
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        // VIEWS_STATS should now be at position 0
+        assertThat(jsonCaptor.firstValue).contains("VIEWS_STATS")
+        assertThat(jsonCaptor.firstValue.indexOf("VIEWS_STATS"))
+            .isLessThan(jsonCaptor.firstValue.indexOf("TODAYS_STATS"))
+    }
+
+    @Test
+    fun `when moveCardUp is called on first card, then nothing changes`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardUp(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+
+        // setStatsCardsConfigurationJson should not be called since card is already first
+        verify(appPrefsWrapper, org.mockito.kotlin.never()).setStatsCardsConfigurationJson(any(), any())
+    }
+
+    @Test
+    fun `when moveCardToTop is called, then card is moved to first position`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardToTop(TEST_SITE_ID, StatsCardType.COUNTRIES)
+
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        // COUNTRIES should now be at position 0
+        assertThat(jsonCaptor.firstValue.indexOf("COUNTRIES"))
+            .isLessThan(jsonCaptor.firstValue.indexOf("TODAYS_STATS"))
+        assertThat(jsonCaptor.firstValue.indexOf("COUNTRIES"))
+            .isLessThan(jsonCaptor.firstValue.indexOf("VIEWS_STATS"))
+    }
+
+    @Test
+    fun `when moveCardToTop is called on first card, then nothing changes`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardToTop(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+
+        verify(appPrefsWrapper, org.mockito.kotlin.never()).setStatsCardsConfigurationJson(any(), any())
+    }
+
+    @Test
+    fun `when moveCardDown is called, then card is moved down one position`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardDown(TEST_SITE_ID, StatsCardType.VIEWS_STATS)
+
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        // VIEWS_STATS should now be after COUNTRIES
+        assertThat(jsonCaptor.firstValue.indexOf("VIEWS_STATS"))
+            .isGreaterThan(jsonCaptor.firstValue.indexOf("COUNTRIES"))
+    }
+
+    @Test
+    fun `when moveCardDown is called on last card, then nothing changes`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardDown(TEST_SITE_ID, StatsCardType.COUNTRIES)
+
+        verify(appPrefsWrapper, org.mockito.kotlin.never()).setStatsCardsConfigurationJson(any(), any())
+    }
+
+    @Test
+    fun `when moveCardToBottom is called, then card is moved to last position`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardToBottom(TEST_SITE_ID, StatsCardType.TODAYS_STATS)
+
+        val jsonCaptor = argumentCaptor<String>()
+        verify(appPrefsWrapper).setStatsCardsConfigurationJson(eq(TEST_SITE_ID), jsonCaptor.capture())
+        // TODAYS_STATS should now be at the end
+        assertThat(jsonCaptor.firstValue.indexOf("TODAYS_STATS"))
+            .isGreaterThan(jsonCaptor.firstValue.indexOf("VIEWS_STATS"))
+        assertThat(jsonCaptor.firstValue.indexOf("TODAYS_STATS"))
+            .isGreaterThan(jsonCaptor.firstValue.indexOf("COUNTRIES"))
+    }
+
+    @Test
+    fun `when moveCardToBottom is called on last card, then nothing changes`() = test {
+        val initialJson = """
+            {
+                "visibleCards": ["TODAYS_STATS", "VIEWS_STATS", "COUNTRIES"]
+            }
+        """.trimIndent()
+        whenever(appPrefsWrapper.getStatsCardsConfigurationJson(TEST_SITE_ID)).thenReturn(initialJson)
+
+        repository.moveCardToBottom(TEST_SITE_ID, StatsCardType.COUNTRIES)
+
+        verify(appPrefsWrapper, org.mockito.kotlin.never()).setStatsCardsConfigurationJson(any(), any())
+    }
+    // endregion
+
     companion object {
         private const val TEST_SITE_ID = 123L
     }


### PR DESCRIPTION
## Description                                                                                                                                                                  
                                                                                                                                                                                  
  This PR adds card position management functionality to stats cards, allowing users to reorder cards via a "Move Card" sub-menu. It also adds no-connection handling and displays
   the selected period in the top bar.                                                                                                                                            
                                                                                                                                                                                  
  ### Changes:                                                                                                                                                                    
  - **Move Card sub-menu**: Added Move Up, Move to Top, Move Down, and Move to Bottom options with descriptive icons                                                              
    - Top card hides up/top options; bottom card hides down/bottom options                                                                                                        
    - Single card hides all move options                                                                                                                                          
  - **No-connection handling**: When offline, cards are hidden and a message with Retry button is shown                                                                           
    - Retry shows loading state on cards (not error state)                                                                                                                        
  - **Period in top bar**: The selected stats period (e.g., "Last 7 days") is now displayed in the top bar next to the date picker icon                                           
    - Custom date ranges show formatted dates (e.g., "Jan 15 - Jan 22")                                                                                                           
    - Clicking the period label opens the period selection menu                                                                                                                   
  - **Code cleanup**: Extracted common move logic into `moveCardToIndex` helper method in repository                                                                              
                                                                                                                                                                                  
  ## Testing instructions                                    

                                                                                                                     
                                                    

https://github.com/user-attachments/assets/d081bc1e-1cc6-47f6-bea1-c2573338d956

                                                                                                                              
  Move card functionality:                                                                                                                                                        
                                                                                                                                                                                  
  1. Open Stats screen with multiple cards visible                                                                                                                                
  2. Tap the three-dot menu on any card                                                                                                                                           
  3. Tap "Move Card" to open the sub-menu                                                                                                                                         
  - [x] Verify first card only shows "Move Down" and "Move to Bottom"                                                                                                             
  - [x] Verify last card only shows "Move Up" and "Move to Top"                                                                                                                   
  - [x] Verify middle cards show all four options                                                                                                                                 
  4. Test each move action                                                                                                                                                        
  - [x] Verify cards reorder correctly                                                                                                                                            
  - [x] Verify order persists after app restart                                                                                                                                   
                                                                                                                                                                                  
  No-connection handling:                                                                                                                                                         
                                                                                                                                                                                  
  1. Enable airplane mode                                                                                                                                                         
  2. Open Stats screen (or pull to refresh)                                                                                                                                       
  - [x] Verify cards are hidden and no-connection message is shown                                                                                                                
  3. Disable airplane mode and tap "Retry"                                                                                                                                        
  - [x] Verify cards show loading state (not error state)                                                                                                                         
  - [x] Verify data loads successfully                                                                                                                                            
                                                                                                                                                                                  
  Period display in top bar:                                                                                                                                                      
                                                                                                                                                                                  
  1. Open Stats screen                                                                                                                                                            
  - [x] Verify the selected period (e.g., "Last 7 days") is shown in the top bar                                                                                                  
  2. Tap the period label or date icon                                                                                                                                            
  - [x] Verify period selection menu opens                                                                                                                                        
  3. Select a different period                                                                                                                                                    
  - [x] Verify the top bar updates to show the new period                                                                                                                         
  4. Select "Custom" and choose a date range                                                                                                                                      
  - [ ] Verify the top bar shows the formatted date range (e.g., "Jan 15 - Jan 22")                                                                                               
                                                                                                                                                                                  
  Single card scenario:                                                                                                                                                           
                                                                                                                                                                                  
  1. Remove all cards except one                                                                                                                                                  
  2. Tap the three-dot menu on the remaining card                                                                                                                                 
  - [x] Verify "Move Card" option is not shown                  