### PR TITLE
Make NEW_STATS flag visible for all builds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -110,10 +110,10 @@ class NewStatsActivity : BaseAppCompatActivity() {
     }
 }
 
-private enum class StatsTab(val titleResId: Int, val debugOnly: Boolean = false) {
+private enum class StatsTab(val titleResId: Int) {
     TRAFFIC(R.string.stats_traffic),
-    INSIGHTS(R.string.stats_insights, debugOnly = true),
-    SUBSCRIBERS(R.string.subscribers, debugOnly = true)
+    INSIGHTS(R.string.stats_insights),
+    SUBSCRIBERS(R.string.subscribers)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -124,7 +124,8 @@ private fun NewStatsScreen(
     val viewsStatsViewModel: ViewsStatsViewModel = viewModel()
     val selectedPeriod by viewsStatsViewModel.selectedPeriod.collectAsState()
 
-    val tabs = StatsTab.entries.filter { !it.debugOnly || BuildConfig.DEBUG }
+    val showTabs = BuildConfig.DEBUG
+    val tabs = if (showTabs) StatsTab.entries else listOf(StatsTab.TRAFFIC)
     val pagerState = rememberPagerState(pageCount = { tabs.size })
     val coroutineScope = rememberCoroutineScope()
     var showPeriodMenu by remember { mutableStateOf(false) }
@@ -198,25 +199,35 @@ private fun NewStatsScreen(
                 .fillMaxSize()
                 .padding(contentPadding)
         ) {
-            PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
-                tabs.forEachIndexed { index, tab ->
-                    Tab(
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(index)
+            if (tabs.size > 1) {
+                PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
+                    tabs.forEachIndexed { index, tab ->
+                        Tab(
+                            selected = pagerState.currentPage == index,
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(index)
+                                }
+                            },
+                            text = {
+                                Text(
+                                    text = stringResource(id = tab.titleResId)
+                                )
                             }
-                        },
-                        text = { Text(text = stringResource(id = tab.titleResId)) }
-                    )
+                        )
+                    }
                 }
             }
 
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize(),
+                userScrollEnabled = tabs.size > 1
             ) { page ->
-                StatsTabContent(tab = tabs[page], viewsStatsViewModel = viewsStatsViewModel)
+                StatsTabContent(
+                    tab = tabs[page],
+                    viewsStatsViewModel = viewsStatsViewModel
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
@@ -109,10 +110,10 @@ class NewStatsActivity : BaseAppCompatActivity() {
     }
 }
 
-private enum class StatsTab(val titleResId: Int) {
+private enum class StatsTab(val titleResId: Int, val debugOnly: Boolean = false) {
     TRAFFIC(R.string.stats_traffic),
-    INSIGHTS(R.string.stats_insights),
-    SUBSCRIBERS(R.string.subscribers)
+    INSIGHTS(R.string.stats_insights, debugOnly = true),
+    SUBSCRIBERS(R.string.subscribers, debugOnly = true)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -123,7 +124,7 @@ private fun NewStatsScreen(
     val viewsStatsViewModel: ViewsStatsViewModel = viewModel()
     val selectedPeriod by viewsStatsViewModel.selectedPeriod.collectAsState()
 
-    val tabs = StatsTab.entries
+    val tabs = StatsTab.entries.filter { !it.debugOnly || BuildConfig.DEBUG }
     val pagerState = rememberPagerState(pageCount = { tabs.size })
     val coroutineScope = rememberCoroutineScope()
     var showPeriodMenu by remember { mutableStateOf(false) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -51,8 +51,8 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     private fun shouldShowFeature(feature: Feature): Boolean {
-        // Only show Post Types and New Stats features in debug builds
-        return if (feature == Feature.EXPERIMENTAL_POST_TYPES || feature == Feature.NEW_STATS) {
+        // Only show Post Types feature in debug builds
+        return if (feature == Feature.EXPERIMENTAL_POST_TYPES) {
             BuildConfig.DEBUG
         } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR


### PR DESCRIPTION
## Description

Enable the NEW_STATS experimental feature flag in all build variants, not just debug builds. Additionally, hide the Insights and Subscribers tabs in release builds since they are still under construction.

## Testing instructions

Feature flag visibility in non-debug builds:

1. Build and run a release/vanilla variant
2. Navigate to experimental features settings
- [ ] Verify NEW_STATS flag is listed and can be toggled
3. Enable the NEW_STATS feature flag
4. Open Stats
- [ ] Verify only the Traffic tab is visible

<img width="255" height="571" alt="Screenshot 2026-02-24 at 16 48 28" src="https://github.com/user-attachments/assets/4b50c0a4-6d78-4bb2-b8b3-14f38495f89f" />

Feature flag visibility in debug builds:

1. Build and run a debug variant
2. Navigate to experimental features settings
- [x] Verify NEW_STATS flag is listed and can be toggled
3. Enable the NEW_STATS feature flag
4. Open Stats
- [x] Verify all 3 tabs are visible: Traffic, Insights, Subscribers

<img width="258" height="571" alt="Screenshot 2026-02-24 at 16 34 58" src="https://github.com/user-attachments/assets/16494f14-5e87-4277-8166-43c978f4b862" />
