### PR TITLE
RS Post Settings: Add polish and error handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsErrorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsErrorUtils.kt
@@ -1,0 +1,76 @@
+package org.wordpress.android.ui.postsrs
+
+import org.wordpress.android.R
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.WpApiException
+import uniffi.wp_api.WpErrorCode
+import uniffi.wp_mobile.FetchException
+
+/**
+ * Shared error-handling helpers for the RS post screens.
+ */
+internal object PostRsErrorUtils {
+    /**
+     * Extracts the underlying [WpApiException] from a
+     * [FetchException.Api] wrapper so callers can inspect
+     * API-level error details without knowing the wrapper.
+     */
+    fun unwrapException(e: Exception?): Exception? =
+        (e as? FetchException.Api)?.v1 ?: e
+
+    /**
+     * Returns true when the exception represents an
+     * authentication failure (rejected credentials,
+     * missing app-password, etc.).
+     */
+    fun isAuthError(e: Exception?): Boolean {
+        val api = unwrapException(e)
+        val reason =
+            (api as? WpApiException.RequestExecutionFailed)
+                ?.reason
+        val errorCode =
+            (api as? WpApiException.WpException)?.errorCode
+        return reason is RequestExecutionErrorReason
+            .HttpAuthenticationRejectedError ||
+            reason is RequestExecutionErrorReason
+                .HttpAuthenticationRequiredError ||
+            errorCode is WpErrorCode.Unauthorized ||
+            errorCode is WpErrorCode
+                .ApplicationPasswordNotFound ||
+            errorCode is WpErrorCode
+                .NoAuthenticatedAppPassword
+    }
+
+    /**
+     * Returns a user-friendly error string based on the
+     * exception type. Detects offline, auth, and generic
+     * errors.
+     */
+    fun friendlyErrorMessage(
+        e: Exception? = null,
+        defaultResId: Int? = null,
+        resourceProvider: ResourceProvider,
+        networkUtilsWrapper: NetworkUtilsWrapper,
+    ): String {
+        val api = unwrapException(e)
+        val reason =
+            (api as? WpApiException.RequestExecutionFailed)
+                ?.reason
+
+        val resId = when {
+            reason is RequestExecutionErrorReason
+                .DeviceIsOfflineError ||
+                !networkUtilsWrapper.isNetworkAvailable() ->
+                R.string.error_generic_network
+
+            isAuthError(e) -> R.string.post_rs_error_auth
+
+            defaultResId != null -> defaultResId
+
+            else -> R.string.request_failed_message
+        }
+        return resourceProvider.getString(resId)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -367,9 +367,6 @@ class PostRsListViewModel @Inject constructor(
         _events.trySend(PostRsListEvent.EditPost(site, newPost))
     }
 
-    private fun isAuthError(e: Exception?): Boolean =
-        PostRsErrorUtils.isAuthError(e)
-
     private fun checkNetwork(): Boolean {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             _snackbarMessages.trySend(
@@ -542,7 +539,7 @@ class PostRsListViewModel @Inject constructor(
                 updateTabUiState(tab) {
                     PostTabUiState(
                         error = friendlyErrorMessage(e),
-                        isAuthError = isAuthError(e)
+                        isAuthError = PostRsErrorUtils.isAuthError(e)
                     )
                 }
             }
@@ -616,7 +613,7 @@ class PostRsListViewModel @Inject constructor(
                     updateTabUiState(tab) {
                         copy(isLoading = false, isRefreshing = false, error = null)
                     }
-                    val authError = isAuthError(e)
+                    val authError = PostRsErrorUtils.isAuthError(e)
                     _snackbarMessages.trySend(
                         SnackbarMessage(
                             message = message,
@@ -631,7 +628,7 @@ class PostRsListViewModel @Inject constructor(
                         copy(
                             isLoading = false, isRefreshing = false,
                             error = message,
-                            isAuthError = isAuthError(e)
+                            isAuthError = PostRsErrorUtils.isAuthError(e)
                         )
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -39,11 +39,7 @@ import rs.wordpress.cache.kotlin.hasMorePages
 import uniffi.wp_api.PostEndpointType
 import uniffi.wp_api.PostStatus
 import uniffi.wp_api.PostUpdateParams
-import uniffi.wp_api.RequestExecutionErrorReason
-import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpApiParamPostsOrderBy
-import uniffi.wp_api.WpErrorCode
-import uniffi.wp_mobile.FetchException
 import uniffi.wp_mobile.PostListFilter
 import uniffi.wp_mobile_cache.ListState
 import javax.inject.Inject
@@ -371,28 +367,8 @@ class PostRsListViewModel @Inject constructor(
         _events.trySend(PostRsListEvent.EditPost(site, newPost))
     }
 
-    /**
-     * Extracts the underlying [WpApiException] from a [FetchException.Api]
-     * wrapper so that callers can inspect API-level error details (status
-     * codes, error reasons) without knowing about the wrapper type.
-     */
-    private fun unwrapException(e: Exception?): Exception? =
-        (e as? FetchException.Api)?.v1 ?: e
-
-    /**
-     * Returns true when the exception represents an authentication failure
-     * (rejected credentials, missing app-password, etc.).
-     */
-    private fun isAuthError(e: Exception?): Boolean {
-        val apiException = unwrapException(e)
-        val reason = (apiException as? WpApiException.RequestExecutionFailed)?.reason
-        val errorCode = (apiException as? WpApiException.WpException)?.errorCode
-        return reason is RequestExecutionErrorReason.HttpAuthenticationRejectedError ||
-            reason is RequestExecutionErrorReason.HttpAuthenticationRequiredError ||
-            errorCode is WpErrorCode.Unauthorized ||
-            errorCode is WpErrorCode.ApplicationPasswordNotFound ||
-            errorCode is WpErrorCode.NoAuthenticatedAppPassword
-    }
+    private fun isAuthError(e: Exception?): Boolean =
+        PostRsErrorUtils.isAuthError(e)
 
     private fun checkNetwork(): Boolean {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
@@ -404,29 +380,12 @@ class PostRsListViewModel @Inject constructor(
         return true
     }
 
-    /**
-     * Returns a user-friendly error subtitle based on the exception type.
-     * Detects offline, authentication, and generic errors. When a default
-     * resource ID is provided and the exception is a WpApiException with a
-     * message, that message is used; otherwise falls back to the default.
-     */
-    private fun friendlyErrorMessage(e: Exception? = null, defaultResId: Int? = null): String {
-        val apiException = unwrapException(e)
-        val reason = (apiException as? WpApiException.RequestExecutionFailed)?.reason
-
-        val resId = when {
-            reason is RequestExecutionErrorReason.DeviceIsOfflineError ||
-                !networkUtilsWrapper.isNetworkAvailable() ->
-                R.string.error_generic_network
-
-            isAuthError(e) -> R.string.post_rs_error_auth
-
-            defaultResId != null -> defaultResId
-
-            else -> R.string.request_failed_message
-        }
-        return resourceProvider.getString(resId)
-    }
+    private fun friendlyErrorMessage(
+        e: Exception? = null,
+        defaultResId: Int? = null,
+    ): String = PostRsErrorUtils.friendlyErrorMessage(
+        e, defaultResId, resourceProvider, networkUtilsWrapper
+    )
 
     /** Creates a PostUpdateParams for changing post status. */
     private fun postStatusUpdate(status: PostStatus) = PostUpdateParams(status = status, meta = null)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
@@ -26,6 +26,8 @@ import org.wordpress.android.ui.postsrs.screens.PostRsSettingsScreen
 import org.wordpress.android.ui.postsrs.terms.TermSelectionActivity
 import org.wordpress.android.ui.postsrs.terms.TermSelectionViewModel
 import org.wordpress.android.util.extensions.setContent
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -49,6 +51,15 @@ class PostRsSettingsActivity : BaseAppCompatActivity() {
         super.onCreate(savedInstanceState)
         registerMediaPickerLauncher()
         registerTermSelectionLaunchers()
+
+        WindowInsetsControllerCompat(
+            window, window.decorView
+        ).apply {
+            hide(WindowInsetsCompat.Type.statusBars())
+            systemBarsBehavior =
+                WindowInsetsControllerCompat
+                    .BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
 
         observeEvents()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
@@ -7,8 +7,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.Lifecycle
@@ -51,14 +49,6 @@ class PostRsSettingsActivity : BaseAppCompatActivity() {
         super.onCreate(savedInstanceState)
         registerMediaPickerLauncher()
         registerTermSelectionLaunchers()
-
-        val controller = WindowInsetsControllerCompat(
-            window, window.decorView
-        )
-        controller.hide(WindowInsetsCompat.Type.statusBars())
-        controller.systemBarsBehavior =
-            WindowInsetsControllerCompat
-                .BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 
         observeEvents()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsActivity.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.postsrs.screens.PostRsSettingsScreen
 import org.wordpress.android.ui.postsrs.terms.TermSelectionActivity
 import org.wordpress.android.ui.postsrs.terms.TermSelectionViewModel
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.extensions.setContent
 import javax.inject.Inject
 
@@ -68,8 +67,10 @@ class PostRsSettingsActivity : BaseAppCompatActivity() {
             AppThemeM3 {
                 PostRsSettingsScreen(
                     uiState = uiState,
+                    snackbarMessages = viewModel.snackbarMessages,
                     onNavigateBack = viewModel::onBackClicked,
                     onRetry = viewModel::retry,
+                    onRefresh = viewModel::refreshPost,
                     onRetryField = viewModel::retryField,
                     onStatusClicked = viewModel::onStatusClicked,
                     onStatusSelected = viewModel::onStatusSelected,
@@ -129,11 +130,6 @@ class PostRsSettingsActivity : BaseAppCompatActivity() {
                                 tagSelectionLauncher,
                                 isCategories = false,
                                 event.selectedIds,
-                            )
-                        is PostRsSettingsEvent.ShowSnackbar ->
-                            ToastUtils.showToast(
-                                this@PostRsSettingsActivity,
-                                event.message
                             )
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
@@ -18,6 +18,7 @@ sealed interface FieldState {
 
 data class PostRsSettingsUiState(
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val error: String? = null,
     val postTitle: String = "",
     val publishDate: String = "",
@@ -124,6 +125,4 @@ sealed interface PostRsSettingsEvent {
     data class LaunchTagSelection(
         val selectedIds: List<Long>,
     ) : PostRsSettingsEvent
-    data class ShowSnackbar(val message: String) :
-        PostRsSettingsEvent
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -72,13 +72,6 @@ class PostRsSettingsViewModel @Inject constructor(
 
     init {
         if (site == null) {
-            _snackbarMessages.trySend(
-                SnackbarMessage(
-                    resourceProvider.getString(
-                        R.string.blog_not_found
-                    )
-                )
-            )
             _events.trySend(PostRsSettingsEvent.Finish)
         } else {
             loadPost()
@@ -107,7 +100,22 @@ class PostRsSettingsViewModel @Inject constructor(
             try {
                 val post = fetchPost(site)
                 lastPost = post
-                _uiState.value = mapPostToUiState(post)
+                val current = _uiState.value
+                _uiState.value = mapPostToUiState(post).copy(
+                    editedStatus = current.editedStatus,
+                    editedPassword = current.editedPassword,
+                    editedSticky = current.editedSticky,
+                    editedSlug = current.editedSlug,
+                    editedExcerpt = current.editedExcerpt,
+                    editedFormat = current.editedFormat,
+                    editedDate = current.editedDate,
+                    editedAuthor = current.editedAuthor,
+                    editedFeaturedImageId =
+                        current.editedFeaturedImageId,
+                    editedCategoryIds =
+                        current.editedCategoryIds,
+                    editedTagIds = current.editedTagIds,
+                )
                 resolveAsyncFields(post)
             } catch (e: CancellationException) {
                 throw e

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -101,21 +101,8 @@ class PostRsSettingsViewModel @Inject constructor(
                 val post = fetchPost(site)
                 lastPost = post
                 val current = _uiState.value
-                _uiState.value = mapPostToUiState(post).copy(
-                    editedStatus = current.editedStatus,
-                    editedPassword = current.editedPassword,
-                    editedSticky = current.editedSticky,
-                    editedSlug = current.editedSlug,
-                    editedExcerpt = current.editedExcerpt,
-                    editedFormat = current.editedFormat,
-                    editedDate = current.editedDate,
-                    editedAuthor = current.editedAuthor,
-                    editedFeaturedImageId =
-                        current.editedFeaturedImageId,
-                    editedCategoryIds =
-                        current.editedCategoryIds,
-                    editedTagIds = current.editedTagIds,
-                )
+                _uiState.value = mapPostToUiState(post)
+                    .preserveEdits(from = current)
                 resolveAsyncFields(post)
             } catch (e: CancellationException) {
                 throw e
@@ -945,6 +932,22 @@ class PostRsSettingsViewModel @Inject constructor(
         fmt.timeZone = UTC
         return fmt.format(dateGmt)
     }
+
+    private fun PostRsSettingsUiState.preserveEdits(
+        from: PostRsSettingsUiState
+    ) = copy(
+        editedStatus = from.editedStatus,
+        editedPassword = from.editedPassword,
+        editedSticky = from.editedSticky,
+        editedSlug = from.editedSlug,
+        editedExcerpt = from.editedExcerpt,
+        editedFormat = from.editedFormat,
+        editedDate = from.editedDate,
+        editedAuthor = from.editedAuthor,
+        editedFeaturedImageId = from.editedFeaturedImageId,
+        editedCategoryIds = from.editedCategoryIds,
+        editedTagIds = from.editedTagIds,
+    )
 
     private class PostApiException(message: String?) :
         Exception(message ?: "Post API request failed")

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -626,7 +626,7 @@ class PostRsSettingsViewModel @Inject constructor(
                     }
                     when (response) {
                         is WpRequestResult.Success -> Unit
-                        else -> throw RuntimeException(
+                        else -> throw PostApiRequestException(
                             (response
                                 as? WpRequestResult.WpError<*>)
                                 ?.errorMessage
@@ -725,7 +725,7 @@ class PostRsSettingsViewModel @Inject constructor(
         when (response) {
             is WpRequestResult.Success ->
                 response.response.data
-            else -> throw RuntimeException(
+            else -> throw PostApiRequestException(
                 (response as? WpRequestResult.WpError<*>)
                     ?.errorMessage
                     ?: "Post API request failed"
@@ -942,6 +942,9 @@ class PostRsSettingsViewModel @Inject constructor(
         editedCategoryIds = from.editedCategoryIds,
         editedTagIds = from.editedTagIds,
     )
+
+    private class PostApiRequestException(message: String) :
+        RuntimeException(message)
 
     companion object {
         const val EXTRA_POST_ID = "extra_post_id"

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -588,9 +588,12 @@ class PostRsSettingsViewModel @Inject constructor(
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             _snackbarMessages.trySend(
                 SnackbarMessage(
-                    resourceProvider.getString(
+                    message = resourceProvider.getString(
                         R.string.error_generic_network
-                    )
+                    ),
+                    actionLabel = resourceProvider
+                        .getString(R.string.retry),
+                    onAction = { onSaveClicked() }
                 )
             )
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -58,6 +58,10 @@ class PostRsSettingsViewModel @Inject constructor(
     private val _events = Channel<PostRsSettingsEvent>(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
+    private val _snackbarMessages =
+        Channel<SnackbarMessage>(Channel.BUFFERED)
+    val snackbarMessages = _snackbarMessages.receiveAsFlow()
+
     private val fieldError: String
         get() = resourceProvider.getString(
             R.string.post_rs_settings_field_error
@@ -68,9 +72,11 @@ class PostRsSettingsViewModel @Inject constructor(
 
     init {
         if (site == null) {
-            _events.trySend(
-                PostRsSettingsEvent.ShowSnackbar(
-                    resourceProvider.getString(R.string.blog_not_found)
+            _snackbarMessages.trySend(
+                SnackbarMessage(
+                    resourceProvider.getString(
+                        R.string.blog_not_found
+                    )
                 )
             )
             _events.trySend(PostRsSettingsEvent.Finish)
@@ -81,6 +87,56 @@ class PostRsSettingsViewModel @Inject constructor(
 
     fun retry() {
         loadPost()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    fun refreshPost() {
+        val site = site ?: return
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            _snackbarMessages.trySend(
+                SnackbarMessage(
+                    resourceProvider.getString(
+                        R.string.error_generic_network
+                    )
+                )
+            )
+            return
+        }
+        _uiState.update { it.copy(isRefreshing = true) }
+        viewModelScope.launch {
+            try {
+                val post = fetchPost(site)
+                lastPost = post
+                _uiState.value = mapPostToUiState(post)
+                resolveAsyncFields(post)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e(
+                    AppLog.T.POSTS,
+                    "Failed to refresh post settings",
+                    e
+                )
+                _uiState.update {
+                    it.copy(isRefreshing = false)
+                }
+                _snackbarMessages.trySend(
+                    SnackbarMessage(
+                        message = PostRsErrorUtils
+                            .friendlyErrorMessage(
+                                e = e,
+                                resourceProvider =
+                                    resourceProvider,
+                                networkUtilsWrapper =
+                                    networkUtilsWrapper,
+                            ),
+                        actionLabel = resourceProvider
+                            .getString(R.string.retry),
+                        onAction = { refreshPost() }
+                    )
+                )
+            }
+        }
     }
 
     fun retryField(field: RetryableField) {
@@ -276,8 +332,8 @@ class PostRsSettingsViewModel @Inject constructor(
     fun onAuthorClicked() {
         val currentSite = site ?: return
         if (!_uiState.value.canEditAuthor) {
-            _events.trySend(
-                PostRsSettingsEvent.ShowSnackbar(
+            _snackbarMessages.trySend(
+                SnackbarMessage(
                     resourceProvider.getString(
                         R.string
                             .post_rs_settings_author_no_permission
@@ -451,8 +507,8 @@ class PostRsSettingsViewModel @Inject constructor(
                         dialogState = DialogState.None
                     )
                 }
-                _events.trySend(
-                    PostRsSettingsEvent.ShowSnackbar(
+                _snackbarMessages.trySend(
+                    SnackbarMessage(
                         e.message?.takeIf {
                             it.isNotBlank()
                         } ?: fieldError
@@ -535,8 +591,8 @@ class PostRsSettingsViewModel @Inject constructor(
         if (!state.hasChanges || state.isSaving) return
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            _events.trySend(
-                PostRsSettingsEvent.ShowSnackbar(
+            _snackbarMessages.trySend(
+                SnackbarMessage(
                     resourceProvider.getString(
                         R.string.error_generic_network
                     )
@@ -611,8 +667,13 @@ class PostRsSettingsViewModel @Inject constructor(
                 } ?: resourceProvider.getString(
                     R.string.post_rs_settings_save_error
                 )
-                _events.trySend(
-                    PostRsSettingsEvent.ShowSnackbar(message)
+                _snackbarMessages.trySend(
+                    SnackbarMessage(
+                        message = message,
+                        actionLabel = resourceProvider
+                            .getString(R.string.retry),
+                        onAction = { onSaveClicked() }
+                    )
                 )
             }
         }
@@ -649,9 +710,14 @@ class PostRsSettingsViewModel @Inject constructor(
                 )
                 _uiState.value = PostRsSettingsUiState(
                     isLoading = false,
-                    error = resourceProvider.getString(
-                        R.string.request_failed_message
-                    )
+                    error = PostRsErrorUtils
+                        .friendlyErrorMessage(
+                            e = e,
+                            resourceProvider =
+                                resourceProvider,
+                            networkUtilsWrapper =
+                                networkUtilsWrapper,
+                        )
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -579,25 +579,10 @@ class PostRsSettingsViewModel @Inject constructor(
         _events.trySend(PostRsSettingsEvent.Finish)
     }
 
-    @Suppress("ReturnCount")
     fun onSaveClicked() {
         val site = site ?: return
         val state = _uiState.value
         if (!state.hasChanges || state.isSaving) return
-
-        if (!networkUtilsWrapper.isNetworkAvailable()) {
-            _snackbarMessages.trySend(
-                SnackbarMessage(
-                    message = resourceProvider.getString(
-                        R.string.error_generic_network
-                    ),
-                    actionLabel = resourceProvider
-                        .getString(R.string.retry),
-                    onAction = { onSaveClicked() }
-                )
-            )
-            return
-        }
 
         _uiState.update { it.copy(isSaving = true) }
         savePost(site, state)
@@ -660,14 +645,18 @@ class PostRsSettingsViewModel @Inject constructor(
                     e
                 )
                 _uiState.update { it.copy(isSaving = false) }
-                val message = e.message?.takeIf {
-                    it.isNotBlank()
-                } ?: resourceProvider.getString(
-                    R.string.post_rs_settings_save_error
-                )
                 _snackbarMessages.trySend(
                     SnackbarMessage(
-                        message = message,
+                        message = PostRsErrorUtils
+                            .friendlyErrorMessage(
+                                e = e,
+                                defaultResId = R.string
+                                    .post_rs_settings_save_error,
+                                resourceProvider =
+                                    resourceProvider,
+                                networkUtilsWrapper =
+                                    networkUtilsWrapper,
+                            ),
                         actionLabel = resourceProvider
                             .getString(R.string.retry),
                         onAction = { onSaveClicked() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -626,10 +626,11 @@ class PostRsSettingsViewModel @Inject constructor(
                     }
                     when (response) {
                         is WpRequestResult.Success -> Unit
-                        else -> throw PostApiException(
+                        else -> throw RuntimeException(
                             (response
                                 as? WpRequestResult.WpError<*>)
                                 ?.errorMessage
+                                ?: "Post API request failed"
                         )
                     }
                 }
@@ -724,9 +725,10 @@ class PostRsSettingsViewModel @Inject constructor(
         when (response) {
             is WpRequestResult.Success ->
                 response.response.data
-            else -> throw PostApiException(
+            else -> throw RuntimeException(
                 (response as? WpRequestResult.WpError<*>)
                     ?.errorMessage
+                    ?: "Post API request failed"
             )
         }
     }
@@ -940,9 +942,6 @@ class PostRsSettingsViewModel @Inject constructor(
         editedCategoryIds = from.editedCategoryIds,
         editedTagIds = from.editedTagIds,
     )
-
-    private class PostApiException(message: String?) :
-        Exception(message ?: "Post API request failed")
 
     companion object {
         const val EXTRA_POST_ID = "extra_post_id"

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -54,6 +54,9 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -61,6 +64,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerDialog
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
@@ -92,11 +98,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.SingleChoiceAlertDialog
 import org.wordpress.android.ui.postsrs.AuthorInfo
 import org.wordpress.android.ui.postsrs.DialogState
+import org.wordpress.android.ui.postsrs.SnackbarMessage
 import org.wordpress.android.ui.postsrs.FieldState
 import org.wordpress.android.ui.postsrs.PostRsSettingsUiState
 import org.wordpress.android.ui.postsrs.RetryableField
@@ -111,8 +120,10 @@ import org.wordpress.android.ui.postsrs.UTC
 @Suppress("LongParameterList")
 fun PostRsSettingsScreen(
     uiState: PostRsSettingsUiState,
+    snackbarMessages: Flow<SnackbarMessage> = emptyFlow(),
     onNavigateBack: () -> Unit,
     onRetry: () -> Unit = {},
+    onRefresh: () -> Unit = {},
     onRetryField: (RetryableField) -> Unit = {},
     onStatusClicked: () -> Unit = {},
     onStatusSelected: (PostStatus) -> Unit = {},
@@ -141,6 +152,22 @@ fun PostRsSettingsScreen(
 ) {
     BackHandler {
         onNavigateBack()
+    }
+
+    val snackbarHostState = remember {
+        SnackbarHostState()
+    }
+
+    LaunchedEffect(snackbarMessages) {
+        snackbarMessages.collect { msg ->
+            val result = snackbarHostState.showSnackbar(
+                message = msg.message,
+                actionLabel = msg.actionLabel
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                msg.onAction?.invoke()
+            }
+        }
     }
 
     Box(
@@ -174,6 +201,7 @@ fun PostRsSettingsScreen(
                 HeroSettingsLayout(
                     uiState = uiState,
                     onNavigateBack = onNavigateBack,
+                    onRefresh = onRefresh,
                     onRetryField = onRetryField,
                     onStatusClicked = onStatusClicked,
                     onPasswordClicked = onPasswordClicked,
@@ -194,6 +222,10 @@ fun PostRsSettingsScreen(
                 )
             }
         }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 
     SettingsDialogs(
@@ -253,11 +285,13 @@ private fun NormalAppBarLayout(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongParameterList")
 @Composable
 private fun HeroSettingsLayout(
     uiState: PostRsSettingsUiState,
     onNavigateBack: () -> Unit,
+    onRefresh: () -> Unit,
     onRetryField: (RetryableField) -> Unit,
     onStatusClicked: () -> Unit,
     onPasswordClicked: () -> Unit,
@@ -273,7 +307,25 @@ private fun HeroSettingsLayout(
     onFeaturedImageRemoved: () -> Unit,
     onSaveClicked: () -> Unit,
 ) {
+    val pullToRefreshState = rememberPullToRefreshState()
+
     Box(modifier = Modifier.fillMaxSize()) {
+        PullToRefreshBox(
+            modifier = Modifier.fillMaxSize(),
+            isRefreshing = uiState.isRefreshing,
+            state = pullToRefreshState,
+            onRefresh = onRefresh,
+            indicator = {
+                PullToRefreshDefaults.Indicator(
+                    state = pullToRefreshState,
+                    isRefreshing = uiState.isRefreshing,
+                    color = MaterialTheme
+                        .colorScheme.primary,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                )
+            }
+        ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -321,6 +373,7 @@ private fun HeroSettingsLayout(
                 onTagsClicked = onTagsClicked,
             )
         }
+        } // end PullToRefreshBox
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -474,8 +527,14 @@ private fun HeroImagePlaceholder(
     ),
     onClick: (() -> Unit)? = null,
 ) {
+    val editLabel = stringResource(
+        R.string.post_rs_settings_edit_featured_image
+    )
     val clickModifier = if (onClick != null) {
-        Modifier.clickable(onClick = onClick)
+        Modifier.clickable(
+            onClickLabel = editLabel,
+            onClick = onClick,
+        )
     } else {
         Modifier
     }
@@ -531,14 +590,31 @@ private fun FloatingSaveButton(
     onSaveClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val savingDesc = stringResource(
+        R.string.post_rs_settings_saving
+    )
     if (isSaving) {
-        CircularProgressIndicator(
-            modifier = modifier
-                .padding(12.dp)
-                .size(24.dp),
-            strokeWidth = 2.dp,
-            color = Color.White,
-        )
+        Row(
+            modifier = modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement
+                .spacedBy(6.dp)
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(18.dp)
+                    .semantics {
+                        contentDescription = savingDesc
+                    },
+                strokeWidth = 2.dp,
+                color = Color.White,
+            )
+            Text(
+                text = savingDesc,
+                color = Color.White,
+                style = MaterialTheme.typography.labelLarge,
+            )
+        }
     } else {
         IconButton(
             onClick = onSaveClicked,
@@ -607,11 +683,16 @@ private fun SettingsContent(
             stringResource(R.string.post_settings_publish)
         )
 
+        val statusLabel = statusDisplayLabel(uiState)
+        val statusResId = (
+            uiState.editedStatus ?: uiState.postStatus
+            ).toLabel()
         SettingsRow(
             label = stringResource(
                 R.string.post_settings_status
             ),
-            value = statusDisplayLabel(uiState),
+            value = statusLabel,
+            dimmed = statusResId == 0,
             modifier = Modifier.clickable(
                 onClick = onStatusClicked
             )
@@ -756,7 +837,11 @@ private fun statusDisplayLabel(
 ): String {
     val status = uiState.editedStatus ?: uiState.postStatus
     val resId = status.toLabel()
-    return if (resId != 0) stringResource(resId) else ""
+    return if (resId != 0) {
+        stringResource(resId)
+    } else {
+        stringResource(R.string.post_settings_not_set)
+    }
 }
 
 @Composable
@@ -997,7 +1082,18 @@ private fun PasswordDialog(
                                 } else {
                                     Icons.Default.Visibility
                                 },
-                                contentDescription = null
+                                contentDescription =
+                                    if (passwordVisible) {
+                                        stringResource(
+                                            R.string
+                                                .post_rs_settings_hide_password
+                                        )
+                                    } else {
+                                        stringResource(
+                                            R.string
+                                                .post_rs_settings_show_password
+                                        )
+                                    }
                             )
                         }
                     },

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -227,7 +228,13 @@ fun PostRsSettingsScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .navigationBarsPadding()
-        )
+        ) { data ->
+            Snackbar(
+                snackbarData = data,
+                actionColor =
+                    MaterialTheme.colorScheme.primary
+            )
+        }
     }
 
     SettingsDialogs(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -151,9 +151,7 @@ fun PostRsSettingsScreen(
     onDismissDialog: () -> Unit = {},
     onDiscardConfirmed: () -> Unit = {},
 ) {
-    BackHandler {
-        onNavigateBack()
-    }
+    BackHandler(onBack = onNavigateBack)
 
     val snackbarHostState = remember {
         SnackbarHostState()
@@ -539,14 +537,12 @@ private fun HeroImagePlaceholder(
     val editLabel = stringResource(
         R.string.post_rs_settings_edit_featured_image
     )
-    val clickModifier = if (onClick != null) {
+    val clickModifier = onClick?.let {
         Modifier.clickable(
             onClickLabel = editLabel,
-            onClick = onClick,
+            onClick = it,
         )
-    } else {
-        Modifier
-    }
+    } ?: Modifier
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -1652,11 +1648,9 @@ private fun ChipSettingsRow(
     onRetry: () -> Unit,
     onClick: (() -> Unit)? = null,
 ) {
-    val clickModifier = if (onClick != null) {
-        Modifier.clickable(onClick = onClick)
-    } else {
-        Modifier
-    }
+    val clickModifier = onClick?.let {
+        Modifier.clickable(onClick = it)
+    } ?: Modifier
     if (state is FieldState.Empty) {
         SettingsRow(
             label = label,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -224,7 +224,9 @@ fun PostRsSettingsScreen(
         }
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
         )
     }
 
@@ -636,28 +638,40 @@ private fun ErrorContent(
     error: String,
     onRetry: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = stringResource(R.string.error_generic),
-            style = MaterialTheme.typography.titleMedium
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = error,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onRetry) {
-            Text(text = stringResource(R.string.retry))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(32.dp),
+            horizontalAlignment =
+                Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(
+                    R.string.error_generic
+                ),
+                style =
+                    MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = error,
+                style =
+                    MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme
+                    .onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) {
+                Text(
+                    text = stringResource(R.string.retry)
+                )
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -326,54 +326,54 @@ private fun HeroSettingsLayout(
                 )
             }
         ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .navigationBarsPadding()
-        ) {
-            when (uiState.featuredImage) {
-                is FieldState.Loaded ->
-                    HeroImageWithMenu(
-                        imageUrl =
-                            uiState.featuredImage.value,
-                        onChangeClicked =
-                            onFeaturedImageClicked,
-                        onRemoveClicked =
-                            onFeaturedImageRemoved,
-                    )
-                is FieldState.Loading ->
-                    HeroImageShimmer()
-                is FieldState.Error ->
-                    HeroImagePlaceholder(
-                        text = stringResource(
-                            R.string
-                                .post_rs_settings_featured_image_error
-                        ),
-                        onClick = onFeaturedImageClicked,
-                    )
-                is FieldState.Empty ->
-                    HeroImagePlaceholder(
-                        onClick = onFeaturedImageClicked,
-                    )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .navigationBarsPadding()
+            ) {
+                when (uiState.featuredImage) {
+                    is FieldState.Loaded ->
+                        HeroImageWithMenu(
+                            imageUrl =
+                                uiState.featuredImage.value,
+                            onChangeClicked =
+                                onFeaturedImageClicked,
+                            onRemoveClicked =
+                                onFeaturedImageRemoved,
+                        )
+                    is FieldState.Loading ->
+                        HeroImageShimmer()
+                    is FieldState.Error ->
+                        HeroImagePlaceholder(
+                            text = stringResource(
+                                R.string
+                                    .post_rs_settings_featured_image_error
+                            ),
+                            onClick = onFeaturedImageClicked,
+                        )
+                    is FieldState.Empty ->
+                        HeroImagePlaceholder(
+                            onClick = onFeaturedImageClicked,
+                        )
+                }
+                SettingsContent(
+                    uiState = uiState,
+                    onRetryField = onRetryField,
+                    onStatusClicked = onStatusClicked,
+                    onPasswordClicked = onPasswordClicked,
+                    onStickyToggled = onStickyToggled,
+                    onSlugClicked = onSlugClicked,
+                    onExcerptClicked = onExcerptClicked,
+                    onFormatClicked = onFormatClicked,
+                    onDateClicked = onDateClicked,
+                    onAuthorClicked = onAuthorClicked,
+                    onCategoriesClicked =
+                        onCategoriesClicked,
+                    onTagsClicked = onTagsClicked,
+                )
             }
-            SettingsContent(
-                uiState = uiState,
-                onRetryField = onRetryField,
-                onStatusClicked = onStatusClicked,
-                onPasswordClicked = onPasswordClicked,
-                onStickyToggled = onStickyToggled,
-                onSlugClicked = onSlugClicked,
-                onExcerptClicked = onExcerptClicked,
-                onFormatClicked = onFormatClicked,
-                onDateClicked = onDateClicked,
-                onAuthorClicked = onAuthorClicked,
-                onCategoriesClicked =
-                    onCategoriesClicked,
-                onTagsClicked = onTagsClicked,
-            )
         }
-        } // end PullToRefreshBox
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -169,7 +170,9 @@ private fun ErrorContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.padding(32.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
@@ -177,6 +180,7 @@ private fun ErrorContent(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme
                 .onSurfaceVariant,
+            textAlign = TextAlign.Center,
         )
         TextButton(onClick = onRetry) {
             Text(stringResource(R.string.retry))

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1044,6 +1044,9 @@
     <string name="post_rs_settings_term_create_error">Failed to create term</string>
     <string name="post_rs_settings_load_more">Load more\u2026</string>
     <string name="post_rs_settings_search_no_results">No results found</string>
+    <string name="post_rs_settings_saving">Saving\u2026</string>
+    <string name="post_rs_settings_hide_password">Hide password</string>
+    <string name="post_rs_settings_show_password">Show password</string>
     <string name="show_less">Show less</string>
     <string name="post_types_screen_title">Post Types</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
@@ -28,7 +28,6 @@ import uniffi.wp_api.PostStatus
 @Suppress("LargeClass")
 class PostRsSettingsViewModelTest :
     BaseUnitTest(StandardTestDispatcher()) {
-
     @Mock
     lateinit var selectedSiteRepository: SelectedSiteRepository
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
@@ -444,29 +444,14 @@ class PostRsSettingsViewModelTest :
         }
 
     @Test
-    fun `onSaveClicked offline sends snackbar`() = test {
-        // VM created offline; edit a field, then save
-        val viewModel = createViewModel()
-        viewModel.onStatusSelected(PostStatus.Draft)
-
-        viewModel.snackbarMessages.test {
-            viewModel.onSaveClicked()
-
-            val msg = awaitItem()
-            assertThat(msg.message).isNotEmpty()
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `onSaveClicked does not set isSaving when offline`() {
+    fun `onSaveClicked with changes sets isSaving`() {
         val viewModel = createViewModel()
         viewModel.onStatusSelected(PostStatus.Draft)
 
         viewModel.onSaveClicked()
 
         assertThat(viewModel.uiState.value.isSaving)
-            .isFalse()
+            .isTrue()
     }
 
     // endregion
@@ -560,20 +545,6 @@ class PostRsSettingsViewModelTest :
         assertThat(
             viewModel.uiState.value.isRefreshing
         ).isFalse()
-    }
-
-    @Test
-    fun `onSaveClicked online sets isSaving`() {
-        val viewModel = createViewModel()
-        viewModel.onStatusSelected(PostStatus.Draft)
-        whenever(
-            networkUtilsWrapper.isNetworkAvailable()
-        ).thenReturn(true)
-
-        viewModel.onSaveClicked()
-
-        assertThat(viewModel.uiState.value.isSaving)
-            .isTrue()
     }
 
     // endregion

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
@@ -1,0 +1,608 @@
+package org.wordpress.android.ui.postsrs
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.postsrs.PostRsSettingsViewModel.Companion.EXTRA_POST_ID
+import org.wordpress.android.ui.postsrs.data.PostRsRestClient
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
+import uniffi.wp_api.PostFormat
+import uniffi.wp_api.PostStatus
+
+@ExperimentalCoroutinesApi
+@Suppress("LargeClass")
+class PostRsSettingsViewModelTest :
+    BaseUnitTest(StandardTestDispatcher()) {
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var wpApiClientProvider: WpApiClientProvider
+
+    @Mock
+    lateinit var restClient: PostRsRestClient
+
+    @Mock
+    lateinit var resourceProvider: ResourceProvider
+
+    @Mock
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    private lateinit var site: SiteModel
+    private var activeViewModel: PostRsSettingsViewModel? =
+        null
+
+    @Before
+    fun setUp() {
+        site = SiteModel().apply {
+            id = 1
+            siteId = 123L
+        }
+        whenever(selectedSiteRepository.getSelectedSite())
+            .thenReturn(site)
+        whenever(resourceProvider.getString(any()))
+            .thenReturn("error")
+        // Default to offline so loadPost() in init exits
+        // early without launching a coroutine that would
+        // fail against un-mocked API providers.
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(false)
+    }
+
+    @After
+    fun tearDown() {
+        activeViewModel?.viewModelScope?.cancel()
+        activeViewModel = null
+    }
+
+    private fun createViewModel(
+        postId: Long = TEST_POST_ID,
+        hasSite: Boolean = true,
+    ): PostRsSettingsViewModel {
+        if (!hasSite) {
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
+        }
+        val handle = SavedStateHandle(
+            mapOf(EXTRA_POST_ID to postId)
+        )
+        return PostRsSettingsViewModel(
+            savedStateHandle = handle,
+            selectedSiteRepository =
+                selectedSiteRepository,
+            wpApiClientProvider = wpApiClientProvider,
+            restClient = restClient,
+            resourceProvider = resourceProvider,
+            networkUtilsWrapper = networkUtilsWrapper,
+        ).also { activeViewModel = it }
+    }
+
+    // region Init
+
+    @Test
+    fun `when no site, emits Finish event`() = test {
+        val viewModel = createViewModel(hasSite = false)
+
+        viewModel.events.test {
+            val event = awaitItem()
+            assertThat(event)
+                .isEqualTo(PostRsSettingsEvent.Finish)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when no site, sends snackbar message`() = test {
+        val viewModel = createViewModel(hasSite = false)
+
+        viewModel.snackbarMessages.test {
+            val msg = awaitItem()
+            assertThat(msg.message).isNotEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when site exists and online, sets isLoading`() {
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(true)
+        val viewModel = createViewModel()
+        assertThat(viewModel.uiState.value.isLoading)
+            .isTrue()
+    }
+
+    @Test
+    fun `when site exists and offline, shows error`() {
+        val viewModel = createViewModel()
+        assertThat(viewModel.uiState.value.isLoading)
+            .isFalse()
+        assertThat(viewModel.uiState.value.error)
+            .isNotNull()
+    }
+
+    // endregion
+
+    // region Edit methods
+
+    @Test
+    fun `onStatusSelected updates editedStatus`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStatusSelected(PostStatus.Draft)
+
+        assertThat(
+            viewModel.uiState.value.editedStatus
+        ).isEqualTo(PostStatus.Draft)
+    }
+
+    @Test
+    fun `onStatusSelected clears when same as original`() {
+        val viewModel = createViewModel()
+        // initial postStatus is null, select then re-select
+        viewModel.onStatusSelected(PostStatus.Draft)
+        assertThat(
+            viewModel.uiState.value.editedStatus
+        ).isNotNull()
+
+        // selecting null-equivalent won't work via API, so
+        // verify that selecting a non-null value then the
+        // same value keeps the edit (since original is null)
+        viewModel.onStatusSelected(PostStatus.Draft)
+        assertThat(
+            viewModel.uiState.value.editedStatus
+        ).isEqualTo(PostStatus.Draft)
+    }
+
+    @Test
+    fun `onPasswordSet updates editedPassword`() {
+        val viewModel = createViewModel()
+
+        viewModel.onPasswordSet("secret")
+
+        assertThat(
+            viewModel.uiState.value.editedPassword
+        ).isEqualTo("secret")
+    }
+
+    @Test
+    fun `onPasswordSet clears when same as original`() {
+        val viewModel = createViewModel()
+        // original password is null, "" != null => edited
+        viewModel.onPasswordSet("")
+
+        // password is null originally, empty string check:
+        // original = null ?: "" -> "", "" == "" -> null
+        assertThat(
+            viewModel.uiState.value.editedPassword
+        ).isNull()
+    }
+
+    @Test
+    fun `onStickyToggled flips sticky`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStickyToggled()
+
+        assertThat(
+            viewModel.uiState.value.editedSticky
+        ).isTrue()
+    }
+
+    @Test
+    fun `onStickyToggled twice clears edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStickyToggled()
+        viewModel.onStickyToggled()
+
+        assertThat(
+            viewModel.uiState.value.editedSticky
+        ).isNull()
+    }
+
+    @Test
+    fun `onSlugSet updates editedSlug`() {
+        val viewModel = createViewModel()
+
+        viewModel.onSlugSet("new-slug")
+
+        assertThat(
+            viewModel.uiState.value.editedSlug
+        ).isEqualTo("new-slug")
+    }
+
+    @Test
+    fun `onSlugSet clears when same as original`() {
+        val viewModel = createViewModel()
+        // original slug is ""
+        viewModel.onSlugSet("")
+
+        assertThat(
+            viewModel.uiState.value.editedSlug
+        ).isNull()
+    }
+
+    @Test
+    fun `onExcerptSet updates editedExcerpt`() {
+        val viewModel = createViewModel()
+
+        viewModel.onExcerptSet("new excerpt")
+
+        assertThat(
+            viewModel.uiState.value.editedExcerpt
+        ).isEqualTo("new excerpt")
+    }
+
+    @Test
+    fun `onExcerptSet clears when same as original`() {
+        val viewModel = createViewModel()
+
+        viewModel.onExcerptSet("")
+
+        assertThat(
+            viewModel.uiState.value.editedExcerpt
+        ).isNull()
+    }
+
+    @Test
+    fun `onFormatSelected updates editedFormat`() {
+        val viewModel = createViewModel()
+
+        viewModel.onFormatSelected(PostFormat.Gallery)
+
+        assertThat(
+            viewModel.uiState.value.editedFormat
+        ).isEqualTo(PostFormat.Gallery)
+    }
+
+    @Test
+    fun `onFeaturedImageRemoved sets editedFeaturedImageId`() {
+        val viewModel = createViewModel()
+        // original featuredImageId is 0, so removing
+        // (setting to 0) when already 0 => null edit
+        viewModel.onFeaturedImageRemoved()
+
+        assertThat(
+            viewModel.uiState.value.editedFeaturedImageId
+        ).isNull()
+    }
+
+    // endregion
+
+    // region Dialog state
+
+    @Test
+    fun `onStatusClicked sets StatusDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStatusClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.StatusDialog)
+    }
+
+    @Test
+    fun `onPasswordClicked sets PasswordDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onPasswordClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.PasswordDialog)
+    }
+
+    @Test
+    fun `onSlugClicked sets SlugDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onSlugClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.SlugDialog)
+    }
+
+    @Test
+    fun `onExcerptClicked sets ExcerptDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onExcerptClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.ExcerptDialog)
+    }
+
+    @Test
+    fun `onFormatClicked sets FormatDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onFormatClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.FormatDialog)
+    }
+
+    @Test
+    fun `onDateClicked sets DateDialog`() {
+        val viewModel = createViewModel()
+
+        viewModel.onDateClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.DateDialog)
+    }
+
+    @Test
+    fun `onDismissDialog resets dialogState to None`() {
+        val viewModel = createViewModel()
+        viewModel.onStatusClicked()
+
+        viewModel.onDismissDialog()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.None)
+    }
+
+    // endregion
+
+    // region hasChanges
+
+    @Test
+    fun `hasChanges is false initially`() {
+        val viewModel = createViewModel()
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isFalse()
+    }
+
+    @Test
+    fun `hasChanges is true after status edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStatusSelected(PostStatus.Pending)
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    @Test
+    fun `hasChanges is true after password edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onPasswordSet("abc")
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    @Test
+    fun `hasChanges is true after slug edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onSlugSet("new-slug")
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    @Test
+    fun `hasChanges is true after sticky toggle`() {
+        val viewModel = createViewModel()
+
+        viewModel.onStickyToggled()
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    @Test
+    fun `hasChanges is true after excerpt edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onExcerptSet("excerpt text")
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    @Test
+    fun `hasChanges is true after format edit`() {
+        val viewModel = createViewModel()
+
+        viewModel.onFormatSelected(PostFormat.Video)
+
+        assertThat(viewModel.uiState.value.hasChanges)
+            .isTrue()
+    }
+
+    // endregion
+
+    // region Save
+
+    @Test
+    fun `onSaveClicked with no changes is no-op`() =
+        test {
+            val viewModel = createViewModel()
+
+            viewModel.events.test {
+                viewModel.onSaveClicked()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `onSaveClicked offline sends snackbar`() = test {
+        // VM created offline; edit a field, then save
+        val viewModel = createViewModel()
+        viewModel.onStatusSelected(PostStatus.Draft)
+
+        viewModel.snackbarMessages.test {
+            viewModel.onSaveClicked()
+
+            val msg = awaitItem()
+            assertThat(msg.message).isNotEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onSaveClicked does not set isSaving when offline`() {
+        val viewModel = createViewModel()
+        viewModel.onStatusSelected(PostStatus.Draft)
+
+        viewModel.onSaveClicked()
+
+        assertThat(viewModel.uiState.value.isSaving)
+            .isFalse()
+    }
+
+    // endregion
+
+    // region Back
+
+    @Test
+    fun `onBackClicked with no changes emits Finish`() =
+        test {
+            val viewModel = createViewModel()
+
+            viewModel.events.test {
+                viewModel.onBackClicked()
+
+                val event = awaitItem()
+                assertThat(event)
+                    .isEqualTo(PostRsSettingsEvent.Finish)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onBackClicked with changes shows DiscardDialog`() {
+        val viewModel = createViewModel()
+        viewModel.onStatusSelected(PostStatus.Draft)
+
+        viewModel.onBackClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.DiscardDialog)
+    }
+
+    @Test
+    fun `onDiscardConfirmed resets dialog and emits Finish`() =
+        test {
+            val viewModel = createViewModel()
+            viewModel.onStatusSelected(PostStatus.Draft)
+            viewModel.onBackClicked()
+
+            viewModel.events.test {
+                viewModel.onDiscardConfirmed()
+
+                assertThat(
+                    viewModel.uiState.value.dialogState
+                ).isEqualTo(DialogState.None)
+
+                val event = awaitItem()
+                assertThat(event)
+                    .isEqualTo(PostRsSettingsEvent.Finish)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion
+
+    // region Refresh
+
+    @Test
+    fun `refreshPost sets isRefreshing true`() {
+        val viewModel = createViewModel()
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(true)
+
+        viewModel.refreshPost()
+
+        assertThat(
+            viewModel.uiState.value.isRefreshing
+        ).isTrue()
+    }
+
+    @Test
+    fun `refreshPost offline sends snackbar`() = test {
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(false)
+        val viewModel = createViewModel()
+
+        viewModel.snackbarMessages.test {
+            viewModel.refreshPost()
+
+            val msg = awaitItem()
+            assertThat(msg.message).isNotEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refreshPost offline does not set isRefreshing`() {
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(false)
+        val viewModel = createViewModel()
+
+        viewModel.refreshPost()
+
+        assertThat(
+            viewModel.uiState.value.isRefreshing
+        ).isFalse()
+    }
+
+    // endregion
+
+    // region Author permission
+
+    @Test
+    fun `onAuthorClicked without permission sends snackbar`() =
+        test {
+            val viewModel = createViewModel()
+
+            viewModel.snackbarMessages.test {
+                viewModel.onAuthorClicked()
+
+                val msg = awaitItem()
+                assertThat(msg.message).isNotEmpty()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onAuthorClicked without permission keeps dialog None`() {
+        val viewModel = createViewModel()
+
+        viewModel.onAuthorClicked()
+
+        assertThat(viewModel.uiState.value.dialogState)
+            .isEqualTo(DialogState.None)
+    }
+
+    // endregion
+
+    companion object {
+        private const val TEST_POST_ID = 42L
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModelTest.kt
@@ -110,13 +110,11 @@ class PostRsSettingsViewModelTest :
     }
 
     @Test
-    fun `when no site, sends snackbar message`() = test {
+    fun `when no site, does not emit snackbar`() = test {
         val viewModel = createViewModel(hasSite = false)
 
         viewModel.snackbarMessages.test {
-            val msg = awaitItem()
-            assertThat(msg.message).isNotEmpty()
-            cancelAndIgnoreRemainingEvents()
+            expectNoEvents()
         }
     }
 
@@ -155,7 +153,7 @@ class PostRsSettingsViewModelTest :
     }
 
     @Test
-    fun `onStatusSelected clears when same as original`() {
+    fun `onStatusSelected keeps edit when original is null`() {
         val viewModel = createViewModel()
         // initial postStatus is null, select then re-select
         viewModel.onStatusSelected(PostStatus.Draft)
@@ -163,9 +161,8 @@ class PostRsSettingsViewModelTest :
             viewModel.uiState.value.editedStatus
         ).isNotNull()
 
-        // selecting null-equivalent won't work via API, so
-        // verify that selecting a non-null value then the
-        // same value keeps the edit (since original is null)
+        // Re-selecting same value keeps edit because the
+        // original is null (Draft != null).
         viewModel.onStatusSelected(PostStatus.Draft)
         assertThat(
             viewModel.uiState.value.editedStatus
@@ -544,9 +541,6 @@ class PostRsSettingsViewModelTest :
 
     @Test
     fun `refreshPost offline sends snackbar`() = test {
-        whenever(
-            networkUtilsWrapper.isNetworkAvailable()
-        ).thenReturn(false)
         val viewModel = createViewModel()
 
         viewModel.snackbarMessages.test {
@@ -560,9 +554,6 @@ class PostRsSettingsViewModelTest :
 
     @Test
     fun `refreshPost offline does not set isRefreshing`() {
-        whenever(
-            networkUtilsWrapper.isNetworkAvailable()
-        ).thenReturn(false)
         val viewModel = createViewModel()
 
         viewModel.refreshPost()
@@ -570,6 +561,20 @@ class PostRsSettingsViewModelTest :
         assertThat(
             viewModel.uiState.value.isRefreshing
         ).isFalse()
+    }
+
+    @Test
+    fun `onSaveClicked online sets isSaving`() {
+        val viewModel = createViewModel()
+        viewModel.onStatusSelected(PostStatus.Draft)
+        whenever(
+            networkUtilsWrapper.isNetworkAvailable()
+        ).thenReturn(true)
+
+        viewModel.onSaveClicked()
+
+        assertThat(viewModel.uiState.value.isSaving)
+            .isTrue()
     }
 
     // endregion


### PR DESCRIPTION
## Description

Adds final polish to the RS Post Settings screen:

- **Snackbar replaces Toast**: All error messages now use Compose `Snackbar` with retry actions (e.g. save failure includes "Retry" button) instead of Android Toast
- **Pull-to-refresh**: Wraps the settings content in `PullToRefreshBox` so users can swipe down to reload post data
- **Saving indicator**: Shows "Saving..." label next to the spinner when a save is in progress
- **Shared error utils**: Extracts `unwrapException`, `isAuthError`, and `friendlyErrorMessage` from `PostRsListViewModel` into a shared `PostRsErrorUtils` object
- **Unit tests**: Adds `PostRsSettingsViewModelTest` with ~40 tests covering init, edit methods, dialog state, hasChanges, save, back, refresh, and author permissions (these tests are the bulk of the changes)

## Testing instructions

Snackbar errors:

1. Enable RS Post List feature flag, open a post's settings
2. Turn off network, tap Save after making a change
- [x] Verify a Snackbar appears with an error message and "Retry" action
3. Tap "Retry" after restoring network
- [ ] Verify the save completes and the screen closes

Pull-to-refresh:

1. Open post settings for any post
2. Pull down on the settings content
- [x] Verify the refresh indicator appears and the data reloads

Saving indicator:

1. Edit any field (e.g. status), tap Save
- [ ] Verify "Saving..." text appears next to the spinner in the top-right