### PR TITLE
Surface errors when post publish silently fails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -662,6 +662,13 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
     public void onPostUploaded(OnPostUploaded event) {
         // check if the event is related to the PostModel that is being uploaded by PostUploadHandler
         if (!isPostUploading(event.post)) {
+            AppLog.w(T.POSTS, "PostUploadHandler > onPostUploaded: ignoring event for post "
+                              + (event.post != null ? event.post.getId() : "null")
+                              + " because it is not the currently uploading post"
+                              + " (current=" + (sCurrentUploadingPost != null
+                              ? sCurrentUploadingPost.getId() : "null") + ")"
+                              + (event.isError() ? " error: " + event.error.type
+                              + " " + event.error.message : ""));
             return;
         }
         SiteModel site = mSiteStore.getSiteByLocalId(event.post.getLocalSiteId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -459,6 +459,8 @@ public class UploadUtils {
             if (onPublishingCallback != null) {
                 onPublishingCallback.onPublishing(isFirstTimePublish);
             }
+        } else {
+            ToastUtils.showToast(activity, R.string.no_network_message, ToastUtils.Duration.SHORT);
         }
         PostUtils.trackSavePostAnalytics(post, site);
     }


### PR DESCRIPTION
## Summary

Investigating [CMM-1297](https://linear.app/a8c/issue/CMM-1297): posts intermittently stay in draft after tapping Publish with no error shown.

Two small changes to surface errors that are currently silently swallowed:

- **`UploadUtils.publishPost()`**: Added an `else` branch to the existing network availability check. Previously, if the network was unavailable at the moment of publish, the upload was silently skipped with no user feedback. Now shows a "no network" toast.
- **`PostUploadHandler.onPostUploaded()`**: Added warning log when an `OnPostUploaded` event is received for a post that is no longer tracked as the currently uploading post. Logs the post IDs involved and any error details that would otherwise be silently dropped. This will help diagnose cases where the upload response arrives but the handler state has been cleared (e.g. service killed by OS on low-memory devices).

These are additive-only changes — no existing control flow is altered.

## Test plan
- [x] Verify publish still works normally with network available
- [ ] Enable airplane mode, attempt to publish a post, confirm toast is shown
- [ ] Check that diagnostic logs capture the new warning messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)