### PR TITLE
Improve media upload recovery and retry reliability

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -70,7 +71,10 @@ public class UploadService extends Service {
     private static final String KEY_SHOULD_TRACK_ANALYTICS = "shouldTrackPostAnalytics";
     private static final String KEY_SOURCE_FOR_LOGGING = "sourceForLogging";
 
-    private static final Set<Integer> RECOVERED_MEDIA_IDS = new HashSet<>();
+    // Accessed only on the main thread from onCreate(). Retains IDs for the process lifetime
+    // to prevent re-recovery loops; naturally cleared when the process dies.
+    private static final Set<Integer> RECOVERED_MEDIA_IDS =
+            Collections.synchronizedSet(new HashSet<>());
 
     private static @Nullable UploadService sInstance;
 
@@ -277,9 +281,9 @@ public class UploadService extends Service {
                 if (!RECOVERED_MEDIA_IDS.contains(media.getId())) {
                     mMediaUploadHandler.upload(media);
                     RECOVERED_MEDIA_IDS.add(media.getId());
+                    allRecoveredMedia.add(media);
                 }
             }
-            allRecoveredMedia.addAll(mediaToRecover);
         }
 
         if (!allRecoveredMedia.isEmpty()) {
@@ -293,7 +297,7 @@ public class UploadService extends Service {
     private boolean hasValidFile(MediaModel media) {
         String filePath = media.getFilePath();
         return filePath != null && !filePath.isEmpty()
-                && new java.io.File(filePath).exists();
+                && new File(filePath).exists();
     }
 
     private void registerPostModelsForMedia(List<MediaModel> mediaList, boolean isRetry) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -70,7 +70,7 @@ public class UploadService extends Service {
     private static final String KEY_SHOULD_TRACK_ANALYTICS = "shouldTrackPostAnalytics";
     private static final String KEY_SOURCE_FOR_LOGGING = "sourceForLogging";
 
-    private static final Set<Integer> sRecoveredMediaIds = new HashSet<>();
+    private static final Set<Integer> RECOVERED_MEDIA_IDS = new HashSet<>();
 
     private static @Nullable UploadService sInstance;
 
@@ -274,9 +274,9 @@ public class UploadService extends Service {
             }
 
             for (MediaModel media : mediaToRecover) {
-                if (!sRecoveredMediaIds.contains(media.getId())) {
+                if (!RECOVERED_MEDIA_IDS.contains(media.getId())) {
                     mMediaUploadHandler.upload(media);
-                    sRecoveredMediaIds.add(media.getId());
+                    RECOVERED_MEDIA_IDS.add(media.getId());
                 }
             }
             allRecoveredMedia.addAll(mediaToRecover);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -70,6 +70,8 @@ public class UploadService extends Service {
     private static final String KEY_SHOULD_TRACK_ANALYTICS = "shouldTrackPostAnalytics";
     private static final String KEY_SOURCE_FOR_LOGGING = "sourceForLogging";
 
+    private static final Set<Integer> sRecoveredMediaIds = new HashSet<>();
+
     private static @Nullable UploadService sInstance;
 
     private MediaUploadHandler mMediaUploadHandler;
@@ -99,7 +101,6 @@ public class UploadService extends Service {
         AppLog.i(T.MAIN, "UploadService > Created");
         mDispatcher.register(this);
         sInstance = this;
-        // TODO: Recover any posts/media uploads that were interrupted by the service being stopped
 
         if (mMediaUploadHandler == null) {
             mMediaUploadHandler = new MediaUploadHandler();
@@ -112,6 +113,8 @@ public class UploadService extends Service {
         if (mPostUploadHandler == null) {
             mPostUploadHandler = new PostUploadHandler(mPostUploadNotifier);
         }
+
+        recoverInterruptedMediaUploads();
     }
 
     @Override
@@ -245,6 +248,52 @@ public class UploadService extends Service {
                 mPostUploadNotifier.addMediaInfoToForegroundNotification(toBeUploadedMediaList);
             }
         }
+    }
+
+    private void recoverInterruptedMediaUploads() {
+        List<MediaModel> allRecoveredMedia = new ArrayList<>();
+        for (SiteModel site : mSiteStore.getSites()) {
+            List<MediaModel> mediaToRecover = new ArrayList<>(
+                    mMediaStore.getSiteMediaWithState(site, MediaUploadState.QUEUED));
+
+            for (MediaModel media : mMediaStore.getSiteMediaWithState(
+                    site, MediaUploadState.UPLOADING)) {
+                media.setUploadState(MediaUploadState.QUEUED.toString());
+                mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
+                mediaToRecover.add(media);
+            }
+
+            for (MediaModel media : mMediaStore.getSiteMediaWithState(
+                    site, MediaUploadState.FAILED)) {
+                if (media.getLocalPostId() > 0 && hasValidFile(media)) {
+                    media.setUploadState(MediaUploadState.QUEUED.toString());
+                    mDispatcher.dispatch(
+                            MediaActionBuilder.newUpdateMediaAction(media));
+                    mediaToRecover.add(media);
+                }
+            }
+
+            for (MediaModel media : mediaToRecover) {
+                if (!sRecoveredMediaIds.contains(media.getId())) {
+                    mMediaUploadHandler.upload(media);
+                    sRecoveredMediaIds.add(media.getId());
+                }
+            }
+            allRecoveredMedia.addAll(mediaToRecover);
+        }
+
+        if (!allRecoveredMedia.isEmpty()) {
+            registerPostModelsForMedia(allRecoveredMedia, false);
+            AppLog.i(T.MEDIA, "UploadService > Recovered "
+                    + allRecoveredMedia.size()
+                    + " interrupted media uploads");
+        }
+    }
+
+    private boolean hasValidFile(MediaModel media) {
+        String filePath = media.getFilePath();
+        return filePath != null && !filePath.isEmpty()
+                && new java.io.File(filePath).exists();
     }
 
     private void registerPostModelsForMedia(List<MediaModel> mediaList, boolean isRetry) {

--- a/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
@@ -34,6 +34,7 @@ class UploadWorker(
         private const val UPLOAD_FROM_ALL_SITES = -1
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun doWork(): Result {
         AppLog.i(AppLog.T.MAIN, "UploadWorker started")
         return try {
@@ -70,6 +71,8 @@ class UploadWorker(
     }
 }
 
+private const val BACKOFF_DELAY_MINUTES = 10L
+
 private fun getUploadConstraints(): Constraints {
     return Constraints.Builder()
         .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -79,7 +82,7 @@ private fun getUploadConstraints(): Constraints {
 fun enqueueUploadWorkRequestForSite(site: SiteModel): Pair<WorkRequest, Operation> {
     val request = OneTimeWorkRequestBuilder<UploadWorker>()
         .setConstraints(getUploadConstraints())
-        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, MINUTES)
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_MINUTES, MINUTES)
         .setInputData(workDataOf(WordPress.LOCAL_SITE_ID to site.id))
         .build()
     val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniqueWork(
@@ -92,7 +95,7 @@ fun enqueueUploadWorkRequestForSite(site: SiteModel): Pair<WorkRequest, Operatio
 fun enqueuePeriodicUploadWorkRequestForAllSites(): Pair<WorkRequest, Operation> {
     val request = PeriodicWorkRequestBuilder<UploadWorker>(8, HOURS, 6, HOURS)
         .setConstraints(getUploadConstraints())
-        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, MINUTES)
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_MINUTES, MINUTES)
         .build()
     val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniquePeriodicWork(
         "periodic auto-upload",

--- a/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.util
 
 import android.content.Context
+import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
@@ -21,6 +22,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.uploads.UploadStarter
 import java.util.concurrent.TimeUnit.HOURS
+import java.util.concurrent.TimeUnit.MINUTES
 
 class UploadWorker(
     appContext: Context,
@@ -34,15 +36,20 @@ class UploadWorker(
 
     override fun doWork(): Result {
         AppLog.i(AppLog.T.MAIN, "UploadWorker started")
-        runBlocking {
-            val job = when (val localSiteId = inputData.getInt(WordPress.LOCAL_SITE_ID, UPLOAD_FROM_ALL_SITES)) {
-                UPLOAD_FROM_ALL_SITES -> uploadStarter.queueUploadFromAllSites()
-                else -> siteStore.getSiteByLocalId(localSiteId)?.let { uploadStarter.queueUploadFromSite(it) }
+        return try {
+            runBlocking {
+                val job = when (val localSiteId = inputData.getInt(WordPress.LOCAL_SITE_ID, UPLOAD_FROM_ALL_SITES)) {
+                    UPLOAD_FROM_ALL_SITES -> uploadStarter.queueUploadFromAllSites()
+                    else -> siteStore.getSiteByLocalId(localSiteId)?.let { uploadStarter.queueUploadFromSite(it) }
+                }
+                job?.join()
             }
-            job?.join()
+            AppLog.i(AppLog.T.MAIN, "UploadWorker finished")
+            Result.success()
+        } catch (e: Exception) {
+            AppLog.e(AppLog.T.MAIN, "UploadWorker failed; will retry", e)
+            Result.retry()
         }
-        AppLog.i(AppLog.T.MAIN, "UploadWorker finished")
-        return Result.success()
     }
 
     class Factory(
@@ -65,13 +72,14 @@ class UploadWorker(
 
 private fun getUploadConstraints(): Constraints {
     return Constraints.Builder()
-        .setRequiredNetworkType(NetworkType.NOT_ROAMING)
+        .setRequiredNetworkType(NetworkType.CONNECTED)
         .build()
 }
 
 fun enqueueUploadWorkRequestForSite(site: SiteModel): Pair<WorkRequest, Operation> {
     val request = OneTimeWorkRequestBuilder<UploadWorker>()
         .setConstraints(getUploadConstraints())
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, MINUTES)
         .setInputData(workDataOf(WordPress.LOCAL_SITE_ID to site.id))
         .build()
     val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniqueWork(
@@ -84,6 +92,7 @@ fun enqueueUploadWorkRequestForSite(site: SiteModel): Pair<WorkRequest, Operatio
 fun enqueuePeriodicUploadWorkRequestForAllSites(): Pair<WorkRequest, Operation> {
     val request = PeriodicWorkRequestBuilder<UploadWorker>(8, HOURS, 6, HOURS)
         .setConstraints(getUploadConstraints())
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, MINUTES)
         .build()
     val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniquePeriodicWork(
         "periodic auto-upload",


### PR DESCRIPTION
## Description

Improves reliability of media upload recovery when `UploadService` restarts after an interruption, and adds retry/backoff logic to `UploadWorker`.

**UploadService changes:**
- Recover QUEUED, UPLOADING, and post-bound FAILED media on service startup
- Register recovered media with their associated posts via `registerPostModelsForMedia()` so post uploads proceed after media completes
- Add session-level deduplication (`sRecoveredMediaIds`) to prevent the same media from being re-recovered in a restart loop
- Skip FAILED media whose source file no longer exists on disk
- Only recover FAILED media that belongs to a post (`localPostId > 0`) to avoid retrying standalone media the user may have dismissed

**UploadWorker changes:**
- Wrap `doWork()` in try/catch returning `Result.retry()` on failure instead of crashing
- Add exponential backoff (10 min base) for both one-time and periodic work requests
- Relax network constraint from `NOT_ROAMING` to `CONNECTED`

## Testing instructions

Recovery of interrupted uploads:

1. Start a media upload attached to a post
2. Force-kill the app before the upload completes
3. Relaunch the app
- [ ] Verify the upload resumes (check logcat for "Recovered N interrupted media uploads")
- [ ] Verify the associated post publishes after media completes

Recovery skips missing files:

1. Start a media upload attached to a post
2. Force-kill the app before the upload completes
3. Delete the source image from the device
4. Relaunch the app
- [ ] Verify no crash occurs
- [ ] Verify the missing-file media is skipped (not recovered)

UploadWorker retry:

1. Start an upload with network available
2. Disable network mid-upload
3. Re-enable network
- [ ] Verify the worker retries with backoff and the upload eventually completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)