### PR TITLE
Fix Stats Hours label incorrectly displayed as Years

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -67,9 +67,10 @@ fun StatsSection.toStatsGranularity(): StatsGranularity? {
     }
 }
 
-fun StatsGranularity.toNameResource() = when {
-    this == DAYS -> R.string.stats_timeframe_days
-    this == WEEKS -> R.string.stats_timeframe_weeks
-    this == MONTHS -> R.string.stats_timeframe_months
-    else -> R.string.stats_timeframe_years
+fun StatsGranularity.toNameResource() = when (this) {
+    StatsGranularity.HOURS -> R.string.stats_timeframe_hours
+    DAYS -> R.string.stats_timeframe_days
+    WEEKS -> R.string.stats_timeframe_weeks
+    MONTHS -> R.string.stats_timeframe_months
+    YEARS -> R.string.stats_timeframe_years
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1396,6 +1396,7 @@
     <string name="stats_timeframe_weeks">Weeks</string>
     <string name="stats_timeframe_months">Months</string>
     <string name="stats_timeframe_years">Years</string>
+    <string name="stats_timeframe_hours">Hours</string>
     <string name="stats_timeframe_last_seven_days">Last 7-days</string>
     <string name="stats_timeframe_previous_seven_days">Previous 7-days</string>
     <string name="stats_views">Views</string>


### PR DESCRIPTION
## Description

In the old Stats screen, the `StatsGranularity.toNameResource()` extension function used a `when` expression with an `else` catch-all that defaulted to `R.string.stats_timeframe_years`. Since `StatsGranularity.HOURS` was never explicitly handled, selecting the "Hours" timeframe displayed "Years" instead, creating duplicate "Years" labels in the dropdown.

This fix makes the `when` expression exhaustive by switching to `when (this)` and adds the missing `HOURS` case with a new `stats_timeframe_hours` string resource.

Before / After

<img width="256" height="568" alt="Screenshot 2026-02-20 at 10 45 21" src="https://github.com/user-attachments/assets/e7dc5ea1-2289-4400-afa2-8542b9ac3c8e" /> / <img width="254" height="566" alt="Screenshot 2026-02-20 at 10 43 38" src="https://github.com/user-attachments/assets/3f3c072d-ed11-4e68-ab46-b667f7fa9e64" />


## Testing instructions

Verify Hours label in Stats timeframe dropdown:

1. Open the app and navigate to Stats
2. Tap the timeframe dropdown (Years/Days/Weeks/Months)
- [ ] Verify "Hours" appears correctly instead of a duplicate "Years"
3. Select "Hours"
- [ ] Verify the selected label shows "Hours"
- [ ] Verify stats data loads correctly for the hourly timeframe

Verify other timeframes are unaffected:

1. Select each timeframe option: Days, Weeks, Months, Years
- [ ] Verify each label displays correctly
- [ ] Verify stats data loads correctly for each timeframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)