### PR TITLE
CMM-1256: Fix 401 errors for self-hosted sites with application passwords

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -19,9 +19,11 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         clazz: Class<T>,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        nonce: String? = null
+        nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
-        callMethod(Method.GET, url, params, body, clazz, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+        callMethod(Method.GET, url, params, body, clazz, cont, enableCaching, cacheTimeToLive, nonce, restClient,
+            headers)
     }
     suspend fun <T> syncGetRequest(
         restClient: BaseWPAPIRestClient,
@@ -31,9 +33,11 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         type: Type,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        nonce: String? = null
+        nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
-        callMethod(Method.GET, url, params, body, type, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+        callMethod(Method.GET, url, params, body, type, cont, enableCaching, cacheTimeToLive, nonce, restClient,
+            headers)
     }
 
     suspend fun <T> syncPostRequest(
@@ -41,9 +45,10 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         url: String,
         body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
-        nonce: String? = null
+        nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
-        callMethod(Method.POST, url, null, body, clazz, cont, false, 0, nonce, restClient)
+        callMethod(Method.POST, url, null, body, clazz, cont, false, 0, nonce, restClient, headers)
     }
 
     suspend fun <T> syncPutRequest(
@@ -77,7 +82,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         enableCaching: Boolean,
         cacheTimeToLive: Int,
         nonce: String?,
-        restClient: BaseWPAPIRestClient
+        restClient: BaseWPAPIRestClient,
+        headers: Map<String, String> = emptyMap()
     ) {
         val request = WPAPIGsonRequest(method, url, params, body, clazz, { response ->
             cont.resume(Success(response))
@@ -97,6 +103,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
             request.addHeader("x-wp-nonce", nonce)
         }
 
+        headers.forEach { (key, value) -> request.addHeader(key, value) }
+
         restClient.add(request)
     }
 
@@ -111,7 +119,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         enableCaching: Boolean,
         cacheTimeToLive: Int,
         nonce: String?,
-        restClient: BaseWPAPIRestClient
+        restClient: BaseWPAPIRestClient,
+        headers: Map<String, String> = emptyMap()
     ) {
         val request = WPAPIGsonRequest<T>(method, url, params, body, type, { response ->
             cont.resume(Success(response))
@@ -130,6 +139,8 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         if (nonce != null) {
             request.addHeader("x-wp-nonce", nonce)
         }
+
+        headers.forEach { (key, value) -> request.addHeader(key, value) }
 
         restClient.add(request)
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -28,7 +28,8 @@ class ReactNativeWPAPIRestClient @Inject constructor(
         successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         nonce: String? = null,
-        enableCaching: Boolean = true
+        enableCaching: Boolean = true,
+        headers: Map<String, String> = emptyMap()
     ): ReactNativeFetchResponse {
         val response =
                 wpApiGsonRequestBuilder.syncGetRequest(
@@ -38,7 +39,8 @@ class ReactNativeWPAPIRestClient @Inject constructor(
                         emptyMap(),
                         JsonElement::class.java,
                         enableCaching,
-                        nonce = nonce)
+                        nonce = nonce,
+                        headers = headers)
         return when (response) {
             is Success -> successHandler(response.data)
             is Error -> errorHandler(response.error)
@@ -51,6 +53,7 @@ class ReactNativeWPAPIRestClient @Inject constructor(
         successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
     ): ReactNativeFetchResponse {
         val response =
             wpApiGsonRequestBuilder.syncPostRequest(
@@ -58,7 +61,8 @@ class ReactNativeWPAPIRestClient @Inject constructor(
                 url,
                 body,
                 JsonElement::class.java,
-                nonce = nonce)
+                nonce = nonce,
+                headers = headers)
         return when (response) {
             is Success -> successHandler(response.data)
             is Error -> errorHandler(response.error)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -160,7 +160,7 @@ class ReactNativeStore @VisibleForTesting constructor(
         return Error(error)
     }
 
-    @Suppress("ComplexMethod", "NestedBlockDepth", "LongParameterList")
+    @Suppress("ComplexMethod", "NestedBlockDepth", "LongParameterList", "LongMethod", "ReturnCount")
     private suspend fun executeWPAPIRequest(
         site: SiteModel,
         path: String,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -182,7 +182,9 @@ class ReactNativeStore @VisibleForTesting constructor(
         }
         val fullRestUrl = slashJoin(wpApiRestUrl, path)
 
-        // Use Basic auth for sites with application passwords instead of nonce auth
+        // Use Basic auth for sites with application passwords instead of nonce auth.
+        // Application passwords authenticate via REST API Basic auth and cannot
+        // authenticate via wp-login.php (which is required for nonce-based auth).
         if (site.hasApplicationPassword()) {
             return executeWithApplicationPassword(
                 site, path, method, params, body, enableCaching,
@@ -261,9 +263,15 @@ class ReactNativeStore @VisibleForTesting constructor(
         fullRestUrl: String,
         usingSavedRestUrl: Boolean
     ): ReactNativeFetchResponse {
-        val authHeaderValue = Credentials.basic(
-            site.apiRestUsernamePlain, site.apiRestPasswordPlain
-        )
+        val username = site.apiRestUsernamePlain
+        val password = site.apiRestPasswordPlain
+        if (username == null || password == null) {
+            val error = BaseNetworkError(GenericErrorType.UNKNOWN).apply {
+                message = "Application password credentials missing"
+            }
+            return Error(error)
+        }
+        val authHeaderValue = Credentials.basic(username, password)
         val headers = mapOf(AUTHORIZATION_HEADER to authHeaderValue)
 
         val response = when (method) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
+import okhttp3.Credentials
 import org.wordpress.android.fluxc.network.rest.wpapi.NonceRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.reactnative.ReactNativeWPComRestClient
@@ -174,12 +175,20 @@ class ReactNativeStore @VisibleForTesting constructor(
 
         val usingSavedRestUrl = wpApiRestUrl != null
         if (!usingSavedRestUrl) {
-            wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
-                    ?: slashJoin(site.url, "wp-json/") // fallback to ".../wp-json/" default if discovery fails
+            wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url)
+                    ?: slashJoin(site.url, "wp-json/")
             site.wpApiRestUrl = wpApiRestUrl
             persistSiteSafely(site)
         }
         val fullRestUrl = slashJoin(wpApiRestUrl, path)
+
+        // Use Basic auth for sites with application passwords instead of nonce auth
+        if (site.hasApplicationPassword()) {
+            return executeWithApplicationPassword(
+                site, path, method, params, body, enableCaching,
+                fullRestUrl, usingSavedRestUrl
+            )
+        }
 
         var nonce = nonceRestClient.getNonce(site)
         val usingSavedNonce = nonce is Available
@@ -200,16 +209,16 @@ class ReactNativeStore @VisibleForTesting constructor(
             is Error -> when (response.statusCode()) {
                 HttpURLConnection.HTTP_UNAUTHORIZED -> {
                     if (usingSavedNonce) {
-                        // Call with saved nonce failed, so try getting a new one
                         val previousNonce = nonce?.value
                         val newNonce = nonceRestClient.requestNonce(site)?.value
 
-                        // Try original call again if we have a new nonce
                         val nonceIsUpdated = newNonce != null && newNonce != previousNonce
                         if (nonceIsUpdated) {
                             return when (method) {
-                                RequestMethod.GET -> executeGet(fullRestUrl, params, newNonce, enableCaching)
-                                RequestMethod.POST -> executePost(fullRestUrl, body, newNonce)
+                                RequestMethod.GET ->
+                                    executeGet(fullRestUrl, params, newNonce, enableCaching)
+                                RequestMethod.POST ->
+                                    executePost(fullRestUrl, body, newNonce)
                             }
                         }
                     }
@@ -217,24 +226,60 @@ class ReactNativeStore @VisibleForTesting constructor(
                 }
 
                 HttpURLConnection.HTTP_NOT_FOUND -> {
-                    // call failed with 'not found' so clear the (failing) rest url
                     site.wpApiRestUrl = null
                     persistSiteSafely(site)
 
                     if (usingSavedRestUrl) {
-                        // If we did the previous call with a saved rest url, try again by making
-                        // recursive call. This time there is no saved rest url to use
-                        // so the rest url will be retrieved using discovery
                         executeWPAPIRequest(site, path, method, params, body, enableCaching)
                     } else {
-                        // Already used discovery to fetch the rest base url and still got 'not found', so
-                        // just return the error response
                         response
                     }
-
-                    // For all other failures just return the error response
                 }
 
+                else -> response
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private suspend fun executeWithApplicationPassword(
+        site: SiteModel,
+        path: String,
+        method: RequestMethod,
+        params: Map<String, String>,
+        body: Map<String, Any>,
+        enableCaching: Boolean,
+        fullRestUrl: String,
+        usingSavedRestUrl: Boolean
+    ): ReactNativeFetchResponse {
+        val authHeaderValue = Credentials.basic(
+            site.apiRestUsernamePlain, site.apiRestPasswordPlain
+        )
+        val headers = mapOf(AUTHORIZATION_HEADER to authHeaderValue)
+
+        val response = when (method) {
+            RequestMethod.GET -> executeGet(
+                fullRestUrl, params, nonce = null, enableCaching, headers
+            )
+            RequestMethod.POST -> executePost(
+                fullRestUrl, body, nonce = null, headers
+            )
+        }
+        return when (response) {
+            is Success -> response
+            is Error -> when (response.statusCode()) {
+                HttpURLConnection.HTTP_NOT_FOUND -> {
+                    site.wpApiRestUrl = null
+                    persistSiteSafely(site)
+
+                    if (usingSavedRestUrl) {
+                        executeWPAPIRequest(
+                            site, path, method, params, body, enableCaching
+                        )
+                    } else {
+                        response
+                    }
+                }
                 else -> response
             }
         }
@@ -244,16 +289,24 @@ class ReactNativeStore @VisibleForTesting constructor(
         fullRestApiUrl: String,
         params: Map<String, String>,
         nonce: String?,
-        enableCaching: Boolean
+        enableCaching: Boolean,
+        headers: Map<String, String> = emptyMap()
     ): ReactNativeFetchResponse =
-            wpAPIRestClient.getRequest(fullRestApiUrl, params, ::Success, ::Error, nonce, enableCaching)
+            wpAPIRestClient.getRequest(
+                fullRestApiUrl, params, ::Success, ::Error,
+                nonce, enableCaching, headers
+            )
 
     private suspend fun executePost(
         fullRestApiUrl: String,
         body: Map<String, Any>,
-        nonce: String?
+        nonce: String?,
+        headers: Map<String, String> = emptyMap()
     ): ReactNativeFetchResponse =
-        wpAPIRestClient.postRequest(fullRestApiUrl, body, ::Success, ::Error, nonce)
+        wpAPIRestClient.postRequest(
+            fullRestApiUrl, body, ::Success, ::Error,
+            nonce, headers
+        )
 
     private fun parseUrlAndParamsForWPCom(
         pathWithParams: String,
@@ -294,6 +347,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     private fun getNonce(site: SiteModel) = nonceRestClient.getNonce(site)
 
     companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
         private const val FIVE_MIN_MILLIS: Long = 5 * 60 * 1000
 
         /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -175,8 +175,8 @@ class ReactNativeStore @VisibleForTesting constructor(
 
         val usingSavedRestUrl = wpApiRestUrl != null
         if (!usingSavedRestUrl) {
-            wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url)
-                    ?: slashJoin(site.url, "wp-json/")
+            wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
+                    ?: slashJoin(site.url, "wp-json/") // fallback to ".../wp-json/" default if discovery fails
             site.wpApiRestUrl = wpApiRestUrl
             persistSiteSafely(site)
         }
@@ -209,9 +209,11 @@ class ReactNativeStore @VisibleForTesting constructor(
             is Error -> when (response.statusCode()) {
                 HttpURLConnection.HTTP_UNAUTHORIZED -> {
                     if (usingSavedNonce) {
+                        // Call with saved nonce failed, so try getting a new one
                         val previousNonce = nonce?.value
                         val newNonce = nonceRestClient.requestNonce(site)?.value
 
+                        // Try original call again if we have a new nonce
                         val nonceIsUpdated = newNonce != null && newNonce != previousNonce
                         if (nonceIsUpdated) {
                             return when (method) {
@@ -226,16 +228,23 @@ class ReactNativeStore @VisibleForTesting constructor(
                 }
 
                 HttpURLConnection.HTTP_NOT_FOUND -> {
+                    // call failed with 'not found' so clear the (failing) rest url
                     site.wpApiRestUrl = null
                     persistSiteSafely(site)
 
                     if (usingSavedRestUrl) {
+                        // If we did the previous call with a saved rest url, try again by making
+                        // recursive call. This time there is no saved rest url to use
+                        // so the rest url will be retrieved using discovery
                         executeWPAPIRequest(site, path, method, params, body, enableCaching)
                     } else {
+                        // Already used discovery to fetch the rest base url and still got
+                        // 'not found', so just return the error response
                         response
                     }
                 }
 
+                // For all other failures just return the error response
                 else -> response
             }
         }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
@@ -186,6 +186,7 @@ class PluginWPApiRestClientTest {
                 eq(type),
                 eq(cachingEnabled),
                 any(),
+                any(),
                 any()
             )
         ).thenReturn(response)
@@ -203,6 +204,7 @@ class PluginWPApiRestClientTest {
                 urlCaptor.capture(),
                 bodyCaptor.capture(),
                 eq(PluginResponseModel::class.java),
+                any(),
                 any()
             )
         ).thenReturn(response)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.network.rest.wpapi.NonceRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
@@ -435,6 +436,29 @@ class ReactNativeStoreWPAPITest {
         val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(successResponse, actualResponse)
         inOrder(nonceRestClient, wpApiRestClient) {
+            verify(nonceRestClient).requestNonce(site)
+            verify(wpApiRestClient).getRequest(fetchUrl, nonce.value)
+        }
+    }
+
+    @Test
+    fun `nonce unknown, so requests nonce`() = test {
+        // previous nonce request unknown
+        initStore(Unknown(site.username))
+
+        // refreshes nonce because latest attempt to refresh nonce was not recent
+        val nonce = Available("a_nonce", site.username)
+        whenever(nonceRestClient.requestNonce(site))
+                .thenReturn(nonce)
+
+        val fetchUrl = "${site.wpApiRestUrl}/$restPath"
+        val successResponse = mock<Success>()
+        whenever(wpApiRestClient.getRequest(fetchUrl, nonce.value)) // passes null for nonce
+                .thenReturn(successResponse)
+
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
+        assertEquals(successResponse, actualResponse)
+        inOrder(wpApiRestClient, nonceRestClient) {
             verify(nonceRestClient).requestNonce(site)
             verify(wpApiRestClient).getRequest(fetchUrl, nonce.value)
         }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import okhttp3.Credentials
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -23,7 +22,6 @@ import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.network.rest.wpapi.NonceRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.reactnative.ReactNativeWPAPIRestClient
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -6,7 +6,9 @@ import com.android.volley.VolleyError
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import okhttp3.Credentials
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -45,7 +47,6 @@ class ReactNativeStoreWPAPITest {
     private val wpApiRestClient = mock<ReactNativeWPAPIRestClient>()
     private val discoveryWPAPIRestClient = mock<DiscoveryWPAPIRestClient>()
     private val nonceRestClient = mock<NonceRestClient>()
-
     private lateinit var store: ReactNativeStore
     private lateinit var site: SiteModel
 
@@ -442,29 +443,6 @@ class ReactNativeStoreWPAPITest {
     }
 
     @Test
-    fun `nonce unknown, so requests nonce`() = test {
-        // previous nonce request unknown
-        initStore(Unknown(site.username))
-
-        // refreshes nonce because latest attempt to refresh nonce was not recent
-        val nonce = Available("a_nonce", site.username)
-        whenever(nonceRestClient.requestNonce(site))
-                .thenReturn(nonce)
-
-        val fetchUrl = "${site.wpApiRestUrl}/$restPath"
-        val successResponse = mock<Success>()
-        whenever(wpApiRestClient.getRequest(fetchUrl, nonce.value)) // passes null for nonce
-                .thenReturn(successResponse)
-
-        val actualResponse = store.executeGetRequest(site, restPathWithParams)
-        assertEquals(successResponse, actualResponse)
-        inOrder(wpApiRestClient, nonceRestClient) {
-            verify(nonceRestClient).requestNonce(site)
-            verify(wpApiRestClient).getRequest(fetchUrl, nonce.value)
-        }
-    }
-
-    @Test
     fun `test slashJoin`() {
         assertEquals("begin/end", ReactNativeStore.slashJoin("begin", "end"))
         assertEquals("begin/end", ReactNativeStore.slashJoin("begin/", "end"))
@@ -495,11 +473,93 @@ class ReactNativeStoreWPAPITest {
         assertEquals(UNKNOWN, errorType)
     }
 
-    private suspend fun ReactNativeWPAPIRestClient.getRequest(url: String, nonce: String? = null) =
-        getRequest(url, paramMap, ReactNativeFetchResponse::Success, ReactNativeFetchResponse::Error, nonce)
+    //
+    // Application password tests
+    //
 
-    private suspend fun ReactNativeWPAPIRestClient.postRequest(url: String, nonce: String? = null) =
-        postRequest(url, bodyMap, ReactNativeFetchResponse::Success, ReactNativeFetchResponse::Error, nonce)
+    @Test
+    fun `site with application password uses Basic auth for GET request`() = test {
+        site.apiRestUsernamePlain = "user"
+        site.apiRestPasswordPlain = "pass"
+        val appPasswordAuthHeader = Credentials.basic("user", "pass")
+
+        val fetchUrl = "${site.wpApiRestUrl}/$restPath"
+        val successResponse = mock<Success>()
+        val expectedHeaders = mapOf("Authorization" to appPasswordAuthHeader)
+        whenever(
+            wpApiRestClient.getRequest(
+                fetchUrl, paramMap, ::Success, ::Error,
+                null, true, expectedHeaders
+            )
+        ).thenReturn(successResponse)
+
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
+        assertEquals(successResponse, actualResponse)
+        verify(nonceRestClient, never()).getNonce(any<SiteModel>())
+        verify(nonceRestClient, never()).requestNonce(any())
+    }
+
+    @Test
+    fun `site with application password uses Basic auth for POST request`() = test {
+        site.apiRestUsernamePlain = "user"
+        site.apiRestPasswordPlain = "pass"
+        val appPasswordAuthHeader = Credentials.basic("user", "pass")
+
+        val postUrl = "${site.wpApiRestUrl}/$restPath"
+        val successResponse = mock<Success>()
+        val expectedHeaders = mapOf("Authorization" to appPasswordAuthHeader)
+        whenever(
+            wpApiRestClient.postRequest(
+                postUrl, bodyMap, ::Success, ::Error,
+                null, expectedHeaders
+            )
+        ).thenReturn(successResponse)
+
+        val actualResponse = store.executePostRequest(site, restPathWithParams, bodyMap)
+        assertEquals(successResponse, actualResponse)
+        verify(nonceRestClient, never()).getNonce(any<SiteModel>())
+        verify(nonceRestClient, never()).requestNonce(any())
+    }
+
+    @Test
+    fun `site with application password does not retry nonce on 401`() = test {
+        site.apiRestUsernamePlain = "user"
+        site.apiRestPasswordPlain = "pass"
+        val appPasswordAuthHeader = Credentials.basic("user", "pass")
+
+        val fetchUrl = "${site.wpApiRestUrl}/$restPath"
+        val unauthorizedResponse = errorResponse(StatusCode.UNAUTHORIZED_401)
+        val expectedHeaders = mapOf("Authorization" to appPasswordAuthHeader)
+        whenever(
+            wpApiRestClient.getRequest(
+                fetchUrl, paramMap, ::Success, ::Error,
+                null, true, expectedHeaders
+            )
+        ).thenReturn(unauthorizedResponse)
+
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
+        assertEquals(unauthorizedResponse, actualResponse)
+        verify(nonceRestClient, never()).getNonce(any<SiteModel>())
+        verify(nonceRestClient, never()).requestNonce(any())
+    }
+
+    private suspend fun ReactNativeWPAPIRestClient.getRequest(
+        url: String,
+        nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
+    ) = getRequest(
+        url, paramMap, ReactNativeFetchResponse::Success,
+        ReactNativeFetchResponse::Error, nonce, true, headers
+    )
+
+    private suspend fun ReactNativeWPAPIRestClient.postRequest(
+        url: String,
+        nonce: String? = null,
+        headers: Map<String, String> = emptyMap()
+    ) = postRequest(
+        url, bodyMap, ReactNativeFetchResponse::Success,
+        ReactNativeFetchResponse::Error, nonce, headers
+    )
 
     private fun errorResponse(statusCode: Int): ReactNativeFetchResponse = Error(mock()).apply {
         error.volleyError = VolleyError(NetworkResponse(statusCode, null, false, 0L, null))


### PR DESCRIPTION
## Description

Fixes 401 errors when making GET requests to media and editor settings endpoints on self-hosted WordPress sites that use application passwords. The issue affected both the React Native Gutenberg editor and EditorSettingsStore when fetching settings.

**Root cause:** ReactNativeStore used cookie-nonce authentication for all non-WPCom sites by attempting to log in via `wp-login.php`. However, sites using application passwords cannot authenticate via `wp-login.php`—application passwords only work with REST API Basic authentication. This caused nonce requests to fail silently, and subsequent API requests were sent without authentication headers, resulting in 401 errors.

**Solution:** Added support for Basic authentication headers in the ReactNativeStore request pipeline. When a site has application password credentials (`apiRestUsernamePlain` and `apiRestPasswordPlain`), the store now uses Basic auth directly instead of attempting the nonce flow. This bypasses `wp-login.php` entirely and uses the credentials in the format that application passwords expect.

**Implementation details:**
- Added `headers` parameter throughout the request pipeline (WPAPIGsonRequestBuilder → ReactNativeWPAPIRestClient → ReactNativeStore)
- Detects app password sites via `site.hasApplicationPassword()` check
- Builds Basic auth header using `okhttp3.Credentials.basic()` from the site's application password credentials
- Skips nonce fetch and 401 retry logic for app password sites (not applicable)
- Keeps 404 error handling for REST URL discovery for both auth methods
- Backward compatible: all existing callers unaffected (empty headers map by default)

## Testing instructions

Test on self-hosted WordPress site with application passwords configured:

1. Create a self-hosted WordPress site (or use existing)
2. Configure an application password on the site
3. In the Android app, log in to the self-hosted site using the application password
4. Open the editor
5. Add images and save
5. Verify media list loads without 401 errors
6. Verify editor settings load without 401 errors
7. Create/edit a post and verify media upload works

Test on non-app-password sites (nonce auth):

1. Log in to self-hosted site without application passwords
2. Verify editor and media functionality works as before
3. Verify nonce-based requests still function correctly

Test on WP.com sites:

- Verify bearer token auth still works unchanged