### PR TITLE
RS Posts: Add PostItemState variant UI indicators

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -116,14 +116,14 @@ fun PostItemState.toUiModel(
         is PostItemState.Stale ->
             data.toUiModel(showStatus)
         is PostItemState.FetchingWithData ->
-            data.toUiModel(showStatus).copy(
-                displayState =
-                    PostDisplayState.FETCHING_WITH_DATA
+            data.toUiModel(
+                showStatus,
+                PostDisplayState.FETCHING_WITH_DATA
             )
         is PostItemState.FailedWithData ->
-            data.toUiModel(showStatus).copy(
-                displayState =
-                    PostDisplayState.FAILED_WITH_DATA
+            data.toUiModel(
+                showStatus,
+                PostDisplayState.FAILED_WITH_DATA
             )
         is PostItemState.Missing,
         is PostItemState.Fetching -> PostRsUiModel(
@@ -144,7 +144,8 @@ fun PostItemState.toUiModel(
 }
 
 private fun FullEntityAnyPostWithEditContext.toUiModel(
-    showStatus: Boolean
+    showStatus: Boolean,
+    displayState: PostDisplayState = PostDisplayState.NORMAL
 ): PostRsUiModel {
     val post: AnyPostWithEditContext = data
     return PostRsUiModel(
@@ -171,7 +172,8 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
             post.status.toLabel()
         } else {
             0
-        }
+        },
+        displayState = displayState
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -38,6 +38,14 @@ data class PostTabUiState(
     val isAuthError: Boolean = false
 )
 
+enum class PostDisplayState {
+    NORMAL,
+    FETCHING_WITH_DATA,
+    FAILED_WITH_DATA,
+    PLACEHOLDER,
+    ERROR
+}
+
 data class PostRsUiModel(
     val remotePostId: Long,
     val title: String,
@@ -53,8 +61,8 @@ data class PostRsUiModel(
     val featuredImageId: Long = 0L,
     val featuredImageUrl: String? = null,
     val actions: List<PostRsMenuAction> = emptyList(),
-    val isPlaceholder: Boolean = false,
-    val isError: Boolean = false
+    val displayState: PostDisplayState =
+        PostDisplayState.NORMAL
 )
 
 enum class PostRsMenuAction(
@@ -108,23 +116,29 @@ fun PostItemState.toUiModel(
         is PostItemState.Stale ->
             data.toUiModel(showStatus)
         is PostItemState.FetchingWithData ->
-            data.toUiModel(showStatus)
+            data.toUiModel(showStatus).copy(
+                displayState =
+                    PostDisplayState.FETCHING_WITH_DATA
+            )
         is PostItemState.FailedWithData ->
-            data.toUiModel(showStatus)
+            data.toUiModel(showStatus).copy(
+                displayState =
+                    PostDisplayState.FAILED_WITH_DATA
+            )
         is PostItemState.Missing,
         is PostItemState.Fetching -> PostRsUiModel(
             remotePostId = postId,
             title = "",
             excerpt = "",
             date = "",
-            isPlaceholder = true
+            displayState = PostDisplayState.PLACEHOLDER
         )
         is PostItemState.Failed -> PostRsUiModel(
             remotePostId = postId,
             title = "",
             excerpt = "",
             date = "",
-            isError = true
+            displayState = PostDisplayState.ERROR
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -44,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.wordpress.android.R
+import org.wordpress.android.ui.postsrs.PostDisplayState
 import org.wordpress.android.ui.postsrs.PostRsMenuAction
 import org.wordpress.android.ui.postsrs.PostRsUiModel
 import org.wordpress.android.ui.postsrs.data.PostRsRestClient
@@ -55,10 +58,17 @@ fun PostRsListItem(
     onMenuAction: (PostRsMenuAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    when {
-        post.isPlaceholder -> PlaceholderItem(modifier)
-        post.isError -> ErrorItem(modifier)
-        else -> PostContentItem(post, onClick, onMenuAction, modifier)
+    when (post.displayState) {
+        PostDisplayState.PLACEHOLDER ->
+            PlaceholderItem(modifier)
+        PostDisplayState.ERROR ->
+            ErrorItem(modifier)
+        PostDisplayState.NORMAL,
+        PostDisplayState.FETCHING_WITH_DATA,
+        PostDisplayState.FAILED_WITH_DATA ->
+            PostContentItem(
+                post, onClick, onMenuAction, modifier
+            )
     }
 }
 
@@ -98,11 +108,42 @@ private fun PostContentItem(
                     }
                 }
                 if (dateText.isNotBlank()) {
-                    Text(
-                        text = dateText,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary
-                    )
+                    Row(
+                        verticalAlignment =
+                            Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = dateText,
+                            style = MaterialTheme
+                                .typography.labelSmall,
+                            color = MaterialTheme
+                                .colorScheme.primary,
+                            modifier = Modifier.weight(
+                                1f, fill = false
+                            )
+                        )
+                        if (post.displayState ==
+                            PostDisplayState.FAILED_WITH_DATA
+                        ) {
+                            Spacer(
+                                modifier =
+                                    Modifier.width(4.dp)
+                            )
+                            Icon(
+                                imageVector =
+                                    Icons.Default.Warning,
+                                contentDescription =
+                                    stringResource(
+                                        R.string
+                                            .post_rs_sync_failed
+                                    ),
+                                modifier =
+                                    Modifier.size(14.dp),
+                                tint = MaterialTheme
+                                    .colorScheme.error
+                            )
+                        }
+                    }
                     Spacer(modifier = Modifier.height(4.dp))
                 }
                 Text(
@@ -156,6 +197,19 @@ private fun PostContentItem(
                     )
                 }
             }
+        }
+        if (post.displayState ==
+            PostDisplayState.FETCHING_WITH_DATA
+        ) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp),
+                color = MaterialTheme.colorScheme.primary
+                    .copy(alpha = 0.5f),
+                trackColor = MaterialTheme
+                    .colorScheme.surface
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -337,3 +338,83 @@ private fun ErrorItem(modifier: Modifier = Modifier) {
 }
 
 private val FEATURED_IMAGE_SIZE = PostRsRestClient.FEATURED_IMAGE_SIZE_DP.dp
+
+// region Previews
+
+private fun samplePost(
+    displayState: PostDisplayState = PostDisplayState.NORMAL
+) = PostRsUiModel(
+    remotePostId = 1L,
+    title = "Welcome to the Flavor Journey",
+    excerpt = "Exploring the rich world of seasonal "
+        + "ingredients and traditional techniques.",
+    date = "Dec 15, 2025",
+    authorDisplayName = "Alice",
+    displayState = displayState
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewNormal() {
+    MaterialTheme {
+        PostRsListItem(
+            post = samplePost(),
+            onClick = {},
+            onMenuAction = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewFetchingWithData() {
+    MaterialTheme {
+        PostRsListItem(
+            post = samplePost(
+                PostDisplayState.FETCHING_WITH_DATA
+            ),
+            onClick = {},
+            onMenuAction = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewFailedWithData() {
+    MaterialTheme {
+        PostRsListItem(
+            post = samplePost(
+                PostDisplayState.FAILED_WITH_DATA
+            ),
+            onClick = {},
+            onMenuAction = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewPlaceholder() {
+    MaterialTheme {
+        PostRsListItem(
+            post = samplePost(PostDisplayState.PLACEHOLDER),
+            onClick = {},
+            onMenuAction = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewError() {
+    MaterialTheme {
+        PostRsListItem(
+            post = samplePost(PostDisplayState.ERROR),
+            onClick = {},
+            onMenuAction = {}
+        )
+    }
+}
+
+// endregion

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1012,6 +1012,7 @@
     <string name="post_rs_error_update_status">Failed to update post status</string>
     <string name="post_rs_error_load_more">Couldn\'t load more posts</string>
     <string name="post_rs_error_auth">Your authentication has expired. Please sign in again.</string>
+    <string name="post_rs_sync_failed">Sync failed</string>
     <string name="post_types_screen_title">Post Types</string>
 
     <!-- Debug settings -->


### PR DESCRIPTION
## Summary
This PR updates the experimental post list to support the "state variants" added in [this wordpress-rs PR](https://github.com/Automattic/wordpress-rs/pull/1180#event-23084394792).

<img width="1057" height="623" alt="variants" src="https://github.com/user-attachments/assets/98fc780a-3f02-426a-b03f-46d086f9cad0" />

## Test plan

This PR doesn't lend itself well to testing since it involves various post states. I recommend simply scrolling through a large list of posts to verify everything looks correct, then viewing the previews in `PostRsListItem` to see the various states.

<img width="1326" height="390" alt="preview" src="https://github.com/user-attachments/assets/a89bcc6d-f72c-4be9-b4e6-ff69bd412013" />

