### PR TITLE
fix: Pass null post ID for local drafts in GutenbergKit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -63,7 +63,10 @@ object GutenbergKitSettingsBuilder {
         ).apply {
             setTitle(post?.title ?: "")
             setContent(post?.content ?: "")
-            setPostId(post?.remotePostId?.toInt())
+            setPostId(
+                if (post?.isLocalDraft == true) null
+                else post?.remotePostId?.toInt()
+            )
             setPostStatus(post?.status ?: "draft")
             setAuthHeader(authHeader)
             setSiteApiNamespace(siteApiNamespace)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 
 @RunWith(MockitoJUnitRunner::class)
@@ -427,6 +428,29 @@ class GutenbergKitSettingsBuilderTest {
     @Test
     fun `null remote ID results in null post ID`() {
         val config = buildWPComConfig()
+
+        assertThat(config.postId).isNull()
+    }
+
+    @Test
+    fun `local draft post results in null post ID`() {
+        val site = SiteModel().apply {
+            url = "https://example.wordpress.com"
+            siteId = 123L
+            setIsWPCom(true)
+            setIsJetpackConnected(false)
+            origin = SiteModel.ORIGIN_WPCOM_REST
+        }
+        val post = PostModel().apply {
+            setIsLocalDraft(true)
+            setRemotePostId(99L)
+        }
+        val config = GutenbergKitSettingsBuilder
+            .buildPostConfiguration(
+                site = site,
+                post = post,
+                accessToken = "test_token"
+            )
 
         assertThat(config.postId).isNull()
     }


### PR DESCRIPTION
## Description

Local draft posts have `remotePostId` defaulting to `0` (Java's `long` default), which was passed directly to GutenbergKit's `setPostId()`. GBK expects `null` for unsaved posts, but was receiving `0` instead.

This change checks `isLocalDraft` and passes `null` to `setPostId()` for local drafts, ensuring the GBK webview correctly identifies new/unsaved posts.

## Testing instructions

Open a new draft post in GutenbergKit:

1. Create a new post using the GutenbergKit (experimental) editor
2. Inspect the webview configuration
- [ ] Verify the post ID is `null` (not `0`) in the GBK webview

Open an existing published post in GutenbergKit:

1. Open an existing published post in the GutenbergKit editor
- [ ] Verify the post ID is the correct remote post ID (not `null`)