### PR TITLE
RS Posts: Hide Publish for contributors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -476,44 +476,48 @@ class PostRsListViewModel @Inject constructor(
         tab: PostRsListTab,
         hasPassword: Boolean,
         commentsOpen: Boolean
-    ): List<PostRsMenuAction> = buildList {
-        when (tab) {
-            PostRsListTab.PUBLISHED -> {
-                add(PostRsMenuAction.VIEW)
-                add(PostRsMenuAction.READ)
-                add(PostRsMenuAction.MOVE_TO_DRAFT)
-                add(PostRsMenuAction.DUPLICATE)
-                add(PostRsMenuAction.SHARE)
-                if (!hasPassword && blazeFeatureUtils.isSiteBlazeEligible(site)) {
-                    add(PostRsMenuAction.BLAZE)
-                }
-                if (SiteUtils.isAccessedViaWPComRest(site) && site.hasCapabilityViewStats) {
-                    add(PostRsMenuAction.STATS)
-                }
-                if (commentsOpen) add(PostRsMenuAction.COMMENTS)
-                add(PostRsMenuAction.TRASH)
+    ): List<PostRsMenuAction> = when (tab) {
+        PostRsListTab.PUBLISHED ->
+            getPublishedMenuActions(hasPassword, commentsOpen)
+        PostRsListTab.DRAFTS -> buildList {
+            add(PostRsMenuAction.VIEW)
+            add(PostRsMenuAction.READ)
+            if (site.hasCapabilityPublishPosts) {
+                add(PostRsMenuAction.PUBLISH)
             }
-            PostRsListTab.DRAFTS -> {
-                add(PostRsMenuAction.VIEW)
-                add(PostRsMenuAction.READ)
-                if (site.hasCapabilityPublishPosts) {
-                    add(PostRsMenuAction.PUBLISH)
-                }
-                add(PostRsMenuAction.DUPLICATE)
-                add(PostRsMenuAction.SHARE)
-                add(PostRsMenuAction.TRASH)
-            }
-            PostRsListTab.SCHEDULED -> {
-                add(PostRsMenuAction.VIEW)
-                add(PostRsMenuAction.READ)
-                add(PostRsMenuAction.SHARE)
-                add(PostRsMenuAction.TRASH)
-            }
-            PostRsListTab.TRASHED -> {
-                add(PostRsMenuAction.MOVE_TO_DRAFT)
-                add(PostRsMenuAction.DELETE_PERMANENTLY)
-            }
+            add(PostRsMenuAction.DUPLICATE)
+            add(PostRsMenuAction.SHARE)
+            add(PostRsMenuAction.TRASH)
         }
+        PostRsListTab.SCHEDULED -> listOf(
+            PostRsMenuAction.VIEW,
+            PostRsMenuAction.READ,
+            PostRsMenuAction.SHARE,
+            PostRsMenuAction.TRASH
+        )
+        PostRsListTab.TRASHED -> listOf(
+            PostRsMenuAction.MOVE_TO_DRAFT,
+            PostRsMenuAction.DELETE_PERMANENTLY
+        )
+    }
+
+    private fun getPublishedMenuActions(
+        hasPassword: Boolean,
+        commentsOpen: Boolean
+    ): List<PostRsMenuAction> = buildList {
+        add(PostRsMenuAction.VIEW)
+        add(PostRsMenuAction.READ)
+        add(PostRsMenuAction.MOVE_TO_DRAFT)
+        add(PostRsMenuAction.DUPLICATE)
+        add(PostRsMenuAction.SHARE)
+        if (!hasPassword && blazeFeatureUtils.isSiteBlazeEligible(site)) {
+            add(PostRsMenuAction.BLAZE)
+        }
+        if (SiteUtils.isAccessedViaWPComRest(site) && site.hasCapabilityViewStats) {
+            add(PostRsMenuAction.STATS)
+        }
+        if (commentsOpen) add(PostRsMenuAction.COMMENTS)
+        add(PostRsMenuAction.TRASH)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -496,7 +496,9 @@ class PostRsListViewModel @Inject constructor(
             PostRsListTab.DRAFTS -> {
                 add(PostRsMenuAction.VIEW)
                 add(PostRsMenuAction.READ)
-                add(PostRsMenuAction.PUBLISH)
+                if (site.hasCapabilityPublishPosts) {
+                    add(PostRsMenuAction.PUBLISH)
+                }
                 add(PostRsMenuAction.DUPLICATE)
                 add(PostRsMenuAction.SHARE)
                 add(PostRsMenuAction.TRASH)


### PR DESCRIPTION
## Summary

Previously in the RS post list, on the Drafts tab we always had a Publish menu item. For contributors, this should have been hidden since they can't publish posts.

## Test plan

* In the app, sign into a site where you're a contributor
* Create a post on the web as that contributor
* In the app, tap the three dot menu on that post
* Ensure the Publish menu item doesn't appear
* On the web, change the role of the contributor to Author or Admin
* Force quit the app and restart it
* Ensure the Publish menu item **does** appear for that post


<img width="610" height="629" alt="admin-author" src="https://github.com/user-attachments/assets/8192c1d5-633d-4821-b095-ac62a5d7060c" />
