### PR TITLE
RS Posts: Add post status badges

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -61,6 +61,7 @@ data class PostRsUiModel(
     val featuredImageId: Long = 0L,
     val featuredImageUrl: String? = null,
     val actions: List<PostRsMenuAction> = emptyList(),
+    @StringRes val badges: List<Int> = emptyList(),
     val displayState: PostDisplayState =
         PostDisplayState.NORMAL
 )
@@ -172,6 +173,17 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
             post.status.toLabel()
         } else {
             0
+        },
+        badges = buildList {
+            if (post.status is PostStatus.Private) {
+                add(R.string.post_status_post_private)
+            }
+            if (post.status is PostStatus.Pending) {
+                add(R.string.post_status_pending_review)
+            }
+            if (post.sticky == true) {
+                add(R.string.post_status_sticky)
+            }
         },
         displayState = displayState
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -61,7 +61,7 @@ data class PostRsUiModel(
     val featuredImageId: Long = 0L,
     val featuredImageUrl: String? = null,
     val actions: List<PostRsMenuAction> = emptyList(),
-    @StringRes val badges: List<Int> = emptyList(),
+    val badges: List<Int> = emptyList(),
     val displayState: PostDisplayState =
         PostDisplayState.NORMAL
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.postsrs.screens
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,9 +14,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun BadgeRow(
+internal fun BadgeRow(
     badges: List<Int>,
     modifier: Modifier = Modifier
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
@@ -54,12 +54,8 @@ fun BadgeRow(
 @Composable
 private fun PreviewStickyBadge() {
     MaterialTheme {
-        PostRsListItem(
-            post = samplePost().copy(
-                badges = listOf(R.string.post_status_sticky)
-            ),
-            onClick = {},
-            onMenuAction = {}
+        BadgeRow(
+            badges = listOf(R.string.post_status_sticky)
         )
     }
 }
@@ -68,14 +64,10 @@ private fun PreviewStickyBadge() {
 @Composable
 private fun PreviewPendingReviewBadge() {
     MaterialTheme {
-        PostRsListItem(
-            post = samplePost().copy(
-                badges = listOf(
-                    R.string.post_status_pending_review
-                )
-            ),
-            onClick = {},
-            onMenuAction = {}
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_pending_review
+            )
         )
     }
 }
@@ -84,14 +76,10 @@ private fun PreviewPendingReviewBadge() {
 @Composable
 private fun PreviewPrivateBadge() {
     MaterialTheme {
-        PostRsListItem(
-            post = samplePost().copy(
-                badges = listOf(
-                    R.string.post_status_post_private
-                )
-            ),
-            onClick = {},
-            onMenuAction = {}
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_post_private
+            )
         )
     }
 }
@@ -100,15 +88,11 @@ private fun PreviewPrivateBadge() {
 @Composable
 private fun PreviewMultipleBadges() {
     MaterialTheme {
-        PostRsListItem(
-            post = samplePost().copy(
-                badges = listOf(
-                    R.string.post_status_post_private,
-                    R.string.post_status_sticky
-                )
-            ),
-            onClick = {},
-            onMenuAction = {}
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_post_private,
+                R.string.post_status_sticky
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
@@ -54,8 +54,12 @@ fun BadgeRow(
 @Composable
 private fun PreviewStickyBadge() {
     MaterialTheme {
-        BadgeRow(
-            badges = listOf(R.string.post_status_sticky)
+        PostRsListItem(
+            post = samplePost().copy(
+                badges = listOf(R.string.post_status_sticky)
+            ),
+            onClick = {},
+            onMenuAction = {}
         )
     }
 }
@@ -64,10 +68,14 @@ private fun PreviewStickyBadge() {
 @Composable
 private fun PreviewPendingReviewBadge() {
     MaterialTheme {
-        BadgeRow(
-            badges = listOf(
-                R.string.post_status_pending_review
-            )
+        PostRsListItem(
+            post = samplePost().copy(
+                badges = listOf(
+                    R.string.post_status_pending_review
+                )
+            ),
+            onClick = {},
+            onMenuAction = {}
         )
     }
 }
@@ -76,10 +84,14 @@ private fun PreviewPendingReviewBadge() {
 @Composable
 private fun PreviewPrivateBadge() {
     MaterialTheme {
-        BadgeRow(
-            badges = listOf(
-                R.string.post_status_post_private
-            )
+        PostRsListItem(
+            post = samplePost().copy(
+                badges = listOf(
+                    R.string.post_status_post_private
+                )
+            ),
+            onClick = {},
+            onMenuAction = {}
         )
     }
 }
@@ -88,11 +100,15 @@ private fun PreviewPrivateBadge() {
 @Composable
 private fun PreviewMultipleBadges() {
     MaterialTheme {
-        BadgeRow(
-            badges = listOf(
-                R.string.post_status_post_private,
-                R.string.post_status_sticky
-            )
+        PostRsListItem(
+            post = samplePost().copy(
+                badges = listOf(
+                    R.string.post_status_post_private,
+                    R.string.post_status_sticky
+                )
+            ),
+            onClick = {},
+            onMenuAction = {}
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
@@ -1,0 +1,100 @@
+package org.wordpress.android.ui.postsrs.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun BadgeRow(
+    @StringRes badges: List<Int>,
+    modifier: Modifier = Modifier
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        badges.forEach { labelResId ->
+            Text(
+                text = stringResource(labelResId),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme
+                            .colorScheme.tertiary
+                            .copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .padding(
+                        horizontal = 6.dp,
+                        vertical = 2.dp
+                    )
+            )
+        }
+    }
+}
+
+// region Previews
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewStickyBadge() {
+    MaterialTheme {
+        BadgeRow(
+            badges = listOf(R.string.post_status_sticky)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewPendingReviewBadge() {
+    MaterialTheme {
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_pending_review
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewPrivateBadge() {
+    MaterialTheme {
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_post_private
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewMultipleBadges() {
+    MaterialTheme {
+        BadgeRow(
+            badges = listOf(
+                R.string.post_status_post_private,
+                R.string.post_status_sticky
+            )
+        )
+    }
+}
+
+// endregion

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsBadges.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.postsrs.screens
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -19,7 +18,7 @@ import org.wordpress.android.R
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun BadgeRow(
-    @StringRes badges: List<Int>,
+    badges: List<Int>,
     modifier: Modifier = Modifier
 ) {
     FlowRow(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -345,7 +345,7 @@ private val FEATURED_IMAGE_SIZE = PostRsRestClient.FEATURED_IMAGE_SIZE_DP.dp
 
 // region Previews
 
-internal fun samplePost(
+private fun samplePost(
     displayState: PostDisplayState = PostDisplayState.NORMAL
 ) = PostRsUiModel(
     remotePostId = 1L,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -7,13 +7,9 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -218,31 +214,6 @@ private fun PostContentItem(
                     .copy(alpha = 0.5f),
                 trackColor = MaterialTheme
                     .colorScheme.surface
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun BadgeRow(badges: List<Int>) {
-    FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        badges.forEach { labelResId ->
-            Text(
-                text = stringResource(labelResId),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.tertiary,
-                modifier = Modifier
-                    .border(
-                        width = 1.dp,
-                        color = MaterialTheme.colorScheme.tertiary
-                            .copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(4.dp)
-                    )
-                    .padding(
-                        horizontal = 6.dp,
-                        vertical = 2.dp
-                    )
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -7,9 +7,13 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -147,6 +151,10 @@ private fun PostContentItem(
                     }
                     Spacer(modifier = Modifier.height(4.dp))
                 }
+                if (post.badges.isNotEmpty()) {
+                    BadgeRow(post.badges)
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
                 Text(
                     text = post.title.ifBlank { stringResource(R.string.untitled_in_parentheses) },
                     style = MaterialTheme.typography.titleMedium,
@@ -210,6 +218,31 @@ private fun PostContentItem(
                     .copy(alpha = 0.5f),
                 trackColor = MaterialTheme
                     .colorScheme.surface
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun BadgeRow(badges: List<Int>) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        badges.forEach { labelResId ->
+            Text(
+                text = stringResource(labelResId),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.tertiary
+                            .copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .padding(
+                        horizontal = 6.dp,
+                        vertical = 2.dp
+                    )
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListItem.kt
@@ -345,7 +345,7 @@ private val FEATURED_IMAGE_SIZE = PostRsRestClient.FEATURED_IMAGE_SIZE_DP.dp
 
 // region Previews
 
-private fun samplePost(
+internal fun samplePost(
     displayState: PostDisplayState = PostDisplayState.NORMAL
 ) = PostRsUiModel(
     remotePostId = 1L,


### PR DESCRIPTION
## Summary

Add Sticky, Pending Review, and Private badge chips to the RS post list items.


## Test plan

Using the test site I sent separately:

- [x] Verify Sticky badge appears on sticky posts in the Published tab
- [x] Verify Pending Review badge appears on posts with pending status in the Drafts tab
- [x] Verify Private badge appears on private posts in the Published tab
- [x] Verify multiple badges render correctly side-by-side
- [x] Verify no badges appear on normal published/draft/scheduled posts

<img width="610" height="465" alt="1" src="https://github.com/user-attachments/assets/d6e2139d-3bf6-4b4e-8e70-1efcd6d0e12c" />


