### PR TITLE
CMM 1267 stats devices card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -86,6 +86,9 @@ import org.wordpress.android.ui.newstats.authors.AuthorsCardUiState
 import org.wordpress.android.ui.newstats.authors.AuthorsDetailActivity
 import org.wordpress.android.ui.newstats.authors.AuthorsViewModel
 import org.wordpress.android.ui.newstats.clicks.ClicksViewModel
+import org.wordpress.android.ui.newstats.devices.DevicesCard
+import org.wordpress.android.ui.newstats.devices.DevicesCardUiState
+import org.wordpress.android.ui.newstats.devices.DevicesViewModel
 import org.wordpress.android.ui.newstats.filedownloads.FileDownloadsViewModel
 import org.wordpress.android.ui.newstats.locations.LocationsCardUiState
 import org.wordpress.android.ui.newstats.searchterms.SearchTermsViewModel
@@ -259,6 +262,7 @@ private fun TrafficTabContent(
     searchTermsViewModel: SearchTermsViewModel = viewModel(),
     videoPlaysViewModel: VideoPlaysViewModel = viewModel(),
     fileDownloadsViewModel: FileDownloadsViewModel = viewModel(),
+    devicesViewModel: DevicesViewModel = viewModel(),
     newStatsViewModel: NewStatsViewModel = viewModel()
 ) {
     val context = LocalContext.current
@@ -273,6 +277,8 @@ private fun TrafficTabContent(
     val searchTermsUiState by searchTermsViewModel.uiState.collectAsState()
     val videoPlaysUiState by videoPlaysViewModel.uiState.collectAsState()
     val fileDownloadsUiState by fileDownloadsViewModel.uiState.collectAsState()
+    val devicesUiState by devicesViewModel.uiState.collectAsState()
+    val selectedDeviceType by devicesViewModel.selectedDeviceType.collectAsState()
     val selectedPeriod by viewsStatsViewModel.selectedPeriod.collectAsState()
     val isTodaysStatsRefreshing by todaysStatsViewModel.isRefreshing.collectAsState()
     val isViewsStatsRefreshing by viewsStatsViewModel.isRefreshing.collectAsState()
@@ -289,12 +295,14 @@ private fun TrafficTabContent(
         .isRefreshing.collectAsState()
     val isFileDownloadsRefreshing by fileDownloadsViewModel
         .isRefreshing.collectAsState()
+    val isDevicesRefreshing by devicesViewModel.isRefreshing.collectAsState()
     val isRefreshing = listOf(
         isTodaysStatsRefreshing, isViewsStatsRefreshing,
         isMostViewedPostsRefreshing, isMostViewedReferrersRefreshing,
         isLocationsRefreshing, isAuthorsRefreshing,
         isClicksRefreshing, isSearchTermsRefreshing,
-        isVideoPlaysRefreshing, isFileDownloadsRefreshing
+        isVideoPlaysRefreshing, isFileDownloadsRefreshing,
+        isDevicesRefreshing
     ).any { it }
     val pullToRefreshState = rememberPullToRefreshState()
 
@@ -342,6 +350,9 @@ private fun TrafficTabContent(
             },
             onFileDownloads = {
                 fileDownloadsViewModel.onPeriodChanged(selectedPeriod)
+            },
+            onDevices = {
+                devicesViewModel.onPeriodChanged(selectedPeriod)
             }
         )
     }
@@ -374,7 +385,8 @@ private fun TrafficTabContent(
             onClicks = { clicksViewModel.loadData() },
             onSearchTerms = { searchTermsViewModel.loadData() },
             onVideoPlays = { videoPlaysViewModel.loadData() },
-            onFileDownloads = { fileDownloadsViewModel.loadData() }
+            onFileDownloads = { fileDownloadsViewModel.loadData() },
+            onDevices = { devicesViewModel.loadData() }
         )
     }
 
@@ -424,7 +436,8 @@ private fun TrafficTabContent(
                 onVideoPlays = { videoPlaysViewModel.refresh() },
                 onFileDownloads = {
                     fileDownloadsViewModel.refresh()
-                }
+                },
+                onDevices = { devicesViewModel.refresh() }
             )
         },
         indicator = {
@@ -556,6 +569,39 @@ private fun TrafficTabContent(
                                 LocationsCardUiState.Error)
                                 ?.isAuthError == true,
                             getAdminUrl = locationsViewModel::getAdminUrl,
+                            context = context
+                        )
+                    )
+                    StatsCardType.DEVICES -> DevicesCard(
+                        uiState = devicesUiState,
+                        selectedDeviceType = selectedDeviceType,
+                        onDeviceTypeChanged =
+                            devicesViewModel::onDeviceTypeChanged,
+                        onRetry = devicesViewModel::onRetry,
+                        onRemoveCard = {
+                            newStatsViewModel.removeCard(cardType)
+                        },
+                        cardPosition = cardPosition,
+                        onMoveUp = {
+                            newStatsViewModel.moveCardUp(cardType)
+                        },
+                        onMoveToTop = {
+                            newStatsViewModel.moveCardToTop(cardType)
+                        },
+                        onMoveDown = {
+                            newStatsViewModel.moveCardDown(cardType)
+                        },
+                        onMoveToBottom = {
+                            newStatsViewModel.moveCardToBottom(
+                                cardType
+                            )
+                        },
+                        onOpenWpAdmin = buildOpenWpAdminAction(
+                            isAuthError = (devicesUiState as?
+                                DevicesCardUiState.Error)
+                                ?.isAuthError == true,
+                            getAdminUrl =
+                                devicesViewModel::getAdminUrl,
                             context = context
                         )
                     )
