### PR TITLE
Hotfix: Aztec toolbar background 26.5

### DIFF
--- a/WordPress/src/main/res/values-night/colors_aztec.xml
+++ b/WordPress/src/main/res/values-night/colors_aztec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--Overloaded Aztec colors. Remove after Aztec is phased out.-->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingDefaultResource">
-    <color name="format_bar_background">#282828</color>  <!-- 4dp elevated surface -->
+    <color name="format_bar_background" tools:ignore="UnusedResources">#282828</color>  <!-- 4dp elevated surface -->
     <color name="format_bar_divider">?android:attr/listDivider</color>
     <color name="text">@color/material_on_surface_emphasis_high_type</color>
     <color name="title_color">@color/text</color>

--- a/WordPress/src/main/res/values-night/colors_aztec.xml
+++ b/WordPress/src/main/res/values-night/colors_aztec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--Overloaded Aztec colors. Remove after Aztec is phased out.-->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingDefaultResource">
     <color name="format_bar_background" tools:ignore="UnusedResources">#282828</color>  <!-- 4dp elevated surface -->
-    <color name="format_bar_divider">?android:attr/listDivider</color>
+    <color name="format_bar_divider" tools:ignore="UnusedResources">?android:attr/listDivider</color>
     <color name="text">@color/material_on_surface_emphasis_high_type</color>
     <color name="title_color">@color/text</color>
     <color name="hint_text">@color/material_on_surface_emphasis_medium</color>

--- a/WordPress/src/main/res/values-night/colors_aztec.xml
+++ b/WordPress/src/main/res/values-night/colors_aztec.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--Overloaded Aztec colors. Remove after Aztec is phased out.-->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingDefaultResource">
+    <color name="format_bar_background">#282828</color>  <!-- 4dp elevated surface -->
     <color name="format_bar_divider">?android:attr/listDivider</color>
     <color name="text">@color/material_on_surface_emphasis_high_type</color>
     <color name="title_color">@color/text</color>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -129,6 +129,10 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
+    <style name="DividerVertical" tools:ignore="UnusedResources">
+        <item name="android:background">?android:attr/listDivider</item>
+    </style>
+
     <!--Post Settings Styles-->
     <style name="PostSettingsTheme" parent="Base.Wordpress">
         <item name="colorPrimary">@color/colorPrimaryEditor</item>

--- a/libs/editor/src/main/res/values/colors.xml
+++ b/libs/editor/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <color name="format_bar_background">#f9fbfc</color>
+    <color name="format_bar_background" tools:ignore="UnusedResources">#f9fbfc</color>
     <color name="format_bar_divider">@color/wp_grey_lighten_10</color>
     <color name="format_bar_ripple_animation" tools:ignore="UnusedResources">@color/wp_grey_lighten_10</color>
 

--- a/libs/editor/src/main/res/values/colors.xml
+++ b/libs/editor/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
+    <color name="format_bar_background">#f9fbfc</color>
     <color name="format_bar_divider">@color/wp_grey_lighten_10</color>
     <color name="format_bar_ripple_animation" tools:ignore="UnusedResources">@color/wp_grey_lighten_10</color>
 


### PR DESCRIPTION
A customer reported that in 26.5, legacy posts created with the Aztec editor show a UI regression in dark mode. The editor toolbar renders with a light background, while the icons remain light/grey, resulting in very low contrast / near-invisible icons.

<img width="1641" height="567" alt="SCR-20260205-kfoo" src="https://github.com/user-attachments/assets/a39bdf04-486f-4984-918f-9d2c1e3f2078" />

The problem was due to the color resource `format_bar_background` being identified as unused and removed. This PR resolves this.

<img width="297" height="629" alt="dark" src="https://github.com/user-attachments/assets/7f1c1df1-85bf-4a2f-b0e4-8eb0b4f3af7d" />
