### PR TITLE
Update AGP to 8.10.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/ReaderLinkHandler.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.deeplinks.handlers
 
 import android.content.Intent
+import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.R
@@ -125,9 +126,7 @@ class ReaderLinkHandler
         ) {
             // Convert applink to https URL that OpenInReader can handle
             val httpsUri = UriWrapper(
-                android.net.Uri.parse(
-                    "https://$HOST_WORDPRESS_COM/$PATH_READ/${segments.joinToString("/")}"
-                )
+                "https://$HOST_WORDPRESS_COM/$PATH_READ/${segments.joinToString("/")}".toUri()
             )
             return OpenInReader(httpsUri)
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostFetcher.kt
@@ -54,7 +54,9 @@ class PostFetcher constructor(
             }
     }
 
-    @Suppress("unused")
+    // ImplicitSamInstance is a false positive here – RemoteId is a data class
+    // with proper equals/hashCode, so HashSet.remove() matches by value correctly.
+    @Suppress("unused", "ImplicitSamInstance")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onPostChanged(event: OnPostChanged) {
         (event.causeOfChange as? UpdatePost)?.let { updatePostCauseOfChange ->

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -77,6 +77,9 @@
     <issue id="ObsoleteSdkInt">
         <ignore path="**/generated/ksp/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
     </issue>
+    <issue id="UseRequiresApi"> <!-- Hilt's View codegen emits @TargetApi instead of @RequiresApi -->
+        <ignore path="**/generated/ksp/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
+    </issue>
     <issue id="IconDensities" severity="warning" /> <!--    fluxc-->
     <!-- INTEROPERABILITY -->
     <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/pull/21430 -->

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -36,6 +36,7 @@
     <issue id="MissingNullAnnotationOnMethodReturnType">
         <ignore path="**/generated/**" />
     </issue>
+    <issue id="Aligned16KB" severity="ignore" /> <!-- Will be addressed by removing Gutenberg Mobile -->
     <issue id="VectorRaster" severity="warning" /> <!--    fluxc-->
     <!-- SECURITY -->
     <issue id="TrustAllX509TrustManager">

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,3 @@ android.enableR8.fullMode=false
 # Dependency Analysis Plugin
 dependency.analysis.android.ignored.variants=release,wordpressVanillaDebug,wordpressVanillaRelease,wordpressWasabiDebug,wordpressWasabiRelease,wordpressJalapenoRelease,jetpackVanillaDebug,jetpackVanillaRelease,jetpackWasabiDebug,jetpackWasabiRelease,jetpackJalapenoRelease
 dependency.analysis.test.analysis=false
-
-# Use lint from AGP 8.8.1
-# The lint shipped with currently used AGP (8.7.3) combined with androidx.lifecycle 2.9.0 crashes
-# https://issuetracker.google.com/issues/418014548
-# Remove this after bumping AGP to 8.8.1 or higher
-android.experimental.lint.version=8.8.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = '8.7.3'
+agp = '8.10.1'
 airbnb-lottie = '6.7.1'
 android-desugar = '2.1.5'
 android-installreferrer = '2.2'


### PR DESCRIPTION
This resolves an issue where Android Studio would show many thousands of warnings while building.

## Testing instructions
1. Build the project using Android Studio in `trunk`. Note the ~15,000 warnings.
2. Build the project using Android Studio in this branch – note the warnings are gone.