### PR TITLE
Add linkable items dropdown data for navigation menus

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusUiState.kt
@@ -155,8 +155,7 @@ enum class MenuItemTypeOption(
  */
 data class LinkableItemOption(
     val id: Long,
-    val title: String,
-    val indentLevel: Int = 0
+    val title: String
 )
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
@@ -516,7 +516,7 @@ class NavMenusViewModel @Inject constructor(
         _menuItemDetailState.value = currentState.copy(
             selectedLinkableItem = item,
             objectId = item.id,
-            title = currentState.title.ifBlank { item.title }
+            title = item.title
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
@@ -461,8 +461,57 @@ class NavMenusViewModel @Inject constructor(
             url = if (typeOption == MenuItemTypeOption.CUSTOM_LINK) currentState.url else "",
             objectId = 0L,
             selectedLinkableItem = null,
-            linkableItemsState = LinkableItemsState()
+            linkableItemsState = LinkableItemsState(isLoading = typeOption != MenuItemTypeOption.CUSTOM_LINK)
         )
+
+        // Load linkable items for non-custom types
+        if (typeOption != MenuItemTypeOption.CUSTOM_LINK) {
+            loadLinkableItems(typeOption)
+        }
+    }
+
+    private fun loadLinkableItems(typeOption: MenuItemTypeOption) {
+        viewModelScope.launch {
+            val site = selectedSiteRepository.getSelectedSite() ?: return@launch
+
+            val result = withContext(ioDispatcher) {
+                when (typeOption) {
+                    MenuItemTypeOption.CATEGORY -> navMenuRestClient.fetchCategories(site)
+                    MenuItemTypeOption.TAG -> navMenuRestClient.fetchTags(site)
+                    // Posts and pages not yet supported in wordpress-rs
+                    MenuItemTypeOption.POST,
+                    MenuItemTypeOption.PAGE -> {
+                        NavMenuRestClient.LinkableItemsResult.Success(emptyList())
+                    }
+                    MenuItemTypeOption.CUSTOM_LINK -> {
+                        NavMenuRestClient.LinkableItemsResult.Success(emptyList())
+                    }
+                }
+            }
+
+            val currentState = _menuItemDetailState.value ?: return@launch
+            // Only update if the type hasn't changed while loading
+            if (currentState.selectedTypeOption == typeOption) {
+                _menuItemDetailState.value = when (result) {
+                    is NavMenuRestClient.LinkableItemsResult.Success -> {
+                        currentState.copy(
+                            linkableItemsState = LinkableItemsState(
+                                isLoading = false,
+                                items = result.items
+                            )
+                        )
+                    }
+                    is NavMenuRestClient.LinkableItemsResult.Error -> {
+                        currentState.copy(
+                            linkableItemsState = LinkableItemsState(
+                                isLoading = false,
+                                error = result.message
+                            )
+                        )
+                    }
+                }
+            }
+        }
     }
 
     fun updateSelectedLinkableItem(item: LinkableItemOption) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
@@ -112,11 +112,11 @@ class NavMenusViewModel @Inject constructor(
         val itemCountByMenuId = buildItemCountMap(allItemsResult)
 
         return when (menusResult) {
-            is NavMenuRestClient.NavMenusResult.Success -> {
+            is NavMenuRestClient.NavMenuListResult.Success -> {
                 currentMenus = menusResult.menus
                 buildSuccessState(menusResult.menus, locationsResult, itemCountByMenuId)
             }
-            is NavMenuRestClient.NavMenusResult.Error -> {
+            is NavMenuRestClient.NavMenuListResult.Error -> {
                 val errorMessage = menusResult.message.takeIf { it.isNotBlank() } ?: "Failed to load menus"
                 MenuListUiState(isLoading = false, error = errorMessage)
             }
@@ -124,12 +124,12 @@ class NavMenusViewModel @Inject constructor(
     }
 
     private fun buildItemCountMap(
-        result: NavMenuRestClient.NavMenuItemsResult
+        result: NavMenuRestClient.NavMenuItemListResult
     ): Map<Long, Int> = when (result) {
-        is NavMenuRestClient.NavMenuItemsResult.Success -> {
+        is NavMenuRestClient.NavMenuItemListResult.Success -> {
             result.items.groupingBy { it.menuId }.eachCount()
         }
-        is NavMenuRestClient.NavMenuItemsResult.Error -> emptyMap()
+        is NavMenuRestClient.NavMenuItemListResult.Error -> emptyMap()
     }
 
     private fun buildSuccessState(
@@ -203,7 +203,7 @@ class NavMenusViewModel @Inject constructor(
 
                 withContext(mainDispatcher) {
                     when (result) {
-                        is NavMenuRestClient.NavMenuItemsResult.Success -> {
+                        is NavMenuRestClient.NavMenuItemListResult.Success -> {
                             currentMenuItems = result.items
                             val sortedItems = sortItemsHierarchically(result.items)
                             _menuItemListState.value = _menuItemListState.value.copy(
@@ -211,7 +211,7 @@ class NavMenusViewModel @Inject constructor(
                                 items = sortedItems
                             )
                         }
-                        is NavMenuRestClient.NavMenuItemsResult.Error -> {
+                        is NavMenuRestClient.NavMenuItemListResult.Error -> {
                             _menuItemListState.value = _menuItemListState.value.copy(
                                 isLoading = false,
                                 error = result.message

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/NavMenusViewModel.kt
@@ -476,13 +476,10 @@ class NavMenusViewModel @Inject constructor(
 
             val result = withContext(ioDispatcher) {
                 when (typeOption) {
+                    MenuItemTypeOption.POST -> navMenuRestClient.fetchPosts(site)
+                    MenuItemTypeOption.PAGE -> navMenuRestClient.fetchPages(site)
                     MenuItemTypeOption.CATEGORY -> navMenuRestClient.fetchCategories(site)
                     MenuItemTypeOption.TAG -> navMenuRestClient.fetchTags(site)
-                    // Posts and pages not yet supported in wordpress-rs
-                    MenuItemTypeOption.POST,
-                    MenuItemTypeOption.PAGE -> {
-                        NavMenuRestClient.LinkableItemsResult.Success(emptyList())
-                    }
                     MenuItemTypeOption.CUSTOM_LINK -> {
                         NavMenuRestClient.LinkableItemsResult.Success(emptyList())
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -427,15 +427,41 @@ class NavMenuRestClient @Inject constructor(
     }
 
     private fun parseErrorMessage(response: WpRequestResult<*>): String {
+        appLogWrapper.e(AppLog.T.API, "API error: $response")
+
+        // Check for network availability first
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            return context.getString(R.string.no_network_message)
+        }
+
         return when (response) {
             is WpRequestResult.Success -> "Unexpected error"
-            else -> {
-                appLogWrapper.e(AppLog.T.API, "API error: $response")
-                if (!networkUtilsWrapper.isNetworkAvailable()) {
-                    context.getString(R.string.no_network_message)
-                } else {
-                    context.getString(R.string.request_failed_message)
-                }
+
+            is WpRequestResult.WpError<*> -> {
+                // Extract the specific error message from the API response
+                response.errorMessage.takeIf { it.isNotBlank() }
+                    ?: context.getString(R.string.request_failed_message)
+            }
+
+            is WpRequestResult.InvalidHttpStatusCode<*> -> {
+                context.getString(R.string.request_failed_message)
+            }
+
+            is WpRequestResult.ResponseParsingError<*> -> {
+                context.getString(R.string.request_failed_message)
+            }
+
+            is WpRequestResult.SiteUrlParsingError<*> -> {
+                context.getString(R.string.request_failed_message)
+            }
+
+            is WpRequestResult.RequestExecutionFailed<*> -> {
+                context.getString(R.string.request_failed_message)
+            }
+
+            is WpRequestResult.MediaFileNotFound<*>,
+            is WpRequestResult.UnknownError<*> -> {
+                context.getString(R.string.request_failed_message)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.navmenus.toJsonStringArray
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import rs.wordpress.api.kotlin.WpRequestResult
+import org.wordpress.android.ui.navmenus.LinkableItemOption
 import uniffi.wp_api.MenuLocationWithViewContext
 import uniffi.wp_api.NavMenuCreateParams
 import uniffi.wp_api.NavMenuItemCreateParams
@@ -24,6 +25,10 @@ import uniffi.wp_api.NavMenuItemWithEditContext
 import uniffi.wp_api.NavMenuListParams
 import uniffi.wp_api.NavMenuUpdateParams
 import uniffi.wp_api.NavMenuWithEditContext
+import uniffi.wp_api.TermEndpointType
+import uniffi.wp_api.TermListParams
+import uniffi.wp_api.WpApiParamOrder
+import uniffi.wp_api.WpApiParamTermsOrderBy
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -296,6 +301,70 @@ class NavMenuRestClient @Inject constructor(
         }
     }
 
+    // ========== Linkable Items Operations ==========
+
+    /**
+     * Fetches categories for menu item linking. Limited to 20 items, sorted alphabetically.
+     */
+    suspend fun fetchCategories(site: SiteModel): LinkableItemsResult {
+        val client = wpApiClientProvider.getWpApiClient(site)
+
+        val response = client.request { requestBuilder ->
+            requestBuilder.terms().listWithEditContext(
+                termEndpointType = TermEndpointType.Categories,
+                params = TermListParams(
+                    perPage = PAGE_SIZE,
+                    order = WpApiParamOrder.ASC,
+                    orderby = WpApiParamTermsOrderBy.NAME
+                )
+            )
+        }
+
+        return when (response) {
+            is WpRequestResult.Success -> {
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} categories")
+                val items = response.response.data.map { LinkableItemOption(it.id, it.name) }
+                LinkableItemsResult.Success(items)
+            }
+            else -> {
+                val errorMessage = parseErrorMessage(response)
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch categories: $errorMessage")
+                LinkableItemsResult.Error(errorMessage)
+            }
+        }
+    }
+
+    /**
+     * Fetches tags for menu item linking. Limited to 20 items, sorted alphabetically.
+     */
+    suspend fun fetchTags(site: SiteModel): LinkableItemsResult {
+        val client = wpApiClientProvider.getWpApiClient(site)
+
+        val response = client.request { requestBuilder ->
+            requestBuilder.terms().listWithEditContext(
+                termEndpointType = TermEndpointType.Tags,
+                params = TermListParams(
+                    perPage = PAGE_SIZE,
+                    order = WpApiParamOrder.ASC,
+                    orderby = WpApiParamTermsOrderBy.NAME
+                )
+            )
+        }
+
+        return when (response) {
+            is WpRequestResult.Success -> {
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} tags")
+                val items = response.response.data.map { LinkableItemOption(it.id, it.name) }
+                LinkableItemsResult.Success(items)
+            }
+            else -> {
+                val errorMessage = parseErrorMessage(response)
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch tags: $errorMessage")
+                LinkableItemsResult.Error(errorMessage)
+            }
+        }
+    }
+
     // ========== Helper Functions ==========
 
     private fun buildMenuItemCreateParams(item: NavMenuItemModel): NavMenuItemCreateParams {
@@ -434,5 +503,14 @@ class NavMenuRestClient @Inject constructor(
     sealed class NavMenuLocationsResult {
         data class Success(val locations: List<NavMenuLocationModel>) : NavMenuLocationsResult()
         data class Error(val message: String) : NavMenuLocationsResult()
+    }
+
+    sealed class LinkableItemsResult {
+        data class Success(val items: List<LinkableItemOption>) : LinkableItemsResult()
+        data class Error(val message: String) : LinkableItemsResult()
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20u
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -352,7 +352,10 @@ class NavMenuRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} $typeName")
                 val items = response.response.data.map {
-                    LinkableItemOption(it.id, it.title?.raw ?: "")
+                    val title = it.title?.raw?.takeIf { raw -> raw.isNotBlank() }
+                        ?: it.title?.rendered
+                        ?: ""
+                    LinkableItemOption(it.id, title)
                 }
                 LinkableItemsResult.Success(items)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -309,45 +309,37 @@ class NavMenuRestClient @Inject constructor(
     /**
      * Fetches posts for menu item linking. Limited to 20 items, sorted by date (newest first).
      */
-    suspend fun fetchPosts(site: SiteModel): LinkableItemsResult {
-        val client = wpApiClientProvider.getWpApiClient(site)
-
-        val response = client.request { requestBuilder ->
-            requestBuilder.posts().listWithEditContext(
-                postEndpointType = PostEndpointType.Posts,
-                params = PostListParams(
-                    perPage = PAGE_SIZE,
-                    order = WpApiParamOrder.DESC,
-                    orderby = WpApiParamPostsOrderBy.DATE
-                )
-            )
-        }
-
-        return when (response) {
-            is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} posts")
-                val items = response.response.data.map {
-                    LinkableItemOption(it.id, it.title?.raw ?: "")
-                }
-                LinkableItemsResult.Success(items)
-            }
-            else -> {
-                val errorMessage = parseErrorMessage(response)
-                appLogWrapper.e(AppLog.T.API, "Failed to fetch posts: $errorMessage")
-                LinkableItemsResult.Error(errorMessage)
-            }
-        }
-    }
+    suspend fun fetchPosts(site: SiteModel): LinkableItemsResult =
+        fetchPostType(site, PostEndpointType.Posts, "posts")
 
     /**
      * Fetches pages for menu item linking. Limited to 20 items, sorted by date (newest first).
      */
-    suspend fun fetchPages(site: SiteModel): LinkableItemsResult {
+    suspend fun fetchPages(site: SiteModel): LinkableItemsResult =
+        fetchPostType(site, PostEndpointType.Pages, "pages")
+
+    /**
+     * Fetches categories for menu item linking. Limited to 20 items, sorted alphabetically.
+     */
+    suspend fun fetchCategories(site: SiteModel): LinkableItemsResult =
+        fetchTermType(site, TermEndpointType.Categories, "categories")
+
+    /**
+     * Fetches tags for menu item linking. Limited to 20 items, sorted alphabetically.
+     */
+    suspend fun fetchTags(site: SiteModel): LinkableItemsResult =
+        fetchTermType(site, TermEndpointType.Tags, "tags")
+
+    private suspend fun fetchPostType(
+        site: SiteModel,
+        endpointType: PostEndpointType,
+        typeName: String
+    ): LinkableItemsResult {
         val client = wpApiClientProvider.getWpApiClient(site)
 
         val response = client.request { requestBuilder ->
             requestBuilder.posts().listWithEditContext(
-                postEndpointType = PostEndpointType.Pages,
+                postEndpointType = endpointType,
                 params = PostListParams(
                     perPage = PAGE_SIZE,
                     order = WpApiParamOrder.DESC,
@@ -358,7 +350,7 @@ class NavMenuRestClient @Inject constructor(
 
         return when (response) {
             is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} pages")
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} $typeName")
                 val items = response.response.data.map {
                     LinkableItemOption(it.id, it.title?.raw ?: "")
                 }
@@ -366,21 +358,22 @@ class NavMenuRestClient @Inject constructor(
             }
             else -> {
                 val errorMessage = parseErrorMessage(response)
-                appLogWrapper.e(AppLog.T.API, "Failed to fetch pages: $errorMessage")
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch $typeName: $errorMessage")
                 LinkableItemsResult.Error(errorMessage)
             }
         }
     }
 
-    /**
-     * Fetches categories for menu item linking. Limited to 20 items, sorted alphabetically.
-     */
-    suspend fun fetchCategories(site: SiteModel): LinkableItemsResult {
+    private suspend fun fetchTermType(
+        site: SiteModel,
+        endpointType: TermEndpointType,
+        typeName: String
+    ): LinkableItemsResult {
         val client = wpApiClientProvider.getWpApiClient(site)
 
         val response = client.request { requestBuilder ->
             requestBuilder.terms().listWithEditContext(
-                termEndpointType = TermEndpointType.Categories,
+                termEndpointType = endpointType,
                 params = TermListParams(
                     perPage = PAGE_SIZE,
                     order = WpApiParamOrder.ASC,
@@ -391,44 +384,13 @@ class NavMenuRestClient @Inject constructor(
 
         return when (response) {
             is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} categories")
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} $typeName")
                 val items = response.response.data.map { LinkableItemOption(it.id, it.name) }
                 LinkableItemsResult.Success(items)
             }
             else -> {
                 val errorMessage = parseErrorMessage(response)
-                appLogWrapper.e(AppLog.T.API, "Failed to fetch categories: $errorMessage")
-                LinkableItemsResult.Error(errorMessage)
-            }
-        }
-    }
-
-    /**
-     * Fetches tags for menu item linking. Limited to 20 items, sorted alphabetically.
-     */
-    suspend fun fetchTags(site: SiteModel): LinkableItemsResult {
-        val client = wpApiClientProvider.getWpApiClient(site)
-
-        val response = client.request { requestBuilder ->
-            requestBuilder.terms().listWithEditContext(
-                termEndpointType = TermEndpointType.Tags,
-                params = TermListParams(
-                    perPage = PAGE_SIZE,
-                    order = WpApiParamOrder.ASC,
-                    orderby = WpApiParamTermsOrderBy.NAME
-                )
-            )
-        }
-
-        return when (response) {
-            is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} tags")
-                val items = response.response.data.map { LinkableItemOption(it.id, it.name) }
-                LinkableItemsResult.Success(items)
-            }
-            else -> {
-                val errorMessage = parseErrorMessage(response)
-                appLogWrapper.e(AppLog.T.API, "Failed to fetch tags: $errorMessage")
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch $typeName: $errorMessage")
                 LinkableItemsResult.Error(errorMessage)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -25,9 +25,12 @@ import uniffi.wp_api.NavMenuItemWithEditContext
 import uniffi.wp_api.NavMenuListParams
 import uniffi.wp_api.NavMenuUpdateParams
 import uniffi.wp_api.NavMenuWithEditContext
+import uniffi.wp_api.PostEndpointType
+import uniffi.wp_api.PostListParams
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 import uniffi.wp_api.WpApiParamOrder
+import uniffi.wp_api.WpApiParamPostsOrderBy
 import uniffi.wp_api.WpApiParamTermsOrderBy
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -302,6 +305,72 @@ class NavMenuRestClient @Inject constructor(
     }
 
     // ========== Linkable Items Operations ==========
+
+    /**
+     * Fetches posts for menu item linking. Limited to 20 items, sorted by date (newest first).
+     */
+    suspend fun fetchPosts(site: SiteModel): LinkableItemsResult {
+        val client = wpApiClientProvider.getWpApiClient(site)
+
+        val response = client.request { requestBuilder ->
+            requestBuilder.posts().listWithEditContext(
+                postEndpointType = PostEndpointType.Posts,
+                params = PostListParams(
+                    perPage = PAGE_SIZE,
+                    order = WpApiParamOrder.DESC,
+                    orderby = WpApiParamPostsOrderBy.DATE
+                )
+            )
+        }
+
+        return when (response) {
+            is WpRequestResult.Success -> {
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} posts")
+                val items = response.response.data.map {
+                    LinkableItemOption(it.id, it.title?.raw ?: "")
+                }
+                LinkableItemsResult.Success(items)
+            }
+            else -> {
+                val errorMessage = parseErrorMessage(response)
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch posts: $errorMessage")
+                LinkableItemsResult.Error(errorMessage)
+            }
+        }
+    }
+
+    /**
+     * Fetches pages for menu item linking. Limited to 20 items, sorted by date (newest first).
+     */
+    suspend fun fetchPages(site: SiteModel): LinkableItemsResult {
+        val client = wpApiClientProvider.getWpApiClient(site)
+
+        val response = client.request { requestBuilder ->
+            requestBuilder.posts().listWithEditContext(
+                postEndpointType = PostEndpointType.Pages,
+                params = PostListParams(
+                    perPage = PAGE_SIZE,
+                    order = WpApiParamOrder.DESC,
+                    orderby = WpApiParamPostsOrderBy.DATE
+                )
+            )
+        }
+
+        return when (response) {
+            is WpRequestResult.Success -> {
+                appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} pages")
+                val items = response.response.data.map {
+                    LinkableItemOption(it.id, it.title?.raw ?: "")
+                }
+                LinkableItemsResult.Success(items)
+            }
+            else -> {
+                val errorMessage = parseErrorMessage(response)
+                appLogWrapper.e(AppLog.T.API, "Failed to fetch pages: $errorMessage")
+                LinkableItemsResult.Error(errorMessage)
+            }
+        }
+    }
 
     /**
      * Fetches categories for menu item linking. Limited to 20 items, sorted alphabetically.

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/data/NavMenuRestClient.kt
@@ -47,7 +47,7 @@ class NavMenuRestClient @Inject constructor(
 ) {
     // ========== Menu Operations ==========
 
-    suspend fun fetchMenus(site: SiteModel): NavMenusResult {
+    suspend fun fetchMenus(site: SiteModel): NavMenuListResult {
         val client = wpApiClientProvider.getWpApiClient(site)
 
         val response = client.request { requestBuilder ->
@@ -62,12 +62,12 @@ class NavMenuRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} nav menus")
                 val menus = response.response.data.map { it.toNavMenuModel(site.id) }
-                NavMenusResult.Success(menus)
+                NavMenuListResult.Success(menus)
             }
             else -> {
                 val errorMessage = parseErrorMessage(response)
                 appLogWrapper.e(AppLog.T.API, "Failed to fetch nav menus: $errorMessage")
-                NavMenusResult.Error(errorMessage)
+                NavMenuListResult.Error(errorMessage)
             }
         }
     }
@@ -154,7 +154,7 @@ class NavMenuRestClient @Inject constructor(
 
     // ========== Menu Item Operations ==========
 
-    suspend fun fetchMenuItems(site: SiteModel, menuId: Long): NavMenuItemsResult {
+    suspend fun fetchMenuItems(site: SiteModel, menuId: Long): NavMenuItemListResult {
         val client = wpApiClientProvider.getWpApiClient(site)
 
         val response = client.request { requestBuilder ->
@@ -170,17 +170,17 @@ class NavMenuRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} menu items")
                 val items = response.response.data.map { it.toNavMenuItemModel(site.id, menuId) }
-                NavMenuItemsResult.Success(items)
+                NavMenuItemListResult.Success(items)
             }
             else -> {
                 val errorMessage = parseErrorMessage(response)
                 appLogWrapper.e(AppLog.T.API, "Failed to fetch menu items: $errorMessage")
-                NavMenuItemsResult.Error(errorMessage)
+                NavMenuItemListResult.Error(errorMessage)
             }
         }
     }
 
-    suspend fun fetchAllMenuItems(site: SiteModel): NavMenuItemsResult {
+    suspend fun fetchAllMenuItems(site: SiteModel): NavMenuItemListResult {
         val client = wpApiClientProvider.getWpApiClient(site)
 
         val response = client.request { requestBuilder ->
@@ -195,12 +195,12 @@ class NavMenuRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 appLogWrapper.d(AppLog.T.API, "Fetched ${response.response.data.size} total menu items")
                 val items = response.response.data.map { it.toNavMenuItemModel(site.id) }
-                NavMenuItemsResult.Success(items)
+                NavMenuItemListResult.Success(items)
             }
             else -> {
                 val errorMessage = parseErrorMessage(response)
                 appLogWrapper.e(AppLog.T.API, "Failed to fetch all menu items: $errorMessage")
-                NavMenuItemsResult.Error(errorMessage)
+                NavMenuItemListResult.Error(errorMessage)
             }
         }
     }
@@ -539,9 +539,9 @@ class NavMenuRestClient @Inject constructor(
 
     // ========== Result Types ==========
 
-    sealed class NavMenusResult {
-        data class Success(val menus: List<NavMenuModel>) : NavMenusResult()
-        data class Error(val message: String) : NavMenusResult()
+    sealed class NavMenuListResult {
+        data class Success(val menus: List<NavMenuModel>) : NavMenuListResult()
+        data class Error(val message: String) : NavMenuListResult()
     }
 
     sealed class NavMenuResult {
@@ -554,9 +554,9 @@ class NavMenuRestClient @Inject constructor(
         data class Error(val message: String) : NavMenuDeleteResult()
     }
 
-    sealed class NavMenuItemsResult {
-        data class Success(val items: List<NavMenuItemModel>) : NavMenuItemsResult()
-        data class Error(val message: String) : NavMenuItemsResult()
+    sealed class NavMenuItemListResult {
+        data class Success(val items: List<NavMenuItemModel>) : NavMenuItemListResult()
+        data class Error(val message: String) : NavMenuItemListResult()
     }
 
     sealed class NavMenuItemResult {

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/screens/MenuItemDetailScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/screens/MenuItemDetailScreen.kt
@@ -279,27 +279,17 @@ private fun LinkableItemDropdown(
                         }
                     } else {
                         linkableItemsState.items.forEach { item ->
-                            val itemDescription = stringResource(
-                                R.string.menu_item_accessibility_description,
-                                item.indentLevel + 1,
-                                item.title,
-                                ""
-                            ).trim()
                             DropdownMenuItem(
                                 text = {
                                     Text(
                                         text = item.title,
                                         maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.padding(start = (item.indentLevel * 16).dp)
+                                        overflow = TextOverflow.Ellipsis
                                     )
                                 },
                                 onClick = {
                                     onItemSelected(item)
                                     expanded = false
-                                },
-                                modifier = Modifier.semantics {
-                                    contentDescription = itemDescription
                                 }
                             )
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/navmenus/screens/MenuItemDetailScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/navmenus/screens/MenuItemDetailScreen.kt
@@ -140,6 +140,7 @@ private fun ItemFieldsCard(
                 LinkableItemDropdown(
                     linkableItemsState = state.linkableItemsState,
                     selectedItem = state.selectedLinkableItem,
+                    selectedType = state.selectedTypeOption,
                     onItemSelected = onLinkableItemChange
                 )
             }
@@ -210,9 +211,18 @@ private fun TypeDropdown(
 private fun LinkableItemDropdown(
     linkableItemsState: LinkableItemsState,
     selectedItem: LinkableItemOption?,
+    selectedType: MenuItemTypeOption,
     onItemSelected: (LinkableItemOption) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+
+    val placeholderText = when (selectedType) {
+        MenuItemTypeOption.POST -> stringResource(R.string.menu_item_select_post)
+        MenuItemTypeOption.PAGE -> stringResource(R.string.menu_item_select_page)
+        MenuItemTypeOption.CATEGORY -> stringResource(R.string.menu_item_select_category)
+        MenuItemTypeOption.TAG -> stringResource(R.string.menu_item_select_tag)
+        MenuItemTypeOption.CUSTOM_LINK -> stringResource(R.string.menu_item_select_item)
+    }
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
@@ -231,7 +241,7 @@ private fun LinkableItemDropdown(
                 value = when {
                     linkableItemsState.isLoading -> stringResource(R.string.menu_item_loading_items)
                     selectedItem != null -> selectedItem.title
-                    else -> stringResource(R.string.menu_item_select_item)
+                    else -> placeholderText
                 },
                 onValueChange = {},
                 readOnly = true,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4578,6 +4578,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="menu_item_type_tag">Tag</string>
     <string name="menu_item_link_to_label">Link to</string>
     <string name="menu_item_select_item">Select an item</string>
+    <string name="menu_item_select_post">Select a post</string>
+    <string name="menu_item_select_page">Select a page</string>
+    <string name="menu_item_select_category">Select a category</string>
+    <string name="menu_item_select_tag">Select a tag</string>
     <string name="menu_item_no_items_found">No items found</string>
     <string name="menu_item_loading_items">Loading…</string>
     <string name="menu_item_select_required">Please select an item to link to</string>


### PR DESCRIPTION
## Description

Partially addresses CMM-1166 by implementing the dropdown data loading for the menu item type selection in the navigation menus feature:

- **Posts**: Fetches up to 20 posts, sorted by date (newest first)
- **Pages**: Fetches up to 20 pages, sorted by date (newest first)
- **Categories**: Fetches up to 20 categories, sorted alphabetically (A-Z)
- **Tags**: Fetches up to 20 tags, sorted alphabetically (A-Z)

Uses wordpress-rs networking library (not FluxC) with the following endpoints:
- `posts().listWithEditContext()` with `PostEndpointType.Posts` / `PostEndpointType.Pages`
- `terms().listWithEditContext()` with `TermEndpointType.Categories` / `TermEndpointType.Tags`

Also updates the dropdown placeholder text to be type-specific (e.g., "Select a post" instead of generic "Select an item").

## Limitations
- Pagination will come later
- Saving any menu item other than a "Custom link" will fail

## Test plan

Menu item type dropdown:

1. Open a site with navigation menus enabled
2. Navigate to a menu and tap "Add Item"
3. Select "Post" from the Type dropdown
- [x] Verify dropdown shows "Select a post" placeholder
- [x] Verify posts load and are sorted by date (newest first)
4. Select "Page" from the Type dropdown
- [x] Verify dropdown shows "Select a page" placeholder
- [x] Verify pages load and are sorted by date (newest first)
5. Select "Category" from the Type dropdown
- [x] Verify dropdown shows "Select a category" placeholder
- [x] Verify categories load and are sorted alphabetically
6. Select "Tag" from the Type dropdown
- [x] Verify dropdown shows "Select a tag" placeholder
- [x] Verify tags load and are sorted alphabetically
7. Select an item from any dropdown
- [x] Verify the item title auto-fills 


https://github.com/user-attachments/assets/52b9bb2a-7fd8-4619-89bb-ffe9974db182


