### PR TITLE
Add context menu UI to RS post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -41,9 +41,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
                 .collectAsState()
             val searchQuery by viewModel.searchQuery
                 .collectAsState()
-            val trashPostId by viewModel.trashConfirmPostId
-                .collectAsState()
-            val deletePostId by viewModel.deleteConfirmPostId
+            val confirmation by viewModel.pendingConfirmation
                 .collectAsState()
             AppThemeM3 {
                 PostRsListScreen(
@@ -52,18 +50,14 @@ class PostRsListActivity : BaseAppCompatActivity() {
                     searchQuery = searchQuery,
                     confirmationDialog =
                         ConfirmationDialogState(
-                            showTrash =
-                                trashPostId != null,
-                            showDelete =
-                                deletePostId != null,
-                            onConfirmTrash =
-                                viewModel::onConfirmTrash,
-                            onDismissTrash =
-                                viewModel::onDismissTrash,
-                            onConfirmDelete =
-                                viewModel::onConfirmDelete,
-                            onDismissDelete =
-                                viewModel::onDismissDelete
+                            showTrash = confirmation
+                                is PendingConfirmation.Trash,
+                            showDelete = confirmation
+                                is PendingConfirmation.Delete,
+                            onConfirm =
+                                viewModel::onConfirmPendingAction,
+                            onDismiss =
+                                viewModel::onDismissPendingAction
                         ),
                     onSearchOpen =
                         viewModel::onSearchOpen,
@@ -80,8 +74,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
                     onLoadMore =
                         viewModel::loadMorePosts,
                     onNavigateBack = {
-                        onBackPressedDispatcher
-                            .onBackPressed()
+                        onBackPressedDispatcher.onBackPressed()
                     },
                     onPostClick = viewModel::openPost,
                     onPostMenuAction =

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -50,10 +50,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
                     searchQuery = searchQuery,
                     confirmationDialog =
                         ConfirmationDialogState(
-                            showTrash = confirmation
-                                is PendingConfirmation.Trash,
-                            showDelete = confirmation
-                                is PendingConfirmation.Delete,
+                            pending = confirmation,
                             onConfirm =
                                 viewModel::onConfirmPendingAction,
                             onDismiss =

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.util.extensions.setContent
 class PostRsListActivity : BaseAppCompatActivity() {
     private val viewModel: PostRsListViewModel by viewModels()
 
+    @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -49,10 +49,21 @@ class PostRsListActivity : BaseAppCompatActivity() {
                     tabStates = tabStates,
                     isSearchActive = isSearchActive,
                     searchQuery = searchQuery,
-                    showTrashConfirmation =
-                        trashPostId != null,
-                    showDeleteConfirmation =
-                        deletePostId != null,
+                    confirmationDialog =
+                        ConfirmationDialogState(
+                            showTrash =
+                                trashPostId != null,
+                            showDelete =
+                                deletePostId != null,
+                            onConfirmTrash =
+                                viewModel::onConfirmTrash,
+                            onDismissTrash =
+                                viewModel::onDismissTrash,
+                            onConfirmDelete =
+                                viewModel::onConfirmDelete,
+                            onDismissDelete =
+                                viewModel::onDismissDelete
+                        ),
                     onSearchOpen =
                         viewModel::onSearchOpen,
                     onSearchQueryChanged =
@@ -75,15 +86,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
                     onPostMenuAction =
                         viewModel::onPostMenuAction,
                     onCreatePost =
-                        viewModel::createNewPost,
-                    onConfirmTrash =
-                        viewModel::onConfirmTrash,
-                    onDismissTrash =
-                        viewModel::onDismissTrash,
-                    onConfirmDelete =
-                        viewModel::onConfirmDelete,
-                    onDismissDelete =
-                        viewModel::onDismissDelete
+                        viewModel::createNewPost
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -13,9 +13,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
+import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.postsrs.screens.PostRsListScreen
+import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.ReaderPostPagerActivity.DirectOperation
+import org.wordpress.android.ui.stats.StatsConstants
+import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.extensions.setContent
 
@@ -35,11 +40,19 @@ class PostRsListActivity : BaseAppCompatActivity() {
                 .collectAsState()
             val searchQuery by viewModel.searchQuery
                 .collectAsState()
+            val trashPostId by viewModel.trashConfirmPostId
+                .collectAsState()
+            val deletePostId by viewModel.deleteConfirmPostId
+                .collectAsState()
             AppThemeM3 {
                 PostRsListScreen(
                     tabStates = tabStates,
                     isSearchActive = isSearchActive,
                     searchQuery = searchQuery,
+                    showTrashConfirmation =
+                        trashPostId != null,
+                    showDeleteConfirmation =
+                        deletePostId != null,
                     onSearchOpen =
                         viewModel::onSearchOpen,
                     onSearchQueryChanged =
@@ -52,12 +65,25 @@ class PostRsListActivity : BaseAppCompatActivity() {
                             tab, isUserRefresh = true
                         )
                     },
-                    onLoadMore = viewModel::loadMorePosts,
+                    onLoadMore =
+                        viewModel::loadMorePosts,
                     onNavigateBack = {
-                        onBackPressedDispatcher.onBackPressed()
+                        onBackPressedDispatcher
+                            .onBackPressed()
                     },
                     onPostClick = viewModel::openPost,
-                    onCreatePost = viewModel::createNewPost
+                    onPostMenuAction =
+                        viewModel::onPostMenuAction,
+                    onCreatePost =
+                        viewModel::createNewPost,
+                    onConfirmTrash =
+                        viewModel::onConfirmTrash,
+                    onDismissTrash =
+                        viewModel::onDismissTrash,
+                    onConfirmDelete =
+                        viewModel::onConfirmDelete,
+                    onDismissDelete =
+                        viewModel::onDismissDelete
                 )
             }
         }
@@ -67,37 +93,78 @@ class PostRsListActivity : BaseAppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.events.collect { event ->
-                    when (event) {
-                        is PostRsListEvent.EditPost ->
-                            ActivityLauncher.editPostOrPageForResult(
-                                this@PostRsListActivity,
-                                event.site,
-                                event.post
-                            )
-                        is PostRsListEvent.CreatePost ->
-                            ActivityLauncher.addNewPostForResult(
-                                this@PostRsListActivity,
-                                event.site,
-                                false,
-                                PagePostCreationSourcesDetail
-                                    .POST_FROM_POSTS_LIST,
-                                -1,
-                                null
-                            )
-                        is PostRsListEvent.ShowError ->
-                            ToastUtils.showToast(
-                                this@PostRsListActivity,
-                                event.messageResId
-                            )
-                    }
+                    handleEvent(event)
                 }
             }
         }
     }
 
+    @Suppress("LongMethod")
+    private fun handleEvent(event: PostRsListEvent) {
+        when (event) {
+            is PostRsListEvent.EditPost ->
+                ActivityLauncher.editPostOrPageForResult(
+                    this, event.site, event.post
+                )
+            is PostRsListEvent.CreatePost ->
+                ActivityLauncher.addNewPostForResult(
+                    this,
+                    event.site,
+                    false,
+                    PagePostCreationSourcesDetail
+                        .POST_FROM_POSTS_LIST,
+                    -1,
+                    null
+                )
+            is PostRsListEvent.ShowError ->
+                ToastUtils.showToast(
+                    this, event.messageResId
+                )
+            is PostRsListEvent.ViewPost ->
+                ActivityLauncher.openUrlExternal(
+                    this, event.url
+                )
+            is PostRsListEvent.ReadPost ->
+                ReaderActivityLauncher.showReaderPostDetail(
+                    this, event.blogId, event.postId
+                )
+            is PostRsListEvent.SharePost ->
+                ActivityLauncher.openShareIntent(
+                    this, event.url, event.title
+                )
+            is PostRsListEvent.PromoteWithBlaze ->
+                ActivityLauncher.openPromoteWithBlaze(
+                    this,
+                    event.post,
+                    BlazeFlowSource.POSTS_LIST
+                )
+            is PostRsListEvent.ViewStats ->
+                StatsDetailActivity.start(
+                    this,
+                    event.site,
+                    event.postId,
+                    StatsConstants.ITEM_TYPE_POST,
+                    event.title,
+                    event.url
+                )
+            is PostRsListEvent.ViewComments ->
+                ReaderActivityLauncher.showReaderPostDetail(
+                    this,
+                    false,
+                    event.blogId,
+                    event.postId,
+                    DirectOperation.COMMENT_JUMP,
+                    false
+                )
+        }
+    }
+
     companion object {
         fun createIntent(context: Context): Intent {
-            return Intent(context, PostRsListActivity::class.java)
+            return Intent(
+                context,
+                PostRsListActivity::class.java
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListEvent.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.postsrs
+
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+
+sealed interface PostRsListEvent {
+    data class EditPost(
+        val site: SiteModel,
+        val post: PostModel
+    ) : PostRsListEvent
+
+    data class CreatePost(
+        val site: SiteModel
+    ) : PostRsListEvent
+
+    data class ShowError(
+        val messageResId: Int
+    ) : PostRsListEvent
+
+    data class ViewPost(val url: String) : PostRsListEvent
+
+    data class ReadPost(
+        val blogId: Long,
+        val postId: Long
+    ) : PostRsListEvent
+
+    data class SharePost(
+        val url: String,
+        val title: String
+    ) : PostRsListEvent
+
+    data class PromoteWithBlaze(
+        val site: SiteModel,
+        val post: PostModel
+    ) : PostRsListEvent
+
+    data class ViewStats(
+        val site: SiteModel,
+        val postId: Long,
+        val title: String,
+        val url: String
+    ) : PostRsListEvent
+
+    data class ViewComments(
+        val blogId: Long,
+        val postId: Long
+    ) : PostRsListEvent
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.postsrs
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.util.HtmlUtils
@@ -22,10 +23,52 @@ data class PostRsUiModel(
     val title: String,
     val excerpt: String,
     val date: String,
+    val link: String = "",
+    val hasPassword: Boolean = false,
+    val status: PostStatus? = null,
     @StringRes val statusLabelResId: Int = 0,
+    val featuredImageId: Long = 0,
+    val actions: List<PostRsMenuAction> = emptyList(),
     val isPlaceholder: Boolean = false,
     val isError: Boolean = false
 )
+
+enum class PostRsMenuAction(
+    @StringRes val labelResId: Int,
+    @DrawableRes val iconResId: Int,
+    val isDestructive: Boolean = false
+) {
+    VIEW(R.string.button_view, R.drawable.gb_ic_external),
+    READ(
+        R.string.button_read,
+        R.drawable.ic_reader_glasses_white_24dp
+    ),
+    MOVE_TO_DRAFT(
+        R.string.button_move_to_draft,
+        R.drawable.gb_ic_move_to
+    ),
+    DUPLICATE(R.string.button_copy, R.drawable.gb_ic_copy),
+    SHARE(R.string.button_share, R.drawable.gb_ic_share),
+    BLAZE(
+        R.string.button_promote_with_blaze,
+        R.drawable.ic_blaze_flame_24dp
+    ),
+    STATS(R.string.button_stats, R.drawable.gb_ic_chart_bar),
+    COMMENTS(
+        R.string.button_comments,
+        R.drawable.gb_ic_comment
+    ),
+    TRASH(
+        R.string.button_trash,
+        R.drawable.gb_ic_trash,
+        isDestructive = true
+    ),
+    DELETE_PERMANENTLY(
+        R.string.button_delete_permanently,
+        R.drawable.gb_ic_trash,
+        isDestructive = true
+    ),
+}
 
 fun PostItemState.toUiModel(
     postId: Long,
@@ -75,6 +118,10 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
         date = PostRsDateFormatter.format(
             post.dateGmt, post.status
         ),
+        link = post.link,
+        hasPassword = !post.password.isNullOrEmpty(),
+        status = post.status,
+        featuredImageId = post.featuredMedia ?: 0,
         statusLabelResId = if (showStatus) {
             post.status.toLabel()
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -9,6 +9,15 @@ import uniffi.wp_api.PostStatus
 import uniffi.wp_mobile.FullEntityAnyPostWithEditContext
 import uniffi.wp_mobile.PostItemState
 
+data class ConfirmationDialogState(
+    val showTrash: Boolean = false,
+    val showDelete: Boolean = false,
+    val onConfirmTrash: () -> Unit = {},
+    val onDismissTrash: () -> Unit = {},
+    val onConfirmDelete: () -> Unit = {},
+    val onDismissDelete: () -> Unit = {}
+)
+
 data class PostTabUiState(
     val posts: List<PostRsUiModel> = emptyList(),
     val isLoading: Boolean = false,
@@ -27,7 +36,6 @@ data class PostRsUiModel(
     val hasPassword: Boolean = false,
     val status: PostStatus? = null,
     @StringRes val statusLabelResId: Int = 0,
-    val featuredImageId: Long = 0,
     val actions: List<PostRsMenuAction> = emptyList(),
     val isPlaceholder: Boolean = false,
     val isError: Boolean = false
@@ -121,7 +129,6 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
         link = post.link,
         hasPassword = !post.password.isNullOrEmpty(),
         status = post.status,
-        featuredImageId = post.featuredMedia ?: 0,
         statusLabelResId = if (showStatus) {
             post.status.toLabel()
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -9,7 +9,7 @@ import uniffi.wp_api.PostStatus
 import uniffi.wp_mobile.FullEntityAnyPostWithEditContext
 import uniffi.wp_mobile.PostItemState
 
-data class ConfirmationDialogState(
+class ConfirmationDialogState(
     val showTrash: Boolean = false,
     val showDelete: Boolean = false,
     val onConfirmTrash: () -> Unit = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -15,8 +15,7 @@ sealed interface PendingConfirmation {
 }
 
 class ConfirmationDialogState(
-    val showTrash: Boolean = false,
-    val showDelete: Boolean = false,
+    val pending: PendingConfirmation? = null,
     val onConfirm: () -> Unit = {},
     val onDismiss: () -> Unit = {}
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.util.HtmlUtils
 import uniffi.wp_api.AnyPostWithEditContext
+import uniffi.wp_api.PostCommentStatus
 import uniffi.wp_api.PostStatus
 import uniffi.wp_mobile.FullEntityAnyPostWithEditContext
 import uniffi.wp_mobile.PostItemState
@@ -36,6 +37,7 @@ data class PostRsUiModel(
     val date: String,
     val link: String = "",
     val hasPassword: Boolean = false,
+    val commentsOpen: Boolean = false,
     val status: PostStatus? = null,
     @StringRes val statusLabelResId: Int = 0,
     val actions: List<PostRsMenuAction> = emptyList(),
@@ -134,6 +136,8 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
         ),
         link = post.link,
         hasPassword = !post.password.isNullOrEmpty(),
+        commentsOpen =
+            post.commentStatus is PostCommentStatus.Open,
         status = post.status,
         statusLabelResId = if (showStatus) {
             post.status.toLabel()

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -51,6 +51,10 @@ enum class PostRsMenuAction(
         R.string.button_read,
         R.drawable.ic_reader_glasses_white_24dp
     ),
+    PUBLISH(
+        R.string.button_publish,
+        R.drawable.gb_ic_globe
+    ),
     MOVE_TO_DRAFT(
         R.string.button_move_to_draft,
         R.drawable.gb_ic_move_to

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -9,13 +9,16 @@ import uniffi.wp_api.PostStatus
 import uniffi.wp_mobile.FullEntityAnyPostWithEditContext
 import uniffi.wp_mobile.PostItemState
 
+sealed interface PendingConfirmation {
+    data class Trash(val postId: Long) : PendingConfirmation
+    data class Delete(val postId: Long) : PendingConfirmation
+}
+
 class ConfirmationDialogState(
     val showTrash: Boolean = false,
     val showDelete: Boolean = false,
-    val onConfirmTrash: () -> Unit = {},
-    val onDismissTrash: () -> Unit = {},
-    val onConfirmDelete: () -> Unit = {},
-    val onDismissDelete: () -> Unit = {}
+    val onConfirm: () -> Unit = {},
+    val onDismiss: () -> Unit = {}
 )
 
 data class PostTabUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -16,12 +16,13 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.postsrs.data.WpSelfHostedServiceProvider
 import org.wordpress.android.util.AppLog
+import uniffi.wp_api.PostStatus
 import org.wordpress.android.viewmodel.ResourceProvider
 import rs.wordpress.cache.kotlin.ObservableMetadataCollection
 import rs.wordpress.cache.kotlin.getObservablePostMetadataCollectionWithEditContext
@@ -38,6 +39,7 @@ class PostRsListViewModel @Inject constructor(
     private val serviceProvider: WpSelfHostedServiceProvider,
     private val resourceProvider: ResourceProvider,
     private val postStore: PostStore,
+    private val blazeFeatureUtils: BlazeFeatureUtils,
 ) : ViewModel() {
     private val _tabStates =
         MutableStateFlow<Map<PostRsListTab, PostTabUiState>>(emptyMap())
@@ -59,6 +61,14 @@ class PostRsListViewModel @Inject constructor(
 
     private val _events = Channel<PostRsListEvent>(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
+
+    private val _trashConfirmPostId = MutableStateFlow<Long?>(null)
+    val trashConfirmPostId: StateFlow<Long?> =
+        _trashConfirmPostId.asStateFlow()
+
+    private val _deleteConfirmPostId = MutableStateFlow<Long?>(null)
+    val deleteConfirmPostId: StateFlow<Long?> =
+        _deleteConfirmPostId.asStateFlow()
 
     init {
         @OptIn(FlowPreview::class)
@@ -152,6 +162,153 @@ class PostRsListViewModel @Inject constructor(
         _searchQuery.value = ""
         clearCollections()
         initTab(activeTab)
+    }
+
+    /** Routes a menu action tap to the appropriate event or dialog. */
+    @MainThread
+    @Suppress("LongMethod", "ReturnCount")
+    fun onPostMenuAction(
+        remotePostId: Long,
+        action: PostRsMenuAction
+    ) {
+        val site =
+            selectedSiteRepository.getSelectedSite() ?: return
+        val post = findPost(remotePostId)
+
+        when (action) {
+            PostRsMenuAction.VIEW -> {
+                val url = post?.link ?: return
+                _events.trySend(PostRsListEvent.ViewPost(url))
+            }
+            PostRsMenuAction.READ -> _events.trySend(
+                PostRsListEvent.ReadPost(
+                    site.siteId, remotePostId
+                )
+            )
+            PostRsMenuAction.SHARE -> {
+                val url = post?.link ?: return
+                _events.trySend(
+                    PostRsListEvent.SharePost(
+                        url, post.title
+                    )
+                )
+            }
+            PostRsMenuAction.BLAZE -> {
+                val fluxcPost =
+                    postStore.getPostByRemotePostId(
+                        remotePostId, site
+                    ) ?: return
+                _events.trySend(
+                    PostRsListEvent.PromoteWithBlaze(
+                        site, fluxcPost
+                    )
+                )
+            }
+            PostRsMenuAction.STATS -> _events.trySend(
+                PostRsListEvent.ViewStats(
+                    site = site,
+                    postId = remotePostId,
+                    title = post?.title ?: "",
+                    url = post?.link ?: ""
+                )
+            )
+            PostRsMenuAction.COMMENTS -> _events.trySend(
+                PostRsListEvent.ViewComments(
+                    site.siteId, remotePostId
+                )
+            )
+            PostRsMenuAction.TRASH ->
+                _trashConfirmPostId.value = remotePostId
+            PostRsMenuAction.DELETE_PERMANENTLY ->
+                _deleteConfirmPostId.value = remotePostId
+            PostRsMenuAction.MOVE_TO_DRAFT -> AppLog.d(
+                AppLog.T.POSTS,
+                "Move to draft: no-op (networking excluded)"
+            )
+            PostRsMenuAction.DUPLICATE -> AppLog.d(
+                AppLog.T.POSTS,
+                "Duplicate: no-op (networking excluded)"
+            )
+        }
+    }
+
+    @MainThread
+    fun onConfirmTrash() {
+        val postId = _trashConfirmPostId.value
+        _trashConfirmPostId.value = null
+        AppLog.d(
+            AppLog.T.POSTS,
+            "Trash post $postId: no-op (networking excluded)"
+        )
+    }
+
+    @MainThread
+    fun onDismissTrash() {
+        _trashConfirmPostId.value = null
+    }
+
+    @MainThread
+    fun onConfirmDelete() {
+        val postId = _deleteConfirmPostId.value
+        _deleteConfirmPostId.value = null
+        AppLog.d(
+            AppLog.T.POSTS,
+            "Delete post $postId: no-op (networking excluded)"
+        )
+    }
+
+    @MainThread
+    fun onDismissDelete() {
+        _deleteConfirmPostId.value = null
+    }
+
+    private fun findPost(remotePostId: Long): PostRsUiModel? {
+        return _tabStates.value.values
+            .flatMap { it.posts }
+            .firstOrNull { it.remotePostId == remotePostId }
+    }
+
+    private fun getMenuActions(
+        status: PostStatus?,
+        hasPassword: Boolean
+    ): List<PostRsMenuAction> {
+        val site = selectedSiteRepository.getSelectedSite()
+        return buildList {
+            when (status) {
+                is PostStatus.Publish,
+                is PostStatus.Private -> {
+                    add(PostRsMenuAction.VIEW)
+                    add(PostRsMenuAction.READ)
+                    add(PostRsMenuAction.MOVE_TO_DRAFT)
+                    add(PostRsMenuAction.DUPLICATE)
+                    add(PostRsMenuAction.SHARE)
+                    if (site != null &&
+                        !hasPassword &&
+                        blazeFeatureUtils
+                            .isSiteBlazeEligible(site)
+                    ) {
+                        add(PostRsMenuAction.BLAZE)
+                    }
+                    add(PostRsMenuAction.STATS)
+                    add(PostRsMenuAction.COMMENTS)
+                    add(PostRsMenuAction.TRASH)
+                }
+                is PostStatus.Draft,
+                is PostStatus.Pending -> {
+                    add(PostRsMenuAction.DUPLICATE)
+                    add(PostRsMenuAction.TRASH)
+                }
+                is PostStatus.Future -> {
+                    add(PostRsMenuAction.DUPLICATE)
+                    add(PostRsMenuAction.TRASH)
+                }
+                is PostStatus.Trash -> {
+                    add(PostRsMenuAction.MOVE_TO_DRAFT)
+                    add(PostRsMenuAction.DELETE_PERMANENTLY)
+                }
+                else -> {}
+            }
+        }
     }
 
     private fun clearCollections() {
@@ -343,13 +500,20 @@ class PostRsListViewModel @Inject constructor(
         try {
             val showStatus =
                 _searchQuery.value.isNotBlank()
-            val uiModels = withContext(Dispatchers.IO) {
+            val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
                     item.state.toUiModel(
                         item.id,
                         showStatus = showStatus
                     )
                 }
+            }
+            val uiModels = items.map { model ->
+                model.copy(
+                    actions = getMenuActions(
+                        model.status, model.hasPassword
+                    )
+                )
             }
             updateTabUiState(tab) {
                 copy(
@@ -432,19 +596,4 @@ class PostRsListViewModel @Inject constructor(
             PostRsListTab.entries
                 .flatMap { it.statuses }.distinct()
     }
-}
-
-sealed interface PostRsListEvent {
-    data class EditPost(
-        val site: SiteModel,
-        val post: PostModel
-    ) : PostRsListEvent
-
-    data class CreatePost(
-        val site: SiteModel
-    ) : PostRsListEvent
-
-    data class ShowError(
-        val messageResId: Int
-    ) : PostRsListEvent
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -257,7 +257,8 @@ class PostRsListViewModel @Inject constructor(
 
     private fun getMenuActions(
         tab: PostRsListTab,
-        hasPassword: Boolean
+        hasPassword: Boolean,
+        commentsOpen: Boolean
     ): List<PostRsMenuAction> {
         val site = selectedSiteRepository.getSelectedSite()
         return buildList {
@@ -283,7 +284,9 @@ class PostRsListViewModel @Inject constructor(
                     ) {
                         add(PostRsMenuAction.STATS)
                     }
-                    add(PostRsMenuAction.COMMENTS)
+                    if (commentsOpen) {
+                        add(PostRsMenuAction.COMMENTS)
+                    }
                     add(PostRsMenuAction.TRASH)
                 }
                 PostRsListTab.DRAFTS -> {
@@ -526,7 +529,9 @@ class PostRsListViewModel @Inject constructor(
                 }
                 model.copy(
                     actions = getMenuActions(
-                        effectiveTab, model.hasPassword
+                        effectiveTab,
+                        model.hasPassword,
+                        model.commentsOpen
                     )
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -22,12 +22,12 @@ import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.postsrs.data.WpSelfHostedServiceProvider
 import org.wordpress.android.util.AppLog
-import uniffi.wp_api.PostStatus
 import org.wordpress.android.viewmodel.ResourceProvider
 import rs.wordpress.cache.kotlin.ObservableMetadataCollection
 import rs.wordpress.cache.kotlin.getObservablePostMetadataCollectionWithEditContext
 import rs.wordpress.cache.kotlin.hasMorePages
 import uniffi.wp_api.PostEndpointType
+import uniffi.wp_api.PostStatus
 import uniffi.wp_api.WpApiParamPostsOrderBy
 import uniffi.wp_mobile.PostListFilter
 import uniffi.wp_mobile_cache.ListState
@@ -258,6 +258,8 @@ class PostRsListViewModel @Inject constructor(
         )
     }
 
+    // TODO: replace linear scan with a map lookup if
+    //  post counts grow large
     private fun findPost(remotePostId: Long): PostRsUiModel? {
         return _tabStates.value.values
             .flatMap { it.posts }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -513,17 +513,15 @@ class PostRsListViewModel @Inject constructor(
 
         @Suppress("TooGenericExceptionCaught")
         try {
-            val showStatus =
-                _searchQuery.value.isNotBlank()
+            val isSearch = _searchQuery.value.isNotBlank()
             val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
                     item.state.toUiModel(
                         item.id,
-                        showStatus = showStatus
+                        showStatus = isSearch
                     )
                 }
             }
-            val isSearch = _searchQuery.value.isNotBlank()
             val uiModels = items.map { model ->
                 val effectiveTab = if (isSearch) {
                     tabForStatus(model.status)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -221,25 +221,17 @@ class PostRsListViewModel @Inject constructor(
                 _trashConfirmPostId.value = remotePostId
             PostRsMenuAction.DELETE_PERMANENTLY ->
                 _deleteConfirmPostId.value = remotePostId
-            PostRsMenuAction.MOVE_TO_DRAFT -> AppLog.d(
-                AppLog.T.POSTS,
-                "Move to draft: no-op (networking excluded)"
-            )
-            PostRsMenuAction.DUPLICATE -> AppLog.d(
-                AppLog.T.POSTS,
-                "Duplicate: no-op (networking excluded)"
-            )
+            PostRsMenuAction.MOVE_TO_DRAFT ->
+                sendNotImplemented()
+            PostRsMenuAction.DUPLICATE ->
+                sendNotImplemented()
         }
     }
 
     @MainThread
     fun onConfirmTrash() {
-        val postId = _trashConfirmPostId.value
         _trashConfirmPostId.value = null
-        AppLog.d(
-            AppLog.T.POSTS,
-            "Trash post $postId: no-op (networking excluded)"
-        )
+        sendNotImplemented()
     }
 
     @MainThread
@@ -249,17 +241,21 @@ class PostRsListViewModel @Inject constructor(
 
     @MainThread
     fun onConfirmDelete() {
-        val postId = _deleteConfirmPostId.value
         _deleteConfirmPostId.value = null
-        AppLog.d(
-            AppLog.T.POSTS,
-            "Delete post $postId: no-op (networking excluded)"
-        )
+        sendNotImplemented()
     }
 
     @MainThread
     fun onDismissDelete() {
         _deleteConfirmPostId.value = null
+    }
+
+    private fun sendNotImplemented() {
+        _events.trySend(
+            PostRsListEvent.ShowError(
+                R.string.post_rs_not_implemented_yet
+            )
+        )
     }
 
     private fun findPost(remotePostId: Long): PostRsUiModel? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -601,7 +601,7 @@ class PostRsListViewModel @Inject constructor(
         update: PostTabUiState.() -> PostTabUiState
     ) {
         val current = getTabUiState(tab)
-        _tabStates.value = _tabStates.value + (tab to current.update())
+        _tabStates.value += (tab to current.update())
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -221,6 +221,8 @@ class PostRsListViewModel @Inject constructor(
                 _trashConfirmPostId.value = remotePostId
             PostRsMenuAction.DELETE_PERMANENTLY ->
                 _deleteConfirmPostId.value = remotePostId
+            PostRsMenuAction.PUBLISH ->
+                sendNotImplemented()
             PostRsMenuAction.MOVE_TO_DRAFT ->
                 sendNotImplemented()
             PostRsMenuAction.DUPLICATE ->
@@ -289,7 +291,11 @@ class PostRsListViewModel @Inject constructor(
                     add(PostRsMenuAction.TRASH)
                 }
                 PostRsListTab.DRAFTS -> {
+                    add(PostRsMenuAction.VIEW)
+                    add(PostRsMenuAction.READ)
+                    add(PostRsMenuAction.PUBLISH)
                     add(PostRsMenuAction.DUPLICATE)
+                    add(PostRsMenuAction.SHARE)
                     add(PostRsMenuAction.TRASH)
                 }
                 PostRsListTab.SCHEDULED -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -258,8 +258,6 @@ class PostRsListViewModel @Inject constructor(
         )
     }
 
-    // TODO: replace linear scan with a map lookup if
-    //  post counts grow large
     private fun findPost(remotePostId: Long): PostRsUiModel? {
         return _tabStates.value.values
             .flatMap { it.posts }
@@ -267,14 +265,13 @@ class PostRsListViewModel @Inject constructor(
     }
 
     private fun getMenuActions(
-        status: PostStatus?,
+        tab: PostRsListTab,
         hasPassword: Boolean
     ): List<PostRsMenuAction> {
         val site = selectedSiteRepository.getSelectedSite()
         return buildList {
-            when (status) {
-                is PostStatus.Publish,
-                is PostStatus.Private -> {
+            when (tab) {
+                PostRsListTab.PUBLISHED -> {
                     add(PostRsMenuAction.VIEW)
                     add(PostRsMenuAction.READ)
                     add(PostRsMenuAction.MOVE_TO_DRAFT)
@@ -291,22 +288,36 @@ class PostRsListViewModel @Inject constructor(
                     add(PostRsMenuAction.COMMENTS)
                     add(PostRsMenuAction.TRASH)
                 }
-                is PostStatus.Draft,
-                is PostStatus.Pending -> {
+                PostRsListTab.DRAFTS -> {
                     add(PostRsMenuAction.DUPLICATE)
                     add(PostRsMenuAction.TRASH)
                 }
-                is PostStatus.Future -> {
-                    add(PostRsMenuAction.DUPLICATE)
+                PostRsListTab.SCHEDULED -> {
+                    add(PostRsMenuAction.VIEW)
+                    add(PostRsMenuAction.READ)
+                    add(PostRsMenuAction.SHARE)
                     add(PostRsMenuAction.TRASH)
                 }
-                is PostStatus.Trash -> {
+                PostRsListTab.TRASHED -> {
                     add(PostRsMenuAction.MOVE_TO_DRAFT)
                     add(PostRsMenuAction.DELETE_PERMANENTLY)
                 }
-                else -> {}
             }
         }
+    }
+
+    /**
+     * Maps a [PostStatus] to the corresponding [PostRsListTab].
+     * Used during search when posts from all statuses are
+     * shown together and menu actions must be per-post.
+     */
+    private fun tabForStatus(
+        status: PostStatus?
+    ): PostRsListTab {
+        if (status == null) return PostRsListTab.PUBLISHED
+        return PostRsListTab.entries.firstOrNull { tab ->
+            tab.statuses.any { it == status }
+        } ?: PostRsListTab.PUBLISHED
     }
 
     private fun clearCollections() {
@@ -506,10 +517,16 @@ class PostRsListViewModel @Inject constructor(
                     )
                 }
             }
+            val isSearch = _searchQuery.value.isNotBlank()
             val uiModels = items.map { model ->
+                val effectiveTab = if (isSearch) {
+                    tabForStatus(model.status)
+                } else {
+                    tab
+                }
                 model.copy(
                     actions = getMenuActions(
-                        model.status, model.hasPassword
+                        effectiveTab, model.hasPassword
                     )
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -62,13 +62,10 @@ class PostRsListViewModel @Inject constructor(
     private val _events = Channel<PostRsListEvent>(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
-    private val _trashConfirmPostId = MutableStateFlow<Long?>(null)
-    val trashConfirmPostId: StateFlow<Long?> =
-        _trashConfirmPostId.asStateFlow()
-
-    private val _deleteConfirmPostId = MutableStateFlow<Long?>(null)
-    val deleteConfirmPostId: StateFlow<Long?> =
-        _deleteConfirmPostId.asStateFlow()
+    private val _pendingConfirmation =
+        MutableStateFlow<PendingConfirmation?>(null)
+    val pendingConfirmation: StateFlow<PendingConfirmation?> =
+        _pendingConfirmation.asStateFlow()
 
     init {
         @OptIn(FlowPreview::class)
@@ -218,9 +215,11 @@ class PostRsListViewModel @Inject constructor(
                 )
             )
             PostRsMenuAction.TRASH ->
-                _trashConfirmPostId.value = remotePostId
+                _pendingConfirmation.value =
+                    PendingConfirmation.Trash(remotePostId)
             PostRsMenuAction.DELETE_PERMANENTLY ->
-                _deleteConfirmPostId.value = remotePostId
+                _pendingConfirmation.value =
+                    PendingConfirmation.Delete(remotePostId)
             PostRsMenuAction.PUBLISH ->
                 sendNotImplemented()
             PostRsMenuAction.MOVE_TO_DRAFT ->
@@ -231,25 +230,14 @@ class PostRsListViewModel @Inject constructor(
     }
 
     @MainThread
-    fun onConfirmTrash() {
-        _trashConfirmPostId.value = null
+    fun onConfirmPendingAction() {
+        _pendingConfirmation.value = null
         sendNotImplemented()
     }
 
     @MainThread
-    fun onDismissTrash() {
-        _trashConfirmPostId.value = null
-    }
-
-    @MainThread
-    fun onConfirmDelete() {
-        _deleteConfirmPostId.value = null
-        sendNotImplemented()
-    }
-
-    @MainThread
-    fun onDismissDelete() {
-        _deleteConfirmPostId.value = null
+    fun onDismissPendingAction() {
+        _pendingConfirmation.value = null
     }
 
     private fun sendNotImplemented() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.postsrs.data.WpSelfHostedServiceProvider
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import rs.wordpress.cache.kotlin.ObservableMetadataCollection
 import rs.wordpress.cache.kotlin.getObservablePostMetadataCollectionWithEditContext
@@ -274,7 +275,14 @@ class PostRsListViewModel @Inject constructor(
                     ) {
                         add(PostRsMenuAction.BLAZE)
                     }
-                    add(PostRsMenuAction.STATS)
+                    if (site != null &&
+                        SiteUtils.isAccessedViaWPComRest(
+                            site
+                        ) &&
+                        site.hasCapabilityViewStats
+                    ) {
+                        add(PostRsMenuAction.STATS)
+                    }
                     add(PostRsMenuAction.COMMENTS)
                     add(PostRsMenuAction.TRASH)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -8,35 +8,52 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.postsrs.PostRsMenuAction
 import org.wordpress.android.ui.postsrs.PostRsUiModel
 
 @Composable
 fun PostRsListItem(
     post: PostRsUiModel,
     onClick: () -> Unit,
+    onMenuAction: (PostRsMenuAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when {
         post.isPlaceholder -> PlaceholderItem(modifier)
         post.isError -> ErrorItem(modifier)
-        else -> PostContentItem(post, onClick, modifier)
+        else -> PostContentItem(
+            post, onClick, onMenuAction, modifier
+        )
     }
 }
 
@@ -44,6 +61,7 @@ fun PostRsListItem(
 private fun PostContentItem(
     post: PostRsUiModel,
     onClick: () -> Unit,
+    onMenuAction: (PostRsMenuAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -54,52 +72,136 @@ private fun PostContentItem(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 1.dp
+        )
     ) {
-        Column(
-            modifier = Modifier.padding(16.dp)
+        Row(
+            modifier = Modifier.padding(
+                start = 16.dp,
+                top = 16.dp,
+                bottom = 16.dp
+            ),
+            verticalAlignment = Alignment.Top
         ) {
-            val statusLabel = if (post.statusLabelResId != 0) {
-                stringResource(post.statusLabelResId)
-            } else {
-                null
-            }
-            val bullet = stringResource(
-                R.string.bullet_with_spaces
-            )
-            val dateText = buildString {
-                if (!statusLabel.isNullOrBlank()) {
-                    append(statusLabel)
-                    if (post.date.isNotBlank()) {
-                        append(bullet)
+            Column(modifier = Modifier.weight(1f)) {
+                val statusLabel =
+                    if (post.statusLabelResId != 0) {
+                        stringResource(post.statusLabelResId)
+                    } else {
+                        null
                     }
-                }
-                append(post.date)
-            }
-            if (dateText.isNotBlank()) {
-                Text(
-                    text = dateText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary
+                val bullet = stringResource(
+                    R.string.bullet_with_spaces
                 )
-                Spacer(modifier = Modifier.height(4.dp))
-            }
-            Text(
-                text = post.title.ifBlank {
-                    stringResource(R.string.untitled_in_parentheses)
-                },
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            if (post.excerpt.isNotBlank()) {
-                Spacer(modifier = Modifier.height(4.dp))
+                val dateText = buildString {
+                    if (!statusLabel.isNullOrBlank()) {
+                        append(statusLabel)
+                        if (post.date.isNotBlank()) {
+                            append(bullet)
+                        }
+                    }
+                    append(post.date)
+                }
+                if (dateText.isNotBlank()) {
+                    Text(
+                        text = dateText,
+                        style = MaterialTheme.typography
+                            .labelSmall,
+                        color = MaterialTheme.colorScheme
+                            .primary
+                    )
+                    Spacer(
+                        modifier = Modifier.height(4.dp)
+                    )
+                }
                 Text(
-                    text = post.excerpt,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = post.title.ifBlank {
+                        stringResource(
+                            R.string.untitled_in_parentheses
+                        )
+                    },
+                    style = MaterialTheme.typography
+                        .titleMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
+                )
+                if (post.excerpt.isNotBlank()) {
+                    Spacer(
+                        modifier = Modifier.height(4.dp)
+                    )
+                    Text(
+                        text = post.excerpt,
+                        style = MaterialTheme.typography
+                            .bodyMedium,
+                        color = MaterialTheme.colorScheme
+                            .onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            if (post.actions.isNotEmpty()) {
+                PostMenuButton(
+                    actions = post.actions,
+                    onAction = onMenuAction
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PostMenuButton(
+    actions: List<PostRsMenuAction>,
+    onAction: (PostRsMenuAction) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                Icons.Default.MoreVert,
+                contentDescription = stringResource(
+                    R.string.more
+                ),
+                tint = MaterialTheme.colorScheme
+                    .onSurfaceVariant
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            actions.forEach { action ->
+                val color = if (action.isDestructive) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(
+                                action.labelResId
+                            ),
+                            color = color
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onAction(action)
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(
+                                action.iconResId
+                            ),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = color
+                        )
+                    }
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.postsrs.ConfirmationDialogState
+import org.wordpress.android.ui.postsrs.PendingConfirmation
 import org.wordpress.android.ui.postsrs.PostRsListTab
 import org.wordpress.android.ui.postsrs.PostRsListViewModel.Companion.MIN_SEARCH_QUERY_LENGTH
 import org.wordpress.android.ui.postsrs.PostRsMenuAction
@@ -267,18 +268,15 @@ fun PostRsListScreen(
         }
     }
 
-    if (confirmationDialog.showTrash) {
-        ConfirmationDialog(
+    when (confirmationDialog.pending) {
+        is PendingConfirmation.Trash -> ConfirmationDialog(
             titleResId = R.string.trash,
             messageResId =
                 R.string.post_rs_confirm_trash_message,
             onConfirm = confirmationDialog.onConfirm,
             onDismiss = confirmationDialog.onDismiss
         )
-    }
-
-    if (confirmationDialog.showDelete) {
-        ConfirmationDialog(
+        is PendingConfirmation.Delete -> ConfirmationDialog(
             titleResId = R.string.delete,
             messageResId =
                 R.string.post_rs_confirm_delete_message,
@@ -286,6 +284,7 @@ fun PostRsListScreen(
             onConfirm = confirmationDialog.onConfirm,
             onDismiss = confirmationDialog.onDismiss
         )
+        null -> {}
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -22,6 +23,7 @@ import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
@@ -42,14 +44,18 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.postsrs.PostRsListTab
 import org.wordpress.android.ui.postsrs.PostRsListViewModel.Companion.MIN_SEARCH_QUERY_LENGTH
+import org.wordpress.android.ui.postsrs.PostRsMenuAction
 import org.wordpress.android.ui.postsrs.PostTabUiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList")
 fun PostRsListScreen(
     tabStates: Map<PostRsListTab, PostTabUiState>,
     isSearchActive: Boolean,
     searchQuery: String,
+    showTrashConfirmation: Boolean,
+    showDeleteConfirmation: Boolean,
     onSearchOpen: () -> Unit,
     onSearchQueryChanged: (String, PostRsListTab) -> Unit,
     onSearchClose: (PostRsListTab) -> Unit,
@@ -58,7 +64,12 @@ fun PostRsListScreen(
     onLoadMore: (PostRsListTab) -> Unit,
     onNavigateBack: () -> Unit,
     onPostClick: (Long) -> Unit,
-    onCreatePost: () -> Unit
+    onPostMenuAction: (Long, PostRsMenuAction) -> Unit,
+    onCreatePost: () -> Unit,
+    onConfirmTrash: () -> Unit,
+    onDismissTrash: () -> Unit,
+    onConfirmDelete: () -> Unit,
+    onDismissDelete: () -> Unit
 ) {
     val tabs = PostRsListTab.entries
     val pagerState = rememberPagerState(pageCount = { tabs.size })
@@ -253,9 +264,74 @@ fun PostRsListScreen(
                     onRefresh = { onRefreshTab(tab) },
                     onLoadMore = { onLoadMore(tab) },
                     onPostClick = onPostClick,
+                    onPostMenuAction = onPostMenuAction,
                     onCreatePost = onCreatePost
                 )
             }
         }
+    }
+
+    if (showTrashConfirmation) {
+        AlertDialog(
+            onDismissRequest = onDismissTrash,
+            title = {
+                Text(stringResource(R.string.trash))
+            },
+            text = {
+                Text(
+                    stringResource(
+                        R.string
+                            .post_rs_confirm_trash_message
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onConfirmTrash) {
+                    Text(
+                        stringResource(R.string.trash)
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissTrash) {
+                    Text(
+                        stringResource(R.string.cancel)
+                    )
+                }
+            }
+        )
+    }
+
+    if (showDeleteConfirmation) {
+        AlertDialog(
+            onDismissRequest = onDismissDelete,
+            title = {
+                Text(stringResource(R.string.delete))
+            },
+            text = {
+                Text(
+                    stringResource(
+                        R.string
+                            .post_rs_confirm_delete_message
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onConfirmDelete) {
+                    Text(
+                        stringResource(R.string.delete),
+                        color = MaterialTheme
+                            .colorScheme.error
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissDelete) {
+                    Text(
+                        stringResource(R.string.cancel)
+                    )
+                }
+            }
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.ui.postsrs.ConfirmationDialogState
 import org.wordpress.android.ui.postsrs.PostRsListTab
 import org.wordpress.android.ui.postsrs.PostRsListViewModel.Companion.MIN_SEARCH_QUERY_LENGTH
 import org.wordpress.android.ui.postsrs.PostRsMenuAction
@@ -49,13 +50,11 @@ import org.wordpress.android.ui.postsrs.PostTabUiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("LongParameterList")
 fun PostRsListScreen(
     tabStates: Map<PostRsListTab, PostTabUiState>,
     isSearchActive: Boolean,
     searchQuery: String,
-    showTrashConfirmation: Boolean,
-    showDeleteConfirmation: Boolean,
+    confirmationDialog: ConfirmationDialogState,
     onSearchOpen: () -> Unit,
     onSearchQueryChanged: (String, PostRsListTab) -> Unit,
     onSearchClose: (PostRsListTab) -> Unit,
@@ -65,11 +64,7 @@ fun PostRsListScreen(
     onNavigateBack: () -> Unit,
     onPostClick: (Long) -> Unit,
     onPostMenuAction: (Long, PostRsMenuAction) -> Unit,
-    onCreatePost: () -> Unit,
-    onConfirmTrash: () -> Unit,
-    onDismissTrash: () -> Unit,
-    onConfirmDelete: () -> Unit,
-    onDismissDelete: () -> Unit
+    onCreatePost: () -> Unit
 ) {
     val tabs = PostRsListTab.entries
     val pagerState = rememberPagerState(pageCount = { tabs.size })
@@ -271,67 +266,81 @@ fun PostRsListScreen(
         }
     }
 
-    if (showTrashConfirmation) {
-        AlertDialog(
-            onDismissRequest = onDismissTrash,
-            title = {
-                Text(stringResource(R.string.trash))
-            },
-            text = {
-                Text(
-                    stringResource(
-                        R.string
-                            .post_rs_confirm_trash_message
-                    )
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = onConfirmTrash) {
-                    Text(
-                        stringResource(R.string.trash)
-                    )
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDismissTrash) {
-                    Text(
-                        stringResource(R.string.cancel)
-                    )
-                }
-            }
+    if (confirmationDialog.showTrash) {
+        TrashConfirmationDialog(
+            onConfirm = confirmationDialog.onConfirmTrash,
+            onDismiss = confirmationDialog.onDismissTrash
         )
     }
 
-    if (showDeleteConfirmation) {
-        AlertDialog(
-            onDismissRequest = onDismissDelete,
-            title = {
-                Text(stringResource(R.string.delete))
-            },
-            text = {
-                Text(
-                    stringResource(
-                        R.string
-                            .post_rs_confirm_delete_message
-                    )
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = onConfirmDelete) {
-                    Text(
-                        stringResource(R.string.delete),
-                        color = MaterialTheme
-                            .colorScheme.error
-                    )
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDismissDelete) {
-                    Text(
-                        stringResource(R.string.cancel)
-                    )
-                }
-            }
+    if (confirmationDialog.showDelete) {
+        DeleteConfirmationDialog(
+            onConfirm = confirmationDialog.onConfirmDelete,
+            onDismiss = confirmationDialog.onDismissDelete
         )
     }
+}
+
+@Composable
+private fun TrashConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.trash))
+        },
+        text = {
+            Text(
+                stringResource(
+                    R.string.post_rs_confirm_trash_message
+                )
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.trash))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun DeleteConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.delete))
+        },
+        text = {
+            Text(
+                stringResource(
+                    R.string
+                        .post_rs_confirm_delete_message
+                )
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    stringResource(R.string.delete),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.postsrs.screens
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -267,73 +268,48 @@ fun PostRsListScreen(
     }
 
     if (confirmationDialog.showTrash) {
-        TrashConfirmationDialog(
-            onConfirm = confirmationDialog.onConfirmTrash,
-            onDismiss = confirmationDialog.onDismissTrash
+        ConfirmationDialog(
+            titleResId = R.string.trash,
+            messageResId =
+                R.string.post_rs_confirm_trash_message,
+            onConfirm = confirmationDialog.onConfirm,
+            onDismiss = confirmationDialog.onDismiss
         )
     }
 
     if (confirmationDialog.showDelete) {
-        DeleteConfirmationDialog(
-            onConfirm = confirmationDialog.onConfirmDelete,
-            onDismiss = confirmationDialog.onDismissDelete
+        ConfirmationDialog(
+            titleResId = R.string.delete,
+            messageResId =
+                R.string.post_rs_confirm_delete_message,
+            isDestructive = true,
+            onConfirm = confirmationDialog.onConfirm,
+            onDismiss = confirmationDialog.onDismiss
         )
     }
 }
 
 @Composable
-private fun TrashConfirmationDialog(
+private fun ConfirmationDialog(
+    @StringRes titleResId: Int,
+    @StringRes messageResId: Int,
+    isDestructive: Boolean = false,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = {
-            Text(stringResource(R.string.trash))
-        },
-        text = {
-            Text(
-                stringResource(
-                    R.string.post_rs_confirm_trash_message
-                )
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.trash))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
-            }
-        }
-    )
-}
-
-@Composable
-private fun DeleteConfirmationDialog(
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(stringResource(R.string.delete))
-        },
-        text = {
-            Text(
-                stringResource(
-                    R.string
-                        .post_rs_confirm_delete_message
-                )
-            )
-        },
+        title = { Text(stringResource(titleResId)) },
+        text = { Text(stringResource(messageResId)) },
         confirmButton = {
             TextButton(onClick = onConfirm) {
                 Text(
-                    stringResource(R.string.delete),
-                    color = MaterialTheme.colorScheme.error
+                    stringResource(titleResId),
+                    color = if (isDestructive) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        Color.Unspecified
+                    }
                 )
             }
         },

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsTabListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsTabListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.postsrs.PostRsMenuAction
 import org.wordpress.android.ui.postsrs.PostRsUiModel
 import org.wordpress.android.ui.postsrs.PostTabUiState
 
@@ -41,6 +42,7 @@ fun PostRsTabListScreen(
     onRefresh: () -> Unit,
     onLoadMore: () -> Unit,
     onPostClick: (Long) -> Unit,
+    onPostMenuAction: (Long, PostRsMenuAction) -> Unit,
     onCreatePost: () -> Unit,
     modifier: Modifier = Modifier,
     isSearchIdle: Boolean = false,
@@ -88,7 +90,8 @@ fun PostRsTabListScreen(
                 isLoadingMore = state.isLoadingMore,
                 canLoadMore = state.canLoadMore,
                 onLoadMore = onLoadMore,
-                onPostClick = onPostClick
+                onPostClick = onPostClick,
+                onPostMenuAction = onPostMenuAction
             )
         }
     }
@@ -100,7 +103,8 @@ private fun PostListContent(
     isLoadingMore: Boolean,
     canLoadMore: Boolean,
     onLoadMore: () -> Unit,
-    onPostClick: (Long) -> Unit
+    onPostClick: (Long) -> Unit,
+    onPostMenuAction: (Long, PostRsMenuAction) -> Unit
 ) {
     val listState = rememberLazyListState()
 
@@ -126,7 +130,14 @@ private fun PostListContent(
         ) { post ->
             PostRsListItem(
                 post = post,
-                onClick = { onPostClick(post.remotePostId) }
+                onClick = {
+                    onPostClick(post.remotePostId)
+                },
+                onMenuAction = { action ->
+                    onPostMenuAction(
+                        post.remotePostId, action
+                    )
+                }
             )
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1001,6 +1001,8 @@
     <string name="experimental_rs_post_list">New Post List</string>
     <string name="experimental_rs_post_list_description">Use wordpress-rs for the post list on self-hosted sites with application passwords</string>
     <string name="post_rs_failed_to_load">Failed to load post</string>
+    <string name="post_rs_confirm_trash_message">Are you sure you want to trash this post?</string>
+    <string name="post_rs_confirm_delete_message">This will permanently delete this post. This action cannot be undone.</string>
     <string name="post_types_screen_title">Post Types</string>
 
     <!-- Debug settings -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1001,6 +1001,7 @@
     <string name="experimental_rs_post_list">New Post List</string>
     <string name="experimental_rs_post_list_description">Use wordpress-rs for the post list on self-hosted sites with application passwords</string>
     <string name="post_rs_failed_to_load">Failed to load post</string>
+    <string name="post_rs_not_implemented_yet">Not implemented yet</string>
     <string name="post_rs_confirm_trash_message">Are you sure you want to trash this post?</string>
     <string name="post_rs_confirm_delete_message">This will permanently delete this post. This action cannot be undone.</string>
     <string name="post_types_screen_title">Post Types</string>


### PR DESCRIPTION
## Description

Add a three-dot overflow menu to each post card in the RS post list. Menu actions are
status-aware: Published/Private posts show View, Read, Move to Draft, Duplicate, Share,
Blaze, Stats, Comments, and Trash; Draft/Pending/Scheduled posts show Duplicate and Trash;
Trashed posts show Move to Draft and Delete Permanently.

Navigation actions (View, Read, Share, Stats, Comments) are fully wired to launch
the appropriate activities. Mutation actions (Move to Draft, Duplicate, Trash, Delete
Permanently) show a "Not implemented yet" toast and **will be connected to wordpress-rs
networking in a follow-up PR**.

## Testing instructions

Context menu on published posts:

1. Enable the "New Post List" experimental feature
2. Open the post list on a self-hosted site with application passwords
3. Navigate to the Published tab
4. Tap the three-dot menu on a published post
- [x] Verify the menu shows: View, Read, Move to Draft, Duplicate, Share, Comments, Trash
5. Tap "View"
- [x] Verify the post opens in an external browser
6. Tap "Read"
- [x] Verify the post opens in the Reader
7. Tap "Share"
- [x] Verify the share sheet appears with the post URL
8. Tap "Stats"
- [ ] Verify the stats detail screen opens
9. Tap "Comments"
- [x] Verify the Reader opens scrolled to comments
10. Tap "Move to Draft"
- [x] Verify a "Not implemented yet" toast appears
11. Tap "Duplicate"
- [x] Verify a "Not implemented yet" toast appears

Context menu on trashed posts:

1. Navigate to the Trashed tab
2. Tap the three-dot menu on a trashed post
- [x] Verify the menu shows: Move to Draft, Delete Permanently
3. Tap "Move to Draft"
- [x] Verify a "Not implemented yet" toast appears
4. Tap "Delete Permanently"
- [x] Verify a confirmation dialog appears
5. Tap "Delete" in the dialog
- [x] Verify a "Not implemented yet" toast appears
6. Tap "Delete Permanently" again, then tap "Cancel"
- [x] Verify the dialog dismisses with no action

Trash confirmation:

1. Navigate to the Published tab
2. Tap the three-dot menu on a post, then tap "Trash"
- [x] Verify a confirmation dialog appears
3. Tap "Trash" in the dialog
- [x] Verify a "Not implemented yet" toast appears
4. Repeat and tap "Cancel"
- [x] Verify the dialog dismisses with no action

Destructive action styling:

1. Open any post's three-dot menu that includes Trash or Delete Permanently
- [x] Verify destructive actions (Trash, Delete Permanently) are styled in red/error color


<img width="297" height="629" alt="Screenshot_20260217_141724" src="https://github.com/user-attachments/assets/1524787d-97c3-4ea6-8268-0b033eb89a5e" />

