### PR TITLE
Pin faraday >= 1.10.5 for security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,7 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.0'
 group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
+
+# Security: https://github.com/lostisland/faraday/pull/1665
+# Faraday 2.0 is not compatible with Fastlane
+gem 'faraday', '~> 1.10', '>= 1.10.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     emoji_regex (3.2.3)
     erubi (1.13.1)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -389,6 +389,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-dangermattic (~> 1.2)
+  faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2)
   fastlane-plugin-firebase_app_distribution (~> 0.10)
   fastlane-plugin-sentry


### PR DESCRIPTION
## Summary

- Pins `faraday` to `~> 1.10, >= 1.10.5` to address a security vulnerability.
- See [faraday#1665](https://github.com/lostisland/faraday/pull/1665) for the fix.
- Tracked in [AINFRA-1976](https://linear.app/a8c/issue/AINFRA-1976/track-security-alert-upgrade-fastlane-to-use-faraday-2x).

## Test plan

- [ ] CI passes — no functional change, only a transitive dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*