### PR TITLE
fix: Restore spacing in My Site menu and quick link items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewHolder.kt
@@ -2,6 +2,9 @@ package org.wordpress.android.ui.mysite.cards.quicklinksitem
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.widget.ImageViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.databinding.QuickLinkItemBinding
@@ -12,6 +15,21 @@ class QuickLinksItemViewHolder(
     parent: ViewGroup,
     private val binding: QuickLinkItemBinding = parent.viewBinding(QuickLinkItemBinding::inflate)
 ) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        ViewCompat.setAccessibilityDelegate(
+            binding.quickLinkItemRoot,
+            object : androidx.core.view.AccessibilityDelegateCompat() {
+                override fun onInitializeAccessibilityNodeInfo(
+                    host: View,
+                    info: AccessibilityNodeInfoCompat
+                ) {
+                    super.onInitializeAccessibilityNodeInfo(host, info)
+                    info.className = Button::class.java.name
+                }
+            }
+        )
+    }
+
     fun onBind(item: QuickLinkItem) = with(binding) {
         quickLinkIcon.setImageResource(item.icon)
         if (item.disableTint) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/MySiteListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/MySiteListItemViewHolder.kt
@@ -5,7 +5,10 @@ import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageView
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.widget.ImageViewCompat
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -26,6 +29,21 @@ class MySiteListItemViewHolder(
     private val accountStore: AccountStore,
     private val gravatarLoader: MeGravatarLoader
 ) : MySiteCardAndItemViewHolder<MySiteItemBlockBinding>(parent.viewBinding(MySiteItemBlockBinding::inflate)) {
+    init {
+        ViewCompat.setAccessibilityDelegate(
+            itemView,
+            object : androidx.core.view.AccessibilityDelegateCompat() {
+                override fun onInitializeAccessibilityNodeInfo(
+                    host: View,
+                    info: AccessibilityNodeInfoCompat
+                ) {
+                    super.onInitializeAccessibilityNodeInfo(host, info)
+                    info.className = Button::class.java.name
+                }
+            }
+        )
+    }
+
     fun bind(cardAndItem: ListItem) = with(binding) {
         if (cardAndItem.disablePrimaryIconTint) mySiteItemPrimaryIcon.imageTintList = null
 

--- a/WordPress/src/main/res/layout/my_site_item_block.xml
+++ b/WordPress/src/main/res/layout/my_site_item_block.xml
@@ -14,6 +14,7 @@
         android:layout_marginTop="@dimen/margin_large"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/my_site_item_primary_text"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
@@ -25,9 +26,9 @@
         android:layout_marginBottom="@dimen/margin_large"
         android:layout_marginTop="@dimen/margin_large"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/my_site_item_secondary_icon"
         app:layout_constraintStart_toEndOf="@+id/my_site_item_primary_icon"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         tools:text="@string/posts" />
     <ImageView
         android:id="@+id/my_site_item_secondary_icon"
@@ -37,6 +38,7 @@
         android:src="@drawable/ic_external_white_24dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/guideline2"
         app:layout_constraintStart_toEndOf="@+id/my_site_item_primary_text"/>
 
     <androidx.constraintlayout.widget.Guideline
@@ -48,6 +50,7 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/my_site_item_secondary_text"
         style="@style/MySiteListRowSecondaryTextView"
+        android:layout_marginEnd="32dp"
         android:paddingEnd="0dp"
         android:paddingStart="0dp"
         android:textAlignment="viewEnd"

--- a/WordPress/src/main/res/layout/quick_link_item.xml
+++ b/WordPress/src/main/res/layout/quick_link_item.xml
@@ -9,14 +9,15 @@
     android:clickable="true"
     android:focusable="true"
     android:minHeight="48dp"
-    android:paddingStart="12dp"
-    android:paddingEnd="12dp">
+    android:paddingStart="@dimen/margin_medium"
+    android:paddingEnd="@dimen/margin_medium"
+    android:paddingTop="@dimen/margin_medium_large"
+    android:paddingBottom="@dimen/margin_medium_large">
 
     <ImageView
         android:id="@+id/quick_link_icon"
         android:layout_width="@dimen/quick_link_ribbon_icon_size"
         android:layout_height="@dimen/quick_link_ribbon_icon_size"
-        android:layout_marginEnd="@dimen/quick_link_ribbon_icon_padding"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -28,6 +29,7 @@
         android:id="@+id/quick_link_label"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/quick_link_ribbon_icon_padding"
         android:fontFamily="san-serif"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/quick_link_ribbon_text_size"


### PR DESCRIPTION
## Description

Fix CMM-1257.

Fix spacing regressions introduced by the beta badge additions in #22582 and #22593.

**`my_site_item_block.xml`** — The horizontal constraint chain was broken when `constraintEnd` attributes were removed during the beta badge refactor. Without the chain, ConstraintLayout silently ignored the icon-to-text `marginEnd` (20dp), causing icons and text to render with no gap.

**`quick_link_item.xml`** — When `MaterialButton` was replaced with manual `ImageView` + `TextView`, the icon-to-text spacing was placed as `marginEnd` on the icon, but the icon has no `End` constraint so ConstraintLayout ignored it. Additionally, horizontal padding didn't match the original `TextButton` defaults (8dp), and the `MaterialButton`'s vertical inset+padding (10dp total) was lost, causing the "Authenticate using Application Password" banner text to sit too close to the card border.

**Accessibility** — The `MaterialButton`-to-manual-views conversion also lost the button accessibility role. TalkBack no longer announced these navigation items as buttons. Added `AccessibilityDelegateCompat` to both `QuickLinksItemViewHolder` and `MySiteListItemViewHolder` to restore the button role announcement.

<details><summary>Before vs after screenshots</summary>
<p>

Before | After
-- | --
![before-wpcom](https://github.com/user-attachments/assets/420dc422-343c-4f53-b571-8fec15f2f274) | ![after-wpcom](https://github.com/user-attachments/assets/73c9993c-a08d-4710-be1d-3dced7fd4cb9)
![before-wow](https://github.com/user-attachments/assets/338d998a-a688-4f28-b224-2e578b41a587) | ![after-wow](https://github.com/user-attachments/assets/9b665631-e69f-4de2-8516-f4c0fd77c31a)
![before-wp](https://github.com/user-attachments/assets/4f10d28e-2bea-4d7b-aafe-d23d51538fe6) | ![after-wp](https://github.com/user-attachments/assets/34d3b9ac-3a94-482e-aae7-c46edfa8c9d7)

</p>
</details> 

## Testing instructions

My Site menu item spacing (self-hosted site):

1. Log into a self-hosted site
2. Navigate to the My Site tab
3. Tap "More" to see the full menu list
- [ ] Verify there is a visible gap between the icon and text for each menu item (Posts, Pages, Media, etc.)
- [ ] Verify spacing matches the pre-regression appearance

Quick link item spacing (WP.com / Jetpack site):

1. Log into a WP.com site on Jetpack or WordPress app
2. Navigate to the My Site tab
- [ ] Verify there is a visible gap between the icon and text for Posts, Pages, Stats, More
- [ ] Verify the items have appropriate vertical padding (text not crowded against row edges)

Application Password banner spacing:

1. Log into a self-hosted site that shows the "Authenticate using Application Password" banner
2. Navigate to the My Site tab
- [ ] Verify there is vertical space between the banner text and the card border
- [ ] Verify the icon-to-text spacing in the banner matches other quick link items

Accessibility (screen reader):

1. Enable TalkBack on the device
2. Navigate to the My Site tab on a WP.com site
3. Swipe through the quick link items (Posts, Pages, Stats, More)
- [ ] Verify each item is announced as a button (e.g., "Posts, button")
4. Navigate to My Site on a self-hosted site and swipe through the menu list items
- [ ] Verify each item is announced as a button