### PR TITLE
Fix Java source/target compatibility warning in analytics module

### DIFF
--- a/libs/analytics/build.gradle
+++ b/libs/analytics/build.gradle
@@ -18,4 +18,9 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         compileSdk rootProject.compileSdkVersion
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
+    }
 }


### PR DESCRIPTION
## Summary
- Sets `sourceCompatibility` and `targetCompatibility` to Java 11 in the analytics module, matching the project-wide version in `libs.versions.toml`
- Resolves the `Java compiler version 21 has deprecated support for compiling with source/target version 8` warning during `:libs:analytics:compileDebugJavaWithJavac`

## Test plan
1. Build the project
- [ ] Verify no Java source/target deprecation warning for `:libs:analytics:compileDebugJavaWithJavac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)