### PR TITLE
fix: open redirect_to URL in browser to prevent infinite deep link loop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -131,12 +131,21 @@ class DeepLinkingIntentReceiverViewModel
 
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction? {
         return when {
-            deepLinkUriUtils.isTrackingUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)
-                ?.also {
-                    // The new URL was build so we need to hit the original `mbar` tracking URL
+            deepLinkUriUtils.isTrackingUrl(uri) -> {
+                val redirectUri = deepLinkUriUtils.getRedirectUri(uri)
+                val navigateAction = redirectUri?.let { buildNavigateAction(it, rootUri) }
+                if (navigateAction != null) {
                     serverTrackingHandler.request(uri)
+                    navigateAction
+                } else {
+                    // Open the redirect destination (not the tracking URL) to avoid
+                    // an infinite loop with the app's own intent filter.
+                    // Fall back to the tracking URL only if there's no redirect_to.
+                    OpenInBrowser(
+                        redirectUri ?: rootUri.copy(REGULAR_TRACKING_PATH)
+                    )
                 }
-                ?: OpenInBrowser(rootUri.copy(REGULAR_TRACKING_PATH))
+            }
             deepLinkUriUtils.isWpLoginUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)
             else -> deepLinkHandlers.buildNavigateAction(uri)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -135,15 +135,22 @@ class DeepLinkingIntentReceiverViewModel
                 val redirectUri = deepLinkUriUtils.getRedirectUri(uri)
                 val navigateAction = redirectUri?.let { buildNavigateAction(it, rootUri) }
                 if (navigateAction != null) {
+                    // Handled in-app — fire the tracking pixel since the
+                    // server won't see the request otherwise.
                     serverTrackingHandler.request(uri)
                     navigateAction
+                } else if (redirectUri != null) {
+                    // Can't handle in-app. Open the redirect destination
+                    // (not the tracking URL) to avoid an infinite loop with
+                    // the app's intent filter. Fire the tracking pixel
+                    // explicitly since the browser won't hit the tracking URL.
+                    serverTrackingHandler.request(uri)
+                    OpenInBrowser(redirectUri)
                 } else {
-                    // Open the redirect destination (not the tracking URL) to avoid
-                    // an infinite loop with the app's own intent filter.
-                    // Fall back to the tracking URL only if there's no redirect_to.
-                    OpenInBrowser(
-                        redirectUri ?: rootUri.copy(REGULAR_TRACKING_PATH)
-                    )
+                    // No redirect_to param — open the /bar/ tracking URL in
+                    // the browser. The browser request itself will handle
+                    // server-side tracking, so no explicit pixel needed.
+                    OpenInBrowser(rootUri.copy(REGULAR_TRACKING_PATH))
                 }
             }
             deepLinkUriUtils.isWpLoginUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -137,26 +137,34 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val startUrl = mock<UriWrapper>()
         val wpLoginUri = initWpLoginUri(startUrl)
         val uri = initTrackingUri(wpLoginUri)
-        val barUri = buildUri("public-api.wordpress.com")
 
         whenever(deepLinkHandlers.buildNavigateAction(startUrl)).thenReturn(null)
-        whenever(uri.copy("bar")).thenReturn(barUri)
 
         viewModel.start(null, uri, DEFAULT, null)
 
-        assertUriHandled(OpenInBrowser(barUri))
+        assertUriHandled(OpenInBrowser(wpLoginUri))
+    }
+
+    @Test
+    fun `tracking URL with unhandled direct redirect opens redirect URL in browser`() {
+        val redirectUri = buildUri("wordpress.com")
+        val uri = initTrackingUri(redirectUri)
+
+        whenever(deepLinkHandlers.buildNavigateAction(redirectUri)).thenReturn(null)
+
+        viewModel.start(null, uri, DEFAULT, null)
+
+        assertUriHandled(OpenInBrowser(redirectUri))
     }
 
     @Test
     fun `wp-login mbar URL redirects user to browser with missing second redirect`() {
         val wpLoginUri = initWpLoginUri()
         val uri = initTrackingUri(wpLoginUri)
-        val barUri = buildUri("public-api.wordpress.com")
-        whenever(uri.copy("bar")).thenReturn(barUri)
 
         viewModel.start(null, uri, DEFAULT, null)
 
-        assertUriHandled(OpenInBrowser(barUri))
+        assertUriHandled(OpenInBrowser(wpLoginUri))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -143,6 +143,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         viewModel.start(null, uri, DEFAULT, null)
 
         assertUriHandled(OpenInBrowser(wpLoginUri))
+        verify(serverTrackingHandler).request(uri)
     }
 
     @Test
@@ -155,6 +156,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         viewModel.start(null, uri, DEFAULT, null)
 
         assertUriHandled(OpenInBrowser(redirectUri))
+        verify(serverTrackingHandler).request(uri)
     }
 
     @Test
@@ -165,6 +167,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         viewModel.start(null, uri, DEFAULT, null)
 
         assertUriHandled(OpenInBrowser(wpLoginUri))
+        verify(serverTrackingHandler).request(uri)
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix CMM-1230. Fix NL-473. 

When the Jetpack app receives a `public-api.wordpress.com/bar/` or `/mbar/` tracking URL (e.g. from a WordPress passwordless login email), it extracts the `redirect_to` parameter and tries to handle the destination in-app. If no handler exists for the destination (e.g. `wordpress.com/log-in/link/use` for passwordless login), the fallback opens the **original tracking URL** in the browser.

This causes an infinite loop on Play Store builds. The exact interception mechanism is unclear — the app's intent filter uses `pathPattern="/bar/.*"` which shouldn't match `/bar/` with no trailing path segment, and local debug builds don't reproduce the issue. It may be related to Android App Links verification behaving differently for Play Store installs, or the server-side 302 redirect from `/bar` to `/bar/` interacting with the verified domain. Regardless, the app repeatedly cycles between trying to handle the URL and falling back to the browser.

This PR changes the fallback in `buildNavigateAction()` so that when a tracking URL's `redirect_to` target can't be handled in-app, it opens the **extracted redirect_to URL** in the browser instead of the original tracking URL. This breaks the loop because the redirect destination (e.g. `wordpress.com/log-in/link/use`) is not matched by any of the app's intent filters.

When there is no `redirect_to` parameter at all, the existing behavior (open tracking URL with `bar` path in browser) is preserved.

## Testing instructions

Passwordless login flow:

1. Uninstall previous apps, install the PR's prototype build.
2. In the app, log in with a password-less WordPress.com account.
3. Finish the log in process in the browser that launches.
4. Tap Approve for the OAuth connection in the browser UI.
- [x] Verify the app launches and the user is logged into the app.