@@ -794,7 +840,8 @@ private fun List<StatsCardType>.dispatchToVisibleCards(
     onClicks: () -> Unit,
     onSearchTerms: () -> Unit,
     onVideoPlays: () -> Unit,
-    onFileDownloads: () -> Unit
+    onFileDownloads: () -> Unit,
+    onDevices: () -> Unit
 ) {
     if (StatsCardType.TODAYS_STATS in this) onTodaysStats()
     if (StatsCardType.VIEWS_STATS in this) onViewsStats()
@@ -810,6 +857,7 @@ private fun List<StatsCardType>.dispatchToVisibleCards(
     if (StatsCardType.SEARCH_TERMS in this) onSearchTerms()
     if (StatsCardType.VIDEO_PLAYS in this) onVideoPlays()
     if (StatsCardType.FILE_DOWNLOADS in this) onFileDownloads()
+    if (StatsCardType.DEVICES in this) onDevices()
 }
 
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
@@ -19,7 +19,8 @@ enum class StatsCardType(
     CLICKS(R.string.stats_clicks),
     SEARCH_TERMS(R.string.stats_search_terms),
     VIDEO_PLAYS(R.string.stats_videos),
-    FILE_DOWNLOADS(R.string.stats_file_downloads);
+    FILE_DOWNLOADS(R.string.stats_file_downloads),
+    DEVICES(R.string.stats_devices_title);
 
     companion object {
         /**
@@ -31,7 +32,8 @@ enum class StatsCardType(
             MOST_VIEWED_POSTS_AND_PAGES,
             MOST_VIEWED_REFERRERS,
             LOCATIONS,
-            AUTHORS
+            AUTHORS,
+            DEVICES
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSource.kt
@@ -165,6 +165,48 @@ interface StatsDataSource {
         dateRange: StatsDateRange,
         max: Int = 10
     ): FileDownloadsDataResult
+
+    /**
+     * Fetches device screen size stats for a specific site.
+     *
+     * @param siteId The WordPress.com site ID
+     * @param dateRange The date range parameters for the query
+     * @param max Maximum number of items to return
+     * @return Result containing the device screen size data or an error
+     */
+    suspend fun fetchDevicesScreensize(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int = 10
+    ): DevicesDataResult
+
+    /**
+     * Fetches device browser stats for a specific site.
+     *
+     * @param siteId The WordPress.com site ID
+     * @param dateRange The date range parameters for the query
+     * @param max Maximum number of items to return
+     * @return Result containing the device browser data or an error
+     */
+    suspend fun fetchDevicesBrowser(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int = 10
+    ): DevicesDataResult
+
+    /**
+     * Fetches device platform stats for a specific site.
+     *
+     * @param siteId The WordPress.com site ID
+     * @param dateRange The date range parameters for the query
+     * @param max Maximum number of items to return
+     * @return Result containing the device platform data or an error
+     */
+    suspend fun fetchDevicesPlatform(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int = 10
+    ): DevicesDataResult
 }
 
 /**
@@ -472,3 +514,18 @@ data class FileDownloadDataItem(
     val name: String,
     val downloads: Long
 )
+
+/**
+ * Result wrapper for devices stats fetch operation.
+ */
+sealed class DevicesDataResult {
+    data class Success(val data: DevicesData) : DevicesDataResult()
+    data class Error(val errorType: StatsErrorType) : DevicesDataResult()
+}
+
+/**
+ * Devices data from the API.
+ * Contains top values as a map of device name to its value
+ * (percentage for screen size, view count for browser/platform).
+ */
+data class DevicesData(val items: Map<String, Double>)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
@@ -16,6 +16,8 @@ import uniffi.wp_api.StatsReferrersParams
 import uniffi.wp_api.StatsReferrersPeriod
 import uniffi.wp_api.StatsRegionViewsParams
 import uniffi.wp_api.StatsRegionViewsPeriod
+import uniffi.wp_api.StatsDevicesParams
+import uniffi.wp_api.StatsDevicesPeriod
 import uniffi.wp_api.StatsSearchTermsParams
 import uniffi.wp_api.StatsSearchTermsPeriod
 import uniffi.wp_api.StatsTopAuthorsParams
@@ -535,6 +537,26 @@ class StatsDataSourceImpl @Inject constructor(
         )
     }
 
+    private fun buildDevicesParams(
+        dateRange: StatsDateRange,
+        max: Int
+    ) = when (dateRange) {
+        is StatsDateRange.Preset -> StatsDevicesParams(
+            period = StatsDevicesPeriod.DAY,
+            date = dateRange.date,
+            num = dateRange.num.toUInt(),
+            max = max.coerceAtLeast(1).toUInt(),
+            summarize = true
+        )
+        is StatsDateRange.Custom -> StatsDevicesParams(
+            period = StatsDevicesPeriod.DAY,
+            date = dateRange.date,
+            startDate = dateRange.startDate,
+            max = max.coerceAtLeast(1).toUInt(),
+            summarize = true
+        )
+    }
+
     override suspend fun fetchClicks(
         siteId: Long,
         dateRange: StatsDateRange,
@@ -571,6 +593,45 @@ class StatsDataSourceImpl @Inject constructor(
                 "fetchClicks", result
             ) {
                 ClicksDataResult.Error(it)
+            }
+        }
+    }
+
+    override suspend fun fetchDevicesScreensize(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int
+    ): DevicesDataResult {
+        val params = buildDevicesParams(dateRange, max)
+        val result = getOrCreateClient().request { requestBuilder ->
+            requestBuilder.statsDevicesScreensize()
+                .getStatsDevicesScreensize(
+                    wpComSiteId = siteId.toULong(),
+                    params = params
+                )
+        }
+        logResultType("fetchDevicesScreensize", result)
+        return when (result) {
+            is WpRequestResult.Success -> {
+                val topValues = result.response.data.topValues
+                AppLog.d(
+                    T.STATS,
+                    "StatsDataSourceImpl: fetchDevicesScreensize " +
+                        "success - ${topValues.size} items"
+                )
+                DevicesDataResult.Success(
+                    DevicesData(items = topValues)
+                )
+            }
+            is WpRequestResult.WpError -> logErrorAndReturn(
+                "fetchDevicesScreensize", result
+            ) {
+                DevicesDataResult.Error(it)
+            }
+            else -> logErrorAndReturn(
+                "fetchDevicesScreensize", result
+            ) {
+                DevicesDataResult.Error(it)
             }
         }
     }
