### PR TITLE
fix: Preserve featured image metadata in WP REST API upload responses

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -160,7 +160,11 @@ abstract class BaseWPV2MediaRestClient constructor(
                     if (response.isSuccessful) {
                         try {
                             val res = gson.fromJson(response.body!!.string(), MediaWPRESTResponse::class.java)
-                            val uploadedMedia = res.toMediaModel(site.id)
+                            val uploadedMedia = res.toMediaModel(site.id).apply {
+                                id = media.id
+                                localPostId = media.localPostId
+                                markedLocallyAsFeatured = media.markedLocallyAsFeatured
+                            }
                             val payload = ProgressPayload(uploadedMedia, 1f, true, false)
                             try {
                                 trySendBlocking(payload)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
@@ -229,6 +229,7 @@ class MediaRSApiRestClient @Inject constructor(
         dispatcher.dispatch(MediaActionBuilder.newDeletedMediaAction(payload))
     }
 
+    @Suppress("LongMethod")
     fun uploadMedia(site: SiteModel, media: MediaModel?) {
         if (media == null || media.id == 0) {
             // we can't have a MediaModel without an ID - otherwise we can't keep track of them.

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
@@ -277,6 +277,8 @@ class MediaRSApiRestClient @Inject constructor(
                     val responseMedia: MediaModel = mediaResponse.response.data.toMediaModel(site.id).apply {
                         id = media.id // be sure we are using the same local id when getting the remote response
                         localSiteId = site.id
+                        localPostId = media.localPostId
+                        markedLocallyAsFeatured = media.markedLocallyAsFeatured
                     }
                     notifyMediaUploaded(
                         media = responseMedia,


### PR DESCRIPTION
## Description

Fix CMM-1254. 

Fix a bug where featured images could not be set via the post settings pane on self-hosted sites using application passwords.

**Root cause:** When a media upload completes on the WP REST API path (used by self-hosted sites with application passwords), the `MediaRSApiRestClient` and `BaseWPV2MediaRestClient` create a new `MediaModel` from the API response but don't carry over app-level metadata from the original model—specifically `localPostId` and `markedLocallyAsFeatured`.

Without `markedLocallyAsFeatured = true`, the upload completion handler in `EditPostActivity.onUploadSuccess()` takes the wrong branch—it treats the media as a regular editor upload instead of a featured image, so `setFeaturedImageId()` is never called.

The WP.com REST client and XMLRPC client already preserve these fields, which is why the bug only affects self-hosted sites with application passwords:
- [`MediaRestClient.java#L249-L252`](https://github.com/wordpress-mobile/WordPress-Android/blob/5fb23967dd0/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java#L249-L252)
- [`MediaXMLRPCClient.java#L231-L235`](https://github.com/wordpress-mobile/WordPress-Android/blob/5fb23967dd0/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java#L231-L235)
- [`MediaXMLRPCClient.java#L354-L357`](https://github.com/wordpress-mobile/WordPress-Android/blob/5fb23967dd0/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java#L354-L357)

**Fix:** Preserve `localPostId` and `markedLocallyAsFeatured` (and `id` for `BaseWPV2MediaRestClient`) from the original media model when constructing the response model after a successful upload, matching the behavior of the WP.com and XMLRPC clients.

## Testing instructions

Set featured image from post settings on a self-hosted site:

1. Connect a self-hosted WordPress site using an application password
2. Create a new post
3. Open the post settings pane
4. Tap "Set Featured Image"
5. Select an image from the device (not from the WP media library)
- [x] Verify the image uploads and the featured image is set successfully
- [x] Verify the featured image thumbnail appears in the post settings pane

Verify setting featured image from an Image block still works:

1. On a self-hosted site with an application password, create a new post
2. Add an Image block and select an image
3. Use the block's menu to "Set as Featured Image"
- [x] Verify the featured image is set successfully

Verify no regression on WP.com sites:

1. Open an existing post on a WP.com site
2. Open the post settings pane
3. Set a featured image from the device
- [x] Verify the featured image is set successfully