### PR TITLE
Fix run-app skill launch commands for debug build variants

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -107,10 +107,11 @@ devices are present):
 adb [-s <serial>] install -r "$APK"
 ```
 
-Then launch the app:
+Then launch the app. The debug build type appends `.prealpha` to the
+application ID, so use the correct package name:
 
-- **Jetpack**: `adb [-s <serial>] shell am start -n com.jetpack.android/org.wordpress.android.ui.WPLaunchActivity`
-- **WordPress**: `adb [-s <serial>] shell am start -n org.wordpress.android/org.wordpress.android.ui.WPLaunchActivity`
+- **Jetpack debug**: `adb [-s <serial>] shell monkey -p com.jetpack.android.prealpha -c android.intent.category.LAUNCHER 1`
+- **WordPress debug**: `adb [-s <serial>] shell monkey -p org.wordpress.android.prealpha -c android.intent.category.LAUNCHER 1`
 
 ### 6. Report the result
 


### PR DESCRIPTION
## Description

After PR #22651 removed the wasabi/jalapeno/vanilla flavors, the run-app
skill's launch commands still used the old package names
(`com.jetpack.android`, `org.wordpress.android`) which don't account for
the `.prealpha` debug suffix. This caused `am start` to fail with
"Activity class does not exist."

Changes:
- Updated package names to include the `.prealpha` debug suffix
- Switched from `am start` to `monkey` to auto-resolve the launcher
  activity

## Testing instructions

Just check the skill changes