### PR TITLE
New Stats: polish iteration — layout, icons, colors, chart fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ClockModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ClockModule.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.modules
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.time.Clock
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class ClockModule {
+    @Provides
+    @Singleton
+    fun provideClock(): Clock {
+        return Clock.systemDefaultZone()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsColors.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsColors.kt
@@ -7,6 +7,6 @@ import androidx.compose.ui.graphics.Color
  * Centralizes color definitions for consistency and maintainability.
  */
 object StatsColors {
-    val ChangeBadgePositive = Color(0xFF4CAF50)
+    val ChangeBadgePositive = Color(0xFF2E7D32)
     val ChangeBadgeNegative = Color(0xFFE91E63)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/authors/AuthorsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/authors/AuthorsCard.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonOutline
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -202,7 +202,7 @@ fun AuthorAvatar(
             contentAlignment = Alignment.Center
         ) {
             Icon(
-                imageVector = Icons.Default.Person,
+                imageVector = Icons.Default.PersonOutline,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(size * 0.6f)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardCommon.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardCommon.kt
@@ -280,7 +280,7 @@ fun StatsViewsColumn(
     Column(horizontalAlignment = Alignment.End) {
         Text(
             text = formatStatValue(views),
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface
         )
@@ -298,7 +298,7 @@ fun StatsItemName(
 ) {
     Text(
         text = name,
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
@@ -342,7 +342,7 @@ fun StatsListItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 8.dp),
+                .padding(vertical = 12.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             icon()
@@ -378,7 +378,7 @@ fun StatsDetailListItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 8.dp),
+                .padding(vertical = 12.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             StatsPositionNumber(position = position)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardCommon.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsCardCommon.kt
@@ -313,7 +313,7 @@ fun StatsItemName(
 fun StatsPositionNumber(position: Int) {
     Text(
         text = position.toString(),
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.bodyLarge,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.width(32.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsSummaryCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsSummaryCard.kt
@@ -109,10 +109,10 @@ private fun ViewsChangeIndicator(
             tint = color
         )
         Text(
-            text = "$sign${formatStatValue(abs(change))} (${
-                String.format(Locale.getDefault(), "%.1f%%", abs(changePercent))
-            })",
-            style = MaterialTheme.typography.labelSmall,
+            text = String.format(
+                Locale.getDefault(), "%s%.1f%%", sign, abs(changePercent)
+            ),
+            style = MaterialTheme.typography.labelMedium,
             color = color
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsViewChange.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/components/StatsViewChange.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.ui.newstats.StatsColors
-import org.wordpress.android.ui.newstats.util.formatStatValue
 import java.util.Locale
 
 /**
@@ -33,15 +32,11 @@ sealed class StatsViewChange : Parcelable {
 fun StatsChangeIndicator(change: StatsViewChange) {
     val (text, color) = when (change) {
         is StatsViewChange.Positive -> Pair(
-            "+${formatStatValue(change.value)} (${
-                String.format(Locale.getDefault(), "%.1f%%", change.percentage)
-            })",
+            String.format(Locale.getDefault(), "+%.1f%%", change.percentage),
             StatsColors.ChangeBadgePositive
         )
         is StatsViewChange.Negative -> Pair(
-            "-${formatStatValue(change.value)} (${
-                String.format(Locale.getDefault(), "%.1f%%", change.percentage)
-            })",
+            String.format(Locale.getDefault(), "-%.1f%%", change.percentage),
             StatsColors.ChangeBadgeNegative
         )
         is StatsViewChange.NoChange -> return
@@ -49,7 +44,7 @@ fun StatsChangeIndicator(change: StatsViewChange) {
 
     Text(
         text = text,
-        style = MaterialTheme.typography.labelSmall,
+        style = MaterialTheme.typography.labelMedium,
         color = color
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.newstats.mostviewed
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,6 +35,7 @@ import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.newstats.StatsCardType
 import org.wordpress.android.ui.newstats.StatsColors
 import org.wordpress.android.ui.newstats.components.CardPosition
+import org.wordpress.android.ui.newstats.components.ShowAllFooter
 import org.wordpress.android.ui.newstats.components.StatsCardMenu
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 import org.wordpress.android.ui.newstats.util.formatStatValue
@@ -377,31 +377,6 @@ private fun EmptyStateContent() {
             text = stringResource(R.string.stats_no_data_yet),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-@Composable
-private fun ShowAllFooter(onClick: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = stringResource(R.string.stats_show_all),
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Icon(
-            imageVector = Icons.Default.ChevronRight,
-            contentDescription = null,
-            modifier = Modifier.size(16.dp),
-            tint = MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -304,13 +304,13 @@ private fun MostViewedItemRow(item: MostViewedItem, percentage: Float) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 8.dp),
+                .padding(vertical = 12.dp, horizontal = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = item.title,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -324,7 +324,7 @@ private fun MostViewedItemRow(item: MostViewedItem, percentage: Float) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = formatStatValue(item.views),
-                            style = MaterialTheme.typography.bodyMedium,
+                            style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -347,19 +347,15 @@ private fun MostViewedItemRow(item: MostViewedItem, percentage: Float) {
 internal fun ChangeIndicator(change: MostViewedChange) {
     val (text, color) = when (change) {
         is MostViewedChange.Positive -> Pair(
-            "+${formatStatValue(change.value)} (${
-                String.format(Locale.getDefault(), "%.1f%%", change.percentage)
-            })",
+            String.format(Locale.getDefault(), "+%.1f%%", change.percentage),
             StatsColors.ChangeBadgePositive
         )
         is MostViewedChange.Negative -> Pair(
-            "-${formatStatValue(change.value)} (${
-                String.format(Locale.getDefault(), "%.1f%%", change.percentage)
-            })",
+            String.format(Locale.getDefault(), "-%.1f%%", change.percentage),
             StatsColors.ChangeBadgeNegative
         )
         is MostViewedChange.NoChange -> Pair(
-            "+0 (0%)",
+            "0%",
             MaterialTheme.colorScheme.onSurfaceVariant
         )
         is MostViewedChange.NotAvailable -> return
@@ -367,7 +363,7 @@ internal fun ChangeIndicator(change: MostViewedChange) {
 
     Text(
         text = text,
-        style = MaterialTheme.typography.labelSmall,
+        style = MaterialTheme.typography.labelMedium,
         color = color
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -354,10 +354,7 @@ internal fun ChangeIndicator(change: MostViewedChange) {
             String.format(Locale.getDefault(), "-%.1f%%", change.percentage),
             StatsColors.ChangeBadgeNegative
         )
-        is MostViewedChange.NoChange -> Pair(
-            "0%",
-            MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        is MostViewedChange.NoChange -> return
         is MostViewedChange.NotAvailable -> return
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
@@ -249,12 +249,12 @@ private fun DetailItemRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 8.dp),
+                .padding(vertical = 12.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = position.toString(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.width(32.dp)
@@ -262,7 +262,7 @@ private fun DetailItemRow(
 
             Text(
                 text = item.title,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyLarge,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)
@@ -274,7 +274,7 @@ private fun DetailItemRow(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         text = formatStatValue(item.views),
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold
                     )
                     Spacer(modifier = Modifier.width(4.dp))

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
@@ -390,7 +390,7 @@ private fun StatsChart(chartData: ChartData) {
     // Create gradient shader for area fill (primary color fading to transparent)
     val areaGradient = ShaderProvider.verticalGradient(
         colors = arrayOf(
-            primaryColor.copy(alpha = 0.8f),
+            primaryColor.copy(alpha = 0.3f),
             primaryColor.copy(alpha = 0f)
         )
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsCard.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonOutline
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -64,7 +64,7 @@ import java.util.Locale
 private val CardCornerRadius = 10.dp
 private val CardPadding = 16.dp
 private val CardMargin = 16.dp
-private val ChartHeight = 80.dp
+private val ChartHeight = 50.dp
 private val MetricIconSize = 16.dp
 private val MetricSpacing = 4.dp
 
@@ -135,13 +135,13 @@ private fun LoadingContent() {
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        // Top section: Title + Chart placeholder
+        // Top section: Title + Chart placeholder in single row
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
+            verticalAlignment = Alignment.CenterVertically
         ) {
             // Left: Title and date placeholder
-            Column(modifier = Modifier.weight(0.4f)) {
+            Column {
                 Box(
                     modifier = Modifier
                         .width(80.dp)
@@ -158,10 +158,11 @@ private fun LoadingContent() {
                         .background(shimmerBrush)
                 )
             }
-            // Right: Chart placeholder
+            Spacer(modifier = Modifier.width(16.dp))
+            // Chart placeholder (fills remaining space)
             Box(
                 modifier = Modifier
-                    .weight(0.6f)
+                    .weight(1f)
                     .height(ChartHeight)
                     .clip(RoundedCornerShape(8.dp))
                     .background(shimmerBrush)
@@ -223,13 +224,16 @@ private fun LoadedContent(
             .clickable(onClick = state.onCardClick)
             .padding(CardPadding)
     ) {
-        // Header with menu
+        // Header: Title on left, sparkline in middle, menu on right
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleSection()
+            Spacer(modifier = Modifier.width(16.dp))
+            Box(modifier = Modifier.weight(1f)) {
+                StatsChart(chartData = state.chartData)
+            }
             StatsCardMenu(
                 onRemoveClick = onRemoveCard,
                 cardPosition = cardPosition,
@@ -239,9 +243,6 @@ private fun LoadedContent(
                 onMoveToBottom = onMoveToBottom
             )
         }
-        Spacer(modifier = Modifier.height(8.dp))
-        // Chart
-        StatsChart(chartData = state.chartData)
         Spacer(modifier = Modifier.height(12.dp))
         // Bottom section: Metrics
         MetricsRow(
@@ -268,13 +269,31 @@ private fun ErrorContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        // Header with menu
+        // Header: Title on left, empty chart in middle, menu on right
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleSection()
+            Spacer(modifier = Modifier.width(16.dp))
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(ChartHeight)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant
+                            .copy(alpha = 0.3f)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.stats_no_data_yet),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme
+                        .onSurfaceVariant
+                )
+            }
             StatsCardMenu(
                 onRemoveClick = onRemoveCard,
                 cardPosition = cardPosition,
@@ -282,22 +301,6 @@ private fun ErrorContent(
                 onMoveToTop = onMoveToTop,
                 onMoveDown = onMoveDown,
                 onMoveToBottom = onMoveToBottom
-            )
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        // Empty chart placeholder
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(ChartHeight)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = stringResource(R.string.stats_no_data_yet),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
@@ -442,7 +445,7 @@ private fun MetricsRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             SecondaryMetricItem(
-                icon = Icons.Default.Person,
+                icon = Icons.Default.PersonOutline,
                 value = formatStatValue(visitors)
             )
             SecondaryMetricItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.newstats.repository.HourlyViewsResult
 import org.wordpress.android.ui.newstats.repository.StatsRepository
 import org.wordpress.android.ui.newstats.repository.TodayAggregatesResult
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.time.Clock
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -32,6 +33,8 @@ class TodaysStatsViewModel @Inject constructor(
     private val statsRepository: StatsRepository,
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
+    @Suppress("VisibleForTests")
+    internal var clock: Clock = Clock.systemDefaultZone()
     private val _uiState = MutableStateFlow<TodaysStatsCardUiState>(TodaysStatsCardUiState.Loading)
     val uiState: StateFlow<TodaysStatsCardUiState> = _uiState.asStateFlow()
 
@@ -193,16 +196,12 @@ class TodaysStatsViewModel @Inject constructor(
     private fun trimFutureHours(
         dataPoints: List<HourlyViewsDataPoint>
     ): List<HourlyViewsDataPoint> {
-        val currentHour = LocalDateTime.now().hour
-        val inputFormat = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd HH:mm:ss",
-            Locale.getDefault()
-        )
+        val currentHour = LocalDateTime.now(clock).hour
         return dataPoints.filter { dataPoint ->
             try {
                 val dateTime = LocalDateTime.parse(
                     dataPoint.period,
-                    inputFormat
+                    HOURLY_PERIOD_FORMAT
                 )
                 dateTime.hour <= currentHour
             } catch (e: Exception) {
@@ -214,18 +213,17 @@ class TodaysStatsViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun formatHourlyLabel(period: String): String {
         return try {
-            // API returns period in format "2024-01-16 14:00:00" for hourly data
-            val inputFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-            val outputFormat = DateTimeFormatter.ofPattern("ha", Locale.getDefault())
-            val dateTime = LocalDateTime.parse(period, inputFormat)
-            dateTime.format(outputFormat).lowercase()
+            val dateTime = LocalDateTime.parse(
+                period, HOURLY_PERIOD_FORMAT
+            )
+            dateTime.format(HOURLY_LABEL_FORMAT).lowercase()
         } catch (e: Exception) {
-            // Fallback: try parsing just the hour if full format fails
+            // Fallback: try parsing without seconds
             try {
-                val inputFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.getDefault())
-                val outputFormat = DateTimeFormatter.ofPattern("ha", Locale.getDefault())
-                val dateTime = LocalDateTime.parse(period, inputFormat)
-                dateTime.format(outputFormat).lowercase()
+                val dateTime = LocalDateTime.parse(
+                    period, HOURLY_PERIOD_SHORT_FORMAT
+                )
+                dateTime.format(HOURLY_LABEL_FORMAT).lowercase()
             } catch (e2: Exception) {
                 period
             }
@@ -246,4 +244,17 @@ class TodaysStatsViewModel @Inject constructor(
         val likes: Long,
         val comments: Long
     )
+
+    companion object {
+        private val HOURLY_PERIOD_FORMAT =
+            DateTimeFormatter.ofPattern(
+                "yyyy-MM-dd HH:mm:ss", Locale.US
+            )
+        private val HOURLY_PERIOD_SHORT_FORMAT =
+            DateTimeFormatter.ofPattern(
+                "yyyy-MM-dd HH:mm", Locale.US
+            )
+        private val HOURLY_LABEL_FORMAT =
+            DateTimeFormatter.ofPattern("ha", Locale.US)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.repository.HourlyViewsDataPoint
 import org.wordpress.android.ui.newstats.repository.HourlyViewsResult
 import org.wordpress.android.ui.newstats.repository.StatsRepository
 import org.wordpress.android.ui.newstats.repository.TodayAggregatesResult
@@ -168,7 +169,12 @@ class TodaysStatsViewModel @Inject constructor(
 
         return when (result) {
             is HourlyViewsResult.Success -> {
-                result.dataPoints.map { dataPoint ->
+                val dataPoints = if (offsetDays == 0) {
+                    trimFutureHours(result.dataPoints)
+                } else {
+                    result.dataPoints
+                }
+                dataPoints.map { dataPoint ->
                     ViewsDataPoint(
                         label = formatHourlyLabel(dataPoint.period),
                         views = dataPoint.views
@@ -176,6 +182,32 @@ class TodaysStatsViewModel @Inject constructor(
                 }
             }
             is HourlyViewsResult.Error -> emptyList()
+        }
+    }
+
+    /**
+     * Filters out data points for hours after the current hour
+     * to avoid showing a misleading drop to zero in the sparkline.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun trimFutureHours(
+        dataPoints: List<HourlyViewsDataPoint>
+    ): List<HourlyViewsDataPoint> {
+        val currentHour = LocalDateTime.now().hour
+        val inputFormat = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd HH:mm:ss",
+            Locale.getDefault()
+        )
+        return dataPoints.filter { dataPoint ->
+            try {
+                val dateTime = LocalDateTime.parse(
+                    dataPoint.period,
+                    inputFormat
+                )
+                dateTime.hour <= currentHour
+            } catch (e: Exception) {
+                true
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
@@ -31,10 +31,9 @@ class TodaysStatsViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val accountStore: AccountStore,
     private val statsRepository: StatsRepository,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val clock: Clock
 ) : ViewModel() {
-    @Suppress("VisibleForTests")
-    internal var clock: Clock = Clock.systemDefaultZone()
     private val _uiState = MutableStateFlow<TodaysStatsCardUiState>(TodaysStatsCardUiState.Loading)
     val uiState: StateFlow<TodaysStatsCardUiState> = _uiState.asStateFlow()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -363,14 +363,12 @@ private fun HeaderSection(
             Column(horizontalAlignment = Alignment.End) {
                 DateRangeWithDot(
                     dateRange = state.currentPeriodDateRange,
-                    dotColor = MaterialTheme.colorScheme.primary,
-                    isFilled = true
+                    dotColor = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 DateRangeWithDot(
                     dateRange = state.previousPeriodDateRange,
-                    dotColor = MaterialTheme.colorScheme.outline,
-                    isFilled = true
+                    dotColor = MaterialTheme.colorScheme.outline
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 AverageRow(average = state.periodAverage)
@@ -443,7 +441,7 @@ private fun DifferenceRow(difference: Long, percentageChange: Double) {
 }
 
 @Composable
-private fun DateRangeWithDot(dateRange: String, dotColor: Color, isFilled: Boolean) {
+private fun DateRangeWithDot(dateRange: String, dotColor: Color) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = dateRange,
@@ -454,17 +452,8 @@ private fun DateRangeWithDot(dateRange: String, dotColor: Color, isFilled: Boole
         Box(
             modifier = Modifier
                 .size(8.dp)
-                .then(
-                    if (isFilled) {
-                        Modifier
-                            .clip(CircleShape)
-                            .background(dotColor)
-                    } else {
-                        Modifier
-                            .clip(CircleShape)
-                            .border(1.5.dp, dotColor, CircleShape)
-                    }
-                )
+                .clip(CircleShape)
+                .background(dotColor)
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -27,7 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ShowChart
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.ModeEditOutline
+import androidx.compose.material.icons.outlined.ModeEditOutline
 import androidx.compose.material.icons.filled.PersonOutline
 import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.Visibility
@@ -672,7 +672,7 @@ private fun StatItemCard(stat: StatItem) {
         stringResource(R.string.stats_visitors) -> Icons.Default.PersonOutline
         stringResource(R.string.stats_likes) -> Icons.Default.FavoriteBorder
         stringResource(R.string.stats_comments) -> Icons.Default.ChatBubbleOutline
-        stringResource(R.string.posts) -> Icons.Default.ModeEditOutline
+        stringResource(R.string.posts) -> Icons.Outlined.ModeEditOutline
         else -> Icons.Outlined.Visibility
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -280,7 +280,7 @@ private fun LoadedContent(
             onMoveDown = onMoveDown,
             onMoveToBottom = onMoveToBottom
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         // Chart Section
         ViewsStatsChart(
             chartData = state.chartData,
@@ -573,6 +573,7 @@ private fun ViewsStatsChart(
                 shape = CorneredShape.rounded(allPercent = 25)
             )
         ),
+        labelPosition = DefaultCartesianMarker.LabelPosition.AroundPoint,
         guideline = LineComponent(
             fill = fill(MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)),
             thicknessDp = 1f
@@ -615,7 +616,9 @@ private fun ViewsStatsChart(
                         )
                     ),
                     startAxis = VerticalAxis.rememberStart(line = null),
-                    bottomAxis = HorizontalAxis.rememberBottom(valueFormatter = bottomAxisValueFormatter),
+                    bottomAxis = HorizontalAxis.rememberBottom(
+                        valueFormatter = bottomAxisValueFormatter
+                    ),
                     marker = marker,
                     decorations = listOf(averageLine)
                 ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import org.wordpress.android.ui.newstats.StatsColors
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -92,8 +93,6 @@ private val CardMargin = 16.dp
 private val ChartHeight = 180.dp
 private val StatItemWidth = 100.dp
 private val BadgeCornerRadius = 4.dp
-private val ChangeBadgePositiveColor = Color(0xFF2E7D32)
-private val ChangeBadgeNegativeColor = Color(0xFFE91E63)
 
 // Preview sample data constants
 private const val SAMPLE_CURRENT_VIEWS = 7467L
@@ -418,7 +417,7 @@ private fun DifferenceRow(difference: Long, percentageChange: Double) {
     val arrowText = if (isNegative) "↘" else if (difference > 0) "↗" else "↔"
     val color = when {
         difference < 0 -> MaterialTheme.colorScheme.error
-        difference > 0 -> ChangeBadgePositiveColor
+        difference > 0 -> StatsColors.ChangeBadgePositive
         else -> MaterialTheme.colorScheme.outline
     }
 
@@ -723,13 +722,13 @@ private fun ChangeBadge(change: StatChange) {
     val (text, backgroundColor, textColor) = when (change) {
         is StatChange.Positive -> Triple(
             "↗ ${String.format(Locale.getDefault(), "%.1f%%", change.percentage)}",
-            ChangeBadgePositiveColor.copy(alpha = 0.15f),
-            ChangeBadgePositiveColor
+            StatsColors.ChangeBadgePositive.copy(alpha = 0.15f),
+            StatsColors.ChangeBadgePositive
         )
         is StatChange.Negative -> Triple(
             "↘ ${String.format(Locale.getDefault(), "%.1f%%", change.percentage)}",
-            ChangeBadgeNegativeColor.copy(alpha = 0.15f),
-            ChangeBadgeNegativeColor
+            StatsColors.ChangeBadgeNegative.copy(alpha = 0.15f),
+            StatsColors.ChangeBadgeNegative
         )
         is StatChange.NoChange -> Triple(
             "↔ 0%",

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -741,7 +741,7 @@ private fun ChangeBadge(change: StatChange) {
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.labelSmall,
+            style = MaterialTheme.typography.labelMedium,
             color = textColor,
             fontWeight = FontWeight.Medium
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -24,13 +24,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ShowChart
-import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.automirrored.outlined.ShowChart
 import androidx.compose.material.icons.filled.ChatBubbleOutline
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.ModeEditOutline
+import androidx.compose.material.icons.filled.PersonOutline
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -392,7 +392,7 @@ private fun ChartTypeMenuItems(
         enabled = currentChartType != ChartType.LINE,
         leadingIcon = {
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.ShowChart,
+                imageVector = Icons.AutoMirrored.Outlined.ShowChart,
                 contentDescription = null
             )
         }
@@ -403,7 +403,7 @@ private fun ChartTypeMenuItems(
         enabled = currentChartType != ChartType.BAR,
         leadingIcon = {
             Icon(
-                imageVector = Icons.Default.BarChart,
+                imageVector = Icons.Outlined.BarChart,
                 contentDescription = null
             )
         }
@@ -675,12 +675,12 @@ private fun BottomStatsRow(stats: List<StatItem>) {
 @Composable
 private fun StatItemCard(stat: StatItem) {
     val icon = when (stat.label) {
-        stringResource(R.string.stats_views) -> Icons.Default.Visibility
-        stringResource(R.string.stats_visitors) -> Icons.Default.Person
+        stringResource(R.string.stats_views) -> Icons.Outlined.Visibility
+        stringResource(R.string.stats_visitors) -> Icons.Default.PersonOutline
         stringResource(R.string.stats_likes) -> Icons.Default.FavoriteBorder
         stringResource(R.string.stats_comments) -> Icons.Default.ChatBubbleOutline
-        stringResource(R.string.posts) -> Icons.Default.Edit
-        else -> Icons.Default.Visibility
+        stringResource(R.string.posts) -> Icons.Default.ModeEditOutline
+        else -> Icons.Outlined.Visibility
     }
 
     Column(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -89,10 +89,10 @@ import kotlin.math.abs
 private val CardCornerRadius = 10.dp
 private val CardPadding = 16.dp
 private val CardMargin = 16.dp
-private val ChartHeight = 120.dp
+private val ChartHeight = 180.dp
 private val StatItemWidth = 100.dp
 private val BadgeCornerRadius = 4.dp
-private val ChangeBadgePositiveColor = Color(0xFF4CAF50)
+private val ChangeBadgePositiveColor = Color(0xFF2E7D32)
 private val ChangeBadgeNegativeColor = Color(0xFFE91E63)
 
 // Preview sample data constants
@@ -330,7 +330,7 @@ private fun HeaderSection(
                 }
             )
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(4.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -338,18 +338,20 @@ private fun HeaderSection(
         ) {
             // Left: Current and previous period totals with difference
             Column {
-                Row(verticalAlignment = Alignment.Bottom) {
+                Row {
                     Text(
                         text = formatStatValue(state.currentPeriodViews),
                         style = MaterialTheme.typography.headlineLarge,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.alignByBaseline()
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = formatStatValue(state.previousPeriodViews),
                         style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.alignByBaseline()
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
@@ -417,7 +419,7 @@ private fun DifferenceRow(difference: Long, percentageChange: Double) {
     val color = when {
         difference < 0 -> MaterialTheme.colorScheme.error
         difference > 0 -> ChangeBadgePositiveColor
-        else -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.outline
     }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -447,7 +449,7 @@ private fun DateRangeWithDot(dateRange: String, dotColor: Color, isFilled: Boole
         Text(
             text = dateRange,
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.outline
         )
         Spacer(modifier = Modifier.width(6.dp))
         Box(
@@ -474,7 +476,7 @@ private fun AverageRow(average: Long) {
         Text(
             text = stringResource(R.string.stats_weekly_average, formatStatValue(average)),
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.outline
         )
         Spacer(modifier = Modifier.width(6.dp))
         Box(
@@ -591,7 +593,7 @@ private fun ViewsStatsChart(
         ChartType.LINE -> {
             val areaGradient = ShaderProvider.verticalGradient(
                 colors = arrayOf(
-                    primaryColor.copy(alpha = 0.8f),
+                    primaryColor.copy(alpha = 0.3f),
                     primaryColor.copy(alpha = 0f)
                 )
             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
@@ -60,12 +60,14 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
     }
 
     private fun initViewModel() {
+        // Use a clock at 23:00 so trimFutureHours never filters test data
+        val endOfDay = Instant.parse("2024-01-16T23:00:00Z")
         viewModel = TodaysStatsViewModel(
             selectedSiteRepository,
             accountStore,
             statsRepository,
             resourceProvider,
-            Clock.systemDefaultZone()
+            Clock.fixed(endOfDay, ZoneId.of("UTC"))
         )
         viewModel.loadData()
     }
@@ -479,12 +481,13 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
         whenever(statsRepository.fetchHourlyViews(any(), any()))
             .thenReturn(createHourlyViewsResult())
 
+        val endOfDay = Instant.parse("2024-01-16T23:00:00Z")
         viewModel = TodaysStatsViewModel(
             selectedSiteRepository,
             accountStore,
             statsRepository,
             resourceProvider,
-            Clock.systemDefaultZone()
+            Clock.fixed(endOfDay, ZoneId.of("UTC"))
         )
         viewModel.loadDataIfNeeded()
         advanceUntilIdle()

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
@@ -21,6 +21,9 @@ import org.wordpress.android.ui.newstats.repository.StatsRepository
 import org.wordpress.android.ui.newstats.repository.TodayAggregates
 import org.wordpress.android.ui.newstats.repository.TodayAggregatesResult
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 @ExperimentalCoroutinesApi
 class TodaysStatsViewModelTest : BaseUnitTest() {
@@ -61,7 +64,8 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
             selectedSiteRepository,
             accountStore,
             statsRepository,
-            resourceProvider
+            resourceProvider,
+            Clock.systemDefaultZone()
         )
         viewModel.loadData()
     }
@@ -479,7 +483,8 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
             selectedSiteRepository,
             accountStore,
             statsRepository,
-            resourceProvider
+            resourceProvider,
+            Clock.systemDefaultZone()
         )
         viewModel.loadDataIfNeeded()
         advanceUntilIdle()
@@ -519,6 +524,144 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
         assertThat(state.chartData.currentPeriod).isEmpty()
     }
 
+    private fun initViewModelWithClock(hour: Int) {
+        // Fixed clock at 2024-01-16T{hour}:30 UTC
+        val instant = Instant.parse(
+            "2024-01-16T%02d:30:00Z".format(hour)
+        )
+        viewModel = TodaysStatsViewModel(
+            selectedSiteRepository,
+            accountStore,
+            statsRepository,
+            resourceProvider,
+            Clock.fixed(instant, ZoneId.of("UTC"))
+        )
+        viewModel.loadData()
+    }
+
+    @Test
+    fun `when current period, then future hours are filtered out`() =
+        test {
+            val aggregates = createTodayAggregates()
+            val hourlyData = createHourlyViewsResultWithHours()
+
+            whenever(statsRepository.fetchTodayAggregates(any()))
+                .thenReturn(TodayAggregatesResult.Success(aggregates))
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(0))
+            ).thenReturn(hourlyData)
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(1))
+            ).thenReturn(hourlyData)
+
+            // Clock fixed at 14:30 — hours 12, 13, 14 kept; 15, 16 filtered
+            initViewModelWithClock(CLOCK_HOUR)
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as TodaysStatsCardUiState.Loaded
+            assertThat(state.chartData.currentPeriod).hasSize(3)
+        }
+
+    @Test
+    fun `when previous period, then future hours are not filtered`() =
+        test {
+            val aggregates = createTodayAggregates()
+            val hourlyData = createHourlyViewsResultWithHours()
+
+            whenever(statsRepository.fetchTodayAggregates(any()))
+                .thenReturn(TodayAggregatesResult.Success(aggregates))
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(0))
+            ).thenReturn(hourlyData)
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(1))
+            ).thenReturn(hourlyData)
+
+            initViewModelWithClock(CLOCK_HOUR)
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as TodaysStatsCardUiState.Loaded
+            // Previous period is not trimmed — all 5 data points remain
+            assertThat(state.chartData.previousPeriod).hasSize(5)
+        }
+
+    @Test
+    fun `when current hour matches data point, then it is included`() =
+        test {
+            val aggregates = createTodayAggregates()
+            // Single data point at exactly the clock hour
+            val hourlyData = HourlyViewsResult.Success(
+                listOf(
+                    HourlyViewsDataPoint(
+                        period = "2024-01-16 14:00:00",
+                        views = 100L
+                    )
+                )
+            )
+
+            whenever(statsRepository.fetchTodayAggregates(any()))
+                .thenReturn(TodayAggregatesResult.Success(aggregates))
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(0))
+            ).thenReturn(hourlyData)
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(1))
+            ).thenReturn(HourlyViewsResult.Success(emptyList()))
+
+            initViewModelWithClock(CLOCK_HOUR)
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as TodaysStatsCardUiState.Loaded
+            assertThat(state.chartData.currentPeriod).hasSize(1)
+        }
+
+    @Test
+    fun `when period string is malformed, then data point is kept`() =
+        test {
+            val aggregates = createTodayAggregates()
+            val hourlyData = HourlyViewsResult.Success(
+                listOf(
+                    HourlyViewsDataPoint(
+                        period = "bad-format",
+                        views = 42L
+                    )
+                )
+            )
+
+            whenever(statsRepository.fetchTodayAggregates(any()))
+                .thenReturn(TodayAggregatesResult.Success(aggregates))
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(0))
+            ).thenReturn(hourlyData)
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(1))
+            ).thenReturn(HourlyViewsResult.Success(emptyList()))
+
+            initViewModelWithClock(CLOCK_HOUR)
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as TodaysStatsCardUiState.Loaded
+            // Malformed period falls through to catch → kept
+            assertThat(state.chartData.currentPeriod).hasSize(1)
+        }
+
+    /**
+     * Creates hourly data spanning hours 12-16 for trim tests.
+     */
+    private fun createHourlyViewsResultWithHours() =
+        HourlyViewsResult.Success(
+            (12..16).map { hour ->
+                HourlyViewsDataPoint(
+                    period = "2024-01-16 %02d:00:00".format(hour),
+                    views = hour * 10L
+                )
+            }
+        )
+
     private fun createTodayAggregates() = TodayAggregates(
         views = TEST_VIEWS,
         visitors = TEST_VISITORS,
@@ -540,6 +683,7 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
     )
 
     companion object {
+        private const val CLOCK_HOUR = 14
         private const val TEST_SITE_ID = 123L
         private const val TEST_ACCESS_TOKEN = "test_access_token"
         private const val TEST_VIEWS = 500L


### PR DESCRIPTION
## Description

Visual polish pass for the new stats cards based on design feedback comparing iOS and Android implementations.

**Changes across all cards:**
- Switch from filled to outlined icons for consistency
- Simplify change indicators to show percentage only (drop absolute values)
- Bump list item fonts from `bodyMedium` to `bodyLarge` and badge fonts from `labelSmall` to `labelMedium`
- Increase list item horizontal margin from 8dp to 16dp
- Darken green change badge color for better contrast (Material Green 800)

**Views card:**
- Tighten header spacing and baseline-align current/previous values
- Increase chart height from 120dp to 180dp
- Tone down area gradient (0.8 → 0.3 alpha)
- Use lighter color for secondary text (dates, averages)
- Fix top gap above chart caused by marker `LabelPosition.AbovePoint` → `AroundPoint`
- Deduplicate local color constants in favor of shared `StatsColors`

**Today's card:**
- Inline sparkline into header row (title left, chart middle, menu right)
- Tone down area gradient (0.8 → 0.3 alpha)
- Trim future hours from sparkline to avoid misleading zero-value tail
- Hoist `DateTimeFormatter` to companion object; inject `Clock` for testability

**Most Viewed card:**
- Align `NoChange` indicator behavior (return early, matching other cards)

Before / After

<img width="261" height="405" alt="Screenshot 2026-03-04 at 19 32 42" src="https://github.com/user-attachments/assets/ba6f882a-926f-4a80-882b-90bd60725207" /> / <img width="254" height="408" alt="Screenshot 2026-03-04 at 19 30 19" src="https://github.com/user-attachments/assets/eb4c188c-9ccc-409d-81c4-95bb9f850f05" />

<img width="257" height="463" alt="Screenshot 2026-03-04 at 19 33 07" src="https://github.com/user-attachments/assets/c48f3cdd-813f-479f-9c11-978797f9faf1" /> / <img width="254" height="455" alt="Screenshot 2026-03-04 at 19 30 34" src="https://github.com/user-attachments/assets/2a8861ba-50d1-40a2-a5dd-b95ed64d9e6d" />

<img width="256" height="465" alt="Screenshot 2026-03-04 at 19 33 22" src="https://github.com/user-attachments/assets/4e8503b2-7ad6-4b65-8c58-7e2c8377b0af" /> / <img width="261" height="443" alt="Screenshot 2026-03-04 at 19 30 57" src="https://github.com/user-attachments/assets/d6a87475-b7b0-4ca6-983b-a8c42c856105" />



## Testing instructions

Stats polish verification:

1. Open the app and navigate to the new Stats screen
2. Scroll through all cards (Today's Stats, Views, Most Viewed, Authors)
- [ ] Icons are outlined (not filled) across all cards
- [x] Change indicators show percentage only (e.g., "+12.5%", not "+150 (12.5%)")
- [x] Green badge text has good contrast against white background

Views card:

1. View the Views card
- [x] Chart is taller with no blank gap above it
- [x] Area gradient under chart line is subtle

Today's card:

1. View the Today's Stats card
- [x] Sparkline appears inline in the header row (not below title)
- [x] Sparkline does not show a drop to zero for future hours

- [ ] Stats smoke tests look good