@@ -635,6 +696,45 @@ class StatsDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun fetchDevicesBrowser(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int
+    ): DevicesDataResult {
+        val params = buildDevicesParams(dateRange, max)
+        val result = getOrCreateClient().request { requestBuilder ->
+            requestBuilder.statsDevicesBrowser()
+                .getStatsDevicesBrowser(
+                    wpComSiteId = siteId.toULong(),
+                    params = params
+                )
+        }
+        logResultType("fetchDevicesBrowser", result)
+        return when (result) {
+            is WpRequestResult.Success -> {
+                val topValues = result.response.data.topValues
+                AppLog.d(
+                    T.STATS,
+                    "StatsDataSourceImpl: fetchDevicesBrowser " +
+                        "success - ${topValues.size} items"
+                )
+                DevicesDataResult.Success(
+                    DevicesData(items = topValues)
+                )
+            }
+            is WpRequestResult.WpError -> logErrorAndReturn(
+                "fetchDevicesBrowser", result
+            ) {
+                DevicesDataResult.Error(it)
+            }
+            else -> logErrorAndReturn(
+                "fetchDevicesBrowser", result
+            ) {
+                DevicesDataResult.Error(it)
+            }
+        }
+    }
+
     private fun buildVideoPlaysParams(
         dateRange: StatsDateRange,
         max: Int
@@ -691,6 +791,45 @@ class StatsDataSourceImpl @Inject constructor(
                 "fetchVideoPlays", result
             ) {
                 VideoPlaysDataResult.Error(it)
+            }
+        }
+    }
+
+    override suspend fun fetchDevicesPlatform(
+        siteId: Long,
+        dateRange: StatsDateRange,
+        max: Int
+    ): DevicesDataResult {
+        val params = buildDevicesParams(dateRange, max)
+        val result = getOrCreateClient().request { requestBuilder ->
+            requestBuilder.statsDevicesPlatform()
+                .getStatsDevicesPlatform(
+                    wpComSiteId = siteId.toULong(),
+                    params = params
+                )
+        }
+        logResultType("fetchDevicesPlatform", result)
+        return when (result) {
+            is WpRequestResult.Success -> {
+                val topValues = result.response.data.topValues
+                AppLog.d(
+                    T.STATS,
+                    "StatsDataSourceImpl: fetchDevicesPlatform " +
+                        "success - ${topValues.size} items"
+                )
+                DevicesDataResult.Success(
+                    DevicesData(items = topValues)
+                )
+            }
+            is WpRequestResult.WpError -> logErrorAndReturn(
+                "fetchDevicesPlatform", result
+            ) {
+                DevicesDataResult.Error(it)
+            }
+            else -> logErrorAndReturn(
+                "fetchDevicesPlatform", result
+            ) {
+                DevicesDataResult.Error(it)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesCard.kt
@@ -1,0 +1,401 @@
+package org.wordpress.android.ui.newstats.devices
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.CardPosition
+import org.wordpress.android.ui.newstats.components.StatsCardContainer
+import org.wordpress.android.ui.newstats.components.StatsCardEmptyContent
+import org.wordpress.android.ui.newstats.components.StatsCardErrorContent
+import org.wordpress.android.ui.newstats.components.StatsCardHeader
+import org.wordpress.android.ui.newstats.components.StatsListHeader
+import org.wordpress.android.ui.newstats.components.StatsListRowContainer
+import org.wordpress.android.ui.newstats.components.StatsItemName
+import org.wordpress.android.ui.newstats.util.ShimmerBox
+import java.util.Locale
+
+private val CardPadding = 16.dp
+private const val LOADING_ITEM_COUNT = 4
+private const val CHART_SIZE_FRACTION = 0.5f
+
+@Composable
+fun DevicesCard(
+    uiState: DevicesCardUiState,
+    selectedDeviceType: DeviceType,
+    onDeviceTypeChanged: (DeviceType) -> Unit,
+    onRetry: () -> Unit,
+    onRemoveCard: () -> Unit,
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null,
+    onOpenWpAdmin: (() -> Unit)? = null
+) {
+    StatsCardContainer(modifier = modifier) {
+        when (uiState) {
+            is DevicesCardUiState.Loading -> LoadingContent(
+                selectedDeviceType = selectedDeviceType,
+                onDeviceTypeChanged = onDeviceTypeChanged,
+                onRemoveCard = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
+            is DevicesCardUiState.Loaded -> LoadedContent(
+                uiState, selectedDeviceType,
+                onDeviceTypeChanged, onRemoveCard,
+                cardPosition, onMoveUp, onMoveToTop,
+                onMoveDown, onMoveToBottom
+            )
+            is DevicesCardUiState.Error -> {
+                StatsCardErrorContent(
+                    titleResId = R.string.stats_devices_title,
+                    errorMessageResId = uiState.messageResId,
+                    onRetry = onRetry,
+                    onRemoveCard = onRemoveCard,
+                    cardPosition = cardPosition,
+                    onMoveUp = onMoveUp,
+                    onMoveToTop = onMoveToTop,
+                    onMoveDown = onMoveDown,
+                    onMoveToBottom = onMoveToBottom,
+                    onOpenWpAdmin = onOpenWpAdmin,
+                    headerExtra = {
+                        DeviceTypeSelector(
+                            selectedType = selectedDeviceType,
+                            onTypeSelected = onDeviceTypeChanged
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent(
+    selectedDeviceType: DeviceType,
+    onDeviceTypeChanged: (DeviceType) -> Unit,
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
+    Column(modifier = Modifier.padding(CardPadding)) {
+        StatsCardHeader(
+            titleResId = R.string.stats_devices_title,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DeviceTypeSelector(
+            selectedType = selectedDeviceType,
+            onTypeSelected = onDeviceTypeChanged
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Ring chart placeholder
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            ShimmerBox(
+                modifier = Modifier
+                    .size(150.dp)
+                    .clip(CircleShape)
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        StatsListHeader(
+            leftHeaderResId =
+                R.string.stats_devices_device_header
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        repeat(LOADING_ITEM_COUNT) { index ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        vertical = 12.dp,
+                        horizontal = 8.dp
+                    ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ShimmerBox(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(16.dp)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                ShimmerBox(
+                    modifier = Modifier
+                        .width(50.dp)
+                        .height(16.dp)
+                )
+            }
+            if (index < LOADING_ITEM_COUNT - 1) {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedContent(
+    state: DevicesCardUiState.Loaded,
+    selectedDeviceType: DeviceType,
+    onDeviceTypeChanged: (DeviceType) -> Unit,
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
+    Column(modifier = Modifier.padding(CardPadding)) {
+        StatsCardHeader(
+            titleResId = R.string.stats_devices_title,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        DeviceTypeSelector(
+            selectedType = selectedDeviceType,
+            onTypeSelected = onDeviceTypeChanged
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        if (state.items.isEmpty()) {
+            StatsCardEmptyContent()
+        } else {
+            val colors = ringChartColors()
+            val chartEntries = state.items.mapIndexed { index, item ->
+                RingChartEntry(
+                    label = item.name,
+                    value = item.value,
+                    color = colors[index % colors.size]
+                )
+            }
+
+            // Ring chart
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                StatsRingChart(
+                    entries = chartEntries,
+                    modifier = Modifier
+                        .fillMaxWidth(CHART_SIZE_FRACTION)
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val isPercentage =
+                selectedDeviceType == DeviceType.SCREENSIZE
+            StatsListHeader(
+                leftHeaderResId =
+                    R.string.stats_devices_device_header,
+                rightHeaderResId = if (isPercentage) {
+                    R.string.stats_devices_percentage_header
+                } else {
+                    R.string.stats_countries_views_header
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            state.items.forEachIndexed { index, item ->
+                val barFraction =
+                    if (state.maxValueForBar > 0.0) {
+                        (item.value / state.maxValueForBar)
+                            .toFloat()
+                    } else {
+                        0f
+                    }
+                DeviceRow(
+                    item = item,
+                    percentage = barFraction,
+                    color = colors[index % colors.size],
+                    isPercentage = isPercentage
+                )
+                if (index < state.items.lastIndex) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceRow(
+    item: DeviceItem,
+    percentage: Float,
+    color: Color,
+    isPercentage: Boolean
+) {
+    StatsListRowContainer(percentage = percentage) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(color)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            StatsItemName(
+                name = item.name,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = formatDeviceValue(
+                    item.value, isPercentage
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeviceTypeSelector(
+    selectedType: DeviceType,
+    onTypeSelected: (DeviceType) -> Unit
+) {
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        DeviceType.entries.forEachIndexed { index, type ->
+            SegmentedButton(
+                shape = SegmentedButtonDefaults.itemShape(
+                    index = index,
+                    count = DeviceType.entries.size
+                ),
+                onClick = { onTypeSelected(type) },
+                selected = type == selectedType,
+                icon = {}
+            ) {
+                Text(text = stringResource(type.labelResId))
+            }
+        }
+    }
+}
+
+@Suppress("ReturnCount")
+private fun formatDeviceValue(
+    value: Double,
+    isPercentage: Boolean
+): String = when {
+    isPercentage -> {
+        // Round to nearest int; show "-" if the result is 0
+        // (covers both exact 0.0 and near-zero like 0.3)
+        val rounded = Math.round(value)
+        if (rounded == 0L) "-" else "$rounded%"
+    }
+    value == 0.0 -> "-"
+    value % 1.0 == 0.0 -> value.toLong().toString()
+    else -> String.format(
+        Locale.getDefault(), "%.1f", value
+    )
+}
+
+// Previews
+@Preview(showBackground = true)
+@Composable
+private fun DevicesCardLoadingPreview() {
+    AppThemeM3 {
+        DevicesCard(
+            uiState = DevicesCardUiState.Loading,
+            selectedDeviceType = DeviceType.SCREENSIZE,
+            onDeviceTypeChanged = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DevicesCardLoadedPreview() {
+    AppThemeM3 {
+        DevicesCard(
+            uiState = DevicesCardUiState.Loaded(
+                items = listOf(
+                    DeviceItem("Desktop", 57.6),
+                    DeviceItem("Mobile", 23.9),
+                    DeviceItem("Tablet", 0.5)
+                ),
+                maxValueForBar = 57.6
+            ),
+            selectedDeviceType = DeviceType.SCREENSIZE,
+            onDeviceTypeChanged = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DevicesCardErrorPreview() {
+    AppThemeM3 {
+        DevicesCard(
+            uiState = DevicesCardUiState.Error(
+                R.string.stats_error_api
+            ),
+            selectedDeviceType = DeviceType.SCREENSIZE,
+            onDeviceTypeChanged = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesCardUiState.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.newstats.devices
+
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+
+/**
+ * UI State for the Devices stats card.
+ */
+sealed class DevicesCardUiState {
+    data object Loading : DevicesCardUiState()
+
+    data class Loaded(
+        val items: List<DeviceItem>,
+        val maxValueForBar: Double
+    ) : DevicesCardUiState()
+
+    data class Error(
+        @StringRes val messageResId: Int,
+        val isAuthError: Boolean = false
+    ) : DevicesCardUiState()
+}
+
+/**
+ * Represents the type of device data being displayed.
+ */
+enum class DeviceType(@StringRes val labelResId: Int) {
+    SCREENSIZE(R.string.stats_devices_screensize),
+    BROWSER(R.string.stats_devices_browser),
+    PLATFORM(R.string.stats_devices_platform)
+}
+
+/**
+ * A single device item for display.
+ */
+data class DeviceItem(
+    val name: String,
+    val value: Double
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/DevicesViewModel.kt
@@ -1,0 +1,287 @@
+package org.wordpress.android.ui.newstats.devices
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.launch
+import androidx.annotation.StringRes
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.StatsPeriod
+import org.wordpress.android.ui.newstats.repository.DevicesResult
+import org.wordpress.android.ui.newstats.repository.StatsRepository
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+
+private const val CARD_MAX_ITEMS = 10
+
+@HiltViewModel
+class DevicesViewModel @Inject constructor(
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val accountStore: AccountStore,
+    private val statsRepository: StatsRepository
+) : ViewModel() {
+    private val _screensizeUiState =
+        MutableStateFlow<DevicesCardUiState>(DevicesCardUiState.Loading)
+    private val _browserUiState =
+        MutableStateFlow<DevicesCardUiState>(DevicesCardUiState.Loading)
+    private val _platformUiState =
+        MutableStateFlow<DevicesCardUiState>(DevicesCardUiState.Loading)
+
+    private val _selectedDeviceType =
+        MutableStateFlow(DeviceType.SCREENSIZE)
+    val selectedDeviceType: StateFlow<DeviceType> =
+        _selectedDeviceType.asStateFlow()
+
+    val uiState: StateFlow<DevicesCardUiState> = combine(
+        _selectedDeviceType,
+        _screensizeUiState,
+        _browserUiState,
+        _platformUiState
+    ) { type, screensize, browser, platform ->
+        when (type) {
+            DeviceType.SCREENSIZE -> screensize
+            DeviceType.BROWSER -> browser
+            DeviceType.PLATFORM -> platform
+        }
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        DevicesCardUiState.Loading
+    )
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    private var currentPeriod: StatsPeriod = StatsPeriod.Last7Days
+
+    // Per-type loaded period tracking for lazy fetching
+    private var screensizeLoadedPeriod: StatsPeriod? = null
+    private var browserLoadedPeriod: StatsPeriod? = null
+    private var platformLoadedPeriod: StatsPeriod? = null
+
+    fun loadData() {
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            setAllStatesError(R.string.stats_error_no_site)
+            return
+        }
+
+        val accessToken = accountStore.accessToken
+        if (accessToken.isNullOrEmpty()) {
+            setAllStatesError(R.string.stats_error_api)
+            return
+        }
+
+        statsRepository.init(accessToken)
+        setCurrentTypeLoading()
+
+        viewModelScope.launch {
+            fetchForCurrentType(site)
+        }
+    }
+
+    fun refresh() {
+        val site = selectedSiteRepository.getSelectedSite() ?: return
+        val accessToken = accountStore.accessToken
+        if (accessToken.isNullOrEmpty()) return
+
+        statsRepository.init(accessToken)
+        viewModelScope.launch {
+            try {
+                _isRefreshing.value = true
+                resetLoadedPeriodForCurrentType()
+                fetchForCurrentType(site)
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+
+    fun onRetry() {
+        loadData()
+    }
+
+    fun getAdminUrl(): String? =
+        selectedSiteRepository.getSelectedSite()?.adminUrl
+
+    fun onPeriodChanged(period: StatsPeriod) {
+        if (period == currentPeriod &&
+            isTypeLoadedForCurrentPeriod(
+                _selectedDeviceType.value
+            )
+        ) return
+        currentPeriod = period
+        screensizeLoadedPeriod = null
+        browserLoadedPeriod = null
+        platformLoadedPeriod = null
+        loadData()
+    }
+
+    @Suppress("ReturnCount")
+    fun onDeviceTypeChanged(type: DeviceType) {
+        if (_selectedDeviceType.value == type) return
+        _selectedDeviceType.value = type
+
+        if (!isTypeLoadedForCurrentPeriod(type)) {
+            val site =
+                selectedSiteRepository.getSelectedSite() ?: return
+            val accessToken = accountStore.accessToken
+            if (accessToken.isNullOrEmpty()) return
+            statsRepository.init(accessToken)
+
+            setTypeLoading(type)
+            viewModelScope.launch {
+                fetchForType(type, site)
+            }
+        }
+    }
+
+    private fun setAllStatesError(
+        @StringRes messageResId: Int,
+        isAuthError: Boolean = false
+    ) {
+        val error = DevicesCardUiState.Error(
+            messageResId, isAuthError
+        )
+        _screensizeUiState.value = error
+        _browserUiState.value = error
+        _platformUiState.value = error
+    }
+
+    private fun setCurrentTypeLoading() {
+        setTypeLoading(_selectedDeviceType.value)
+    }
+
+    private fun setTypeLoading(type: DeviceType) {
+        when (type) {
+            DeviceType.SCREENSIZE ->
+                _screensizeUiState.value = DevicesCardUiState.Loading
+            DeviceType.BROWSER ->
+                _browserUiState.value = DevicesCardUiState.Loading
+            DeviceType.PLATFORM ->
+                _platformUiState.value = DevicesCardUiState.Loading
+        }
+    }
+
+    private fun resetLoadedPeriodForCurrentType() {
+        when (_selectedDeviceType.value) {
+            DeviceType.SCREENSIZE ->
+                screensizeLoadedPeriod = null
+            DeviceType.BROWSER ->
+                browserLoadedPeriod = null
+            DeviceType.PLATFORM ->
+                platformLoadedPeriod = null
+        }
+    }
+
+    private fun isTypeLoadedForCurrentPeriod(
+        type: DeviceType
+    ): Boolean {
+        return when (type) {
+            DeviceType.SCREENSIZE ->
+                screensizeLoadedPeriod == currentPeriod
+            DeviceType.BROWSER ->
+                browserLoadedPeriod == currentPeriod
+            DeviceType.PLATFORM ->
+                platformLoadedPeriod == currentPeriod
+        }
+    }
+
+    private suspend fun fetchForCurrentType(site: SiteModel) {
+        fetchForType(_selectedDeviceType.value, site)
+    }
+
+    private suspend fun fetchForType(
+        type: DeviceType,
+        site: SiteModel
+    ) {
+        val stateFlow = when (type) {
+            DeviceType.SCREENSIZE -> _screensizeUiState
+            DeviceType.BROWSER -> _browserUiState
+            DeviceType.PLATFORM -> _platformUiState
+        }
+        val setLoadedPeriod: () -> Unit = when (type) {
+            DeviceType.SCREENSIZE ->
+                { -> screensizeLoadedPeriod = currentPeriod }
+            DeviceType.BROWSER ->
+                { -> browserLoadedPeriod = currentPeriod }
+            DeviceType.PLATFORM ->
+                { -> platformLoadedPeriod = currentPeriod }
+        }
+        fetchAndUpdate(stateFlow, setLoadedPeriod) {
+            when (type) {
+                DeviceType.SCREENSIZE ->
+                    statsRepository.fetchDevicesScreensize(
+                        site.siteId, currentPeriod
+                    )
+                DeviceType.BROWSER ->
+                    statsRepository.fetchDevicesBrowser(
+                        site.siteId, currentPeriod
+                    )
+                DeviceType.PLATFORM ->
+                    statsRepository.fetchDevicesPlatform(
+                        site.siteId, currentPeriod
+                    )
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchAndUpdate(
+        stateFlow: MutableStateFlow<DevicesCardUiState>,
+        setLoadedPeriod: () -> Unit,
+        fetch: suspend () -> DevicesResult
+    ) {
+        try {
+            when (val result = fetch()) {
+                is DevicesResult.Success -> {
+                    setLoadedPeriod()
+                    stateFlow.value = mapToLoadedState(result)
+                }
+                is DevicesResult.Error -> {
+                    stateFlow.value = DevicesCardUiState.Error(
+                        result.messageResId,
+                        result.isAuthError
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            AppLog.e(
+                AppLog.T.STATS,
+                "Error fetching devices data", e
+            )
+            stateFlow.value = DevicesCardUiState.Error(
+                R.string.stats_error_unknown
+            )
+        }
+    }
+
+    private fun mapToLoadedState(
+        result: DevicesResult.Success
+    ): DevicesCardUiState {
+        if (result.items.isEmpty()) {
+            return DevicesCardUiState.Loaded(
+                items = emptyList(),
+                maxValueForBar = 0.0
+            )
+        }
+        val cardItems = result.items
+            .take(CARD_MAX_ITEMS)
+            .map { DeviceItem(name = it.name, value = it.views) }
+        val maxValueForBar =
+            cardItems.maxOfOrNull { it.value } ?: 0.0
+        return DevicesCardUiState.Loaded(
+            items = cardItems,
+            maxValueForBar = maxValueForBar
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/StatsRingChart.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/devices/StatsRingChart.kt
@@ -1,0 +1,111 @@
+package org.wordpress.android.ui.newstats.devices
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+
+private const val START_ANGLE = -90f
+private const val FULL_CIRCLE = 360f
+private const val GAP_DEGREES = 3f
+private const val STROKE_WIDTH_RATIO = 0.15f
+
+data class RingChartEntry(
+    val label: String,
+    val value: Double,
+    val color: Color
+)
+
+@Composable
+fun StatsRingChart(
+    entries: List<RingChartEntry>,
+    modifier: Modifier = Modifier
+) {
+    val entryDescriptionFormat = stringResource(
+        R.string.stats_ring_chart_entry_description
+    )
+    val description = entries.joinToString(", ") {
+        String.format(entryDescriptionFormat, it.label, it.value)
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .semantics {
+                contentDescription = description
+            }
+    ) {
+        val total = entries.sumOf { it.value }
+        if (total <= 0) return@Canvas
+
+        val strokeWidth = size.minDimension * STROKE_WIDTH_RATIO
+        val radius = (size.minDimension - strokeWidth) / 2f
+        val topLeft = Offset(
+            (size.width - radius * 2) / 2f,
+            (size.height - radius * 2) / 2f
+        )
+        val arcSize = Size(radius * 2, radius * 2)
+        val totalGap = GAP_DEGREES * entries.size
+        val availableDegrees = FULL_CIRCLE - totalGap
+
+        var currentAngle = START_ANGLE
+        entries.forEach { entry ->
+            val sweep =
+                (entry.value / total * availableDegrees).toFloat()
+            drawArc(
+                color = entry.color,
+                startAngle = currentAngle,
+                sweepAngle = sweep,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(
+                    width = strokeWidth,
+                    cap = StrokeCap.Round
+                )
+            )
+            currentAngle += sweep + GAP_DEGREES
+        }
+    }
+}
+
+@Composable
+fun ringChartColors(): List<Color> {
+    return listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.secondary,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+        MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f),
+        MaterialTheme.colorScheme.tertiary.copy(alpha = 0.5f)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StatsRingChartPreview() {
+    AppThemeM3 {
+        val colors = ringChartColors()
+        StatsRingChart(
+            entries = listOf(
+                RingChartEntry("Desktop", 60.0, colors[0]),
+                RingChartEntry("Mobile", 30.0, colors[1]),
+                RingChartEntry("Tablet", 10.0, colors[2])
+            )
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/locations/LocationsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/locations/LocationsCard.kt
@@ -305,7 +305,8 @@ private fun LocationTypeSelector(
                     count = LocationType.entries.size
                 ),
                 onClick = { onTypeSelected(type) },
-                selected = type == selectedType
+                selected = type == selectedType,
+                icon = {}
             ) {
                 Text(text = stringResource(type.labelResId))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.coroutineScope
 import org.wordpress.android.ui.newstats.datasource.CityViewsDataResult
 import org.wordpress.android.ui.newstats.datasource.ClicksDataResult
 import org.wordpress.android.ui.newstats.datasource.CountryViewsDataResult
+import org.wordpress.android.ui.newstats.datasource.DevicesDataResult
 import org.wordpress.android.ui.newstats.datasource.FileDownloadsDataResult
 import org.wordpress.android.ui.newstats.datasource.ReferrersDataResult
 import org.wordpress.android.ui.newstats.datasource.RegionViewsDataResult
@@ -681,6 +682,28 @@ class StatsRepository @Inject constructor(
      * Calculates current and previous date ranges for comparison stats.
      * Used by multiple stats types (MostViewed, Countries, etc.)
      */
+    private fun calculateCurrentDateRange(period: StatsPeriod): StatsDateRange {
+        val today = LocalDate.now()
+        val todayString = today.format(dateFormatter)
+        return when (period) {
+            is StatsPeriod.Today ->
+                StatsDateRange.Preset(num = NUM_DAYS_TODAY, date = todayString)
+            is StatsPeriod.Last7Days ->
+                StatsDateRange.Preset(num = DAYS_IN_7_DAYS, date = todayString)
+            is StatsPeriod.Last30Days ->
+                StatsDateRange.Preset(num = DAYS_IN_30_DAYS, date = todayString)
+            is StatsPeriod.Last6Months ->
+                StatsDateRange.Preset(num = DAYS_IN_6_MONTHS, date = todayString)
+            is StatsPeriod.Last12Months ->
+                StatsDateRange.Preset(num = DAYS_IN_12_MONTHS, date = todayString)
+            is StatsPeriod.Custom ->
+                StatsDateRange.Custom(
+                    startDate = period.startDate.format(dateFormatter),
+                    date = period.endDate.format(dateFormatter)
+                )
+        }
+    }
+
     private fun calculateComparisonDateRanges(period: StatsPeriod): Pair<StatsDateRange, StatsDateRange> {
         val today = LocalDate.now()
         val todayString = today.format(dateFormatter)
@@ -1159,6 +1182,67 @@ class StatsRepository @Inject constructor(
         logLabel = "file downloads"
     )
 
+    /**
+     * Fetches device screen size stats for a specific site and period.
+     */
+    suspend fun fetchDevicesScreensize(
+        siteId: Long,
+        period: StatsPeriod
+    ): DevicesResult = withContext(ioDispatcher) {
+        val dateRange = calculateCurrentDateRange(period)
+        fetchDevicesData { statsDataSource.fetchDevicesScreensize(siteId, dateRange) }
+    }
+
+    /**
+     * Fetches device browser stats for a specific site and period.
+     */
+    suspend fun fetchDevicesBrowser(
+        siteId: Long,
+        period: StatsPeriod
+    ): DevicesResult = withContext(ioDispatcher) {
+        val dateRange = calculateCurrentDateRange(period)
+        fetchDevicesData { statsDataSource.fetchDevicesBrowser(siteId, dateRange) }
+    }
+
+    /**
+     * Fetches device platform stats for a specific site and period.
+     */
+    suspend fun fetchDevicesPlatform(
+        siteId: Long,
+        period: StatsPeriod
+    ): DevicesResult = withContext(ioDispatcher) {
+        val dateRange = calculateCurrentDateRange(period)
+        fetchDevicesData { statsDataSource.fetchDevicesPlatform(siteId, dateRange) }
+    }
+
+    private suspend fun fetchDevicesData(
+        fetch: suspend () -> DevicesDataResult
+    ): DevicesResult {
+        return when (val result = fetch()) {
+            is DevicesDataResult.Success -> {
+                val items = result.data.items
+                    .map { (name, views) ->
+                        DeviceItemData(
+                            name = name,
+                            views = views
+                        )
+                    }
+                    .sortedByDescending { it.views }
+                DevicesResult.Success(items = items)
+            }
+            is DevicesDataResult.Error -> {
+                appLogWrapper.e(
+                    AppLog.T.STATS,
+                    "Error fetching devices: ${result.errorType}"
+                )
+                DevicesResult.Error(
+                    result.errorType.messageResId,
+                    result.errorType == StatsErrorType.AUTH_ERROR
+                )
+            }
+        }
+    }
+
     private fun calculateChangePercent(
         totalViews: Long,
         previousTotalViews: Long,
@@ -1597,3 +1681,24 @@ data class FileDownloadItemData(
             downloads, previousDownloads
         )
 }
+
+/**
+ * Result wrapper for devices stats fetch operation.
+ */
+sealed class DevicesResult {
+    data class Success(
+        val items: List<DeviceItemData>
+    ) : DevicesResult()
+    data class Error(
+        @StringRes val messageResId: Int,
+        val isAuthError: Boolean = false
+    ) : DevicesResult()
+}
+
+/**
+ * Data for a single device item from the repository layer.
+ */
+data class DeviceItemData(
+    val name: String,
+    val views: Double
+)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1577,6 +1577,9 @@
     <string name="stats_error_parsing">There was a problem loading the data. Please try again</string>
     <string name="stats_error_admin_url_unavailable">Unable to open WP Admin for this site</string>
 
+    <!-- stats ring chart accessibility -->
+    <string name="stats_ring_chart_entry_description">%1$s: %2$s</string>
+
     <!-- stats period selector -->
     <string name="stats_period_today">Today</string>
     <string name="stats_period_last_7_days">Last 7 days</string>
@@ -1606,6 +1609,14 @@
     <!-- Authors Stats Card -->
     <string name="stats_authors_title">Authors</string>
     <string name="stats_authors_author_header">Author</string>
+
+    <!-- Devices Stats Card -->
+    <string name="stats_devices_title">Devices</string>
+    <string name="stats_devices_screensize">Size</string>
+    <string name="stats_devices_browser">Browser</string>
+    <string name="stats_devices_platform">Platform</string>
+    <string name="stats_devices_device_header">Device</string>
+    <string name="stats_devices_percentage_header">Percentage</string>
 
     <!-- Stats Card Configuration -->
     <string name="stats_card_remove">Remove Card</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsCardsConfigurationTest.kt
@@ -27,7 +27,8 @@ class StatsCardsConfigurationTest {
             StatsCardType.CLICKS,
             StatsCardType.SEARCH_TERMS,
             StatsCardType.VIDEO_PLAYS,
-            StatsCardType.FILE_DOWNLOADS
+            StatsCardType.FILE_DOWNLOADS,
+            StatsCardType.DEVICES
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/devices/DevicesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/devices/DevicesViewModelTest.kt
@@ -1,0 +1,573 @@
+package org.wordpress.android.ui.newstats.devices
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.StatsPeriod
+import org.wordpress.android.ui.newstats.repository.DeviceItemData
+import org.wordpress.android.ui.newstats.repository.DevicesResult
+import org.wordpress.android.ui.newstats.repository.StatsRepository
+
+@ExperimentalCoroutinesApi
+@Suppress("LargeClass")
+class DevicesViewModelTest : BaseUnitTest() {
+    @Mock
+    private lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    private lateinit var accountStore: AccountStore
+
+    @Mock
+    private lateinit var statsRepository: StatsRepository
+
+    private lateinit var viewModel: DevicesViewModel
+
+    private val testSite = SiteModel().apply {
+        id = 1
+        siteId = TEST_SITE_ID
+        name = "Test Site"
+    }
+
+    @Before
+    fun setUp() {
+        whenever(selectedSiteRepository.getSelectedSite())
+            .thenReturn(testSite)
+        whenever(accountStore.accessToken)
+            .thenReturn(TEST_ACCESS_TOKEN)
+    }
+
+    private fun initViewModel() {
+        viewModel = DevicesViewModel(
+            selectedSiteRepository,
+            accountStore,
+            statsRepository
+        )
+        viewModel.onPeriodChanged(StatsPeriod.Last7Days)
+    }
+
+    // region Error states
+    @Test
+    fun `when no site selected, then error state is emitted`() =
+        test {
+            whenever(selectedSiteRepository.getSelectedSite())
+                .thenReturn(null)
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Error::class.java
+            )
+            assertThat(
+                (state as DevicesCardUiState.Error).messageResId
+            ).isEqualTo(R.string.stats_error_no_site)
+        }
+
+    @Test
+    fun `when no access token, then error state is emitted`() =
+        test {
+            whenever(accountStore.accessToken).thenReturn(null)
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Error::class.java
+            )
+            assertThat(
+                (state as DevicesCardUiState.Error).messageResId
+            ).isEqualTo(R.string.stats_error_api)
+        }
+
+    @Test
+    fun `when fetch fails, then error state is emitted`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(
+            DevicesResult.Error(R.string.stats_error_api)
+        )
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            DevicesCardUiState.Error::class.java
+        )
+        assertThat(
+            (state as DevicesCardUiState.Error).messageResId
+        ).isEqualTo(R.string.stats_error_api)
+    }
+
+    @Test
+    fun `when auth error, then isAuthError is true`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(
+            DevicesResult.Error(
+                R.string.stats_error_auth,
+                isAuthError = true
+            )
+        )
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            DevicesCardUiState.Error::class.java
+        )
+        assertThat(
+            (state as DevicesCardUiState.Error).isAuthError
+        ).isTrue()
+    }
+
+    @Test
+    fun `when browser fetch fails, then error state is emitted`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+            whenever(
+                statsRepository.fetchDevicesBrowser(any(), any())
+            ).thenReturn(
+                DevicesResult.Error(R.string.stats_error_api)
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDeviceTypeChanged(DeviceType.BROWSER)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Error::class.java
+            )
+        }
+
+    @Test
+    fun `when platform fetch fails, then error state is emitted`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+            whenever(
+                statsRepository.fetchDevicesPlatform(any(), any())
+            ).thenReturn(
+                DevicesResult.Error(R.string.stats_error_api)
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDeviceTypeChanged(DeviceType.PLATFORM)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Error::class.java
+            )
+        }
+
+    @Test
+    fun `when repository throws exception, then unknown error state is emitted`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenThrow(RuntimeException("Network error"))
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Error::class.java
+            )
+            assertThat(
+                (state as DevicesCardUiState.Error).messageResId
+            ).isEqualTo(R.string.stats_error_unknown)
+            assertThat(state.isAuthError).isFalse()
+        }
+    // endregion
+
+    // region Success states
+    @Test
+    fun `when data loads successfully, then loaded state is emitted`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                DevicesCardUiState.Loaded::class.java
+            )
+        }
+
+    @Test
+    fun `when data loads, then items have correct values`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(createScreensizeSuccess())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        val state =
+            viewModel.uiState.value as DevicesCardUiState.Loaded
+        assertThat(state.items).hasSize(3)
+        assertThat(state.items[0].name)
+            .isEqualTo(TEST_DEVICE_NAME_1)
+        assertThat(state.items[0].value)
+            .isEqualTo(TEST_DEVICE_VIEWS_1)
+        assertThat(state.items[1].name)
+            .isEqualTo(TEST_DEVICE_NAME_2)
+        assertThat(state.items[1].value)
+            .isEqualTo(TEST_DEVICE_VIEWS_2)
+    }
+
+    @Test
+    fun `when data loads, then maxValueForBar is set to first item views`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as DevicesCardUiState.Loaded
+            assertThat(state.maxValueForBar)
+                .isEqualTo(TEST_DEVICE_VIEWS_1)
+        }
+
+    @Test
+    fun `when data has zero-value items, then they are included`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(
+                    any(), any()
+                )
+            ).thenReturn(
+                DevicesResult.Success(
+                    items = listOf(
+                        DeviceItemData("Desktop", 57.6),
+                        DeviceItemData("Mobile", 23.9),
+                        DeviceItemData("Tablet", 0.0)
+                    )
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+                as DevicesCardUiState.Loaded
+            assertThat(state.items).hasSize(3)
+            assertThat(state.items[2].name)
+                .isEqualTo("Tablet")
+            assertThat(state.items[2].value).isEqualTo(0.0)
+        }
+
+    @Test
+    fun `when data has zero-value items, then maxValueForBar ignores zeros`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(
+                    any(), any()
+                )
+            ).thenReturn(
+                DevicesResult.Success(
+                    items = listOf(
+                        DeviceItemData("Desktop", 57.6),
+                        DeviceItemData("Tablet", 0.0)
+                    )
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+                as DevicesCardUiState.Loaded
+            assertThat(state.maxValueForBar).isEqualTo(57.6)
+        }
+
+    @Test
+    fun `when data loads with empty items, then loaded state with empty list is emitted`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(
+                DevicesResult.Success(items = emptyList())
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as DevicesCardUiState.Loaded
+            assertThat(state.items).isEmpty()
+            assertThat(state.maxValueForBar).isEqualTo(0.0)
+        }
+    // endregion
+
+    // region Period changes
+    @Test
+    fun `when period changes, then data is reloaded`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(createScreensizeSuccess())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.onPeriodChanged(StatsPeriod.Last30Days)
+        advanceUntilIdle()
+
+        verify(statsRepository, times(2))
+            .fetchDevicesScreensize(any(), any())
+        verify(statsRepository).fetchDevicesScreensize(
+            eq(TEST_SITE_ID), eq(StatsPeriod.Last30Days)
+        )
+    }
+
+    @Test
+    fun `when same period is selected, then data is not reloaded`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onPeriodChanged(StatsPeriod.Last7Days)
+            advanceUntilIdle()
+
+            verify(statsRepository, times(1))
+                .fetchDevicesScreensize(any(), any())
+        }
+    // endregion
+
+    // region Device type switching
+    @Test
+    fun `when switching to browser, then browser data is fetched`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+            whenever(
+                statsRepository.fetchDevicesBrowser(any(), any())
+            ).thenReturn(createBrowserSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDeviceTypeChanged(DeviceType.BROWSER)
+            advanceUntilIdle()
+
+            verify(statsRepository).fetchDevicesBrowser(
+                eq(TEST_SITE_ID), any()
+            )
+        }
+
+    @Test
+    fun `when switching to same type, then data is not re-fetched`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDeviceTypeChanged(DeviceType.SCREENSIZE)
+            advanceUntilIdle()
+
+            verify(statsRepository, times(1))
+                .fetchDevicesScreensize(any(), any())
+        }
+
+    @Test
+    fun `when switching to platform, then platform data is fetched`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+            whenever(
+                statsRepository.fetchDevicesPlatform(any(), any())
+            ).thenReturn(createPlatformSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.onDeviceTypeChanged(DeviceType.PLATFORM)
+            advanceUntilIdle()
+
+            verify(statsRepository).fetchDevicesPlatform(
+                eq(TEST_SITE_ID), any()
+            )
+        }
+    // endregion
+
+    // region Refresh and Retry
+    @Test
+    fun `when refresh is called, then isRefreshing becomes true then false`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isRefreshing.value).isFalse()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isRefreshing.value).isFalse()
+        }
+
+    @Test
+    fun `when refresh is called, then data is fetched`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(createScreensizeSuccess())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        verify(statsRepository, times(2))
+            .fetchDevicesScreensize(eq(TEST_SITE_ID), any())
+    }
+
+    @Test
+    fun `when refresh with no site, then data is not fetched`() =
+        test {
+            whenever(
+                statsRepository.fetchDevicesScreensize(any(), any())
+            ).thenReturn(createScreensizeSuccess())
+
+            initViewModel()
+            advanceUntilIdle()
+
+            whenever(selectedSiteRepository.getSelectedSite())
+                .thenReturn(null)
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            verify(statsRepository, times(1))
+                .fetchDevicesScreensize(any(), any())
+        }
+
+    @Test
+    fun `when onRetry is called, then data is reloaded`() = test {
+        whenever(
+            statsRepository.fetchDevicesScreensize(any(), any())
+        ).thenReturn(createScreensizeSuccess())
+
+        initViewModel()
+        advanceUntilIdle()
+
+        viewModel.onRetry()
+        advanceUntilIdle()
+
+        verify(statsRepository, times(2))
+            .fetchDevicesScreensize(any(), any())
+    }
+    // endregion
+
+    // region getAdminUrl
+    @Test
+    fun `when getAdminUrl called with site, then returns admin url`() =
+        test {
+            testSite.adminUrl = "https://example.com/wp-admin"
+
+            initViewModel()
+
+            assertThat(viewModel.getAdminUrl())
+                .isEqualTo("https://example.com/wp-admin")
+        }
+
+    @Test
+    fun `when getAdminUrl called without site, then returns null`() =
+        test {
+            whenever(selectedSiteRepository.getSelectedSite())
+                .thenReturn(null)
+
+            initViewModel()
+
+            assertThat(viewModel.getAdminUrl()).isNull()
+        }
+    // endregion
+
+    // region Helper functions
+    private fun createScreensizeSuccess() = DevicesResult.Success(
+        items = listOf(
+            DeviceItemData(
+                name = TEST_DEVICE_NAME_1,
+                views = TEST_DEVICE_VIEWS_1
+            ),
+            DeviceItemData(
+                name = TEST_DEVICE_NAME_2,
+                views = TEST_DEVICE_VIEWS_2
+            ),
+            DeviceItemData(
+                name = TEST_DEVICE_NAME_3,
+                views = TEST_DEVICE_VIEWS_3
+            )
+        )
+    )
+
+    private fun createBrowserSuccess() = DevicesResult.Success(
+        items = listOf(
+            DeviceItemData(name = "Chrome", views = 400.0),
+            DeviceItemData(name = "Safari", views = 200.0)
+        )
+    )
+
+    private fun createPlatformSuccess() = DevicesResult.Success(
+        items = listOf(
+            DeviceItemData(name = "Windows", views = 350.0),
+            DeviceItemData(name = "macOS", views = 250.0)
+        )
+    )
+    // endregion
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+        private const val TEST_ACCESS_TOKEN = "test_access_token"
+
+        private const val TEST_DEVICE_NAME_1 = "Desktop"
+        private const val TEST_DEVICE_NAME_2 = "Mobile"
+        private const val TEST_DEVICE_NAME_3 = "Tablet"
+        private const val TEST_DEVICE_VIEWS_1 = 500.0
+        private const val TEST_DEVICE_VIEWS_2 = 300.0
+        private const val TEST_DEVICE_VIEWS_3 = 100.0
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryDevicesTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryDevicesTest.kt
@@ -1,0 +1,340 @@
+package org.wordpress.android.ui.newstats.repository
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.newstats.StatsPeriod
+import org.wordpress.android.ui.newstats.datasource.DevicesData
+import org.wordpress.android.ui.newstats.datasource.DevicesDataResult
+import org.wordpress.android.ui.newstats.datasource.StatsDataSource
+import org.wordpress.android.ui.newstats.datasource.StatsErrorType
+
+@ExperimentalCoroutinesApi
+class StatsRepositoryDevicesTest : BaseUnitTest() {
+    @Mock
+    private lateinit var statsDataSource: StatsDataSource
+
+    @Mock
+    private lateinit var appLogWrapper: AppLogWrapper
+
+    private lateinit var repository: StatsRepository
+
+    @Before
+    fun setUp() {
+        repository = StatsRepository(
+            statsDataSource = statsDataSource,
+            appLogWrapper = appLogWrapper,
+            ioDispatcher = testDispatcher()
+        )
+    }
+
+    // region Screensize
+    @Test
+    fun `given success, when fetchDevicesScreensize, then items are returned sorted by views`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Mobile" to 200.0,
+                            "Desktop" to 500.0,
+                            "Tablet" to 100.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            assertThat(result)
+                .isInstanceOf(DevicesResult.Success::class.java)
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(3)
+            assertThat(success.items[0].name).isEqualTo("Desktop")
+            assertThat(success.items[0].views).isEqualTo(500.0)
+            assertThat(success.items[1].name).isEqualTo("Mobile")
+            assertThat(success.items[2].name).isEqualTo("Tablet")
+        }
+
+    @Test
+    fun `given items with zero views, when fetchDevicesScreensize, then zero-view items are included`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Desktop" to 500.0,
+                            "Mobile" to 0.0,
+                            "Tablet" to 100.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(3)
+            assertThat(success.items.map { it.name })
+                .containsExactly("Desktop", "Tablet", "Mobile")
+        }
+
+    @Test
+    fun `given all items zero views, when fetchDevicesScreensize, then items are still returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Desktop" to 0.0,
+                            "Mobile" to 0.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(2)
+        }
+
+    @Test
+    fun `given empty response, when fetchDevicesScreensize, then empty list is returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(items = emptyMap())
+                )
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).isEmpty()
+        }
+
+    @Test
+    fun `given decimal values, when fetchDevicesScreensize, then values are preserved`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Desktop" to 57.6,
+                            "Mobile" to 23.9,
+                            "Tablet" to 0.5
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(3)
+            assertThat(success.items[0].views)
+                .isEqualTo(57.6)
+            assertThat(success.items[1].views)
+                .isEqualTo(23.9)
+            assertThat(success.items[2].views)
+                .isEqualTo(0.5)
+        }
+
+    @Test
+    fun `given error, when fetchDevicesScreensize, then error result is returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Error(StatsErrorType.API_ERROR)
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            assertThat(result)
+                .isInstanceOf(DevicesResult.Error::class.java)
+            val error = result as DevicesResult.Error
+            assertThat(error.messageResId)
+                .isEqualTo(R.string.stats_error_api)
+        }
+
+    @Test
+    fun `given auth error, when fetchDevicesScreensize, then isAuthError is true`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesScreensize(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Error(StatsErrorType.AUTH_ERROR)
+            )
+
+            val result = repository.fetchDevicesScreensize(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val error = result as DevicesResult.Error
+            assertThat(error.isAuthError).isTrue()
+        }
+    // endregion
+
+    // region Browser
+    @Test
+    fun `given success, when fetchDevicesBrowser, then items are returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesBrowser(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Chrome" to 400.0,
+                            "Safari" to 200.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesBrowser(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(2)
+            assertThat(success.items[0].name).isEqualTo("Chrome")
+        }
+
+    @Test
+    fun `given items with zero views, when fetchDevicesBrowser, then zero-view items are included`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesBrowser(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Chrome" to 400.0,
+                            "IE" to 0.0,
+                            "Safari" to 200.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesBrowser(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(3)
+            assertThat(success.items.map { it.name })
+                .containsExactly("Chrome", "Safari", "IE")
+        }
+    // endregion
+
+    // region Platform
+    @Test
+    fun `given success, when fetchDevicesPlatform, then items are returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesPlatform(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Windows" to 350.0,
+                            "macOS" to 250.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesPlatform(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(2)
+            assertThat(success.items[0].name).isEqualTo("Windows")
+        }
+
+    @Test
+    fun `given items with zero views, when fetchDevicesPlatform, then zero-view items are included`() =
+        test {
+            whenever(
+                statsDataSource.fetchDevicesPlatform(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                DevicesDataResult.Success(
+                    DevicesData(
+                        items = mapOf(
+                            "Windows" to 350.0,
+                            "Linux" to 0.0
+                        )
+                    )
+                )
+            )
+
+            val result = repository.fetchDevicesPlatform(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            val success = result as DevicesResult.Success
+            assertThat(success.items).hasSize(2)
+            assertThat(success.items[0].name).isEqualTo("Windows")
+        }
+    // endregion
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+    }
+}

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1578,6 +1578,9 @@
     <string name="stats_error_parsing">There was a problem loading the data. Please try again</string>
     <string name="stats_error_admin_url_unavailable">Unable to open WP Admin for this site</string>
 
+    <!-- stats ring chart accessibility -->
+    <string name="stats_ring_chart_entry_description">%1$s: %2$d views</string>
+
     <!-- stats period selector -->
     <string name="stats_period_today">Today</string>
     <string name="stats_period_last_7_days">Last 7 days</string>


### PR DESCRIPTION
## Description                                                                                                                                                                  
                                                                                                                                                                                  
  Add a new "Devices" card to the new stats screen that displays device statistics (screen size, browser, and platform) using a ring (donut) chart and a sorted list. The card    
  includes a segmented selector to switch between the three device categories. Items with zero views are filtered out.                                                            
                                                                                                                                                                                  
  The implementation follows the same architecture as the Locations card but is simpler — no detail screen ("Show All") and no previous-period comparison.                        

  ### Changes                                                                                                                                                                     
                                                                                                                                                                                  
  - **Data layer**: Added `fetchDevicesScreensize`, `fetchDevicesBrowser`, `fetchDevicesPlatform` to `StatsDataSource` interface and `StatsDataSourceImpl`, using the new         
  `StatsDevicesParams`/`StatsDevicesPeriod` uniffi types                                                                                                                          
  - **Repository layer**: Added corresponding repository methods with zero-view filtering and descending sort
  - **UI state**: `DevicesCardUiState` (Loading/Loaded/Error), `DeviceType` enum, `DeviceItem` data class
  - **ViewModel**: `DevicesViewModel` with per-type lazy loading, period tracking, and refresh support
  - **Ring chart**: `StatsRingChart` — Canvas-based donut chart with proportional arcs and accessibility support
  - **Card UI**: `DevicesCard` composable with segmented type selector, ring chart, color-coded device list, shimmer loading state, and card management actions
  - **Card registration**: Added `DEVICES` to `StatsCardType` enum and integrated into `NewStatsActivity`

  ## Testing instructions

  Devices card on new stats screen:

  1. Enable FF and open the new stats screen
  2. Scroll down to the "Devices" card
  - [x] Verify the card displays with the "Screen size" tab selected by default
  - [x] Verify a ring (donut) chart is shown with color-coded segments
  - [x] Verify a list of devices is shown below the chart with color dots, names, and view counts

- [x] Verify Browser and Platform tab works as well


https://github.com/user-attachments/assets/23274e4e-12c3-4cfa-8c7c-df52acdccde9
