### PR TITLE
Add Most Popular Time card and centralize Insights data fetching

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsCardType.kt
@@ -14,6 +14,9 @@ enum class InsightsCardType(
     ),
     MOST_POPULAR_DAY(
         R.string.stats_insights_most_popular_day
+    ),
+    MOST_POPULAR_TIME(
+        R.string.stats_insights_most_popular_time
     );
 
     companion object {
@@ -21,7 +24,8 @@ enum class InsightsCardType(
             listOf(
                 YEAR_IN_REVIEW,
                 ALL_TIME_STATS,
-                MOST_POPULAR_DAY
+                MOST_POPULAR_DAY,
+                MOST_POPULAR_TIME
             )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
 import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
+import kotlin.coroutines.cancellation.CancellationException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -67,7 +68,10 @@ class InsightsViewModel @Inject constructor(
     val isDataRefreshing: StateFlow<Boolean> =
         _isDataRefreshing.asStateFlow()
 
+    @Volatile
     private var isDataLoaded = false
+
+    @Volatile
     private var isDataLoading = false
 
     init {
@@ -115,7 +119,10 @@ class InsightsViewModel @Inject constructor(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress(
+        "TooGenericExceptionCaught",
+        "InstanceOfCheckForException"
+    )
     private suspend fun fetchSummary(
         siteId: Long,
         forceRefresh: Boolean
@@ -126,6 +133,7 @@ class InsightsViewModel @Inject constructor(
             )
             _summaryResult.emit(result)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             AppLog.e(
                 AppLog.T.STATS,
                 "Error fetching stats summary:" +
@@ -140,7 +148,10 @@ class InsightsViewModel @Inject constructor(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress(
+        "TooGenericExceptionCaught",
+        "InstanceOfCheckForException"
+    )
     private suspend fun fetchInsights(
         siteId: Long,
         forceRefresh: Boolean
@@ -151,6 +162,7 @@ class InsightsViewModel @Inject constructor(
             )
             _insightsResult.emit(result)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             AppLog.e(
                 AppLog.T.STATS,
                 "Error fetching insights:" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
@@ -70,10 +70,6 @@ class InsightsViewModel @Inject constructor(
     private var isDataLoaded = false
     private var isDataLoading = false
 
-    private val siteId: Long
-        get() = selectedSiteRepository
-            .getSelectedSite()?.siteId ?: 0L
-
     init {
         checkNetworkStatus()
         loadConfiguration()
@@ -162,6 +158,7 @@ class InsightsViewModel @Inject constructor(
 
     fun refreshData() {
         isDataLoaded = false
+        isDataLoading = true
         _isDataRefreshing.value = true
         fetchData(forceRefresh = true)
     }
@@ -190,7 +187,8 @@ class InsightsViewModel @Inject constructor(
         viewModelScope.launch {
             cardConfigurationRepository.configurationFlow
                 .collect { pair ->
-                    val currentSiteId = siteId
+                    val currentSiteId =
+                        resolvedSiteId() ?: return@collect
                     if (pair != null &&
                         pair.first == currentSiteId
                     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
@@ -91,7 +91,6 @@ class InsightsViewModel @Inject constructor(
         fetchData()
     }
 
-    @Suppress("TooGenericExceptionCaught")
     fun fetchData(forceRefresh: Boolean = false) {
         val siteId = resolvedSiteId() ?: run {
             isDataLoading = false
@@ -102,50 +101,10 @@ class InsightsViewModel @Inject constructor(
             try {
                 coroutineScope {
                     launch {
-                        try {
-                            val result =
-                                statsSummaryUseCase(
-                                    siteId, forceRefresh
-                                )
-                            _summaryResult.emit(result)
-                        } catch (e: Exception) {
-                            AppLog.e(
-                                AppLog.T.STATS,
-                                "Error fetching stats" +
-                                    " summary:" +
-                                    " ${e.message}",
-                                e
-                            )
-                            _summaryResult.emit(
-                                StatsSummaryResult.Error(
-                                    e.message
-                                        ?: "Unknown error"
-                                )
-                            )
-                        }
+                        fetchSummary(siteId, forceRefresh)
                     }
                     launch {
-                        try {
-                            val result =
-                                statsInsightsUseCase(
-                                    siteId, forceRefresh
-                                )
-                            _insightsResult.emit(result)
-                        } catch (e: Exception) {
-                            AppLog.e(
-                                AppLog.T.STATS,
-                                "Error fetching" +
-                                    " insights:" +
-                                    " ${e.message}",
-                                e
-                            )
-                            _insightsResult.emit(
-                                InsightsResult.Error(
-                                    e.message
-                                        ?: "Unknown error"
-                                )
-                            )
-                        }
+                        fetchInsights(siteId, forceRefresh)
                     }
                 }
                 isDataLoaded = true
@@ -153,6 +112,56 @@ class InsightsViewModel @Inject constructor(
                 isDataLoading = false
                 _isDataRefreshing.value = false
             }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchSummary(
+        siteId: Long,
+        forceRefresh: Boolean
+    ) {
+        try {
+            val result = statsSummaryUseCase(
+                siteId, forceRefresh
+            )
+            _summaryResult.emit(result)
+        } catch (e: Exception) {
+            AppLog.e(
+                AppLog.T.STATS,
+                "Error fetching stats summary:" +
+                    " ${e.message}",
+                e
+            )
+            _summaryResult.emit(
+                StatsSummaryResult.Error(
+                    e.message ?: "Unknown error"
+                )
+            )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun fetchInsights(
+        siteId: Long,
+        forceRefresh: Boolean
+    ) {
+        try {
+            val result = statsInsightsUseCase(
+                siteId, forceRefresh
+            )
+            _insightsResult.emit(result)
+        } catch (e: Exception) {
+            AppLog.e(
+                AppLog.T.STATS,
+                "Error fetching insights:" +
+                    " ${e.message}",
+                e
+            )
+            _insightsResult.emit(
+                InsightsResult.Error(
+                    e.message ?: "Unknown error"
+                )
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/InsightsViewModel.kt
@@ -3,12 +3,20 @@ package org.wordpress.android.ui.newstats
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.InsightsCardsConfigurationRepository
+import org.wordpress.android.ui.newstats.repository.InsightsResult
+import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
+import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
@@ -19,7 +27,9 @@ class InsightsViewModel @Inject constructor(
         SelectedSiteRepository,
     private val cardConfigurationRepository:
         InsightsCardsConfigurationRepository,
-    private val networkUtilsWrapper: NetworkUtilsWrapper
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val statsSummaryUseCase: StatsSummaryUseCase,
+    private val statsInsightsUseCase: StatsInsightsUseCase
 ) : ViewModel() {
     private val _visibleCards =
         MutableStateFlow<List<InsightsCardType>>(
@@ -42,6 +52,24 @@ class InsightsViewModel @Inject constructor(
     val cardsToLoad: StateFlow<List<InsightsCardType>> =
         _cardsToLoad.asStateFlow()
 
+    // Data fetching coordination
+    private val _summaryResult =
+        MutableSharedFlow<StatsSummaryResult>(replay = 1)
+    val summaryResult: SharedFlow<StatsSummaryResult> =
+        _summaryResult.asSharedFlow()
+
+    private val _insightsResult =
+        MutableSharedFlow<InsightsResult>(replay = 1)
+    val insightsResult: SharedFlow<InsightsResult> =
+        _insightsResult.asSharedFlow()
+
+    private val _isDataRefreshing = MutableStateFlow(false)
+    val isDataRefreshing: StateFlow<Boolean> =
+        _isDataRefreshing.asStateFlow()
+
+    private var isDataLoaded = false
+    private var isDataLoading = false
+
     private val siteId: Long
         get() = selectedSiteRepository
             .getSelectedSite()?.siteId ?: 0L
@@ -58,6 +86,89 @@ class InsightsViewModel @Inject constructor(
         _isNetworkAvailable.value = isAvailable
         return isAvailable
     }
+
+    // region Data fetching
+
+    fun loadDataIfNeeded() {
+        if (isDataLoaded || isDataLoading) return
+        isDataLoading = true
+        fetchData()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    fun fetchData(forceRefresh: Boolean = false) {
+        val siteId = resolvedSiteId() ?: run {
+            isDataLoading = false
+            _isDataRefreshing.value = false
+            return
+        }
+        viewModelScope.launch {
+            try {
+                coroutineScope {
+                    launch {
+                        try {
+                            val result =
+                                statsSummaryUseCase(
+                                    siteId, forceRefresh
+                                )
+                            _summaryResult.emit(result)
+                        } catch (e: Exception) {
+                            AppLog.e(
+                                AppLog.T.STATS,
+                                "Error fetching stats" +
+                                    " summary:" +
+                                    " ${e.message}",
+                                e
+                            )
+                            _summaryResult.emit(
+                                StatsSummaryResult.Error(
+                                    e.message
+                                        ?: "Unknown error"
+                                )
+                            )
+                        }
+                    }
+                    launch {
+                        try {
+                            val result =
+                                statsInsightsUseCase(
+                                    siteId, forceRefresh
+                                )
+                            _insightsResult.emit(result)
+                        } catch (e: Exception) {
+                            AppLog.e(
+                                AppLog.T.STATS,
+                                "Error fetching" +
+                                    " insights:" +
+                                    " ${e.message}",
+                                e
+                            )
+                            _insightsResult.emit(
+                                InsightsResult.Error(
+                                    e.message
+                                        ?: "Unknown error"
+                                )
+                            )
+                        }
+                    }
+                }
+                isDataLoaded = true
+            } finally {
+                isDataLoading = false
+                _isDataRefreshing.value = false
+            }
+        }
+    }
+
+    fun refreshData() {
+        isDataLoaded = false
+        _isDataRefreshing.value = true
+        fetchData(forceRefresh = true)
+    }
+
+    // endregion
+
+    // region Card configuration
 
     private fun loadConfiguration() {
         val currentSiteId = selectedSiteRepository
@@ -144,6 +255,8 @@ class InsightsViewModel @Inject constructor(
                 .moveCardToBottom(currentSiteId, cardType)
         }
     }
+
+    // endregion
 
     private fun resolvedSiteId(): Long? {
         return selectedSiteRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -103,6 +103,8 @@ import org.wordpress.android.ui.newstats.alltimestats.AllTimeStatsCard
 import org.wordpress.android.ui.newstats.alltimestats.AllTimeStatsViewModel
 import org.wordpress.android.ui.newstats.mostpopularday.MostPopularDayCard
 import org.wordpress.android.ui.newstats.mostpopularday.MostPopularDayViewModel
+import org.wordpress.android.ui.newstats.mostpopulartime.MostPopularTimeCard
+import org.wordpress.android.ui.newstats.mostpopulartime.MostPopularTimeViewModel
 import org.wordpress.android.ui.newstats.yearinreview.YearInReviewCard
 import org.wordpress.android.ui.newstats.yearinreview.YearInReviewDetailActivity
 import org.wordpress.android.ui.newstats.yearinreview.YearInReviewViewModel
@@ -886,6 +888,8 @@ private fun InsightsTabContent(
         viewModel(),
     mostPopularDayViewModel: MostPopularDayViewModel =
         viewModel(),
+    mostPopularTimeViewModel: MostPopularTimeViewModel =
+        viewModel(),
     insightsViewModel: InsightsViewModel = viewModel()
 ) {
     val context = LocalContext.current
@@ -903,8 +907,15 @@ private fun InsightsTabContent(
     val popularDayRefreshing by
         mostPopularDayViewModel
             .isRefreshing.collectAsState()
+    val mostPopularTimeUiState by
+        mostPopularTimeViewModel
+            .uiState.collectAsState()
+    val popularTimeRefreshing by
+        mostPopularTimeViewModel
+            .isRefreshing.collectAsState()
     val isRefreshing = yearRefreshing ||
-        allTimeRefreshing || popularDayRefreshing
+        allTimeRefreshing || popularDayRefreshing ||
+        popularTimeRefreshing
     val pullToRefreshState = rememberPullToRefreshState()
 
     val visibleCards by insightsViewModel
@@ -930,6 +941,10 @@ private fun InsightsTabContent(
             },
             onMostPopularDay = {
                 mostPopularDayViewModel
+                    .loadDataIfNeeded()
+            },
+            onMostPopularTime = {
+                mostPopularTimeViewModel
                     .loadDataIfNeeded()
             }
         )
@@ -960,6 +975,9 @@ private fun InsightsTabContent(
             },
             onMostPopularDay = {
                 mostPopularDayViewModel.loadData()
+            },
+            onMostPopularTime = {
+                mostPopularTimeViewModel.loadData()
             }
         )
     }
@@ -1004,6 +1022,9 @@ private fun InsightsTabContent(
                 },
                 onMostPopularDay = {
                     mostPopularDayViewModel.refresh()
+                },
+                onMostPopularTime = {
+                    mostPopularTimeViewModel.refresh()
                 }
             )
         },
@@ -1125,6 +1146,47 @@ private fun InsightsTabContent(
                                     )
                             }
                         )
+                    InsightsCardType.MOST_POPULAR_TIME ->
+                        MostPopularTimeCard(
+                            uiState =
+                                mostPopularTimeUiState,
+                            onRemoveCard = {
+                                insightsViewModel
+                                    .removeCard(
+                                        cardType
+                                    )
+                            },
+                            onRetry = {
+                                mostPopularTimeViewModel
+                                    .onRetry()
+                            },
+                            cardPosition =
+                                cardPosition,
+                            onMoveUp = {
+                                insightsViewModel
+                                    .moveCardUp(
+                                        cardType
+                                    )
+                            },
+                            onMoveToTop = {
+                                insightsViewModel
+                                    .moveCardToTop(
+                                        cardType
+                                    )
+                            },
+                            onMoveDown = {
+                                insightsViewModel
+                                    .moveCardDown(
+                                        cardType
+                                    )
+                            },
+                            onMoveToBottom = {
+                                insightsViewModel
+                                    .moveCardToBottom(
+                                        cardType
+                                    )
+                            }
+                        )
                     InsightsCardType.YEAR_IN_REVIEW ->
                         YearInReviewCard(
                             uiState = yearInReviewUiState,
@@ -1171,7 +1233,8 @@ private fun InsightsTabContent(
 private fun List<InsightsCardType>.dispatchInsightsToVisibleCards(
     onYearInReview: () -> Unit,
     onAllTimeStats: () -> Unit,
-    onMostPopularDay: () -> Unit
+    onMostPopularDay: () -> Unit,
+    onMostPopularTime: () -> Unit
 ) {
     if (InsightsCardType.YEAR_IN_REVIEW in this) {
         onYearInReview()
@@ -1181,6 +1244,9 @@ private fun List<InsightsCardType>.dispatchInsightsToVisibleCards(
     }
     if (InsightsCardType.MOST_POPULAR_DAY in this) {
         onMostPopularDay()
+    }
+    if (InsightsCardType.MOST_POPULAR_TIME in this) {
+        onMostPopularTime()
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -922,8 +922,8 @@ private fun InsightsTabContent(
         insightsViewModel.loadDataIfNeeded()
     }
 
-    val onRetryData = {
-        insightsViewModel.fetchData()
+    val onRetryData = remember {
+        { insightsViewModel.fetchData() }
     }
 
     LaunchedEffect(Unit) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -900,22 +900,11 @@ private fun InsightsTabContent(
     val mostPopularDayUiState by
         mostPopularDayViewModel
             .uiState.collectAsState()
-    val yearRefreshing by yearInReviewViewModel
-        .isRefreshing.collectAsState()
-    val allTimeRefreshing by allTimeStatsViewModel
-        .isRefreshing.collectAsState()
-    val popularDayRefreshing by
-        mostPopularDayViewModel
-            .isRefreshing.collectAsState()
     val mostPopularTimeUiState by
         mostPopularTimeViewModel
             .uiState.collectAsState()
-    val popularTimeRefreshing by
-        mostPopularTimeViewModel
-            .isRefreshing.collectAsState()
-    val isRefreshing = yearRefreshing ||
-        allTimeRefreshing || popularDayRefreshing ||
-        popularTimeRefreshing
+    val isRefreshing by insightsViewModel
+        .isDataRefreshing.collectAsState()
     val pullToRefreshState = rememberPullToRefreshState()
 
     val visibleCards by insightsViewModel
@@ -930,24 +919,28 @@ private fun InsightsTabContent(
     val addCardSheetState = rememberModalBottomSheetState()
 
     LaunchedEffect(cardsToLoad) {
-        cardsToLoad.dispatchInsightsToVisibleCards(
-            onYearInReview = {
-                yearInReviewViewModel
-                    .loadDataIfNeeded()
-            },
-            onAllTimeStats = {
-                allTimeStatsViewModel
-                    .loadDataIfNeeded()
-            },
-            onMostPopularDay = {
-                mostPopularDayViewModel
-                    .loadDataIfNeeded()
-            },
-            onMostPopularTime = {
-                mostPopularTimeViewModel
-                    .loadDataIfNeeded()
-            }
-        )
+        insightsViewModel.loadDataIfNeeded()
+    }
+
+    val onRetryData = {
+        insightsViewModel.fetchData()
+    }
+
+    LaunchedEffect(Unit) {
+        insightsViewModel.summaryResult.collect { result ->
+            allTimeStatsViewModel.handleResult(result)
+            mostPopularDayViewModel.handleResult(result)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        insightsViewModel.insightsResult.collect { result ->
+            yearInReviewViewModel.handleResult(
+                result,
+                onRetry = onRetryData
+            )
+            mostPopularTimeViewModel.handleResult(result)
+        }
     }
 
     if (showAddCardSheet) {
@@ -965,27 +958,10 @@ private fun InsightsTabContent(
         mutableStateOf(!isNetworkAvailable)
     }
 
-    val loadVisibleCards = {
-        visibleCards.dispatchInsightsToVisibleCards(
-            onYearInReview = {
-                yearInReviewViewModel.loadData()
-            },
-            onAllTimeStats = {
-                allTimeStatsViewModel.loadData()
-            },
-            onMostPopularDay = {
-                mostPopularDayViewModel.loadData()
-            },
-            onMostPopularTime = {
-                mostPopularTimeViewModel.loadData()
-            }
-        )
-    }
-
     LaunchedEffect(isNetworkAvailable) {
         if (isNetworkAvailable && showNoConnectionScreen) {
             showNoConnectionScreen = false
-            loadVisibleCards()
+            insightsViewModel.fetchData()
         } else if (!isNetworkAvailable &&
             !showNoConnectionScreen
         ) {
@@ -1000,7 +976,7 @@ private fun InsightsTabContent(
                     insightsViewModel.checkNetworkStatus()
                 if (isAvailable) {
                     showNoConnectionScreen = false
-                    loadVisibleCards()
+                    insightsViewModel.fetchData()
                 }
             }
         )
@@ -1013,20 +989,7 @@ private fun InsightsTabContent(
         state = pullToRefreshState,
         onRefresh = {
             insightsViewModel.checkNetworkStatus()
-            visibleCards.dispatchInsightsToVisibleCards(
-                onYearInReview = {
-                    yearInReviewViewModel.refresh()
-                },
-                onAllTimeStats = {
-                    allTimeStatsViewModel.refresh()
-                },
-                onMostPopularDay = {
-                    mostPopularDayViewModel.refresh()
-                },
-                onMostPopularTime = {
-                    mostPopularTimeViewModel.refresh()
-                }
-            )
+            insightsViewModel.refreshData()
         },
         indicator = {
             PullToRefreshDefaults.Indicator(
@@ -1083,7 +1046,8 @@ private fun InsightsTabContent(
                             },
                             onRetry = {
                                 allTimeStatsViewModel
-                                    .onRetry()
+                                    .showLoading()
+                                onRetryData()
                             },
                             cardPosition = cardPosition,
                             onMoveUp = {
@@ -1117,7 +1081,8 @@ private fun InsightsTabContent(
                             },
                             onRetry = {
                                 mostPopularDayViewModel
-                                    .onRetry()
+                                    .showLoading()
+                                onRetryData()
                             },
                             cardPosition =
                                 cardPosition,
@@ -1158,7 +1123,8 @@ private fun InsightsTabContent(
                             },
                             onRetry = {
                                 mostPopularTimeViewModel
-                                    .onRetry()
+                                    .showLoading()
+                                onRetryData()
                             },
                             cardPosition =
                                 cardPosition,
@@ -1230,25 +1196,6 @@ private fun InsightsTabContent(
     }
 }
 
-private fun List<InsightsCardType>.dispatchInsightsToVisibleCards(
-    onYearInReview: () -> Unit,
-    onAllTimeStats: () -> Unit,
-    onMostPopularDay: () -> Unit,
-    onMostPopularTime: () -> Unit
-) {
-    if (InsightsCardType.YEAR_IN_REVIEW in this) {
-        onYearInReview()
-    }
-    if (InsightsCardType.ALL_TIME_STATS in this) {
-        onAllTimeStats()
-    }
-    if (InsightsCardType.MOST_POPULAR_DAY in this) {
-        onMostPopularDay()
-    }
-    if (InsightsCardType.MOST_POPULAR_TIME in this) {
-        onMostPopularTime()
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/NewStatsActivity.kt
@@ -935,10 +935,7 @@ private fun InsightsTabContent(
 
     LaunchedEffect(Unit) {
         insightsViewModel.insightsResult.collect { result ->
-            yearInReviewViewModel.handleResult(
-                result,
-                onRetry = onRetryData
-            )
+            yearInReviewViewModel.handleResult(result)
             mostPopularTimeViewModel.handleResult(result)
         }
     }
@@ -1166,6 +1163,11 @@ private fun InsightsTabContent(
                                         .getDetailData()
                                 YearInReviewDetailActivity
                                     .start(context, years)
+                            },
+                            onRetry = {
+                                yearInReviewViewModel
+                                    .showLoading()
+                                onRetryData()
                             },
                             cardPosition = cardPosition,
                             onMoveUp = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/alltimestats/AllTimeStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/alltimestats/AllTimeStatsViewModel.kt
@@ -1,26 +1,18 @@
 package org.wordpress.android.ui.newstats.alltimestats
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
-import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 @HiltViewModel
 class AllTimeStatsViewModel @Inject constructor(
-    private val selectedSiteRepository:
-        SelectedSiteRepository,
-    private val resourceProvider: ResourceProvider,
-    private val statsSummaryUseCase: StatsSummaryUseCase
+    private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow<AllTimeStatsCardUiState>(
@@ -29,114 +21,26 @@ class AllTimeStatsViewModel @Inject constructor(
     val uiState: StateFlow<AllTimeStatsCardUiState> =
         _uiState.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> =
-        _isRefreshing.asStateFlow()
-
-    @Volatile
-    private var isLoading = false
-
-    @Volatile
-    private var isLoadedSuccessfully = false
-
-    fun loadDataIfNeeded() {
-        if (isLoadedSuccessfully || isLoading) return
-        isLoading = true
-        loadData()
-    }
-
-    fun refresh() {
-        val site = selectedSiteRepository
-            .getSelectedSite() ?: return
-        viewModelScope.launch {
-            try {
-                _isRefreshing.value = true
-                loadDataInternal(
-                    site.siteId,
-                    forceRefresh = true
+    fun handleResult(result: StatsSummaryResult) {
+        _uiState.value = when (result) {
+            is StatsSummaryResult.Success ->
+                AllTimeStatsCardUiState.Loaded(
+                    views = result.data.views,
+                    visitors = result.data.visitors,
+                    posts = result.data.posts,
+                    comments = result.data.comments
                 )
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun loadData() {
-        val site = selectedSiteRepository.getSelectedSite()
-        if (site == null) {
-            isLoading = false
-            _uiState.value = AllTimeStatsCardUiState.Error(
-                message = resourceProvider.getString(
-                    R.string.stats_error_no_site
-                )
-            )
-            return
-        }
-
-        _uiState.value = AllTimeStatsCardUiState.Loading
-
-        viewModelScope.launch {
-            try {
-                loadDataInternal(site.siteId)
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadDataInternal(
-        siteId: Long,
-        forceRefresh: Boolean = false
-    ) {
-        try {
-            val result = statsSummaryUseCase(
-                siteId,
-                forceRefresh
-            )
-            when (result) {
-                is StatsSummaryResult.Success -> {
-                    isLoadedSuccessfully = true
-                    _uiState.value =
-                        AllTimeStatsCardUiState.Loaded(
-                            views = result.data.views,
-                            visitors =
-                                result.data.visitors,
-                            posts = result.data.posts,
-                            comments =
-                                result.data.comments
-                        )
-                }
-                is StatsSummaryResult.Error -> {
-                    isLoadedSuccessfully = false
-                    _uiState.value =
-                        AllTimeStatsCardUiState.Error(
-                            message = resourceProvider
-                                .getString(
-                                    R.string
-                                        .stats_error_api
-                                )
-                        )
-                }
-            }
-        } catch (e: Exception) {
-            isLoadedSuccessfully = false
-            AppLog.e(
-                AppLog.T.STATS,
-                "Error loading stats summary: " +
-                    "${e.message}",
-                e
-            )
-            _uiState.value =
+            is StatsSummaryResult.Error ->
                 AllTimeStatsCardUiState.Error(
-                    message = resourceProvider.getString(
-                        R.string.stats_error_unknown
-                    )
+                    message = resourceProvider
+                        .getString(
+                            R.string.stats_error_api
+                        )
                 )
         }
     }
 
-    fun onRetry() {
-        loadData()
+    fun showLoading() {
+        _uiState.value = AllTimeStatsCardUiState.Loading
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSource.kt
@@ -566,6 +566,10 @@ sealed class StatsInsightsDataResult {
  * Stats insights data from the API.
  */
 data class StatsInsightsData(
+    val highestHour: Int,
+    val highestHourPercent: Double,
+    val highestDayOfWeek: Int,
+    val highestDayPercent: Double,
     val years: List<YearInsightsData>
 )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
@@ -984,6 +984,7 @@ class StatsDataSourceImpl @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     override suspend fun fetchStatsInsights(
         siteId: Long
     ): StatsInsightsDataResult {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
@@ -1012,6 +1012,15 @@ class StatsDataSourceImpl @Inject constructor(
                 )
                 StatsInsightsDataResult.Success(
                     StatsInsightsData(
+                        highestHour =
+                            data.highestHour.toInt(),
+                        highestHourPercent =
+                            data.highestHourPercent,
+                        highestDayOfWeek =
+                            data.highestDayOfWeek
+                                .toInt(),
+                        highestDayPercent =
+                            data.highestDayPercent,
                         years = years.map { yearData ->
                             YearInsightsData(
                                 year = yearData.year,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayCard.kt
@@ -313,7 +313,7 @@ private fun LoadedContent(
         Text(
             text = stringResource(
                 R.string
-                    .stats_insights_most_popular_day_percent,
+                    .stats_insights_views_percent,
                 state.viewsPercentage
             ),
             style = MaterialTheme.typography.bodyMedium,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayViewModel.kt
@@ -1,18 +1,13 @@
 package org.wordpress.android.ui.newstats.mostpopularday
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
 import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
-import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -21,10 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MostPopularDayViewModel @Inject constructor(
-    private val selectedSiteRepository:
-        SelectedSiteRepository,
-    private val resourceProvider: ResourceProvider,
-    private val statsSummaryUseCase: StatsSummaryUseCase
+    private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow<MostPopularDayCardUiState>(
@@ -33,110 +25,22 @@ class MostPopularDayViewModel @Inject constructor(
     val uiState: StateFlow<MostPopularDayCardUiState> =
         _uiState.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> =
-        _isRefreshing.asStateFlow()
-
-    @Volatile
-    private var isLoading = false
-
-    @Volatile
-    private var isLoadedSuccessfully = false
-
-    fun loadDataIfNeeded() {
-        if (isLoadedSuccessfully || isLoading) return
-        isLoading = true
-        loadData()
-    }
-
-    fun refresh() {
-        val site = selectedSiteRepository
-            .getSelectedSite() ?: return
-        viewModelScope.launch {
-            try {
-                _isRefreshing.value = true
-                loadDataInternal(
-                    site.siteId,
-                    forceRefresh = true
-                )
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun loadData() {
-        val site = selectedSiteRepository.getSelectedSite()
-        if (site == null) {
-            isLoading = false
-            _uiState.value =
+    fun handleResult(result: StatsSummaryResult) {
+        _uiState.value = when (result) {
+            is StatsSummaryResult.Success ->
+                mapToUiState(result.data)
+            is StatsSummaryResult.Error ->
                 MostPopularDayCardUiState.Error(
-                    message = resourceProvider.getString(
-                        R.string.stats_error_no_site
-                    )
-                )
-            return
-        }
-
-        _uiState.value = MostPopularDayCardUiState.Loading
-
-        viewModelScope.launch {
-            try {
-                loadDataInternal(site.siteId)
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadDataInternal(
-        siteId: Long,
-        forceRefresh: Boolean = false
-    ) {
-        try {
-            val result = statsSummaryUseCase(
-                siteId,
-                forceRefresh
-            )
-            when (result) {
-                is StatsSummaryResult.Success -> {
-                    isLoadedSuccessfully = true
-                    _uiState.value = mapToUiState(
-                        result.data
-                    )
-                }
-                is StatsSummaryResult.Error -> {
-                    isLoadedSuccessfully = false
-                    _uiState.value =
-                        MostPopularDayCardUiState.Error(
-                            message = resourceProvider
-                                .getString(
-                                    R.string
-                                        .stats_error_api
-                                )
+                    message = resourceProvider
+                        .getString(
+                            R.string.stats_error_api
                         )
-                }
-            }
-        } catch (e: Exception) {
-            isLoadedSuccessfully = false
-            AppLog.e(
-                AppLog.T.STATS,
-                "Error loading most popular day: " +
-                    "${e.message}",
-                e
-            )
-            _uiState.value =
-                MostPopularDayCardUiState.Error(
-                    message = resourceProvider.getString(
-                        R.string.stats_error_unknown
-                    )
                 )
         }
     }
 
-    fun onRetry() {
-        loadData()
+    fun showLoading() {
+        _uiState.value = MostPopularDayCardUiState.Loading
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
@@ -1,0 +1,437 @@
+package org.wordpress.android.ui.newstats.mostpopulartime
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.newstats.components.CardPosition
+import org.wordpress.android.ui.newstats.components.StatsCardMenu
+import org.wordpress.android.ui.newstats.util.rememberShimmerBrush
+
+private val CardCornerRadius = 10.dp
+private val CardPadding = 16.dp
+private val CardMargin = 16.dp
+
+@Composable
+@Suppress("LongParameterList")
+fun MostPopularTimeCard(
+    uiState: MostPopularTimeCardUiState,
+    onRemoveCard: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+    cardPosition: CardPosition? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveToTop: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
+    onMoveToBottom: (() -> Unit)? = null
+) {
+    val borderColor =
+        MaterialTheme.colorScheme.outlineVariant
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = CardMargin,
+                vertical = 8.dp
+            )
+            .clip(RoundedCornerShape(CardCornerRadius))
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(
+                    CardCornerRadius
+                )
+            )
+            .background(
+                MaterialTheme.colorScheme.surface
+            )
+    ) {
+        when (uiState) {
+            is MostPopularTimeCardUiState.Loading ->
+                LoadingContent()
+            is MostPopularTimeCardUiState.NoData ->
+                NoDataContent(
+                    onRemoveCard,
+                    cardPosition,
+                    onMoveUp,
+                    onMoveToTop,
+                    onMoveDown,
+                    onMoveToBottom
+                )
+            is MostPopularTimeCardUiState.Loaded ->
+                LoadedContent(
+                    uiState,
+                    onRemoveCard,
+                    cardPosition,
+                    onMoveUp,
+                    onMoveToTop,
+                    onMoveDown,
+                    onMoveToBottom
+                )
+            is MostPopularTimeCardUiState.Error ->
+                ErrorContent(
+                    uiState,
+                    onRemoveCard,
+                    onRetry,
+                    cardPosition,
+                    onMoveUp,
+                    onMoveToTop,
+                    onMoveDown,
+                    onMoveToBottom
+                )
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    val shimmerBrush = rememberShimmerBrush()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding)
+    ) {
+        Box(
+            modifier = Modifier
+                .width(180.dp)
+                .height(24.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Box(
+            modifier = Modifier
+                .width(60.dp)
+                .height(14.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .width(120.dp)
+                .height(32.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .width(80.dp)
+                .height(14.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Box(
+            modifier = Modifier
+                .width(60.dp)
+                .height(14.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .width(100.dp)
+                .height(32.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .width(80.dp)
+                .height(14.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(shimmerBrush)
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun NoDataContent(
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment =
+                Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(
+                    R.string
+                        .stats_insights_most_popular_time
+                ),
+                style = MaterialTheme.typography
+                    .titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(
+                R.string.stats_no_data_yet
+            ),
+            style = MaterialTheme.typography
+                .bodyMedium,
+            color = MaterialTheme.colorScheme
+                .onSurfaceVariant
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun LoadedContent(
+    state: MostPopularTimeCardUiState.Loaded,
+    onRemoveCard: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment =
+                Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(
+                    R.string
+                        .stats_insights_most_popular_time
+                ),
+                style = MaterialTheme.typography
+                    .titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        // Best day section
+        Text(
+            text = stringResource(
+                R.string
+                    .stats_insights_best_day
+            ),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme
+                .onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = state.bestDay,
+            style = MaterialTheme.typography
+                .headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = stringResource(
+                R.string
+                    .stats_insights_percent_of_views,
+                state.bestDayPercent
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme
+                .onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        // Best hour section
+        Text(
+            text = stringResource(
+                R.string
+                    .stats_insights_best_hour
+            ),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme
+                .onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = state.bestHour,
+            style = MaterialTheme.typography
+                .headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = stringResource(
+                R.string
+                    .stats_insights_percent_of_views,
+                state.bestHourPercent
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme
+                .onSurfaceVariant
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun ErrorContent(
+    state: MostPopularTimeCardUiState.Error,
+    onRemoveCard: () -> Unit,
+    onRetry: () -> Unit,
+    cardPosition: CardPosition?,
+    onMoveUp: (() -> Unit)?,
+    onMoveToTop: (() -> Unit)?,
+    onMoveDown: (() -> Unit)?,
+    onMoveToBottom: (() -> Unit)?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(CardPadding)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment =
+                Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(
+                    R.string
+                        .stats_insights_most_popular_time
+                ),
+                style = MaterialTheme.typography
+                    .titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
+            )
+            StatsCardMenu(
+                onRemoveClick = onRemoveCard,
+                cardPosition = cardPosition,
+                onMoveUp = onMoveUp,
+                onMoveToTop = onMoveToTop,
+                onMoveDown = onMoveDown,
+                onMoveToBottom = onMoveToBottom
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment =
+                Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = state.message,
+                style = MaterialTheme.typography
+                    .bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) {
+                Text(
+                    text = stringResource(
+                        R.string.retry
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MostPopularTimeCardLoadingPreview() {
+    AppThemeM3 {
+        MostPopularTimeCard(
+            uiState =
+                MostPopularTimeCardUiState.Loading,
+            onRemoveCard = {},
+            onRetry = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MostPopularTimeCardLoadedPreview() {
+    AppThemeM3 {
+        MostPopularTimeCard(
+            uiState =
+                MostPopularTimeCardUiState.Loaded(
+                    bestDay = "Monday",
+                    bestDayPercent = "23",
+                    bestHour = "4:00 PM",
+                    bestHourPercent = "11"
+                ),
+            onRemoveCard = {},
+            onRetry = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MostPopularTimeCardErrorPreview() {
+    AppThemeM3 {
+        MostPopularTimeCard(
+            uiState = MostPopularTimeCardUiState.Error(
+                message = "Failed to load stats"
+            ),
+            onRemoveCard = {},
+            onRetry = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
@@ -286,7 +286,7 @@ private fun LoadedContent(
         Text(
             text = stringResource(
                 R.string
-                    .stats_insights_percent_of_views,
+                    .stats_insights_most_popular_day_percent,
                 state.bestDayPercent
             ),
             style = MaterialTheme.typography.bodyMedium,
@@ -316,7 +316,7 @@ private fun LoadedContent(
         Text(
             text = stringResource(
                 R.string
-                    .stats_insights_percent_of_views,
+                    .stats_insights_most_popular_day_percent,
                 state.bestHourPercent
             ),
             style = MaterialTheme.typography.bodyMedium,

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
@@ -201,7 +201,7 @@ private fun LoadedContent(
             value = state.bestDay,
             percent = stringResource(
                 R.string
-                    .stats_insights_most_popular_day_percent,
+                    .stats_insights_views_percent,
                 state.bestDayPercent
             )
         )
@@ -213,7 +213,7 @@ private fun LoadedContent(
             value = state.bestHour,
             percent = stringResource(
                 R.string
-                    .stats_insights_most_popular_day_percent,
+                    .stats_insights_views_percent,
                 state.bestHourPercent
             )
         )
@@ -255,6 +255,19 @@ private fun MostPopularTimeCardLoadingPreview() {
         MostPopularTimeCard(
             uiState =
                 MostPopularTimeCardUiState.Loading,
+            onRemoveCard = {},
+            onRetry = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MostPopularTimeCardNoDataPreview() {
+    AppThemeM3 {
+        MostPopularTimeCard(
+            uiState =
+                MostPopularTimeCardUiState.NoData,
             onRemoveCard = {},
             onRetry = {}
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCard.kt
@@ -1,23 +1,15 @@
 package org.wordpress.android.ui.newstats.mostpopulartime
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,12 +17,12 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.newstats.components.CardPosition
-import org.wordpress.android.ui.newstats.components.StatsCardMenu
-import org.wordpress.android.ui.newstats.util.rememberShimmerBrush
+import org.wordpress.android.ui.newstats.components.StatsCardContainer
+import org.wordpress.android.ui.newstats.components.StatsCardErrorContent
+import org.wordpress.android.ui.newstats.components.StatsCardHeader
+import org.wordpress.android.ui.newstats.util.ShimmerBox
 
-private val CardCornerRadius = 10.dp
 private val CardPadding = 16.dp
-private val CardMargin = 16.dp
 
 @Composable
 @Suppress("LongParameterList")
@@ -45,28 +37,7 @@ fun MostPopularTimeCard(
     onMoveDown: (() -> Unit)? = null,
     onMoveToBottom: (() -> Unit)? = null
 ) {
-    val borderColor =
-        MaterialTheme.colorScheme.outlineVariant
-
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = CardMargin,
-                vertical = 8.dp
-            )
-            .clip(RoundedCornerShape(CardCornerRadius))
-            .border(
-                width = 1.dp,
-                color = borderColor,
-                shape = RoundedCornerShape(
-                    CardCornerRadius
-                )
-            )
-            .background(
-                MaterialTheme.colorScheme.surface
-            )
-    ) {
+    StatsCardContainer(modifier = modifier) {
         when (uiState) {
             is MostPopularTimeCardUiState.Loading ->
                 LoadingContent()
@@ -90,15 +61,18 @@ fun MostPopularTimeCard(
                     onMoveToBottom
                 )
             is MostPopularTimeCardUiState.Error ->
-                ErrorContent(
-                    uiState,
-                    onRemoveCard,
-                    onRetry,
-                    cardPosition,
-                    onMoveUp,
-                    onMoveToTop,
-                    onMoveDown,
-                    onMoveToBottom
+                StatsCardErrorContent(
+                    titleResId = R.string
+                        .stats_insights_most_popular_time,
+                    errorMessageResId =
+                        R.string.stats_error_api,
+                    onRetry = onRetry,
+                    onRemoveCard = onRemoveCard,
+                    cardPosition = cardPosition,
+                    onMoveUp = onMoveUp,
+                    onMoveToTop = onMoveToTop,
+                    onMoveDown = onMoveDown,
+                    onMoveToBottom = onMoveToBottom
                 )
         }
     }
@@ -106,67 +80,51 @@ fun MostPopularTimeCard(
 
 @Composable
 private fun LoadingContent() {
-    val shimmerBrush = rememberShimmerBrush()
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(180.dp)
                 .height(24.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(20.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(60.dp)
                 .height(14.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(120.dp)
                 .height(32.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(4.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(80.dp)
                 .height(14.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(20.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(60.dp)
                 .height(14.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(100.dp)
                 .height(32.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
         Spacer(modifier = Modifier.height(4.dp))
-        Box(
+        ShimmerBox(
             modifier = Modifier
                 .width(80.dp)
                 .height(14.dp)
-                .clip(RoundedCornerShape(4.dp))
-                .background(shimmerBrush)
         )
     }
 }
@@ -186,30 +144,16 @@ private fun NoDataContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment =
-                Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(
-                    R.string
-                        .stats_insights_most_popular_time
-                ),
-                style = MaterialTheme.typography
-                    .titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f)
-            )
-            StatsCardMenu(
-                onRemoveClick = onRemoveCard,
-                cardPosition = cardPosition,
-                onMoveUp = onMoveUp,
-                onMoveToTop = onMoveToTop,
-                onMoveDown = onMoveDown,
-                onMoveToBottom = onMoveToBottom
-            )
-        }
+        StatsCardHeader(
+            titleResId = R.string
+                .stats_insights_most_popular_time,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = stringResource(
@@ -239,156 +183,69 @@ private fun LoadedContent(
             .fillMaxWidth()
             .padding(CardPadding)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment =
-                Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(
-                    R.string
-                        .stats_insights_most_popular_time
-                ),
-                style = MaterialTheme.typography
-                    .titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f)
-            )
-            StatsCardMenu(
-                onRemoveClick = onRemoveCard,
-                cardPosition = cardPosition,
-                onMoveUp = onMoveUp,
-                onMoveToTop = onMoveToTop,
-                onMoveDown = onMoveDown,
-                onMoveToBottom = onMoveToBottom
-            )
-        }
+        StatsCardHeader(
+            titleResId = R.string
+                .stats_insights_most_popular_time,
+            onRemoveCard = onRemoveCard,
+            cardPosition = cardPosition,
+            onMoveUp = onMoveUp,
+            onMoveToTop = onMoveToTop,
+            onMoveDown = onMoveDown,
+            onMoveToBottom = onMoveToBottom
+        )
         Spacer(modifier = Modifier.height(12.dp))
-        // Best day section
-        Text(
-            text = stringResource(
-                R.string
-                    .stats_insights_best_day
+        StatSection(
+            label = stringResource(
+                R.string.stats_insights_best_day
             ),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme
-                .onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = state.bestDay,
-            style = MaterialTheme.typography
-                .headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.height(2.dp))
-        Text(
-            text = stringResource(
+            value = state.bestDay,
+            percent = stringResource(
                 R.string
                     .stats_insights_most_popular_day_percent,
                 state.bestDayPercent
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme
-                .onSurfaceVariant
+            )
         )
         Spacer(modifier = Modifier.height(16.dp))
-        // Best hour section
-        Text(
-            text = stringResource(
-                R.string
-                    .stats_insights_best_hour
+        StatSection(
+            label = stringResource(
+                R.string.stats_insights_best_hour
             ),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme
-                .onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = state.bestHour,
-            style = MaterialTheme.typography
-                .headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.height(2.dp))
-        Text(
-            text = stringResource(
+            value = state.bestHour,
+            percent = stringResource(
                 R.string
                     .stats_insights_most_popular_day_percent,
                 state.bestHourPercent
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme
-                .onSurfaceVariant
+            )
         )
     }
 }
 
-@Suppress("LongParameterList")
 @Composable
-private fun ErrorContent(
-    state: MostPopularTimeCardUiState.Error,
-    onRemoveCard: () -> Unit,
-    onRetry: () -> Unit,
-    cardPosition: CardPosition?,
-    onMoveUp: (() -> Unit)?,
-    onMoveToTop: (() -> Unit)?,
-    onMoveDown: (() -> Unit)?,
-    onMoveToBottom: (() -> Unit)?
+private fun StatSection(
+    label: String,
+    value: String,
+    percent: String
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(CardPadding)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment =
-                Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(
-                    R.string
-                        .stats_insights_most_popular_time
-                ),
-                style = MaterialTheme.typography
-                    .titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f)
-            )
-            StatsCardMenu(
-                onRemoveClick = onRemoveCard,
-                cardPosition = cardPosition,
-                onMoveUp = onMoveUp,
-                onMoveToTop = onMoveToTop,
-                onMoveDown = onMoveDown,
-                onMoveToBottom = onMoveToBottom
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment =
-                Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = state.message,
-                style = MaterialTheme.typography
-                    .bodyMedium,
-                color = MaterialTheme.colorScheme.error
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onRetry) {
-                Text(
-                    text = stringResource(
-                        R.string.retry
-                    )
-                )
-            }
-        }
-    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme
+            .onSurfaceVariant
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = value,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    Spacer(modifier = Modifier.height(2.dp))
+    Text(
+        text = percent,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme
+            .onSurfaceVariant
+    )
 }
 
 @Preview(showBackground = true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeCardUiState.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.newstats.mostpopulartime
+
+sealed class MostPopularTimeCardUiState {
+    data object Loading : MostPopularTimeCardUiState()
+
+    data object NoData : MostPopularTimeCardUiState()
+
+    data class Loaded(
+        val bestDay: String,
+        val bestDayPercent: String,
+        val bestHour: String,
+        val bestHourPercent: String
+    ) : MostPopularTimeCardUiState()
+
+    data class Error(
+        val message: String
+    ) : MostPopularTimeCardUiState()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.ui.newstats.mostpopulartime
 
+import android.content.Context
+import android.text.format.DateFormat
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,7 +15,6 @@ import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 import java.time.format.TextStyle
 import java.util.Locale
 import javax.inject.Inject
@@ -20,6 +22,7 @@ import kotlin.math.round
 
 @HiltViewModel
 class MostPopularTimeViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
@@ -30,9 +33,11 @@ class MostPopularTimeViewModel @Inject constructor(
         _uiState.asStateFlow()
 
     fun handleResult(result: InsightsResult) {
+        val use24Hour =
+            DateFormat.is24HourFormat(context)
         _uiState.value = when (result) {
             is InsightsResult.Success ->
-                mapToUiState(result.data)
+                mapToUiState(result.data, use24Hour)
             is InsightsResult.Error ->
                 MostPopularTimeCardUiState.Error(
                     message = resourceProvider
@@ -49,7 +54,8 @@ class MostPopularTimeViewModel @Inject constructor(
 
     companion object {
         internal fun mapToUiState(
-            data: StatsInsightsData
+            data: StatsInsightsData,
+            use24HourFormat: Boolean
         ): MostPopularTimeCardUiState {
             if (data.highestDayPercent == 0.0 ||
                 data.highestHourPercent == 0.0
@@ -64,7 +70,8 @@ class MostPopularTimeViewModel @Inject constructor(
                     data.highestDayPercent
                 ),
                 bestHour = formatHour(
-                    data.highestHour
+                    data.highestHour,
+                    use24HourFormat
                 ),
                 bestHourPercent = formatPercent(
                     data.highestHourPercent
@@ -93,12 +100,20 @@ class MostPopularTimeViewModel @Inject constructor(
 
         private const val MAX_HOUR = 23
 
-        private fun formatHour(hour: Int): String {
+        private fun formatHour(
+            hour: Int,
+            use24HourFormat: Boolean
+        ): String {
             if (hour !in 0..MAX_HOUR) return ""
             val time = LocalTime.of(hour, 0)
+            val pattern = if (use24HourFormat) {
+                "HH:mm"
+            } else {
+                "h:mm a"
+            }
             return time.format(
-                DateTimeFormatter.ofLocalizedTime(
-                    FormatStyle.SHORT
+                DateTimeFormatter.ofPattern(
+                    pattern, Locale.getDefault()
                 )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -16,6 +16,7 @@ import java.time.format.FormatStyle
 import java.time.format.TextStyle
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.round
 
 @HiltViewModel
 class MostPopularTimeViewModel @Inject constructor(
@@ -90,7 +91,10 @@ class MostPopularTimeViewModel @Inject constructor(
             )
         }
 
+        private const val MAX_HOUR = 23
+
         private fun formatHour(hour: Int): String {
+            if (hour !in 0..MAX_HOUR) return ""
             val time = LocalTime.of(hour, 0)
             return time.format(
                 DateTimeFormatter.ofLocalizedTime(
@@ -102,7 +106,7 @@ class MostPopularTimeViewModel @Inject constructor(
         private fun formatPercent(
             percent: Double
         ): String {
-            return kotlin.math.round(percent)
+            return round(percent)
                 .toInt().toString()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -1,18 +1,13 @@
 package org.wordpress.android.ui.newstats.mostpopulartime
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -24,10 +19,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MostPopularTimeViewModel @Inject constructor(
-    private val selectedSiteRepository:
-        SelectedSiteRepository,
-    private val resourceProvider: ResourceProvider,
-    private val statsInsightsUseCase: StatsInsightsUseCase
+    private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow<MostPopularTimeCardUiState>(
@@ -36,108 +28,22 @@ class MostPopularTimeViewModel @Inject constructor(
     val uiState: StateFlow<MostPopularTimeCardUiState> =
         _uiState.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> =
-        _isRefreshing.asStateFlow()
-
-    private var isLoading = false
-
-    private var isLoadedSuccessfully = false
-
-    fun loadDataIfNeeded() {
-        if (isLoadedSuccessfully || isLoading) return
-        isLoading = true
-        loadData()
-    }
-
-    fun refresh() {
-        val site = selectedSiteRepository
-            .getSelectedSite() ?: return
-        viewModelScope.launch {
-            try {
-                _isRefreshing.value = true
-                loadDataInternal(
-                    site.siteId,
-                    forceRefresh = true
-                )
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun loadData() {
-        val site = selectedSiteRepository.getSelectedSite()
-        if (site == null) {
-            isLoading = false
-            _uiState.value =
+    fun handleResult(result: InsightsResult) {
+        _uiState.value = when (result) {
+            is InsightsResult.Success ->
+                mapToUiState(result.data)
+            is InsightsResult.Error ->
                 MostPopularTimeCardUiState.Error(
-                    message = resourceProvider.getString(
-                        R.string.stats_error_no_site
-                    )
-                )
-            return
-        }
-
-        _uiState.value = MostPopularTimeCardUiState.Loading
-
-        viewModelScope.launch {
-            try {
-                loadDataInternal(site.siteId)
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadDataInternal(
-        siteId: Long,
-        forceRefresh: Boolean = false
-    ) {
-        try {
-            val result = statsInsightsUseCase(
-                siteId,
-                forceRefresh
-            )
-            when (result) {
-                is InsightsResult.Success -> {
-                    isLoadedSuccessfully = true
-                    _uiState.value = mapToUiState(
-                        result.data
-                    )
-                }
-                is InsightsResult.Error -> {
-                    isLoadedSuccessfully = false
-                    _uiState.value =
-                        MostPopularTimeCardUiState.Error(
-                            message = resourceProvider
-                                .getString(
-                                    R.string
-                                        .stats_error_api
-                                )
+                    message = resourceProvider
+                        .getString(
+                            R.string.stats_error_api
                         )
-                }
-            }
-        } catch (e: Exception) {
-            isLoadedSuccessfully = false
-            AppLog.e(
-                AppLog.T.STATS,
-                "Error loading most popular time:" +
-                    " ${e.message}",
-                e
-            )
-            _uiState.value =
-                MostPopularTimeCardUiState.Error(
-                    message = resourceProvider.getString(
-                        R.string.stats_error_unknown
-                    )
                 )
         }
     }
 
-    fun onRetry() {
-        loadData()
+    fun showLoading() {
+        _uiState.value = MostPopularTimeCardUiState.Loading
     }
 
     companion object {
@@ -175,7 +81,9 @@ class MostPopularTimeViewModel @Inject constructor(
                 return ""
             }
             val dayOfWeek =
-                DayOfWeek.of((wpDayOfWeek % DAYS_IN_WEEK) + 1)
+                DayOfWeek.of(
+                    (wpDayOfWeek % DAYS_IN_WEEK) + 1
+                )
             return dayOfWeek.getDisplayName(
                 TextStyle.FULL,
                 Locale.getDefault()

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -15,6 +15,9 @@ import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.time.format.TextStyle
 import java.util.Locale
 import javax.inject.Inject
@@ -37,10 +40,8 @@ class MostPopularTimeViewModel @Inject constructor(
     val isRefreshing: StateFlow<Boolean> =
         _isRefreshing.asStateFlow()
 
-    @Volatile
     private var isLoading = false
 
-    @Volatile
     private var isLoadedSuccessfully = false
 
     fun loadDataIfNeeded() {
@@ -122,8 +123,8 @@ class MostPopularTimeViewModel @Inject constructor(
             isLoadedSuccessfully = false
             AppLog.e(
                 AppLog.T.STATS,
-                "Error loading most popular time: " +
-                    "${e.message}",
+                "Error loading most popular time:" +
+                    " ${e.message}",
                 e
             )
             _uiState.value =
@@ -140,8 +141,6 @@ class MostPopularTimeViewModel @Inject constructor(
     }
 
     companion object {
-        private const val HOURS_IN_HALF_DAY = 12
-
         internal fun mapToUiState(
             data: StatsInsightsData
         ): MostPopularTimeCardUiState {
@@ -181,24 +180,12 @@ class MostPopularTimeViewModel @Inject constructor(
             )
         }
 
-        @Suppress("MagicNumber")
         private fun formatHour(hour: Int): String {
-            val displayHour = when {
-                hour == 0 -> HOURS_IN_HALF_DAY
-                hour > HOURS_IN_HALF_DAY ->
-                    hour - HOURS_IN_HALF_DAY
-                else -> hour
-            }
-            val amPm = if (hour < HOURS_IN_HALF_DAY) {
-                "AM"
-            } else {
-                "PM"
-            }
-            return String.format(
-                Locale.getDefault(),
-                "%d:00 %s",
-                displayHour,
-                amPm
+            val time = LocalTime.of(hour, 0)
+            return time.format(
+                DateTimeFormatter.ofLocalizedTime(
+                    FormatStyle.SHORT
+                )
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -1,0 +1,212 @@
+package org.wordpress.android.ui.newstats.mostpopulartime
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.R
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
+import org.wordpress.android.ui.newstats.repository.InsightsResult
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
+import javax.inject.Inject
+
+@HiltViewModel
+class MostPopularTimeViewModel @Inject constructor(
+    private val selectedSiteRepository:
+        SelectedSiteRepository,
+    private val resourceProvider: ResourceProvider,
+    private val statsInsightsUseCase: StatsInsightsUseCase
+) : ViewModel() {
+    private val _uiState =
+        MutableStateFlow<MostPopularTimeCardUiState>(
+            MostPopularTimeCardUiState.Loading
+        )
+    val uiState: StateFlow<MostPopularTimeCardUiState> =
+        _uiState.asStateFlow()
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> =
+        _isRefreshing.asStateFlow()
+
+    @Volatile
+    private var isLoading = false
+
+    @Volatile
+    private var isLoadedSuccessfully = false
+
+    fun loadDataIfNeeded() {
+        if (isLoadedSuccessfully || isLoading) return
+        isLoading = true
+        loadData()
+    }
+
+    fun refresh() {
+        val site = selectedSiteRepository
+            .getSelectedSite() ?: return
+        viewModelScope.launch {
+            try {
+                _isRefreshing.value = true
+                loadDataInternal(
+                    site.siteId,
+                    forceRefresh = true
+                )
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
+    }
+
+    fun loadData() {
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            isLoading = false
+            _uiState.value =
+                MostPopularTimeCardUiState.Error(
+                    message = resourceProvider.getString(
+                        R.string.stats_error_no_site
+                    )
+                )
+            return
+        }
+
+        _uiState.value = MostPopularTimeCardUiState.Loading
+
+        viewModelScope.launch {
+            try {
+                loadDataInternal(site.siteId)
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun loadDataInternal(
+        siteId: Long,
+        forceRefresh: Boolean = false
+    ) {
+        try {
+            val result = statsInsightsUseCase(
+                siteId,
+                forceRefresh
+            )
+            when (result) {
+                is InsightsResult.Success -> {
+                    isLoadedSuccessfully = true
+                    _uiState.value = mapToUiState(
+                        result.data
+                    )
+                }
+                is InsightsResult.Error -> {
+                    isLoadedSuccessfully = false
+                    _uiState.value =
+                        MostPopularTimeCardUiState.Error(
+                            message = resourceProvider
+                                .getString(
+                                    R.string
+                                        .stats_error_api
+                                )
+                        )
+                }
+            }
+        } catch (e: Exception) {
+            isLoadedSuccessfully = false
+            AppLog.e(
+                AppLog.T.STATS,
+                "Error loading most popular time: " +
+                    "${e.message}",
+                e
+            )
+            _uiState.value =
+                MostPopularTimeCardUiState.Error(
+                    message = resourceProvider.getString(
+                        R.string.stats_error_unknown
+                    )
+                )
+        }
+    }
+
+    fun onRetry() {
+        loadData()
+    }
+
+    companion object {
+        private const val HOURS_IN_HALF_DAY = 12
+
+        internal fun mapToUiState(
+            data: StatsInsightsData
+        ): MostPopularTimeCardUiState {
+            if (data.highestDayPercent == 0.0 &&
+                data.highestHourPercent == 0.0
+            ) {
+                return MostPopularTimeCardUiState.NoData
+            }
+            return MostPopularTimeCardUiState.Loaded(
+                bestDay = formatDayOfWeek(
+                    data.highestDayOfWeek
+                ),
+                bestDayPercent = formatPercent(
+                    data.highestDayPercent
+                ),
+                bestHour = formatHour(
+                    data.highestHour
+                ),
+                bestHourPercent = formatPercent(
+                    data.highestHourPercent
+                )
+            )
+        }
+
+        private fun formatDayOfWeek(
+            wpDayOfWeek: Int
+        ): String {
+            // WordPress API: 0=Sunday, 1=Monday...6=Saturday
+            val dayOfWeek = if (wpDayOfWeek == 0) {
+                DayOfWeek.SUNDAY
+            } else {
+                DayOfWeek.of(wpDayOfWeek)
+            }
+            return dayOfWeek.getDisplayName(
+                TextStyle.FULL,
+                Locale.getDefault()
+            )
+        }
+
+        @Suppress("MagicNumber")
+        private fun formatHour(hour: Int): String {
+            val displayHour = when {
+                hour == 0 -> HOURS_IN_HALF_DAY
+                hour > HOURS_IN_HALF_DAY ->
+                    hour - HOURS_IN_HALF_DAY
+                else -> hour
+            }
+            val amPm = if (hour < HOURS_IN_HALF_DAY) {
+                "AM"
+            } else {
+                "PM"
+            }
+            return String.format(
+                Locale.getDefault(),
+                "%d:00 %s",
+                displayHour,
+                amPm
+            )
+        }
+
+        private fun formatPercent(
+            percent: Double
+        ): String {
+            return kotlin.math.round(percent)
+                .toInt().toString()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModel.kt
@@ -144,7 +144,7 @@ class MostPopularTimeViewModel @Inject constructor(
         internal fun mapToUiState(
             data: StatsInsightsData
         ): MostPopularTimeCardUiState {
-            if (data.highestDayPercent == 0.0 &&
+            if (data.highestDayPercent == 0.0 ||
                 data.highestHourPercent == 0.0
             ) {
                 return MostPopularTimeCardUiState.NoData
@@ -165,15 +165,17 @@ class MostPopularTimeViewModel @Inject constructor(
             )
         }
 
+        private const val DAYS_IN_WEEK = 7
+
         private fun formatDayOfWeek(
             wpDayOfWeek: Int
         ): String {
-            // WordPress API: 0=Sunday, 1=Monday...6=Saturday
-            val dayOfWeek = if (wpDayOfWeek == 0) {
-                DayOfWeek.SUNDAY
-            } else {
-                DayOfWeek.of(wpDayOfWeek)
+            // WordPress API: 0=Monday, 6=Sunday
+            if (wpDayOfWeek !in 0 until DAYS_IN_WEEK) {
+                return ""
             }
+            val dayOfWeek =
+                DayOfWeek.of((wpDayOfWeek % DAYS_IN_WEEK) + 1)
             return dayOfWeek.getDisplayName(
                 TextStyle.FULL,
                 Locale.getDefault()

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsInsightsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsInsightsUseCase.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.ui.newstats.repository
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatsInsightsUseCase @Inject constructor(
+    private val statsRepository: StatsRepository,
+    private val accountStore: AccountStore
+) {
+    private val mutex = Mutex()
+    private var cachedInsights:
+        Pair<Long, StatsInsightsData>? = null
+
+    suspend operator fun invoke(
+        siteId: Long,
+        forceRefresh: Boolean = false
+    ): InsightsResult {
+        val token = accountStore.accessToken
+        if (token.isNullOrEmpty()) {
+            return InsightsResult.Error(
+                "No access token"
+            )
+        }
+        statsRepository.init(token)
+        return mutex.withLock {
+            val cached = cachedInsights
+            if (!forceRefresh &&
+                cached != null &&
+                cached.first == siteId
+            ) {
+                return@withLock InsightsResult
+                    .Success(cached.second)
+            }
+            val result =
+                statsRepository.fetchInsights(siteId)
+            if (result is InsightsResult.Success) {
+                cachedInsights = siteId to result.data
+            }
+            result
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.datasource.StatsInsightsDataResult
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryDataResult
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
-import org.wordpress.android.ui.newstats.datasource.YearInsightsData
 import org.wordpress.android.ui.newstats.datasource.StatsDateRange
 import org.wordpress.android.ui.newstats.datasource.StatsUnit
 import org.wordpress.android.ui.newstats.datasource.StatsVisitsData

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.newstats.datasource.ReferrersDataResult
 import org.wordpress.android.ui.newstats.datasource.RegionViewsDataResult
 import org.wordpress.android.ui.newstats.datasource.SearchTermsDataResult
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.datasource.StatsInsightsDataResult
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryDataResult
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
@@ -1333,7 +1334,7 @@ class StatsRepository @Inject constructor(
         when (result) {
             is StatsInsightsDataResult.Success ->
                 InsightsResult.Success(
-                    years = result.data.years
+                    data = result.data
                 )
             is StatsInsightsDataResult.Error -> {
                 appLogWrapper.e(
@@ -1761,7 +1762,7 @@ data class DeviceItemData(
  */
 sealed class InsightsResult {
     data class Success(
-        val years: List<YearInsightsData>
+        val data: StatsInsightsData
     ) : InsightsResult()
     data class Error(
         val message: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewCard.kt
@@ -59,6 +59,7 @@ fun YearInReviewCard(
     uiState: YearInReviewCardUiState,
     onRemoveCard: () -> Unit,
     onShowAllClick: () -> Unit,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier,
     cardPosition: CardPosition? = null,
     onMoveUp: (() -> Unit)? = null,
@@ -98,6 +99,7 @@ fun YearInReviewCard(
                 ErrorContent(
                     uiState,
                     onRemoveCard,
+                    onRetry,
                     cardPosition,
                     onMoveUp,
                     onMoveToTop,
@@ -322,6 +324,7 @@ private fun StatMiniCard(
 private fun ErrorContent(
     state: YearInReviewCardUiState.Error,
     onRemoveCard: () -> Unit,
+    onRetry: () -> Unit,
     cardPosition: CardPosition?,
     onMoveUp: (() -> Unit)?,
     onMoveToTop: (() -> Unit)?,
@@ -365,7 +368,7 @@ private fun ErrorContent(
                 color = MaterialTheme.colorScheme.error
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = state.onRetry) {
+            Button(onClick = onRetry) {
                 Text(
                     text = stringResource(R.string.retry)
                 )
@@ -381,7 +384,8 @@ private fun YearInReviewCardLoadingPreview() {
         YearInReviewCard(
             uiState = YearInReviewCardUiState.Loading,
             onRemoveCard = {},
-            onShowAllClick = {}
+            onShowAllClick = {},
+            onRetry = {}
         )
     }
 }
@@ -406,7 +410,8 @@ private fun YearInReviewCardLoadedPreview() {
                 )
             ),
             onRemoveCard = {},
-            onShowAllClick = {}
+            onShowAllClick = {},
+            onRetry = {}
         )
     }
 }
@@ -417,11 +422,11 @@ private fun YearInReviewCardErrorPreview() {
     AppThemeM3 {
         YearInReviewCard(
             uiState = YearInReviewCardUiState.Error(
-                message = "Failed to load stats",
-                onRetry = {}
+                message = "Failed to load stats"
             ),
             onRemoveCard = {},
-            onShowAllClick = {}
+            onShowAllClick = {},
+            onRetry = {}
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewCardUiState.kt
@@ -10,9 +10,8 @@ sealed class YearInReviewCardUiState {
         val years: List<YearSummary>
     ) : YearInReviewCardUiState()
 
-    class Error(
-        val message: String,
-        val onRetry: () -> Unit
+    data class Error(
+        val message: String
     ) : YearInReviewCardUiState()
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
@@ -23,10 +23,7 @@ class YearInReviewViewModel @Inject constructor(
     val uiState: StateFlow<YearInReviewCardUiState> =
         _uiState.asStateFlow()
 
-    fun handleResult(
-        result: InsightsResult,
-        onRetry: () -> Unit
-    ) {
+    fun handleResult(result: InsightsResult) {
         _uiState.value = when (result) {
             is InsightsResult.Success -> {
                 val years = result.data.years
@@ -44,8 +41,7 @@ class YearInReviewViewModel @Inject constructor(
                     message = resourceProvider
                         .getString(
                             R.string.stats_error_api
-                        ),
-                    onRetry = onRetry
+                        )
                 )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
@@ -8,12 +8,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.YearInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsRepository
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.Year
@@ -22,8 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class YearInReviewViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val accountStore: AccountStore,
-    private val statsRepository: StatsRepository,
+    private val statsInsightsUseCase: StatsInsightsUseCase,
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
@@ -52,7 +49,10 @@ class YearInReviewViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 _isRefreshing.value = true
-                loadDataInternal(site)
+                loadDataInternal(
+                    site.siteId,
+                    forceRefresh = true
+                )
             } finally {
                 _isRefreshing.value = false
             }
@@ -72,24 +72,11 @@ class YearInReviewViewModel @Inject constructor(
             return
         }
 
-        val accessToken = accountStore.accessToken
-        if (accessToken.isNullOrEmpty()) {
-            isLoading = false
-            _uiState.value = YearInReviewCardUiState.Error(
-                message = resourceProvider.getString(
-                    R.string.stats_error_api
-                ),
-                onRetry = ::loadData
-            )
-            return
-        }
-
-        statsRepository.init(accessToken)
         _uiState.value = YearInReviewCardUiState.Loading
 
         viewModelScope.launch {
             try {
-                loadDataInternal(site)
+                loadDataInternal(site.siteId)
             } finally {
                 isLoading = false
             }
@@ -97,14 +84,18 @@ class YearInReviewViewModel @Inject constructor(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadDataInternal(site: SiteModel) {
+    private suspend fun loadDataInternal(
+        siteId: Long,
+        forceRefresh: Boolean = false
+    ) {
         try {
-            val result = statsRepository
-                .fetchInsights(site.siteId)
+            val result = statsInsightsUseCase(
+                siteId, forceRefresh
+            )
             when (result) {
                 is InsightsResult.Success -> {
                     isLoadedSuccessfully = true
-                    val years = result.years
+                    val years = result.data.years
                         .map { it.toUiModel() }
                         .ensureCurrentYear()
                         .sortedByDescending {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModel.kt
@@ -1,26 +1,19 @@
 package org.wordpress.android.ui.newstats.yearinreview
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.YearInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.Year
 import javax.inject.Inject
 
 @HiltViewModel
 class YearInReviewViewModel @Inject constructor(
-    private val selectedSiteRepository: SelectedSiteRepository,
-    private val statsInsightsUseCase: StatsInsightsUseCase,
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
     private val _uiState =
@@ -30,112 +23,35 @@ class YearInReviewViewModel @Inject constructor(
     val uiState: StateFlow<YearInReviewCardUiState> =
         _uiState.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> =
-        _isRefreshing.asStateFlow()
-
-    private var isLoading = false
-    private var isLoadedSuccessfully = false
-
-    fun loadDataIfNeeded() {
-        if (isLoadedSuccessfully || isLoading) return
-        isLoading = true
-        loadData()
-    }
-
-    fun refresh() {
-        val site = selectedSiteRepository
-            .getSelectedSite() ?: return
-        viewModelScope.launch {
-            try {
-                _isRefreshing.value = true
-                loadDataInternal(
-                    site.siteId,
-                    forceRefresh = true
-                )
-            } finally {
-                _isRefreshing.value = false
-            }
-        }
-    }
-
-    fun loadData() {
-        val site = selectedSiteRepository.getSelectedSite()
-        if (site == null) {
-            isLoading = false
-            _uiState.value = YearInReviewCardUiState.Error(
-                message = resourceProvider.getString(
-                    R.string.stats_error_no_site
-                ),
-                onRetry = ::loadData
-            )
-            return
-        }
-
-        _uiState.value = YearInReviewCardUiState.Loading
-
-        viewModelScope.launch {
-            try {
-                loadDataInternal(site.siteId)
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun loadDataInternal(
-        siteId: Long,
-        forceRefresh: Boolean = false
+    fun handleResult(
+        result: InsightsResult,
+        onRetry: () -> Unit
     ) {
-        try {
-            val result = statsInsightsUseCase(
-                siteId, forceRefresh
-            )
-            when (result) {
-                is InsightsResult.Success -> {
-                    isLoadedSuccessfully = true
-                    val years = result.data.years
-                        .map { it.toUiModel() }
-                        .ensureCurrentYear()
-                        .sortedByDescending {
-                            it.year
-                        }
-                    _uiState.value =
-                        YearInReviewCardUiState.Loaded(
-                            years = years
-                        )
-                }
-                is InsightsResult.Error -> {
-                    isLoadedSuccessfully = false
-                    _uiState.value =
-                        YearInReviewCardUiState.Error(
-                            message = resourceProvider
-                                .getString(
-                                    R.string.stats_error_api
-                                ),
-                            onRetry = ::loadData
-                        )
-                }
+        _uiState.value = when (result) {
+            is InsightsResult.Success -> {
+                val years = result.data.years
+                    .map { it.toUiModel() }
+                    .ensureCurrentYear()
+                    .sortedByDescending {
+                        it.year
+                    }
+                YearInReviewCardUiState.Loaded(
+                    years = years
+                )
             }
-        } catch (e: Exception) {
-            isLoadedSuccessfully = false
-            AppLog.e(
-                AppLog.T.STATS,
-                "Error loading insights: ${e.message}",
-                e
-            )
-            _uiState.value = YearInReviewCardUiState.Error(
-                message = resourceProvider.getString(
-                    R.string.stats_error_unknown
-                ),
-                onRetry = ::loadData
-            )
+            is InsightsResult.Error ->
+                YearInReviewCardUiState.Error(
+                    message = resourceProvider
+                        .getString(
+                            R.string.stats_error_api
+                        ),
+                    onRetry = onRetry
+                )
         }
     }
 
-    fun onRetry() {
-        loadData()
+    fun showLoading() {
+        _uiState.value = YearInReviewCardUiState.Loading
     }
 
     fun getDetailData(): List<YearSummary> {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1512,7 +1512,7 @@
     <string name="stats_insights_all_time_stats_title">All-time stats</string>
     <string name="stats_insights_most_popular_day">Most popular day</string>
     <string name="stats_insights_most_popular_day_label">Day</string>
-    <string name="stats_insights_most_popular_day_percent">%1$s%% of views</string>
+    <string name="stats_insights_views_percent">%1$s%% of views</string>
     <string name="stats_insights_most_popular_time">Most popular time</string>
     <string name="stats_insights_tags_and_categories">Tags and Categories</string>
     <string name="stats_insights_latest_post_empty">Check back when you\'ve published your first post!</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1514,7 +1514,6 @@
     <string name="stats_insights_most_popular_day_label">Day</string>
     <string name="stats_insights_most_popular_day_percent">%1$s%% of views</string>
     <string name="stats_insights_most_popular_time">Most popular time</string>
-    <string name="stats_insights_percent_of_views">%1$s%% of views</string>
     <string name="stats_insights_tags_and_categories">Tags and Categories</string>
     <string name="stats_insights_latest_post_empty">Check back when you\'ve published your first post!</string>
     <string name="stats_insights_latest_post_with_no_engagement">It\'s been %1$s since %2$s was published. Get the ball rolling and increase your post views by sharing your post:</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1513,6 +1513,8 @@
     <string name="stats_insights_most_popular_day">Most popular day</string>
     <string name="stats_insights_most_popular_day_label">Day</string>
     <string name="stats_insights_most_popular_day_percent">%1$s%% of views</string>
+    <string name="stats_insights_most_popular_time">Most popular time</string>
+    <string name="stats_insights_percent_of_views">%1$s%% of views</string>
     <string name="stats_insights_tags_and_categories">Tags and Categories</string>
     <string name="stats_insights_latest_post_empty">Check back when you\'ve published your first post!</string>
     <string name="stats_insights_latest_post_with_no_engagement">It\'s been %1$s since %2$s was published. Get the ball rolling and increase your post views by sharing your post:</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/InsightsCardsConfigurationTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/InsightsCardsConfigurationTest.kt
@@ -23,6 +23,7 @@ class InsightsCardsConfigurationTest {
         assertThat(hiddenCards).containsExactlyInAnyOrder(
             InsightsCardType.ALL_TIME_STATS,
             InsightsCardType.MOST_POPULAR_DAY,
+            InsightsCardType.MOST_POPULAR_TIME,
             InsightsCardType.YEAR_IN_REVIEW
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/InsightsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/InsightsViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.newstats
 
+import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -10,13 +11,20 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
+import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
 import org.wordpress.android.ui.newstats.repository.InsightsCardsConfigurationRepository
+import org.wordpress.android.ui.newstats.repository.InsightsResult
+import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
+import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 @ExperimentalCoroutinesApi
@@ -34,6 +42,14 @@ class InsightsViewModelTest :
     @Mock
     private lateinit var networkUtilsWrapper:
         NetworkUtilsWrapper
+
+    @Mock
+    private lateinit var statsSummaryUseCase:
+        StatsSummaryUseCase
+
+    @Mock
+    private lateinit var statsInsightsUseCase:
+        StatsInsightsUseCase
 
     private lateinit var viewModel: InsightsViewModel
 
@@ -72,7 +88,9 @@ class InsightsViewModelTest :
         viewModel = InsightsViewModel(
             selectedSiteRepository,
             cardConfigurationRepository,
-            networkUtilsWrapper
+            networkUtilsWrapper,
+            statsSummaryUseCase,
+            statsInsightsUseCase
         )
     }
 
@@ -218,7 +236,9 @@ class InsightsViewModelTest :
             viewModel = InsightsViewModel(
                 selectedSiteRepository,
                 cardConfigurationRepository,
-                networkUtilsWrapper
+                networkUtilsWrapper,
+                statsSummaryUseCase,
+                statsInsightsUseCase
             )
             advanceUntilIdle()
 
@@ -331,7 +351,9 @@ class InsightsViewModelTest :
             viewModel = InsightsViewModel(
                 selectedSiteRepository,
                 cardConfigurationRepository,
-                networkUtilsWrapper
+                networkUtilsWrapper,
+                statsSummaryUseCase,
+                statsInsightsUseCase
             )
 
             assertThat(viewModel.cardsToLoad.value)
@@ -408,8 +430,239 @@ class InsightsViewModelTest :
             ).isTrue()
         }
 
+    // region Data fetching tests
+
+    @Test
+    fun `when loadDataIfNeeded called, then both use cases are invoked`() =
+        test {
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenReturn(
+                StatsSummaryResult.Success(
+                    createTestSummaryData()
+                )
+            )
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            verify(statsSummaryUseCase)
+                .invoke(eq(TEST_SITE_ID), eq(false))
+            verify(statsInsightsUseCase)
+                .invoke(eq(TEST_SITE_ID), eq(false))
+        }
+
+    @Test
+    fun `when loadDataIfNeeded called twice, then use cases invoked only once`() =
+        test {
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenReturn(
+                StatsSummaryResult.Success(
+                    createTestSummaryData()
+                )
+            )
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            verify(statsSummaryUseCase,
+                org.mockito.Mockito.times(1))
+                .invoke(any(), any())
+            verify(statsInsightsUseCase,
+                org.mockito.Mockito.times(1))
+                .invoke(any(), any())
+        }
+
+    @Test
+    fun `when fetchData called, then results are emitted`() =
+        test {
+            val testSummary = createTestSummaryData()
+            val testInsights = createTestInsightsData()
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenReturn(
+                StatsSummaryResult.Success(testSummary)
+            )
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(testInsights)
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.summaryResult.test {
+                viewModel.fetchData()
+                advanceUntilIdle()
+                val result = awaitItem()
+                assertThat(result).isInstanceOf(
+                    StatsSummaryResult
+                        .Success::class.java
+                )
+                assertThat(
+                    (result as StatsSummaryResult.Success)
+                        .data.views
+                ).isEqualTo(TEST_VIEWS)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when refreshData called, then forceRefresh is true`() =
+        test {
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenReturn(
+                StatsSummaryResult.Success(
+                    createTestSummaryData()
+                )
+            )
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.refreshData()
+            advanceUntilIdle()
+
+            verify(statsSummaryUseCase)
+                .invoke(eq(TEST_SITE_ID), eq(true))
+            verify(statsInsightsUseCase)
+                .invoke(eq(TEST_SITE_ID), eq(true))
+        }
+
+    @Test
+    fun `when refreshData called, then isDataRefreshing resets to false`() =
+        test {
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenReturn(
+                StatsSummaryResult.Success(
+                    createTestSummaryData()
+                )
+            )
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.refreshData()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isDataRefreshing.value)
+                .isFalse()
+        }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `when summary use case throws, then error result is emitted`() =
+        test {
+            whenever(
+                statsSummaryUseCase(any(), any())
+            ).thenAnswer {
+                throw RuntimeException("Test error")
+            }
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            initViewModel()
+            advanceUntilIdle()
+
+            viewModel.summaryResult.test {
+                viewModel.fetchData()
+                advanceUntilIdle()
+                val result = awaitItem()
+                assertThat(result).isInstanceOf(
+                    StatsSummaryResult
+                        .Error::class.java
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when no site selected, then fetchData is no-op`() =
+        test {
+            initViewModel()
+            advanceUntilIdle()
+
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
+
+            viewModel.fetchData()
+            advanceUntilIdle()
+
+            verify(statsSummaryUseCase, never())
+                .invoke(any(), any())
+        }
+
+    // endregion
+
     companion object {
         private const val TEST_SITE_ID = 123L
         private const val OTHER_SITE_ID = 456L
+        private const val TEST_VIEWS = 6782856L
+
+        private fun createTestSummaryData() =
+            StatsSummaryData(
+                views = TEST_VIEWS,
+                visitors = 154791L,
+                posts = 42L,
+                comments = 85L,
+                viewsBestDay = "2022-02-22",
+                viewsBestDayTotal = 4600L
+            )
+
+        private fun createTestInsightsData() =
+            StatsInsightsData(
+                highestHour = 14,
+                highestHourPercent = 15.5,
+                highestDayOfWeek = 3,
+                highestDayPercent = 25.0,
+                years = emptyList()
+            )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/alltimestats/AllTimeStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/alltimestats/AllTimeStatsViewModelTest.kt
@@ -8,142 +8,67 @@ import org.mockito.Mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
 import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
-import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @ExperimentalCoroutinesApi
 class AllTimeStatsViewModelTest : BaseUnitTest() {
     @Mock
-    private lateinit var selectedSiteRepository:
-        SelectedSiteRepository
-
-    @Mock
     private lateinit var resourceProvider: ResourceProvider
-
-    @Mock
-    private lateinit var statsSummaryUseCase:
-        StatsSummaryUseCase
 
     private lateinit var viewModel: AllTimeStatsViewModel
 
-    private val testSite = SiteModel().apply {
-        id = 1
-        siteId = TEST_SITE_ID
-        name = "Test Site"
-    }
-
     @Before
     fun setUp() {
-        whenever(
-            selectedSiteRepository.getSelectedSite()
-        ).thenReturn(testSite)
-        whenever(
-            resourceProvider.getString(
-                R.string.stats_error_no_site
-            )
-        ).thenReturn(NO_SITE_SELECTED_ERROR)
         whenever(
             resourceProvider.getString(
                 R.string.stats_error_api
             )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
-        whenever(
-            resourceProvider.getString(
-                R.string.stats_error_unknown
-            )
-        ).thenReturn(UNKNOWN_ERROR)
+        viewModel = AllTimeStatsViewModel(
+            resourceProvider
+        )
     }
 
-    private suspend fun initViewModel() {
-        whenever(
-            statsSummaryUseCase(TEST_SITE_ID)
-        ).thenReturn(
+    @Test
+    fun `initial state is Loading`() {
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                AllTimeStatsCardUiState
+                    .Loading::class.java
+            )
+    }
+
+    @Test
+    fun `when handleResult with success, then loaded state`() {
+        viewModel.handleResult(
             StatsSummaryResult.Success(createTestData())
         )
-        viewModel = AllTimeStatsViewModel(
-            selectedSiteRepository,
-            resourceProvider,
-            statsSummaryUseCase
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            AllTimeStatsCardUiState.Loaded::class.java
         )
-        viewModel.loadData()
+        with(
+            state as AllTimeStatsCardUiState.Loaded
+        ) {
+            assertThat(views)
+                .isEqualTo(TEST_VIEWS)
+            assertThat(visitors)
+                .isEqualTo(TEST_VISITORS)
+            assertThat(posts)
+                .isEqualTo(TEST_POSTS)
+            assertThat(comments)
+                .isEqualTo(TEST_COMMENTS)
+        }
     }
 
     @Test
-    fun `when no site selected, then error state`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                AllTimeStatsCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as AllTimeStatsCardUiState.Error)
-                    .message
-            ).isEqualTo(NO_SITE_SELECTED_ERROR)
-        }
-
-    @Test
-    fun `when data loads successfully, then loaded state`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                AllTimeStatsCardUiState.Loaded::class.java
-            )
-            with(
-                state as AllTimeStatsCardUiState.Loaded
-            ) {
-                assertThat(views)
-                    .isEqualTo(TEST_VIEWS)
-                assertThat(visitors)
-                    .isEqualTo(TEST_VISITORS)
-                assertThat(posts)
-                    .isEqualTo(TEST_POSTS)
-                assertThat(comments)
-                    .isEqualTo(TEST_COMMENTS)
-            }
-        }
-
-    @Test
-    fun `when fetch fails, then error state`() = test {
-        whenever(
-            statsSummaryUseCase(TEST_SITE_ID)
-        ).thenReturn(
+    fun `when handleResult with error, then error state`() {
+        viewModel.handleResult(
             StatsSummaryResult.Error("Network error")
         )
-
-        viewModel = AllTimeStatsViewModel(
-            selectedSiteRepository,
-            resourceProvider,
-            statsSummaryUseCase
-        )
-        viewModel.loadData()
-        advanceUntilIdle()
 
         val state = viewModel.uiState.value
         assertThat(state).isInstanceOf(
@@ -155,245 +80,54 @@ class AllTimeStatsViewModelTest : BaseUnitTest() {
         ).isEqualTo(FAILED_TO_LOAD_ERROR)
     }
 
-    @Suppress("TooGenericExceptionThrown")
     @Test
-    fun `when exception thrown, then error state`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenAnswer {
-                throw RuntimeException("Test")
-            }
-
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
+    fun `when showLoading called, then loading state`() {
+        viewModel.handleResult(
+            StatsSummaryResult.Success(createTestData())
+        )
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                AllTimeStatsCardUiState
+                    .Loaded::class.java
             )
-            viewModel.loadData()
-            advanceUntilIdle()
 
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                AllTimeStatsCardUiState.Error::class.java
+        viewModel.showLoading()
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                AllTimeStatsCardUiState
+                    .Loading::class.java
             )
-            assertThat(
-                (state as AllTimeStatsCardUiState.Error)
-                    .message
-            ).isEqualTo(UNKNOWN_ERROR)
-        }
+    }
 
     @Test
-    fun `when loadDataIfNeeded called multiple times, then loads once`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
+    fun `when handleResult after error, then loaded state`() {
+        viewModel.handleResult(
+            StatsSummaryResult.Error("error")
+        )
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                AllTimeStatsCardUiState
+                    .Error::class.java
             )
 
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
+        viewModel.handleResult(
+            StatsSummaryResult.Success(createTestData())
+        )
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                AllTimeStatsCardUiState
+                    .Loaded::class.java
             )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when onRetry called, then data is reloaded`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-
-            viewModel.onRetry()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when refresh called, then data is fetched`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-            whenever(
-                statsSummaryUseCase(
-                    TEST_SITE_ID,
-                    forceRefresh = true
-                )
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when refresh called, then isRefreshing resets`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-            whenever(
-                statsSummaryUseCase(
-                    TEST_SITE_ID,
-                    forceRefresh = true
-                )
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-        }
-
-    @Test
-    fun `when refresh fails after success, then loadDataIfNeeded reloads`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-
-            viewModel = AllTimeStatsViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-
-            whenever(
-                statsSummaryUseCase(
-                    TEST_SITE_ID,
-                    forceRefresh = true
-                )
-            ).thenReturn(
-                StatsSummaryResult.Error("Network error")
-            )
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Error::class.java
-                )
-
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    createTestData()
-                )
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    AllTimeStatsCardUiState
-                        .Loaded::class.java
-                )
-        }
+    }
 
     companion object {
-        private const val TEST_SITE_ID = 123L
         private const val TEST_VIEWS = 6782856L
         private const val TEST_VISITORS = 154791L
         private const val TEST_POSTS = 42L
         private const val TEST_COMMENTS = 85L
-        private const val NO_SITE_SELECTED_ERROR =
-            "No site selected"
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
-        private const val UNKNOWN_ERROR =
-            "Unknown error"
 
         private fun createTestData() = StatsSummaryData(
             views = TEST_VIEWS,

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopularday/MostPopularDayViewModelTest.kt
@@ -6,142 +6,71 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.lenient
-import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsSummaryData
 import org.wordpress.android.ui.newstats.repository.StatsSummaryResult
-import org.wordpress.android.ui.newstats.repository.StatsSummaryUseCase
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @ExperimentalCoroutinesApi
 class MostPopularDayViewModelTest : BaseUnitTest() {
     @Mock
-    private lateinit var selectedSiteRepository:
-        SelectedSiteRepository
-
-    @Mock
     private lateinit var resourceProvider:
         ResourceProvider
-
-    @Mock
-    private lateinit var statsSummaryUseCase:
-        StatsSummaryUseCase
 
     private lateinit var viewModel:
         MostPopularDayViewModel
 
-    private val testSite = SiteModel().apply {
-        id = 1
-        siteId = TEST_SITE_ID
-        name = "Test Site"
-    }
-
     @Before
     fun setUp() {
-        whenever(
-            selectedSiteRepository.getSelectedSite()
-        ).thenReturn(testSite)
-        lenient().`when`(
-            resourceProvider.getString(
-                R.string.stats_error_no_site
-            )
-        ).thenReturn(NO_SITE_SELECTED_ERROR)
         lenient().`when`(
             resourceProvider.getString(
                 R.string.stats_error_api
             )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
-        lenient().`when`(
-            resourceProvider.getString(
-                R.string.stats_error_unknown
-            )
-        ).thenReturn(UNKNOWN_ERROR)
-    }
-
-    private suspend fun initViewModel() {
-        whenever(
-            statsSummaryUseCase(TEST_SITE_ID)
-        ).thenReturn(
-            StatsSummaryResult.Success(createTestData())
-        )
         viewModel = MostPopularDayViewModel(
-            selectedSiteRepository,
-            resourceProvider,
-            statsSummaryUseCase
+            resourceProvider
         )
-        viewModel.loadData()
     }
 
     @Test
-    fun `when data loads, then loaded state has correct day`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    data = createTestData()
-                )
-            )
-
-            viewModel = MostPopularDayViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
+    fun `initial state is Loading`() {
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
                 MostPopularDayCardUiState
-                    .Loaded::class.java
+                    .Loading::class.java
             )
-            with(
-                state as MostPopularDayCardUiState.Loaded
-            ) {
-                assertThat(dayAndMonth)
-                    .isEqualTo("February 22")
-                assertThat(year).isEqualTo("2022")
-                assertThat(views)
-                    .isEqualTo(TEST_BEST_DAY_TOTAL)
-            }
-        }
+    }
 
     @Test
-    fun `when no site selected, then error state`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                MostPopularDayCardUiState
-                    .Error::class.java
+    fun `when handleResult with success, then loaded state has correct day`() {
+        viewModel.handleResult(
+            StatsSummaryResult.Success(
+                data = createTestData()
             )
+        )
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            MostPopularDayCardUiState
+                .Loaded::class.java
+        )
+        with(
+            state as MostPopularDayCardUiState.Loaded
+        ) {
+            assertThat(dayAndMonth)
+                .isEqualTo("February 22")
+            assertThat(year).isEqualTo("2022")
+            assertThat(views)
+                .isEqualTo(TEST_BEST_DAY_TOTAL)
         }
+    }
 
     @Test
-    fun `when fetch fails, then error state`() = test {
-        whenever(
-            statsSummaryUseCase(TEST_SITE_ID)
-        ).thenReturn(
+    fun `when handleResult with error, then error state`() {
+        viewModel.handleResult(
             StatsSummaryResult.Error("Network error")
         )
-
-        viewModel = MostPopularDayViewModel(
-            selectedSiteRepository,
-            resourceProvider,
-            statsSummaryUseCase
-        )
-        viewModel.loadData()
-        advanceUntilIdle()
 
         assertThat(viewModel.uiState.value)
             .isInstanceOf(
@@ -151,102 +80,18 @@ class MostPopularDayViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when loadDataIfNeeded called multiple times, then loads once`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    data = createTestData()
-                )
+    fun `when showLoading called, then loading state`() {
+        viewModel.handleResult(
+            StatsSummaryResult.Success(createTestData())
+        )
+        viewModel.showLoading()
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                MostPopularDayCardUiState
+                    .Loading::class.java
             )
-
-            viewModel = MostPopularDayViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularDayCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when refresh called, then data is fetched`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    data = createTestData()
-                )
-            )
-            whenever(
-                statsSummaryUseCase(
-                    TEST_SITE_ID,
-                    forceRefresh = true
-                )
-            ).thenReturn(
-                StatsSummaryResult.Success(
-                    data = createTestData()
-                )
-            )
-
-            viewModel = MostPopularDayViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularDayCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Suppress("TooGenericExceptionThrown")
-    @Test
-    fun `when exception thrown, then error state`() =
-        test {
-            whenever(
-                statsSummaryUseCase(TEST_SITE_ID)
-            ).thenAnswer {
-                throw RuntimeException("Test")
-            }
-
-            viewModel = MostPopularDayViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsSummaryUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularDayCardUiState
-                        .Error::class.java
-                )
-            assertThat(
-                (viewModel.uiState.value
-                    as MostPopularDayCardUiState.Error)
-                    .message
-            ).isEqualTo(UNKNOWN_ERROR)
-        }
+    }
 
     @Test
     fun `when mapToUiState called, then percentage is calculated`() {
@@ -304,16 +149,11 @@ class MostPopularDayViewModelTest : BaseUnitTest() {
     }
 
     companion object {
-        private const val TEST_SITE_ID = 123L
         private const val TEST_VIEWS = 6782856L
         private const val TEST_BEST_DAY = "2022-02-22"
         private const val TEST_BEST_DAY_TOTAL = 4600L
-        private const val NO_SITE_SELECTED_ERROR =
-            "No site selected"
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
-        private const val UNKNOWN_ERROR =
-            "Unknown error"
 
         private fun createTestData() = StatsSummaryData(
             views = TEST_VIEWS,

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
@@ -1,0 +1,493 @@
+package org.wordpress.android.ui.newstats.mostpopulartime
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
+import org.wordpress.android.ui.newstats.repository.InsightsResult
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@ExperimentalCoroutinesApi
+class MostPopularTimeViewModelTest : BaseUnitTest() {
+    @Mock
+    private lateinit var selectedSiteRepository:
+        SelectedSiteRepository
+
+    @Mock
+    private lateinit var resourceProvider:
+        ResourceProvider
+
+    @Mock
+    private lateinit var statsInsightsUseCase:
+        StatsInsightsUseCase
+
+    private lateinit var viewModel:
+        MostPopularTimeViewModel
+
+    private val testSite = SiteModel().apply {
+        id = 1
+        siteId = TEST_SITE_ID
+        name = "Test Site"
+    }
+
+    @Before
+    fun setUp() {
+        whenever(
+            selectedSiteRepository.getSelectedSite()
+        ).thenReturn(testSite)
+        lenient().`when`(
+            resourceProvider.getString(
+                R.string.stats_error_no_site
+            )
+        ).thenReturn(NO_SITE_SELECTED_ERROR)
+        lenient().`when`(
+            resourceProvider.getString(
+                R.string.stats_error_api
+            )
+        ).thenReturn(FAILED_TO_LOAD_ERROR)
+        lenient().`when`(
+            resourceProvider.getString(
+                R.string.stats_error_unknown
+            )
+        ).thenReturn(UNKNOWN_ERROR)
+    }
+
+    @Test
+    fun `when data loads, then loaded state has correct values`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                MostPopularTimeCardUiState
+                    .Loaded::class.java
+            )
+            with(
+                state as MostPopularTimeCardUiState.Loaded
+            ) {
+                assertThat(bestDayPercent)
+                    .isEqualTo("25")
+                assertThat(bestHourPercent)
+                    .isEqualTo("16")
+            }
+        }
+
+    @Test
+    fun `when no site selected, then error state`() =
+        test {
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                MostPopularTimeCardUiState
+                    .Error::class.java
+            )
+            assertThat(
+                (state as MostPopularTimeCardUiState.Error)
+                    .message
+            ).isEqualTo(NO_SITE_SELECTED_ERROR)
+        }
+
+    @Test
+    fun `when fetch fails, then error state`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Error("Network error")
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Error::class.java
+                )
+            assertThat(
+                (viewModel.uiState.value
+                    as MostPopularTimeCardUiState.Error)
+                    .message
+            ).isEqualTo(FAILED_TO_LOAD_ERROR)
+        }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `when exception thrown, then error state`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenAnswer {
+                throw RuntimeException("Test")
+            }
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Error::class.java
+                )
+            assertThat(
+                (viewModel.uiState.value
+                    as MostPopularTimeCardUiState.Error)
+                    .message
+            ).isEqualTo(UNKNOWN_ERROR)
+        }
+
+    @Test
+    fun `when loadDataIfNeeded called multiple times, then loads once`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Loaded::class.java
+                )
+        }
+
+    @Test
+    fun `when refresh called, then data is fetched`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Loaded::class.java
+                )
+            verify(statsInsightsUseCase, times(1))
+                .invoke(eq(TEST_SITE_ID), eq(true))
+        }
+
+    @Test
+    fun `when onRetry called, then data is reloaded`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Error("error")
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Error::class.java
+                )
+
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel.onRetry()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Loaded::class.java
+                )
+        }
+
+    @Test
+    fun `when refresh is called, then isRefreshing becomes true then false`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadData()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isRefreshing.value)
+                .isFalse()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isRefreshing.value)
+                .isFalse()
+        }
+
+    @Test
+    fun `when mapToUiState with zero percents, then NoData`() {
+        val data = StatsInsightsData(
+            highestHour = 0,
+            highestHourPercent = 0.0,
+            highestDayOfWeek = 0,
+            highestDayPercent = 0.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+        assertThat(state).isInstanceOf(
+            MostPopularTimeCardUiState
+                .NoData::class.java
+        )
+    }
+
+    @Test
+    fun `when mapToUiState with valid data, then Loaded state`() {
+        val data = StatsInsightsData(
+            highestHour = TEST_HIGHEST_HOUR,
+            highestHourPercent = TEST_HOUR_PERCENT,
+            highestDayOfWeek = TEST_DAY_OF_WEEK,
+            highestDayPercent = TEST_DAY_PERCENT,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDayPercent)
+            .isEqualTo("25")
+        assertThat(state.bestHourPercent)
+            .isEqualTo("16")
+    }
+
+    @Test
+    fun `when mapToUiState with sunday, then correct day name`() {
+        val data = StatsInsightsData(
+            highestHour = 0,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 0,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDay).isEqualTo("Sunday")
+    }
+
+    @Test
+    fun `when mapToUiState with monday, then correct day name`() {
+        val data = StatsInsightsData(
+            highestHour = 0,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 1,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDay).isEqualTo("Monday")
+    }
+
+    @Test
+    fun `when mapToUiState with saturday, then correct day name`() {
+        val data = StatsInsightsData(
+            highestHour = 0,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 6,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDay).isEqualTo("Saturday")
+    }
+
+    @Test
+    fun `when mapToUiState with fractional percent, then rounded`() {
+        val data = StatsInsightsData(
+            highestHour = 14,
+            highestHourPercent = 11.18,
+            highestDayOfWeek = 3,
+            highestDayPercent = 22.66,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDayPercent)
+            .isEqualTo("23")
+        assertThat(state.bestHourPercent)
+            .isEqualTo("11")
+    }
+
+    @Test
+    fun `when refresh fails after success, then loadDataIfNeeded reloads`() =
+        test {
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            viewModel = MostPopularTimeViewModel(
+                selectedSiteRepository,
+                resourceProvider,
+                statsInsightsUseCase
+            )
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Loaded::class.java
+                )
+
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Error("Network error")
+            )
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Error::class.java
+                )
+
+            whenever(
+                statsInsightsUseCase(any(), any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+            viewModel.loadDataIfNeeded()
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    MostPopularTimeCardUiState
+                        .Loaded::class.java
+                )
+        }
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+        private const val TEST_HIGHEST_HOUR = 16
+        private const val TEST_HOUR_PERCENT = 15.5
+        private const val TEST_DAY_OF_WEEK = 3
+        private const val TEST_DAY_PERCENT = 25.0
+        private const val NO_SITE_SELECTED_ERROR =
+            "No site selected"
+        private const val FAILED_TO_LOAD_ERROR =
+            "Failed to load stats"
+        private const val UNKNOWN_ERROR =
+            "Unknown error"
+
+        private fun createTestInsightsData() =
+            StatsInsightsData(
+                highestHour = TEST_HIGHEST_HOUR,
+                highestHourPercent = TEST_HOUR_PERCENT,
+                highestDayOfWeek = TEST_DAY_OF_WEEK,
+                highestDayPercent = TEST_DAY_PERCENT,
+                years = emptyList()
+            )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
@@ -350,26 +350,11 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when mapToUiState with sunday, then correct day name`() {
+    fun `when mapToUiState with day 0, then Monday`() {
         val data = StatsInsightsData(
-            highestHour = 0,
+            highestHour = 10,
             highestHourPercent = 10.0,
             highestDayOfWeek = 0,
-            highestDayPercent = 20.0,
-            years = emptyList()
-        )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
-            as MostPopularTimeCardUiState.Loaded
-        assertThat(state.bestDay).isEqualTo("Sunday")
-    }
-
-    @Test
-    fun `when mapToUiState with monday, then correct day name`() {
-        val data = StatsInsightsData(
-            highestHour = 0,
-            highestHourPercent = 10.0,
-            highestDayOfWeek = 1,
             highestDayPercent = 20.0,
             years = emptyList()
         )
@@ -380,9 +365,24 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when mapToUiState with saturday, then correct day name`() {
+    fun `when mapToUiState with day 5, then Saturday`() {
         val data = StatsInsightsData(
-            highestHour = 0,
+            highestHour = 10,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 5,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDay).isEqualTo("Saturday")
+    }
+
+    @Test
+    fun `when mapToUiState with day 6, then Sunday`() {
+        val data = StatsInsightsData(
+            highestHour = 10,
             highestHourPercent = 10.0,
             highestDayOfWeek = 6,
             highestDayPercent = 20.0,
@@ -391,7 +391,56 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
         val state =
             MostPopularTimeViewModel.mapToUiState(data)
             as MostPopularTimeCardUiState.Loaded
-        assertThat(state.bestDay).isEqualTo("Saturday")
+        assertThat(state.bestDay).isEqualTo("Sunday")
+    }
+
+    @Test
+    fun `when mapToUiState with zero day percent, then NoData`() {
+        val data = StatsInsightsData(
+            highestHour = 14,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 0.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+        assertThat(state).isInstanceOf(
+            MostPopularTimeCardUiState
+                .NoData::class.java
+        )
+    }
+
+    @Test
+    fun `when mapToUiState with zero hour percent, then NoData`() {
+        val data = StatsInsightsData(
+            highestHour = 14,
+            highestHourPercent = 0.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 10.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+        assertThat(state).isInstanceOf(
+            MostPopularTimeCardUiState
+                .NoData::class.java
+        )
+    }
+
+    @Test
+    fun `when mapToUiState with invalid day, then empty day name`() {
+        val data = StatsInsightsData(
+            highestHour = 10,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 7,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestDay).isEmpty()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.newstats.mostpopulartime
 
+import android.content.Context
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -18,6 +19,9 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
     private lateinit var resourceProvider:
         ResourceProvider
 
+    @Mock
+    private lateinit var context: Context
+
     private lateinit var viewModel:
         MostPopularTimeViewModel
 
@@ -29,7 +33,7 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
         viewModel = MostPopularTimeViewModel(
-            resourceProvider
+            context, resourceProvider
         )
     }
 
@@ -40,29 +44,6 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
                 MostPopularTimeCardUiState
                     .Loading::class.java
             )
-    }
-
-    @Test
-    fun `when handleResult with success, then loaded state has correct values`() {
-        viewModel.handleResult(
-            InsightsResult.Success(
-                createTestInsightsData()
-            )
-        )
-
-        val state = viewModel.uiState.value
-        assertThat(state).isInstanceOf(
-            MostPopularTimeCardUiState
-                .Loaded::class.java
-        )
-        with(
-            state as MostPopularTimeCardUiState.Loaded
-        ) {
-            assertThat(bestDayPercent)
-                .isEqualTo("25")
-            assertThat(bestHourPercent)
-                .isEqualTo("16")
-        }
     }
 
     @Test
@@ -131,8 +112,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 0.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
         assertThat(state).isInstanceOf(
             MostPopularTimeCardUiState
                 .NoData::class.java
@@ -148,8 +129,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = TEST_DAY_PERCENT,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDayPercent)
             .isEqualTo("25")
@@ -166,8 +147,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 20.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDay).isEqualTo("Monday")
     }
@@ -181,8 +162,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 20.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDay).isEqualTo("Saturday")
     }
@@ -196,8 +177,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 20.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDay).isEqualTo("Sunday")
     }
@@ -211,8 +192,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 0.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
         assertThat(state).isInstanceOf(
             MostPopularTimeCardUiState
                 .NoData::class.java
@@ -228,8 +209,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 10.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
         assertThat(state).isInstanceOf(
             MostPopularTimeCardUiState
                 .NoData::class.java
@@ -245,8 +226,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 20.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDay).isEmpty()
     }
@@ -260,8 +241,8 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 20.0,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestHour).isEmpty()
     }
@@ -275,13 +256,81 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             highestDayPercent = 22.66,
             years = emptyList()
         )
-        val state =
-            MostPopularTimeViewModel.mapToUiState(data)
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, USE_24H)
             as MostPopularTimeCardUiState.Loaded
         assertThat(state.bestDayPercent)
             .isEqualTo("23")
         assertThat(state.bestHourPercent)
             .isEqualTo("11")
+    }
+
+    @Test
+    fun `when 24h format, then hour shows 24h style`() {
+        val data = StatsInsightsData(
+            highestHour = 16,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, use24HourFormat = true)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestHour).isEqualTo("16:00")
+    }
+
+    @Test
+    fun `when 12h format, then hour shows AM PM style`() {
+        val data = StatsInsightsData(
+            highestHour = 16,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state = MostPopularTimeViewModel
+            .mapToUiState(
+                data, use24HourFormat = false
+            )
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestHour)
+            .contains("4:00")
+            .containsIgnoringCase("pm")
+    }
+
+    @Test
+    fun `when 24h format with morning hour, then padded`() {
+        val data = StatsInsightsData(
+            highestHour = 9,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state = MostPopularTimeViewModel
+            .mapToUiState(data, use24HourFormat = true)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestHour).isEqualTo("09:00")
+    }
+
+    @Test
+    fun `when 12h format with midnight, then 12 AM`() {
+        val data = StatsInsightsData(
+            highestHour = 0,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state = MostPopularTimeViewModel
+            .mapToUiState(
+                data, use24HourFormat = false
+            )
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestHour)
+            .contains("12:00")
+            .containsIgnoringCase("am")
     }
 
     companion object {
@@ -291,6 +340,7 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
         private const val TEST_DAY_PERCENT = 25.0
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
+        private const val USE_24H = true
 
         private fun createTestInsightsData() =
             StatsInsightsData(

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
@@ -6,313 +6,121 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.lenient
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @ExperimentalCoroutinesApi
 class MostPopularTimeViewModelTest : BaseUnitTest() {
     @Mock
-    private lateinit var selectedSiteRepository:
-        SelectedSiteRepository
-
-    @Mock
     private lateinit var resourceProvider:
         ResourceProvider
-
-    @Mock
-    private lateinit var statsInsightsUseCase:
-        StatsInsightsUseCase
 
     private lateinit var viewModel:
         MostPopularTimeViewModel
 
-    private val testSite = SiteModel().apply {
-        id = 1
-        siteId = TEST_SITE_ID
-        name = "Test Site"
-    }
-
     @Before
     fun setUp() {
-        whenever(
-            selectedSiteRepository.getSelectedSite()
-        ).thenReturn(testSite)
-        lenient().`when`(
-            resourceProvider.getString(
-                R.string.stats_error_no_site
-            )
-        ).thenReturn(NO_SITE_SELECTED_ERROR)
         lenient().`when`(
             resourceProvider.getString(
                 R.string.stats_error_api
             )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
-        lenient().`when`(
-            resourceProvider.getString(
-                R.string.stats_error_unknown
-            )
-        ).thenReturn(UNKNOWN_ERROR)
+        viewModel = MostPopularTimeViewModel(
+            resourceProvider
+        )
     }
 
     @Test
-    fun `when data loads, then loaded state has correct values`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
-            )
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
+    fun `initial state is Loading`() {
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
                 MostPopularTimeCardUiState
-                    .Loaded::class.java
+                    .Loading::class.java
             )
-            with(
-                state as MostPopularTimeCardUiState.Loaded
-            ) {
-                assertThat(bestDayPercent)
-                    .isEqualTo("25")
-                assertThat(bestHourPercent)
-                    .isEqualTo("16")
-            }
-        }
+    }
 
     @Test
-    fun `when no site selected, then error state`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
+    fun `when handleResult with success, then loaded state has correct values`() {
+        viewModel.handleResult(
+            InsightsResult.Success(
+                createTestInsightsData()
             )
-            viewModel.loadData()
-            advanceUntilIdle()
+        )
 
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            MostPopularTimeCardUiState
+                .Loaded::class.java
+        )
+        with(
+            state as MostPopularTimeCardUiState.Loaded
+        ) {
+            assertThat(bestDayPercent)
+                .isEqualTo("25")
+            assertThat(bestHourPercent)
+                .isEqualTo("16")
+        }
+    }
+
+    @Test
+    fun `when handleResult with error, then error state`() {
+        viewModel.handleResult(
+            InsightsResult.Error("Network error")
+        )
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
                 MostPopularTimeCardUiState
                     .Error::class.java
             )
-            assertThat(
-                (state as MostPopularTimeCardUiState.Error)
-                    .message
-            ).isEqualTo(NO_SITE_SELECTED_ERROR)
-        }
+        assertThat(
+            (viewModel.uiState.value
+                as MostPopularTimeCardUiState.Error)
+                .message
+        ).isEqualTo(FAILED_TO_LOAD_ERROR)
+    }
 
     @Test
-    fun `when fetch fails, then error state`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Error("Network error")
+    fun `when showLoading called, then loading state`() {
+        viewModel.handleResult(
+            InsightsResult.Success(
+                createTestInsightsData()
             )
+        )
+        viewModel.showLoading()
 
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                MostPopularTimeCardUiState
+                    .Loading::class.java
             )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Error::class.java
-                )
-            assertThat(
-                (viewModel.uiState.value
-                    as MostPopularTimeCardUiState.Error)
-                    .message
-            ).isEqualTo(FAILED_TO_LOAD_ERROR)
-        }
-
-    @Suppress("TooGenericExceptionThrown")
-    @Test
-    fun `when exception thrown, then error state`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenAnswer {
-                throw RuntimeException("Test")
-            }
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Error::class.java
-                )
-            assertThat(
-                (viewModel.uiState.value
-                    as MostPopularTimeCardUiState.Error)
-                    .message
-            ).isEqualTo(UNKNOWN_ERROR)
-        }
+    }
 
     @Test
-    fun `when loadDataIfNeeded called multiple times, then loads once`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
+    fun `when handleResult after error, then loaded state`() {
+        viewModel.handleResult(
+            InsightsResult.Error("error")
+        )
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                MostPopularTimeCardUiState
+                    .Error::class.java
             )
 
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
+        viewModel.handleResult(
+            InsightsResult.Success(
+                createTestInsightsData()
             )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when refresh called, then data is fetched`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
+        )
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                MostPopularTimeCardUiState
+                    .Loaded::class.java
             )
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Loaded::class.java
-                )
-            verify(statsInsightsUseCase, times(1))
-                .invoke(eq(TEST_SITE_ID), eq(true))
-        }
-
-    @Test
-    fun `when onRetry called, then data is reloaded`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Error("error")
-            )
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Error::class.java
-                )
-
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
-            )
-
-            viewModel.onRetry()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when refresh is called, then isRefreshing becomes true then false`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
-            )
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadData()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-        }
+    }
 
     @Test
     fun `when mapToUiState with zero percents, then NoData`() {
@@ -461,74 +269,13 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
             .isEqualTo("11")
     }
 
-    @Test
-    fun `when refresh fails after success, then loadDataIfNeeded reloads`() =
-        test {
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
-            )
-
-            viewModel = MostPopularTimeViewModel(
-                selectedSiteRepository,
-                resourceProvider,
-                statsInsightsUseCase
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Loaded::class.java
-                )
-
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Error("Network error")
-            )
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Error::class.java
-                )
-
-            whenever(
-                statsInsightsUseCase(any(), any())
-            ).thenReturn(
-                InsightsResult.Success(
-                    createTestInsightsData()
-                )
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    MostPopularTimeCardUiState
-                        .Loaded::class.java
-                )
-        }
-
     companion object {
-        private const val TEST_SITE_ID = 123L
         private const val TEST_HIGHEST_HOUR = 16
         private const val TEST_HOUR_PERCENT = 15.5
         private const val TEST_DAY_OF_WEEK = 3
         private const val TEST_DAY_PERCENT = 25.0
-        private const val NO_SITE_SELECTED_ERROR =
-            "No site selected"
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
-        private const val UNKNOWN_ERROR =
-            "Unknown error"
 
         private fun createTestInsightsData() =
             StatsInsightsData(

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/mostpopulartime/MostPopularTimeViewModelTest.kt
@@ -252,6 +252,21 @@ class MostPopularTimeViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when mapToUiState with invalid hour, then empty hour`() {
+        val data = StatsInsightsData(
+            highestHour = 25,
+            highestHourPercent = 10.0,
+            highestDayOfWeek = 3,
+            highestDayPercent = 20.0,
+            years = emptyList()
+        )
+        val state =
+            MostPopularTimeViewModel.mapToUiState(data)
+            as MostPopularTimeCardUiState.Loaded
+        assertThat(state.bestHour).isEmpty()
+    }
+
+    @Test
     fun `when mapToUiState with fractional percent, then rounded`() {
         val data = StatsInsightsData(
             highestHour = 14,

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/InsightsCardsConfigurationRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/InsightsCardsConfigurationRepositoryTest.kt
@@ -90,7 +90,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                 .containsExactly(
                     InsightsCardType.YEAR_IN_REVIEW,
                     InsightsCardType.ALL_TIME_STATS,
-                    InsightsCardType.MOST_POPULAR_DAY
+                    InsightsCardType.MOST_POPULAR_DAY,
+                    InsightsCardType.MOST_POPULAR_TIME
                 )
             verify(appPrefsWrapper)
                 .setStatsInsightsCardsConfigurationJson(
@@ -106,7 +107,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                     "visibleCards": [
                         "YEAR_IN_REVIEW",
                         "ALL_TIME_STATS",
-                        "MOST_POPULAR_DAY"
+                        "MOST_POPULAR_DAY",
+                        "MOST_POPULAR_TIME"
                     ]
                 }
             """.trimIndent()
@@ -124,7 +126,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                 .containsExactly(
                     InsightsCardType.YEAR_IN_REVIEW,
                     InsightsCardType.ALL_TIME_STATS,
-                    InsightsCardType.MOST_POPULAR_DAY
+                    InsightsCardType.MOST_POPULAR_DAY,
+                    InsightsCardType.MOST_POPULAR_TIME
                 )
             verify(
                 appPrefsWrapper,
@@ -161,7 +164,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                     "hiddenCards": [
                         "YEAR_IN_REVIEW",
                         "ALL_TIME_STATS",
-                        "MOST_POPULAR_DAY"
+                        "MOST_POPULAR_DAY",
+                        "MOST_POPULAR_TIME"
                     ]
                 }
             """.trimIndent()
@@ -227,7 +231,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                     "hiddenCards": [
                         "YEAR_IN_REVIEW",
                         "ALL_TIME_STATS",
-                        "MOST_POPULAR_DAY"
+                        "MOST_POPULAR_DAY",
+                        "MOST_POPULAR_TIME"
                     ]
                 }
             """.trimIndent()
@@ -262,7 +267,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                     "hiddenCards": [
                         "YEAR_IN_REVIEW",
                         "ALL_TIME_STATS",
-                        "MOST_POPULAR_DAY"
+                        "MOST_POPULAR_DAY",
+                        "MOST_POPULAR_TIME"
                     ]
                 }
             """.trimIndent()
@@ -370,7 +376,7 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
 
             repository.moveCardDown(
                 TEST_SITE_ID,
-                InsightsCardType.MOST_POPULAR_DAY
+                InsightsCardType.MOST_POPULAR_TIME
             )
 
             verify(
@@ -416,7 +422,7 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
 
             repository.moveCardToBottom(
                 TEST_SITE_ID,
-                InsightsCardType.MOST_POPULAR_DAY
+                InsightsCardType.MOST_POPULAR_TIME
             )
 
             verify(
@@ -434,7 +440,8 @@ class InsightsCardsConfigurationRepositoryTest : BaseUnitTest() {
                 "visibleCards": [
                     "YEAR_IN_REVIEW",
                     "ALL_TIME_STATS",
-                    "MOST_POPULAR_DAY"
+                    "MOST_POPULAR_DAY",
+                    "MOST_POPULAR_TIME"
                 ]
             }
         """.trimIndent()

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsInsightsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsInsightsUseCaseTest.kt
@@ -1,0 +1,233 @@
+package org.wordpress.android.ui.newstats.repository
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
+import org.wordpress.android.ui.newstats.datasource.YearInsightsData
+
+@ExperimentalCoroutinesApi
+class StatsInsightsUseCaseTest : BaseUnitTest() {
+    @Mock
+    private lateinit var statsRepository: StatsRepository
+
+    @Mock
+    private lateinit var accountStore: AccountStore
+
+    private lateinit var useCase: StatsInsightsUseCase
+
+    @Before
+    fun setUp() {
+        whenever(accountStore.accessToken)
+            .thenReturn(TEST_ACCESS_TOKEN)
+        useCase = StatsInsightsUseCase(
+            statsRepository,
+            accountStore
+        )
+    }
+
+    @Test
+    fun `when called, then returns cached on second call`() =
+        test {
+            whenever(
+                statsRepository.fetchInsights(
+                    TEST_SITE_ID
+                )
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            val first = useCase(TEST_SITE_ID)
+            val second = useCase(TEST_SITE_ID)
+
+            assertThat(first).isInstanceOf(
+                InsightsResult.Success::class.java
+            )
+            assertThat(second).isInstanceOf(
+                InsightsResult.Success::class.java
+            )
+            verify(statsRepository, times(1))
+                .fetchInsights(TEST_SITE_ID)
+        }
+
+    @Test
+    fun `when called with forceRefresh, then fetches again`() =
+        test {
+            whenever(
+                statsRepository.fetchInsights(
+                    TEST_SITE_ID
+                )
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            useCase(TEST_SITE_ID)
+            useCase(
+                TEST_SITE_ID,
+                forceRefresh = true
+            )
+
+            verify(statsRepository, times(2))
+                .fetchInsights(TEST_SITE_ID)
+        }
+
+    @Test
+    fun `when called without token, then returns error`() =
+        test {
+            whenever(accountStore.accessToken)
+                .thenReturn(null)
+            useCase = StatsInsightsUseCase(
+                statsRepository,
+                accountStore
+            )
+
+            val result = useCase(TEST_SITE_ID)
+
+            assertThat(result).isInstanceOf(
+                InsightsResult.Error::class.java
+            )
+            verify(statsRepository, never())
+                .fetchInsights(any())
+        }
+
+    @Test
+    fun `when called with empty token, then returns error`() =
+        test {
+            whenever(accountStore.accessToken)
+                .thenReturn("")
+            useCase = StatsInsightsUseCase(
+                statsRepository,
+                accountStore
+            )
+
+            val result = useCase(TEST_SITE_ID)
+
+            assertThat(result).isInstanceOf(
+                InsightsResult.Error::class.java
+            )
+            verify(statsRepository, never())
+                .fetchInsights(any())
+        }
+
+    @Test
+    fun `when errors, then cache is not populated`() =
+        test {
+            whenever(
+                statsRepository.fetchInsights(
+                    TEST_SITE_ID
+                )
+            ).thenReturn(
+                InsightsResult.Error("Network error")
+            )
+
+            val first = useCase(TEST_SITE_ID)
+            assertThat(first).isInstanceOf(
+                InsightsResult.Error::class.java
+            )
+
+            whenever(
+                statsRepository.fetchInsights(
+                    TEST_SITE_ID
+                )
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            val second = useCase(TEST_SITE_ID)
+            assertThat(second).isInstanceOf(
+                InsightsResult.Success::class.java
+            )
+            verify(statsRepository, times(2))
+                .fetchInsights(TEST_SITE_ID)
+        }
+
+    @Test
+    fun `when called for different site, then fetches again`() =
+        test {
+            whenever(
+                statsRepository.fetchInsights(any())
+            ).thenReturn(
+                InsightsResult.Success(
+                    createTestInsightsData()
+                )
+            )
+
+            useCase(TEST_SITE_ID)
+            useCase(OTHER_SITE_ID)
+
+            verify(statsRepository, times(1))
+                .fetchInsights(TEST_SITE_ID)
+            verify(statsRepository, times(1))
+                .fetchInsights(OTHER_SITE_ID)
+        }
+
+    @Test
+    fun `when success, then data is returned correctly`() =
+        test {
+            val testData = createTestInsightsData()
+            whenever(
+                statsRepository.fetchInsights(
+                    TEST_SITE_ID
+                )
+            ).thenReturn(
+                InsightsResult.Success(testData)
+            )
+
+            val result = useCase(TEST_SITE_ID)
+
+            assertThat(result).isInstanceOf(
+                InsightsResult.Success::class.java
+            )
+            val success =
+                result as InsightsResult.Success
+            assertThat(success.data.highestHour)
+                .isEqualTo(TEST_HIGHEST_HOUR)
+            assertThat(success.data.highestDayOfWeek)
+                .isEqualTo(TEST_DAY_OF_WEEK)
+            assertThat(success.data.years).hasSize(1)
+        }
+
+    private fun createTestInsightsData() =
+        StatsInsightsData(
+            highestHour = TEST_HIGHEST_HOUR,
+            highestHourPercent = 15.5,
+            highestDayOfWeek = TEST_DAY_OF_WEEK,
+            highestDayPercent = 25.0,
+            years = listOf(
+                YearInsightsData(
+                    year = "2025",
+                    totalPosts = 42L,
+                    totalWords = 15000L,
+                    avgWords = 357.1,
+                    totalLikes = 230L,
+                    avgLikes = 5.5,
+                    totalComments = 85L,
+                    avgComments = 2.0
+                )
+            )
+        )
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+        private const val OTHER_SITE_ID = 456L
+        private const val TEST_ACCESS_TOKEN =
+            "test_access_token"
+        private const val TEST_HIGHEST_HOUR = 16
+        private const val TEST_DAY_OF_WEEK = 3
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryInsightsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryInsightsTest.kt
@@ -51,15 +51,15 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
                 InsightsResult.Success::class.java
             )
             val success = result as InsightsResult.Success
-            assertThat(success.years).hasSize(2)
-            assertThat(success.years[0].year).isEqualTo("2025")
-            assertThat(success.years[0].totalPosts)
+            assertThat(success.data.years).hasSize(2)
+            assertThat(success.data.years[0].year).isEqualTo("2025")
+            assertThat(success.data.years[0].totalPosts)
                 .isEqualTo(TEST_TOTAL_POSTS)
-            assertThat(success.years[0].totalWords)
+            assertThat(success.data.years[0].totalWords)
                 .isEqualTo(TEST_TOTAL_WORDS)
-            assertThat(success.years[0].totalLikes)
+            assertThat(success.data.years[0].totalLikes)
                 .isEqualTo(TEST_TOTAL_LIKES)
-            assertThat(success.years[0].totalComments)
+            assertThat(success.data.years[0].totalComments)
                 .isEqualTo(TEST_TOTAL_COMMENTS)
         }
 
@@ -83,7 +83,13 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
     @Test
     fun `given empty years list, when fetchInsights, then success with empty list`() =
         test {
-            val emptyData = StatsInsightsData(years = emptyList())
+            val emptyData = StatsInsightsData(
+                highestHour = 0,
+                highestHourPercent = 0.0,
+                highestDayOfWeek = 0,
+                highestDayPercent = 0.0,
+                years = emptyList()
+            )
             whenever(statsDataSource.fetchStatsInsights(any()))
                 .thenReturn(
                     StatsInsightsDataResult.Success(emptyData)
@@ -95,7 +101,7 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
                 InsightsResult.Success::class.java
             )
             val success = result as InsightsResult.Success
-            assertThat(success.years).isEmpty()
+            assertThat(success.data.years).isEmpty()
         }
 
     @Test
@@ -128,12 +134,16 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
             val result = repository.fetchInsights(TEST_SITE_ID)
 
             val success = result as InsightsResult.Success
-            assertThat(success.years[0].year).isEqualTo("2025")
-            assertThat(success.years[1].year).isEqualTo("2024")
-            assertThat(success.years[1].totalPosts).isEqualTo(38L)
+            assertThat(success.data.years[0].year).isEqualTo("2025")
+            assertThat(success.data.years[1].year).isEqualTo("2024")
+            assertThat(success.data.years[1].totalPosts).isEqualTo(38L)
         }
 
     private fun createTestInsightsData() = StatsInsightsData(
+        highestHour = 14,
+        highestHourPercent = 15.5,
+        highestDayOfWeek = 3,
+        highestDayPercent = 25.0,
         years = listOf(
             YearInsightsData(
                 year = "2025",

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
@@ -22,10 +22,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: YearInReviewViewModel
 
-    private var retryCalled = false
-
-    private val onRetry = { retryCalled = true }
-
     @Before
     fun setUp() {
         whenever(
@@ -36,7 +32,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
         viewModel = YearInReviewViewModel(
             resourceProvider
         )
-        retryCalled = false
     }
 
     @Test
@@ -52,7 +47,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     fun `when handleResult with success, then loaded state is emitted`() {
         viewModel.handleResult(
             createSuccessResult(),
-            onRetry = onRetry
         )
 
         val state = viewModel.uiState.value
@@ -82,7 +76,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     fun `when handleResult with error, then error state is emitted`() {
         viewModel.handleResult(
             InsightsResult.Error("Network error"),
-            onRetry = onRetry
         )
 
         val state = viewModel.uiState.value
@@ -96,24 +89,9 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when error state retry is clicked, then onRetry is invoked`() {
-        viewModel.handleResult(
-            InsightsResult.Error("error"),
-            onRetry = onRetry
-        )
-
-        val errorState = viewModel.uiState.value
-            as YearInReviewCardUiState.Error
-        errorState.onRetry()
-
-        assertThat(retryCalled).isTrue()
-    }
-
-    @Test
     fun `when showLoading called, then loading state`() {
         viewModel.handleResult(
             createSuccessResult(),
-            onRetry = onRetry
         )
         viewModel.showLoading()
 
@@ -132,7 +110,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                     emptyList()
                 )
             ),
-            onRetry = onRetry
         )
 
         val state = viewModel.uiState.value
@@ -164,7 +141,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                     yearsWithCurrent
                 )
             ),
-            onRetry = onRetry
         )
 
         val state = viewModel.uiState.value
@@ -180,7 +156,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     fun `when state is loaded, then getDetailData returns years`() {
         viewModel.handleResult(
             createSuccessResult(),
-            onRetry = onRetry
         )
 
         val detailData = viewModel.getDetailData()
@@ -205,7 +180,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     fun `when state is error, then getDetailData returns empty list`() {
         viewModel.handleResult(
             InsightsResult.Error("error"),
-            onRetry = onRetry
         )
 
         assertThat(viewModel.uiState.value)

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
@@ -5,474 +5,217 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.datasource.YearInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.Year
 
 @ExperimentalCoroutinesApi
 class YearInReviewViewModelTest : BaseUnitTest() {
     @Mock
-    private lateinit var selectedSiteRepository:
-        SelectedSiteRepository
-
-    @Mock
-    private lateinit var statsInsightsUseCase:
-        StatsInsightsUseCase
-
-    @Mock
     private lateinit var resourceProvider:
         ResourceProvider
 
     private lateinit var viewModel: YearInReviewViewModel
 
-    private val testSite = SiteModel().apply {
-        id = 1
-        siteId = TEST_SITE_ID
-        name = "Test Site"
-    }
+    private var retryCalled = false
+
+    private val onRetry = { retryCalled = true }
 
     @Before
     fun setUp() {
-        whenever(
-            selectedSiteRepository.getSelectedSite()
-        ).thenReturn(testSite)
-        whenever(
-            resourceProvider.getString(
-                R.string.stats_error_no_site
-            )
-        ).thenReturn(NO_SITE_SELECTED_ERROR)
         whenever(
             resourceProvider.getString(
                 R.string.stats_error_api
             )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
-        whenever(
-            resourceProvider.getString(
-                R.string.stats_error_unknown
-            )
-        ).thenReturn(UNKNOWN_ERROR)
-    }
-
-    private fun initViewModel() {
         viewModel = YearInReviewViewModel(
-            selectedSiteRepository,
-            statsInsightsUseCase,
             resourceProvider
         )
-        viewModel.loadData()
+        retryCalled = false
     }
 
     @Test
-    fun `when no site selected, then error state is emitted`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
+    fun `initial state is Loading`() {
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                YearInReviewCardUiState
+                    .Loading::class.java
             )
-            assertThat(
-                (state as YearInReviewCardUiState.Error)
-                    .message
-            ).isEqualTo(NO_SITE_SELECTED_ERROR)
-        }
+    }
 
     @Test
-    fun `when data loads successfully, then loaded state is emitted`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
+    fun `when handleResult with success, then loaded state is emitted`() {
+        viewModel.handleResult(
+            createSuccessResult(),
+            onRetry = onRetry
+        )
 
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Loaded::class.java
-            )
-            with(
-                state as YearInReviewCardUiState.Loaded
-            ) {
-                assertThat(years).hasSize(3)
-                assertThat(years[0].year)
-                    .isEqualTo(CURRENT_YEAR)
-                assertThat(years[1].year)
-                    .isEqualTo("2025")
-                assertThat(years[1].totalPosts)
-                    .isEqualTo(TEST_TOTAL_POSTS)
-                assertThat(years[1].totalWords)
-                    .isEqualTo(TEST_TOTAL_WORDS)
-                assertThat(years[1].totalLikes)
-                    .isEqualTo(TEST_TOTAL_LIKES)
-                assertThat(years[1].totalComments)
-                    .isEqualTo(TEST_TOTAL_COMMENTS)
-            }
-        }
-
-    @Test
-    fun `when fetch fails with error, then error state is emitted`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(
-                    InsightsResult.Error("Network error")
-                )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error)
-                    .message
-            ).isEqualTo(FAILED_TO_LOAD_ERROR)
-        }
-
-    @Test
-    fun `when exception is thrown during fetch, then error state is emitted`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenThrow(
-                    RuntimeException("Test exception")
-                )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error)
-                    .message
-            ).isEqualTo(UNKNOWN_ERROR)
-        }
-
-    @Test
-    fun `when exception with null message, then unknown error message`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenThrow(RuntimeException())
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error)
-                    .message
-            ).isEqualTo(UNKNOWN_ERROR)
-        }
-
-    @Test
-    fun `when onRetry is called, then data is reloaded`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            initViewModel()
-            advanceUntilIdle()
-
-            viewModel.onRetry()
-            advanceUntilIdle()
-
-            verify(statsInsightsUseCase, times(2))
-                .invoke(eq(TEST_SITE_ID), any())
-        }
-
-    @Test
-    fun `when refresh is called, then isRefreshing becomes true then false`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            initViewModel()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            assertThat(viewModel.isRefreshing.value)
-                .isFalse()
-        }
-
-    @Test
-    fun `when refresh is called, then data is fetched`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            initViewModel()
-            advanceUntilIdle()
-
-            viewModel.refresh()
-            advanceUntilIdle()
-
-            verify(statsInsightsUseCase, times(2))
-                .invoke(eq(TEST_SITE_ID), any())
-        }
-
-    @Test
-    fun `when use case returns auth error, then error state is emitted`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(
-                    InsightsResult.Error(
-                        "No access token"
-                    )
-                )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error)
-                    .message
-            ).isEqualTo(FAILED_TO_LOAD_ERROR)
-        }
-
-    @Test
-    fun `when loadDataIfNeeded is called multiple times, then data is only loaded once`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            viewModel = YearInReviewViewModel(
-                selectedSiteRepository,
-                statsInsightsUseCase,
-                resourceProvider
-            )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            verify(statsInsightsUseCase, times(1))
-                .invoke(eq(TEST_SITE_ID), any())
-        }
-
-    @Test
-    fun `when error state retry is clicked, then data is reloaded`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val errorState = viewModel.uiState.value
-                as YearInReviewCardUiState.Error
-
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(testSite)
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            errorState.onRetry()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    YearInReviewCardUiState
-                        .Loaded::class.java
-                )
-        }
-
-    @Test
-    fun `when data loads with empty years, then current year is added`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        data = createTestInsightsData(
-                            emptyList()
-                        )
-                    )
-                )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-                as YearInReviewCardUiState.Loaded
-            assertThat(state.years).hasSize(1)
-            assertThat(state.years[0].year)
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            YearInReviewCardUiState.Loaded::class.java
+        )
+        with(
+            state as YearInReviewCardUiState.Loaded
+        ) {
+            assertThat(years).hasSize(3)
+            assertThat(years[0].year)
                 .isEqualTo(CURRENT_YEAR)
-            assertThat(state.years[0].totalPosts)
-                .isEqualTo(0L)
-        }
-
-    @Test
-    fun `when current year exists in data, then no duplicate is added`() =
-        test {
-            val yearsWithCurrent = listOf(
-                YearInsightsData(
-                    year = CURRENT_YEAR,
-                    totalPosts = TEST_TOTAL_POSTS,
-                    totalWords = TEST_TOTAL_WORDS,
-                    avgWords = TEST_AVG_WORDS,
-                    totalLikes = TEST_TOTAL_LIKES,
-                    avgLikes = TEST_AVG_LIKES,
-                    totalComments = TEST_TOTAL_COMMENTS,
-                    avgComments = TEST_AVG_COMMENTS
-                )
-            )
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        data = createTestInsightsData(
-                            yearsWithCurrent
-                        )
-                    )
-                )
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val state = viewModel.uiState.value
-                as YearInReviewCardUiState.Loaded
-            assertThat(state.years).hasSize(1)
-            assertThat(state.years[0].year)
-                .isEqualTo(CURRENT_YEAR)
-            assertThat(state.years[0].totalPosts)
-                .isEqualTo(TEST_TOTAL_POSTS)
-        }
-
-    @Test
-    fun `when state is loaded, then getDetailData returns years`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            initViewModel()
-            advanceUntilIdle()
-
-            val detailData = viewModel.getDetailData()
-            assertThat(detailData).hasSize(3)
-            assertThat(detailData[0].year)
-                .isEqualTo(CURRENT_YEAR)
-            assertThat(detailData[1].year)
+            assertThat(years[1].year)
                 .isEqualTo("2025")
-            assertThat(detailData[1].totalPosts)
+            assertThat(years[1].totalPosts)
                 .isEqualTo(TEST_TOTAL_POSTS)
-            assertThat(detailData[2].year)
-                .isEqualTo("2024")
+            assertThat(years[1].totalWords)
+                .isEqualTo(TEST_TOTAL_WORDS)
+            assertThat(years[1].totalLikes)
+                .isEqualTo(TEST_TOTAL_LIKES)
+            assertThat(years[1].totalComments)
+                .isEqualTo(TEST_TOTAL_COMMENTS)
         }
+    }
 
     @Test
-    fun `when state is loading, then getDetailData returns empty list`() =
-        test {
-            viewModel = YearInReviewViewModel(
-                selectedSiteRepository,
-                statsInsightsUseCase,
-                resourceProvider
+    fun `when handleResult with error, then error state is emitted`() {
+        viewModel.handleResult(
+            InsightsResult.Error("Network error"),
+            onRetry = onRetry
+        )
+
+        val state = viewModel.uiState.value
+        assertThat(state).isInstanceOf(
+            YearInReviewCardUiState.Error::class.java
+        )
+        assertThat(
+            (state as YearInReviewCardUiState.Error)
+                .message
+        ).isEqualTo(FAILED_TO_LOAD_ERROR)
+    }
+
+    @Test
+    fun `when error state retry is clicked, then onRetry is invoked`() {
+        viewModel.handleResult(
+            InsightsResult.Error("error"),
+            onRetry = onRetry
+        )
+
+        val errorState = viewModel.uiState.value
+            as YearInReviewCardUiState.Error
+        errorState.onRetry()
+
+        assertThat(retryCalled).isTrue()
+    }
+
+    @Test
+    fun `when showLoading called, then loading state`() {
+        viewModel.handleResult(
+            createSuccessResult(),
+            onRetry = onRetry
+        )
+        viewModel.showLoading()
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                YearInReviewCardUiState
+                    .Loading::class.java
             )
-
-            val detailData = viewModel.getDetailData()
-            assertThat(detailData).isEmpty()
-        }
+    }
 
     @Test
-    fun `when state is error, then getDetailData returns empty list`() =
-        test {
-            whenever(
-                selectedSiteRepository.getSelectedSite()
-            ).thenReturn(null)
-
-            initViewModel()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    YearInReviewCardUiState
-                        .Error::class.java
+    fun `when data loads with empty years, then current year is added`() {
+        viewModel.handleResult(
+            InsightsResult.Success(
+                data = createTestInsightsData(
+                    emptyList()
                 )
-            val detailData = viewModel.getDetailData()
-            assertThat(detailData).isEmpty()
-        }
+            ),
+            onRetry = onRetry
+        )
+
+        val state = viewModel.uiState.value
+            as YearInReviewCardUiState.Loaded
+        assertThat(state.years).hasSize(1)
+        assertThat(state.years[0].year)
+            .isEqualTo(CURRENT_YEAR)
+        assertThat(state.years[0].totalPosts)
+            .isEqualTo(0L)
+    }
 
     @Test
-    fun `when refresh fails after success, then loadDataIfNeeded reloads`() =
-        test {
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-
-            viewModel = YearInReviewViewModel(
-                selectedSiteRepository,
-                statsInsightsUseCase,
-                resourceProvider
+    fun `when current year exists in data, then no duplicate is added`() {
+        val yearsWithCurrent = listOf(
+            YearInsightsData(
+                year = CURRENT_YEAR,
+                totalPosts = TEST_TOTAL_POSTS,
+                totalWords = TEST_TOTAL_WORDS,
+                avgWords = TEST_AVG_WORDS,
+                totalLikes = TEST_TOTAL_LIKES,
+                avgLikes = TEST_AVG_LIKES,
+                totalComments = TEST_TOTAL_COMMENTS,
+                avgComments = TEST_AVG_COMMENTS
             )
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
-
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    YearInReviewCardUiState
-                        .Loaded::class.java
+        )
+        viewModel.handleResult(
+            InsightsResult.Success(
+                data = createTestInsightsData(
+                    yearsWithCurrent
                 )
+            ),
+            onRetry = onRetry
+        )
 
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(
-                    InsightsResult.Error("Network error")
-                )
-            viewModel.refresh()
-            advanceUntilIdle()
+        val state = viewModel.uiState.value
+            as YearInReviewCardUiState.Loaded
+        assertThat(state.years).hasSize(1)
+        assertThat(state.years[0].year)
+            .isEqualTo(CURRENT_YEAR)
+        assertThat(state.years[0].totalPosts)
+            .isEqualTo(TEST_TOTAL_POSTS)
+    }
 
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    YearInReviewCardUiState
-                        .Error::class.java
-                )
+    @Test
+    fun `when state is loaded, then getDetailData returns years`() {
+        viewModel.handleResult(
+            createSuccessResult(),
+            onRetry = onRetry
+        )
 
-            whenever(statsInsightsUseCase(any(), any()))
-                .thenReturn(createSuccessResult())
-            viewModel.loadDataIfNeeded()
-            advanceUntilIdle()
+        val detailData = viewModel.getDetailData()
+        assertThat(detailData).hasSize(3)
+        assertThat(detailData[0].year)
+            .isEqualTo(CURRENT_YEAR)
+        assertThat(detailData[1].year)
+            .isEqualTo("2025")
+        assertThat(detailData[1].totalPosts)
+            .isEqualTo(TEST_TOTAL_POSTS)
+        assertThat(detailData[2].year)
+            .isEqualTo("2024")
+    }
 
-            assertThat(viewModel.uiState.value)
-                .isInstanceOf(
-                    YearInReviewCardUiState
-                        .Loaded::class.java
-                )
-            verify(statsInsightsUseCase, times(3))
-                .invoke(eq(TEST_SITE_ID), any())
-        }
+    @Test
+    fun `when state is loading, then getDetailData returns empty list`() {
+        val detailData = viewModel.getDetailData()
+        assertThat(detailData).isEmpty()
+    }
+
+    @Test
+    fun `when state is error, then getDetailData returns empty list`() {
+        viewModel.handleResult(
+            InsightsResult.Error("error"),
+            onRetry = onRetry
+        )
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(
+                YearInReviewCardUiState
+                    .Error::class.java
+            )
+        val detailData = viewModel.getDetailData()
+        assertThat(detailData).isEmpty()
+    }
 
     private fun createSuccessResult() =
         InsightsResult.Success(
@@ -515,7 +258,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     )
 
     companion object {
-        private const val TEST_SITE_ID = 123L
         private const val TEST_TOTAL_POSTS = 42L
         private const val TEST_TOTAL_WORDS = 15000L
         private const val TEST_AVG_WORDS = 357.1
@@ -523,12 +265,8 @@ class YearInReviewViewModelTest : BaseUnitTest() {
         private const val TEST_AVG_LIKES = 5.5
         private const val TEST_TOTAL_COMMENTS = 85L
         private const val TEST_AVG_COMMENTS = 2.0
-        private const val NO_SITE_SELECTED_ERROR =
-            "No site selected"
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
-        private const val UNKNOWN_ERROR =
-            "Unknown error"
         private val CURRENT_YEAR =
             Year.now().toString()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewViewModelTest.kt
@@ -13,27 +13,27 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.newstats.datasource.StatsInsightsData
 import org.wordpress.android.ui.newstats.datasource.YearInsightsData
 import org.wordpress.android.ui.newstats.repository.InsightsResult
-import org.wordpress.android.ui.newstats.repository.StatsRepository
+import org.wordpress.android.ui.newstats.repository.StatsInsightsUseCase
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.time.Year
 
 @ExperimentalCoroutinesApi
 class YearInReviewViewModelTest : BaseUnitTest() {
     @Mock
-    private lateinit var selectedSiteRepository: SelectedSiteRepository
+    private lateinit var selectedSiteRepository:
+        SelectedSiteRepository
 
     @Mock
-    private lateinit var accountStore: AccountStore
+    private lateinit var statsInsightsUseCase:
+        StatsInsightsUseCase
 
     @Mock
-    private lateinit var statsRepository: StatsRepository
-
-    @Mock
-    private lateinit var resourceProvider: ResourceProvider
+    private lateinit var resourceProvider:
+        ResourceProvider
 
     private lateinit var viewModel: YearInReviewViewModel
 
@@ -45,26 +45,30 @@ class YearInReviewViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        whenever(selectedSiteRepository.getSelectedSite())
-            .thenReturn(testSite)
-        whenever(accountStore.accessToken)
-            .thenReturn(TEST_ACCESS_TOKEN)
         whenever(
-            resourceProvider.getString(R.string.stats_error_no_site)
+            selectedSiteRepository.getSelectedSite()
+        ).thenReturn(testSite)
+        whenever(
+            resourceProvider.getString(
+                R.string.stats_error_no_site
+            )
         ).thenReturn(NO_SITE_SELECTED_ERROR)
         whenever(
-            resourceProvider.getString(R.string.stats_error_api)
+            resourceProvider.getString(
+                R.string.stats_error_api
+            )
         ).thenReturn(FAILED_TO_LOAD_ERROR)
         whenever(
-            resourceProvider.getString(R.string.stats_error_unknown)
+            resourceProvider.getString(
+                R.string.stats_error_unknown
+            )
         ).thenReturn(UNKNOWN_ERROR)
     }
 
     private fun initViewModel() {
         viewModel = YearInReviewViewModel(
             selectedSiteRepository,
-            accountStore,
-            statsRepository,
+            statsInsightsUseCase,
             resourceProvider
         )
         viewModel.loadData()
@@ -73,8 +77,9 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     @Test
     fun `when no site selected, then error state is emitted`() =
         test {
-            whenever(selectedSiteRepository.getSelectedSite())
-                .thenReturn(null)
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
 
             initViewModel()
             advanceUntilIdle()
@@ -84,19 +89,16 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                 YearInReviewCardUiState.Error::class.java
             )
             assertThat(
-                (state as YearInReviewCardUiState.Error).message
+                (state as YearInReviewCardUiState.Error)
+                    .message
             ).isEqualTo(NO_SITE_SELECTED_ERROR)
         }
 
     @Test
     fun `when data loads successfully, then loaded state is emitted`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             initViewModel()
             advanceUntilIdle()
@@ -105,11 +107,14 @@ class YearInReviewViewModelTest : BaseUnitTest() {
             assertThat(state).isInstanceOf(
                 YearInReviewCardUiState.Loaded::class.java
             )
-            with(state as YearInReviewCardUiState.Loaded) {
+            with(
+                state as YearInReviewCardUiState.Loaded
+            ) {
                 assertThat(years).hasSize(3)
                 assertThat(years[0].year)
                     .isEqualTo(CURRENT_YEAR)
-                assertThat(years[1].year).isEqualTo("2025")
+                assertThat(years[1].year)
+                    .isEqualTo("2025")
                 assertThat(years[1].totalPosts)
                     .isEqualTo(TEST_TOTAL_POSTS)
                 assertThat(years[1].totalWords)
@@ -124,8 +129,10 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     @Test
     fun `when fetch fails with error, then error state is emitted`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(InsightsResult.Error("Network error"))
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(
+                    InsightsResult.Error("Network error")
+                )
 
             initViewModel()
             advanceUntilIdle()
@@ -135,15 +142,18 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                 YearInReviewCardUiState.Error::class.java
             )
             assertThat(
-                (state as YearInReviewCardUiState.Error).message
+                (state as YearInReviewCardUiState.Error)
+                    .message
             ).isEqualTo(FAILED_TO_LOAD_ERROR)
         }
 
     @Test
     fun `when exception is thrown during fetch, then error state is emitted`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenThrow(RuntimeException("Test exception"))
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenThrow(
+                    RuntimeException("Test exception")
+                )
 
             initViewModel()
             advanceUntilIdle()
@@ -153,14 +163,15 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                 YearInReviewCardUiState.Error::class.java
             )
             assertThat(
-                (state as YearInReviewCardUiState.Error).message
+                (state as YearInReviewCardUiState.Error)
+                    .message
             ).isEqualTo(UNKNOWN_ERROR)
         }
 
     @Test
     fun `when exception with null message, then unknown error message`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
+            whenever(statsInsightsUseCase(any(), any()))
                 .thenThrow(RuntimeException())
 
             initViewModel()
@@ -171,133 +182,94 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                 YearInReviewCardUiState.Error::class.java
             )
             assertThat(
-                (state as YearInReviewCardUiState.Error).message
+                (state as YearInReviewCardUiState.Error)
+                    .message
             ).isEqualTo(UNKNOWN_ERROR)
         }
 
     @Test
-    fun `when onRetry is called, then data is reloaded`() = test {
-        whenever(statsRepository.fetchInsights(any()))
-            .thenReturn(
-                InsightsResult.Success(
-                    years = createTestYears()
-                )
-            )
+    fun `when onRetry is called, then data is reloaded`() =
+        test {
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
-        initViewModel()
-        advanceUntilIdle()
+            initViewModel()
+            advanceUntilIdle()
 
-        viewModel.onRetry()
-        advanceUntilIdle()
+            viewModel.onRetry()
+            advanceUntilIdle()
 
-        verify(statsRepository, times(2))
-            .fetchInsights(eq(TEST_SITE_ID))
-    }
+            verify(statsInsightsUseCase, times(2))
+                .invoke(eq(TEST_SITE_ID), any())
+        }
 
     @Test
     fun `when refresh is called, then isRefreshing becomes true then false`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             initViewModel()
             advanceUntilIdle()
 
-            assertThat(viewModel.isRefreshing.value).isFalse()
+            assertThat(viewModel.isRefreshing.value)
+                .isFalse()
 
             viewModel.refresh()
             advanceUntilIdle()
 
-            assertThat(viewModel.isRefreshing.value).isFalse()
+            assertThat(viewModel.isRefreshing.value)
+                .isFalse()
         }
 
     @Test
-    fun `when refresh is called, then data is fetched`() = test {
-        whenever(statsRepository.fetchInsights(any()))
-            .thenReturn(
-                InsightsResult.Success(
-                    years = createTestYears()
-                )
-            )
-
-        initViewModel()
-        advanceUntilIdle()
-
-        viewModel.refresh()
-        advanceUntilIdle()
-
-        verify(statsRepository, times(2))
-            .fetchInsights(eq(TEST_SITE_ID))
-    }
-
-    @Test
-    fun `when access token is null, then error state is emitted`() =
+    fun `when refresh is called, then data is fetched`() =
         test {
-            whenever(accountStore.accessToken).thenReturn(null)
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             initViewModel()
             advanceUntilIdle()
 
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error).message
-            ).isEqualTo(FAILED_TO_LOAD_ERROR)
-        }
-
-    @Test
-    fun `when access token is empty, then error state is emitted`() =
-        test {
-            whenever(accountStore.accessToken).thenReturn("")
-
-            initViewModel()
+            viewModel.refresh()
             advanceUntilIdle()
 
-            val state = viewModel.uiState.value
-            assertThat(state).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-            assertThat(
-                (state as YearInReviewCardUiState.Error).message
-            ).isEqualTo(FAILED_TO_LOAD_ERROR)
+            verify(statsInsightsUseCase, times(2))
+                .invoke(eq(TEST_SITE_ID), any())
         }
 
     @Test
-    fun `when loadData is called, then repository is initialized with access token`() =
+    fun `when use case returns auth error, then error state is emitted`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
+            whenever(statsInsightsUseCase(any(), any()))
                 .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
+                    InsightsResult.Error(
+                        "No access token"
                     )
                 )
 
             initViewModel()
             advanceUntilIdle()
 
-            verify(statsRepository).init(eq(TEST_ACCESS_TOKEN))
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(
+                YearInReviewCardUiState.Error::class.java
+            )
+            assertThat(
+                (state as YearInReviewCardUiState.Error)
+                    .message
+            ).isEqualTo(FAILED_TO_LOAD_ERROR)
         }
 
     @Test
     fun `when loadDataIfNeeded is called multiple times, then data is only loaded once`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             viewModel = YearInReviewViewModel(
                 selectedSiteRepository,
-                accountStore,
-                statsRepository,
+                statsInsightsUseCase,
                 resourceProvider
             )
             viewModel.loadDataIfNeeded()
@@ -309,53 +281,56 @@ class YearInReviewViewModelTest : BaseUnitTest() {
             viewModel.loadDataIfNeeded()
             advanceUntilIdle()
 
-            verify(statsRepository, times(1))
-                .fetchInsights(eq(TEST_SITE_ID))
+            verify(statsInsightsUseCase, times(1))
+                .invoke(eq(TEST_SITE_ID), any())
         }
 
     @Test
     fun `when error state retry is clicked, then data is reloaded`() =
         test {
-            whenever(selectedSiteRepository.getSelectedSite())
-                .thenReturn(null)
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
 
             initViewModel()
             advanceUntilIdle()
 
-            val errorState =
-                viewModel.uiState.value as YearInReviewCardUiState.Error
+            val errorState = viewModel.uiState.value
+                as YearInReviewCardUiState.Error
 
-            whenever(selectedSiteRepository.getSelectedSite())
-                .thenReturn(testSite)
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(testSite)
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             errorState.onRetry()
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value).isInstanceOf(
-                YearInReviewCardUiState.Loaded::class.java
-            )
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    YearInReviewCardUiState
+                        .Loaded::class.java
+                )
         }
 
     @Test
     fun `when data loads with empty years, then current year is added`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
+            whenever(statsInsightsUseCase(any(), any()))
                 .thenReturn(
-                    InsightsResult.Success(years = emptyList())
+                    InsightsResult.Success(
+                        data = createTestInsightsData(
+                            emptyList()
+                        )
+                    )
                 )
 
             initViewModel()
             advanceUntilIdle()
 
-            val state =
-                viewModel.uiState.value
-                    as YearInReviewCardUiState.Loaded
+            val state = viewModel.uiState.value
+                as YearInReviewCardUiState.Loaded
             assertThat(state.years).hasSize(1)
             assertThat(state.years[0].year)
                 .isEqualTo(CURRENT_YEAR)
@@ -378,19 +353,20 @@ class YearInReviewViewModelTest : BaseUnitTest() {
                     avgComments = TEST_AVG_COMMENTS
                 )
             )
-            whenever(statsRepository.fetchInsights(any()))
+            whenever(statsInsightsUseCase(any(), any()))
                 .thenReturn(
                     InsightsResult.Success(
-                        years = yearsWithCurrent
+                        data = createTestInsightsData(
+                            yearsWithCurrent
+                        )
                     )
                 )
 
             initViewModel()
             advanceUntilIdle()
 
-            val state =
-                viewModel.uiState.value
-                    as YearInReviewCardUiState.Loaded
+            val state = viewModel.uiState.value
+                as YearInReviewCardUiState.Loaded
             assertThat(state.years).hasSize(1)
             assertThat(state.years[0].year)
                 .isEqualTo(CURRENT_YEAR)
@@ -401,12 +377,8 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     @Test
     fun `when state is loaded, then getDetailData returns years`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             initViewModel()
             advanceUntilIdle()
@@ -415,10 +387,12 @@ class YearInReviewViewModelTest : BaseUnitTest() {
             assertThat(detailData).hasSize(3)
             assertThat(detailData[0].year)
                 .isEqualTo(CURRENT_YEAR)
-            assertThat(detailData[1].year).isEqualTo("2025")
+            assertThat(detailData[1].year)
+                .isEqualTo("2025")
             assertThat(detailData[1].totalPosts)
                 .isEqualTo(TEST_TOTAL_POSTS)
-            assertThat(detailData[2].year).isEqualTo("2024")
+            assertThat(detailData[2].year)
+                .isEqualTo("2024")
         }
 
     @Test
@@ -426,8 +400,7 @@ class YearInReviewViewModelTest : BaseUnitTest() {
         test {
             viewModel = YearInReviewViewModel(
                 selectedSiteRepository,
-                accountStore,
-                statsRepository,
+                statsInsightsUseCase,
                 resourceProvider
             )
 
@@ -438,15 +411,18 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     @Test
     fun `when state is error, then getDetailData returns empty list`() =
         test {
-            whenever(selectedSiteRepository.getSelectedSite())
-                .thenReturn(null)
+            whenever(
+                selectedSiteRepository.getSelectedSite()
+            ).thenReturn(null)
 
             initViewModel()
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    YearInReviewCardUiState
+                        .Error::class.java
+                )
             val detailData = viewModel.getDetailData()
             assertThat(detailData).isEmpty()
         }
@@ -454,50 +430,66 @@ class YearInReviewViewModelTest : BaseUnitTest() {
     @Test
     fun `when refresh fails after success, then loadDataIfNeeded reloads`() =
         test {
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
-                )
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
 
             viewModel = YearInReviewViewModel(
                 selectedSiteRepository,
-                accountStore,
-                statsRepository,
+                statsInsightsUseCase,
                 resourceProvider
             )
             viewModel.loadDataIfNeeded()
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value).isInstanceOf(
-                YearInReviewCardUiState.Loaded::class.java
-            )
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    YearInReviewCardUiState
+                        .Loaded::class.java
+                )
 
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(InsightsResult.Error("Network error"))
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(
+                    InsightsResult.Error("Network error")
+                )
             viewModel.refresh()
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value).isInstanceOf(
-                YearInReviewCardUiState.Error::class.java
-            )
-
-            whenever(statsRepository.fetchInsights(any()))
-                .thenReturn(
-                    InsightsResult.Success(
-                        years = createTestYears()
-                    )
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    YearInReviewCardUiState
+                        .Error::class.java
                 )
+
+            whenever(statsInsightsUseCase(any(), any()))
+                .thenReturn(createSuccessResult())
             viewModel.loadDataIfNeeded()
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value).isInstanceOf(
-                YearInReviewCardUiState.Loaded::class.java
-            )
-            verify(statsRepository, times(3))
-                .fetchInsights(eq(TEST_SITE_ID))
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(
+                    YearInReviewCardUiState
+                        .Loaded::class.java
+                )
+            verify(statsInsightsUseCase, times(3))
+                .invoke(eq(TEST_SITE_ID), any())
         }
+
+    private fun createSuccessResult() =
+        InsightsResult.Success(
+            data = createTestInsightsData(
+                createTestYears()
+            )
+        )
+
+    private fun createTestInsightsData(
+        years: List<YearInsightsData>
+    ) = StatsInsightsData(
+        highestHour = 14,
+        highestHourPercent = 15.5,
+        highestDayOfWeek = 3,
+        highestDayPercent = 25.0,
+        years = years
+    )
 
     private fun createTestYears() = listOf(
         YearInsightsData(
@@ -524,7 +516,6 @@ class YearInReviewViewModelTest : BaseUnitTest() {
 
     companion object {
         private const val TEST_SITE_ID = 123L
-        private const val TEST_ACCESS_TOKEN = "test_access_token"
         private const val TEST_TOTAL_POSTS = 42L
         private const val TEST_TOTAL_WORDS = 15000L
         private const val TEST_AVG_WORDS = 357.1
@@ -536,7 +527,8 @@ class YearInReviewViewModelTest : BaseUnitTest() {
             "No site selected"
         private const val FAILED_TO_LOAD_ERROR =
             "Failed to load stats"
-        private const val UNKNOWN_ERROR = "Unknown error"
+        private const val UNKNOWN_ERROR =
+            "Unknown error"
         private val CURRENT_YEAR =
             Year.now().toString()
     }


### PR DESCRIPTION
## Description

Adds a new "Most Popular Time" insights card that displays the best day-of-week and best hour for site views, with percentages. Also centralizes data fetching at the `InsightsViewModel` level so both API endpoints (stats summary + insights) are fetched once and distributed to card ViewModels via `SharedFlow`, eliminating redundant network calls.

**New feature:**
- `MostPopularTimeCard` (Compose) with Loading, Loaded, NoData, and Error states
- `MostPopularTimeViewModel` with locale-aware hour formatting and WordPress API day-of-week mapping
- `StatsInsightsUseCase` with mutex-based caching (matching existing `StatsSummaryUseCase` pattern)

**Architecture refactor:**
- `InsightsViewModel` fetches data once and broadcasts results via `SharedFlow`
- Card ViewModels (`AllTimeStats`, `MostPopularDay`, `MostPopularTime`, `YearInReview`) simplified to passive result handlers with `handleResult()` / `showLoading()`
- Consistent `onRetry` pattern across all cards (passed as composable parameter)

**Cleanup:**
- Bounds checking on `formatHour` and `formatDayOfWeek` for invalid API values
- Removed duplicate string resource
- Fixed race condition in `refreshData()` concurrent access guard

## Testing instructions

Most Popular Time card:

1. Open the new Stats screen → Insights tab
2. Scroll to the "Most popular time" card
- [x] Verify it shows the best day and best hour with percentage of views
- [ ] Verify the hour is formatted according to the device locale (12h/24h)
3. Pull to refresh
- [x] Verify all cards reload together (single fetch, no duplicate network calls)

<img width="221" height="153" alt="Screenshot 2026-03-12 at 15 32 20" src="https://github.com/user-attachments/assets/7b986e66-603c-4892-acc9-1f15a6f887e4" />

