### PR TITLE
Enable android.nonFinalResIds=true for AGP 9 compatibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui;
 
-import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -148,20 +147,19 @@ public class AppLogViewerActivity extends BaseAppCompatActivity {
     }
 
     @Override
-    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.app_log_share:
-                shareAppLog();
-                return true;
-            case R.id.app_log_copy_to_clipboard:
-                copyAppLogToClipboard();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        int itemId = item.getItemId();
+        if (itemId == android.R.id.home) {
+            finish();
+            return true;
+        } else if (itemId == R.id.app_log_share) {
+            shareAppLog();
+            return true;
+        } else if (itemId == R.id.app_log_copy_to_clipboard) {
+            copyAppLogToClipboard();
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrainOfAvatarsItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrainOfAvatarsItem.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.avatars
 
-import android.annotation.SuppressLint
 import androidx.annotation.DimenRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.avatars.TrainOfAvatarsViewType.AVATAR
@@ -8,12 +7,10 @@ import org.wordpress.android.ui.avatars.TrainOfAvatarsViewType.TRAILING_LABEL
 import org.wordpress.android.ui.utils.UiString
 
 @DimenRes
-@SuppressLint("NonConstantResourceId")
-const val AVATAR_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
+val AVATAR_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
 
 @DimenRes
-@SuppressLint("NonConstantResourceId")
-const val AVATAR_SIZE_DIMEN = R.dimen.avatar_sz_small
+val AVATAR_SIZE_DIMEN = R.dimen.avatar_sz_small
 
 sealed class TrainOfAvatarsItem(val type: TrainOfAvatarsViewType) {
     data class AvatarItem(val userAvatarUrl: String) : TrainOfAvatarsItem(AVATAR)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackBrandingUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackBrandingUiState.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.jetpackoverlay
 
-import android.annotation.SuppressLint
 import org.wordpress.android.R
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -13,18 +12,14 @@ sealed class JetpackBrandingUiState {
         val otherRes: Int
 
         companion object {
-            @SuppressLint("NonConstantResourceId")
-            const val RES_ARE_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_are_moving_in
-            @SuppressLint("NonConstantResourceId")
-            const val RES_IS_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_is_moving_in
+            val RES_ARE_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_are_moving_in
+            val RES_IS_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_is_moving_in
         }
     }
 
     object Soon : JetpackBrandingUiState(), Indeterminate {
-        @SuppressLint("NonConstantResourceId")
-        const val RES_ARE_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_are_moving_soon
-        @SuppressLint("NonConstantResourceId")
-        const val RES_IS_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_is_moving_soon
+        val RES_ARE_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_are_moving_soon
+        val RES_IS_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_is_moving_soon
     }
 
     data class Weeks(override val number: Long) : JetpackBrandingUiState(), Pluralisable {
@@ -41,8 +36,7 @@ sealed class JetpackBrandingUiState {
     object Passed : JetpackBrandingUiState()
 
     companion object {
-        @SuppressLint("NonConstantResourceId")
-        const val RES_JP_POWERED = R.string.wp_jetpack_powered
+        val RES_JP_POWERED = R.string.wp_jetpack_powered
 
         fun between(startDate: LocalDate, endDate: LocalDate): JetpackBrandingUiState {
             val days = ChronoUnit.DAYS.between(startDate, endDate)

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -669,29 +668,28 @@ public class MediaBrowserActivity extends BaseAppCompatActivity implements Media
     }
 
     @Override
-    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                getOnBackPressedDispatcher().onBackPressed();
-                return true;
-            case R.id.menu_new_media:
-                // Do Nothing (handled in action view click listener)
-                return true;
-            case R.id.menu_search:
-                mSearchMenuItem = item;
-                mSearchMenuItem.setOnActionExpandListener(this);
-                mSearchMenuItem.expandActionView();
+        int itemId = item.getItemId();
+        if (itemId == android.R.id.home) {
+            getOnBackPressedDispatcher().onBackPressed();
+            return true;
+        } else if (itemId == R.id.menu_new_media) {
+            // Do Nothing (handled in action view click listener)
+            return true;
+        } else if (itemId == R.id.menu_search) {
+            mSearchMenuItem = item;
+            mSearchMenuItem.setOnActionExpandListener(this);
+            mSearchMenuItem.expandActionView();
 
-                mSearchView = (SearchView) item.getActionView();
-                mSearchView.setOnQueryTextListener(this);
+            mSearchView = (SearchView) item.getActionView();
+            mSearchView.setOnQueryTextListener(this);
 
-                // load last saved query
-                if (!TextUtils.isEmpty(mQuery)) {
-                    onQueryTextSubmit(mQuery);
-                    mSearchView.setQuery(mQuery, true);
-                }
-                return true;
+            // load last saved query
+            if (!TextUtils.isEmpty(mQuery)) {
+                onQueryTextSubmit(mQuery);
+                mSearchView.setQuery(mQuery, true);
+            }
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -130,22 +130,16 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
                 @Override
                 public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
                     GalleryType galleryType;
-                    switch (checkedId) {
-                        case R.id.radio_circles:
-                            galleryType = GalleryType.CIRCLES;
-                            break;
-                        case R.id.radio_slideshow:
-                            galleryType = GalleryType.SLIDESHOW;
-                            break;
-                        case R.id.radio_squares:
-                            galleryType = GalleryType.SQUARES;
-                            break;
-                        case R.id.radio_tiled:
-                            galleryType = GalleryType.TILED;
-                            break;
-                        default:
-                            galleryType = GalleryType.DEFAULT;
-                            break;
+                    if (checkedId == R.id.radio_circles) {
+                        galleryType = GalleryType.CIRCLES;
+                    } else if (checkedId == R.id.radio_slideshow) {
+                        galleryType = GalleryType.SLIDESHOW;
+                    } else if (checkedId == R.id.radio_squares) {
+                        galleryType = GalleryType.SQUARES;
+                    } else if (checkedId == R.id.radio_tiled) {
+                        galleryType = GalleryType.TILED;
+                    } else {
+                        galleryType = GalleryType.DEFAULT;
                     }
                     setGalleryType(galleryType);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.prefs;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -2287,37 +2286,37 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
-        @SuppressLint("NonConstantResourceId")
         public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
-            switch (item.getItemId()) {
-                case R.id.menu_delete:
-                    SparseBooleanArray checkedItems = getAdapter().getItemsSelected();
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_delete) {
+                SparseBooleanArray checkedItems = getAdapter().getItemsSelected();
 
-                    HashMap<String, Object> properties = new HashMap<>();
-                    properties.put("num_items_deleted", checkedItems.size());
-                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_DELETED_LIST_ITEMS,
-                            mSite, properties);
+                HashMap<String, Object> properties = new HashMap<>();
+                properties.put("num_items_deleted", checkedItems.size());
+                AnalyticsUtils.trackWithSiteDetails(
+                        AnalyticsTracker.Stat.SITE_SETTINGS_DELETED_LIST_ITEMS,
+                        mSite, properties);
 
-                    for (int i = checkedItems.size() - 1; i >= 0; i--) {
-                        final int index = checkedItems.keyAt(i);
+                for (int i = checkedItems.size() - 1; i >= 0; i--) {
+                    final int index = checkedItems.keyAt(i);
 
-                        if (checkedItems.get(index)) {
-                            mEditingList.remove(index);
-                        }
+                    if (checkedItems.get(index)) {
+                        mEditingList.remove(index);
                     }
+                }
 
-                    mSiteSettings.saveSettings();
-                    mActionMode.finish();
-                    return true;
-                case R.id.menu_select_all:
-                    for (int i = 0; i < getAdapter().getItemCount(); i++) {
-                        getAdapter().setItemSelected(i);
-                    }
+                mSiteSettings.saveSettings();
+                mActionMode.finish();
+                return true;
+            } else if (itemId == R.id.menu_select_all) {
+                for (int i = 0; i < getAdapter().getItemCount(); i++) {
+                    getAdapter().setItemSelected(i);
+                }
 
-                    mActionMode.invalidate();
-                    return true;
-                default:
-                    return false;
+                mActionMode.invalidate();
+                return true;
+            } else {
+                return false;
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceNotification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceNotification.kt
@@ -1,18 +1,14 @@
 package org.wordpress.android.ui.sitecreation.services
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.content.Context
 import org.wordpress.android.R
 import org.wordpress.android.util.AutoForegroundNotification
 
 object SiteCreationServiceNotification {
-    @SuppressLint("NonConstantResourceId")
-    private const val channelResId = R.string.notification_channel_normal_id
-    @SuppressLint("NonConstantResourceId")
-    private const val colorResId = R.color.primary_50
-    @SuppressLint("NonConstantResourceId")
-    private const val drawableResId = R.drawable.ic_app_white_24dp
+    private val channelResId = R.string.notification_channel_normal_id
+    private val colorResId = R.color.primary_50
+    private val drawableResId = R.drawable.ic_app_white_24dp
 
     fun createCreatingSiteNotification(context: Context): Notification {
         return AutoForegroundNotification.progressIndeterminate(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.viewmodel.pages
 
-import android.annotation.SuppressLint
 import androidx.annotation.ColorRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
@@ -15,12 +14,9 @@ import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostU
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
-@SuppressLint("NonConstantResourceId")
-const val ERROR_COLOR = R.color.error
-@SuppressLint("NonConstantResourceId")
-const val PROGRESS_INFO_COLOR = R.color.neutral_50
-@SuppressLint("NonConstantResourceId")
-const val STATE_INFO_COLOR = R.color.warning_dark
+val ERROR_COLOR = R.color.error
+val PROGRESS_INFO_COLOR = R.color.neutral_50
+val STATE_INFO_COLOR = R.color.warning_dark
 
 class PostPageListLabelColorUseCase @Inject constructor() {
     @ColorRes

--- a/config/lint/baseline.xml
+++ b/config/lint/baseline.xml
@@ -4941,50 +4941,6 @@
     </issue>
 
     <issue
-        id="NonConstantResourceId"
-        message="Resource IDs will be non-final by default in Android Gradle Plugin version 8.0, avoid using them in switch case statements"
-        errorLine1="                        case R.id.radio_circles:"
-        errorLine2="                             ~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java"
-            line="134"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="NonConstantResourceId"
-        message="Resource IDs will be non-final by default in Android Gradle Plugin version 8.0, avoid using them in switch case statements"
-        errorLine1="                        case R.id.radio_slideshow:"
-        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java"
-            line="137"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="NonConstantResourceId"
-        message="Resource IDs will be non-final by default in Android Gradle Plugin version 8.0, avoid using them in switch case statements"
-        errorLine1="                        case R.id.radio_squares:"
-        errorLine2="                             ~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java"
-            line="140"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="NonConstantResourceId"
-        message="Resource IDs will be non-final by default in Android Gradle Plugin version 8.0, avoid using them in switch case statements"
-        errorLine1="                        case R.id.radio_tiled:"
-        errorLine2="                             ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java"
-            line="143"
-            column="30"/>
-    </issue>
-
-    <issue
         id="UseSwitchCompatOrMaterialCode"
         message="Use `SwitchCompat` from AppCompat or `SwitchMaterial` from Material library"
         errorLine1="        Switch switchControl = getSwitch((ViewGroup) view);"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
+android.nonFinalResIds=true
 android.enableR8.fullMode=false
 
 # Dependency Analysis Plugin


### PR DESCRIPTION
## Summary

- Enables `android.nonFinalResIds=true` in `gradle.properties` to prepare for AGP 9, where non-final resource IDs will be the default
- Converts Java `switch` statements on `R.*` resource IDs to `if-else` chains (resource IDs are no longer compile-time constants)
- Changes Kotlin `const val` to `val` for properties referencing `R.*` resources
- Removes all `@SuppressLint("NonConstantResourceId")` annotations and stale lint baseline entries

## Test plan

- [x] Build succeeds for both WordPress and Jetpack debug variants
- [x] Verify gallery type selection works in InsertMediaDialog
- [x] Verify site creation notification displays correctly