### PR TITLE
CMM-1217 Redact sensitive data from mobile network logs

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
@@ -88,8 +88,8 @@ class TrackNetworkRequestsInterceptor(
     }
 
     private fun shouldRedactRequestBody(request: Request): Boolean {
-        val path = request.url.encodedPath
-        return REDACTED_BODY_PATHS.any { path.endsWith(it) }
+        val pathSegments = request.url.pathSegments
+        return REDACTED_BODY_PATHS.any { it in pathSegments }
     }
 
     private fun getOrCreateChuckerInterceptor(): ChuckerInterceptor {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
@@ -4,8 +4,14 @@ import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
+import okhttp3.Call
+import okhttp3.Connection
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import java.util.concurrent.TimeUnit
 
 /**
  * Retention period options for tracked network requests.
@@ -70,10 +76,20 @@ class TrackNetworkRequestsInterceptor(
         // 3. HashMap lookup (negligible)
         // See: https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r1/core/java/android/app/SharedPreferencesImpl.java#345
         return if (preference.isEnabled()) {
-            getOrCreateChuckerInterceptor().intercept(chain)
+            val chucker = getOrCreateChuckerInterceptor()
+            if (shouldRedactRequestBody(chain.request())) {
+                chucker.intercept(RedactedBodyChain(chain))
+            } else {
+                chucker.intercept(chain)
+            }
         } else {
             chain.proceed(chain.request())
         }
+    }
+
+    private fun shouldRedactRequestBody(request: Request): Boolean {
+        val path = request.url.encodedPath
+        return REDACTED_BODY_PATHS.any { path.endsWith(it) }
     }
 
     private fun getOrCreateChuckerInterceptor(): ChuckerInterceptor {
@@ -107,6 +123,54 @@ class TrackNetworkRequestsInterceptor(
             .build()
     }
 
+    /**
+     * A [Interceptor.Chain] wrapper that presents a redacted request body
+     * to Chucker while ensuring the actual network call uses the original
+     * request with the real body.
+     */
+    private class RedactedBodyChain(
+        private val delegate: Interceptor.Chain
+    ) : Interceptor.Chain {
+        private val redactedRequest: Request by lazy {
+            val original = delegate.request()
+            val contentType = original.body?.contentType()
+                ?: "text/plain".toMediaType()
+            val redactedBody = REDACTED_BODY_PLACEHOLDER
+                .toRequestBody(contentType)
+            original.newBuilder().method(original.method, redactedBody).build()
+        }
+
+        override fun request(): Request = redactedRequest
+
+        override fun proceed(request: Request): Response {
+            return delegate.proceed(delegate.request())
+        }
+
+        override fun connection(): Connection? = delegate.connection()
+        override fun call(): Call = delegate.call()
+        override fun connectTimeoutMillis(): Int =
+            delegate.connectTimeoutMillis()
+        override fun withConnectTimeout(
+            timeout: Int,
+            unit: TimeUnit
+        ): Interceptor.Chain =
+            RedactedBodyChain(delegate.withConnectTimeout(timeout, unit))
+        override fun readTimeoutMillis(): Int =
+            delegate.readTimeoutMillis()
+        override fun withReadTimeout(
+            timeout: Int,
+            unit: TimeUnit
+        ): Interceptor.Chain =
+            RedactedBodyChain(delegate.withReadTimeout(timeout, unit))
+        override fun writeTimeoutMillis(): Int =
+            delegate.writeTimeoutMillis()
+        override fun withWriteTimeout(
+            timeout: Int,
+            unit: TimeUnit
+        ): Interceptor.Chain =
+            RedactedBodyChain(delegate.withWriteTimeout(timeout, unit))
+    }
+
     companion object {
         private val SENSITIVE_HEADERS = setOf(
             "Authorization",
@@ -116,5 +180,13 @@ class TrackNetworkRequestsInterceptor(
         )
 
         private const val MAX_CONTENT_LENGTH = 250_000L
+
+        private const val REDACTED_BODY_PLACEHOLDER =
+            "[Body redacted — contains sensitive information]"
+
+        private val REDACTED_BODY_PATHS = listOf(
+            "xmlrpc.php",
+            "wp-login.php"
+        )
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/TrackNetworkRequestsInterceptor.kt
@@ -125,14 +125,19 @@ class TrackNetworkRequestsInterceptor(
 
     /**
      * A [Interceptor.Chain] wrapper that presents a redacted request body
-     * to Chucker while ensuring the actual network call uses the original
-     * request with the real body.
+     * to Chucker for logging purposes, while ensuring the actual network
+     * call uses the original request with the real body intact.
+     *
+     * This achieves selective logging redaction without affecting the
+     * actual HTTP request/response.
      */
     private class RedactedBodyChain(
         private val delegate: Interceptor.Chain
     ) : Interceptor.Chain {
         private val redactedRequest: Request by lazy {
             val original = delegate.request()
+            // Falls back to plain text if original has no body;
+            // the redacted placeholder still needs a content type.
             val contentType = original.body?.contentType()
                 ?: "text/plain".toMediaType()
             val redactedBody = REDACTED_BODY_PLACEHOLDER


### PR DESCRIPTION
## Description                                                                                                                                                                  
                                                                
  Redact request bodies for sensitive endpoints (`xmlrpc.php` and `wp-login.php`) in the network request tracking feature (Chucker). These endpoints carry credentials in their request bodies, which should not be stored in the on-device log.                                                                                                                

  The requests are still fully logged (URL, method, headers, status code, response) — only the request body is replaced with a `[Body redacted]` placeholder. The actual network call is unaffected.

  This is achieved via a `RedactedBodyChain` wrapper that presents a redacted request to Chucker while delegating `proceed()` to the original chain with the real body intact.
  Adding more sensitive endpoints in the future only requires appending to `REDACTED_BODY_PATHS`.

  ## Testing instructions

<img width="257" height="569" alt="Screenshot 2026-02-06 at 18 33 30" src="https://github.com/user-attachments/assets/cc1c6d64-53ec-451f-92a9-320f81b740b8" />


  Redacted body for sensitive endpoints:

  1. Enable the `Network Debugging` experimental feature
  2. Go to Help/Support and enable `Track Network Requests`
  3. Perform an action that triggers an `xmlrpc.php` or `wp-login.php` request (e.g. open a self-hosted site and go to posts)
  4. Tap `View Network Requests` to open Chucker
  5. Find the `xmlrpc.php` / `wp-login.php` entry
  - [x] Verify the request body shows `[Body redacted — contains sensitive information]`
  - [x] Verify the response body, headers, and status code are still visible

  Non-sensitive endpoints unaffected:

  1. With tracking still enabled, perform an action that triggers a regular API call (e.g. open Reader)
  2. Open `View Network Requests`
  - [x] Verify regular requests still show the full request body as before

  Network calls work correctly:

  1. With tracking enabled, perform various actions (login, browse, post)
  - [x] Verify all functionality works normally — redaction only affects what Chucker logs, not the actual requests
