### PR TITLE
fix: open redirect_to URL in browser to prevent infinite deep link loop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -131,12 +131,28 @@ class DeepLinkingIntentReceiverViewModel
 
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction? {
         return when {
-            deepLinkUriUtils.isTrackingUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)
-                ?.also {
-                    // The new URL was build so we need to hit the original `mbar` tracking URL
+            deepLinkUriUtils.isTrackingUrl(uri) -> {
+                val redirectUri = deepLinkUriUtils.getRedirectUri(uri)
+                val navigateAction = redirectUri?.let { buildNavigateAction(it, rootUri) }
+                if (navigateAction != null) {
+                    // Handled in-app — fire the tracking pixel since the
+                    // server won't see the request otherwise.
                     serverTrackingHandler.request(uri)
+                    navigateAction
+                } else if (redirectUri != null) {
+                    // Can't handle in-app. Open the redirect destination
+                    // (not the tracking URL) to avoid an infinite loop with
+                    // the app's intent filter. Fire the tracking pixel
+                    // explicitly since the browser won't hit the tracking URL.
+                    serverTrackingHandler.request(uri)
+                    OpenInBrowser(redirectUri)
+                } else {
+                    // No redirect_to param — open the /bar/ tracking URL in
+                    // the browser. The browser request itself will handle
+                    // server-side tracking, so no explicit pixel needed.
+                    OpenInBrowser(rootUri.copy(REGULAR_TRACKING_PATH))
                 }
-                ?: OpenInBrowser(rootUri.copy(REGULAR_TRACKING_PATH))
+            }
             deepLinkUriUtils.isWpLoginUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)
             else -> deepLinkHandlers.buildNavigateAction(uri)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -137,26 +137,37 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val startUrl = mock<UriWrapper>()
         val wpLoginUri = initWpLoginUri(startUrl)
         val uri = initTrackingUri(wpLoginUri)
-        val barUri = buildUri("public-api.wordpress.com")
 
         whenever(deepLinkHandlers.buildNavigateAction(startUrl)).thenReturn(null)
-        whenever(uri.copy("bar")).thenReturn(barUri)
 
         viewModel.start(null, uri, DEFAULT, null)
 
-        assertUriHandled(OpenInBrowser(barUri))
+        assertUriHandled(OpenInBrowser(wpLoginUri))
+        verify(serverTrackingHandler).request(uri)
+    }
+
+    @Test
+    fun `tracking URL with unhandled direct redirect opens redirect URL in browser`() {
+        val redirectUri = buildUri("wordpress.com")
+        val uri = initTrackingUri(redirectUri)
+
+        whenever(deepLinkHandlers.buildNavigateAction(redirectUri)).thenReturn(null)
+
+        viewModel.start(null, uri, DEFAULT, null)
+
+        assertUriHandled(OpenInBrowser(redirectUri))
+        verify(serverTrackingHandler).request(uri)
     }
 
     @Test
     fun `wp-login mbar URL redirects user to browser with missing second redirect`() {
         val wpLoginUri = initWpLoginUri()
         val uri = initTrackingUri(wpLoginUri)
-        val barUri = buildUri("public-api.wordpress.com")
-        whenever(uri.copy("bar")).thenReturn(barUri)
 
         viewModel.start(null, uri, DEFAULT, null)
 
-        assertUriHandled(OpenInBrowser(barUri))
+        assertUriHandled(OpenInBrowser(wpLoginUri))
+        verify(serverTrackingHandler).request(uri)
     }
 
     @Test


### PR DESCRIPTION
This PR merges the https://github.com/wordpress-mobile/WordPress-Android/pull/22648 changes in the release/26.6.1 branch to the trunk branch.

----

* fix: open redirect_to URL in browser to prevent infinite deep link loop

When a tracking URL's redirect_to target can't be handled in-app, open the extracted redirect_to URL in the browser instead of the original tracking URL. This prevents an infinite loop caused by the app's intent filter re-intercepting its own public-api.wordpress.com/bar/ URLs.

* fix: fire server tracking pixel when redirect_to opens in browser

When a tracking URL's redirect_to target can't be handled in-app, the app now opens the redirect destination in the browser (loop fix) but the server never sees the original tracking URL. Fire the pixel explicitly in this path so email link taps are still recorded.

The no-redirect fallback still opens /bar/ in the browser, which handles tracking implicitly via the browser's HTTP request.

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

## Testing instructions
<!--
Provide specific testing steps for reviewers. Use the following format:

Test case title:

1. Step 1
2. Step 2
- [ ] Verify expected outcome
3. Step 3
- [ ] Verify another expected outcome

Use numbered lists for action steps and checkboxes for verifications.
Organise by test case title when there are multiple scenarios.
-->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->