### PR TITLE
Improve application password storing error logs for debugging

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -63,6 +63,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             if (rawData.isEmpty()) {
                 appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
+                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -120,6 +121,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    siteUrl, "empty_fetch_params"
+                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -139,6 +143,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                siteUrl, "fetch_sites_exception"
             )
             emitErrorFetching(siteUrl)
         }
@@ -173,6 +180,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                                     .siteHasBadCredentials(it)
                             }
                         }"
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 _onFinishedEvent.emit(
                     NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -62,7 +62,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     fun setupSite(rawData: String) {
         viewModelScope.launch {
             if (rawData.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "Cannot store credentials: rawData is empty")
+                appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -95,7 +95,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         try {
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.stackTraceToString()}")
+            appLogWrapper.e(
+                AppLog.T.DB,
+                "A_P: Error storing credentials: ${e.stackTraceToString()}"
+            )
             false
         }
     }
@@ -109,9 +112,14 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         ) = withContext(ioDispatcher) {
         try {
             if (username.isEmpty() || password.isEmpty() || siteUrl.isEmpty() || apiRootUrl.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "Cannot fetch sites for credential storing: " +
-                        "Username: $username, Password: ${password.isEmpty()}, SiteUrl: $siteUrl, " +
-                        "API Root URL: $apiRootUrl")
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: Cannot fetch sites for credential storing" +
+                        " - username isEmpty=${username.isEmpty()}" +
+                        ", password isEmpty=${password.isEmpty()}" +
+                        ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
+                        ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
+                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -128,7 +136,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.stackTraceToString()}")
+            appLogWrapper.e(
+                AppLog.T.API,
+                "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
             emitErrorFetching(siteUrl)
         }
     }
@@ -150,7 +161,19 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
             if (event.rowsAffected < 1 || site == null || applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
-                appLogWrapper.e(AppLog.T.MAIN, "Site not found or credentials are empty.")
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed" +
+                        " for: ${currentUrlLogin?.siteUrl}" +
+                        " - rowsAffected=${event.rowsAffected}" +
+                        ", siteFound=${site != null}" +
+                        ", badCredentials=${
+                            site?.let {
+                                applicationPasswordLoginHelper
+                                    .siteHasBadCredentials(it)
+                            }
+                        }"
+                )
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -63,7 +63,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             if (rawData.isEmpty()) {
                 appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
-                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -121,9 +120,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    siteUrl, "empty_fetch_params"
-                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -143,9 +139,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
-            )
-            applicationPasswordLoginHelper.trackStoringFailed(
-                siteUrl, "fetch_sites_exception"
             )
             emitErrorFetching(siteUrl)
         }
@@ -180,10 +173,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                                     .siteHasBadCredentials(it)
                             }
                         }"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
                 )
                 _onFinishedEvent.emit(
                     NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -121,16 +121,13 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                val availableSiteUrls = siteStore.sites.map {
-                    UrlUtils.normalizeUrl(it.url)
-                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store." +
-                        " Available sites: $availableSiteUrls"
+                        " - site not found in store" +
+                        " (${siteStore.sites.size} sites available)"
                 )
                 false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -15,7 +14,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -24,7 +22,6 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
-private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -35,8 +32,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
-    private val crashLogging: CrashLogging
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -104,7 +100,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
-            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -126,34 +121,20 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
+                val availableSiteUrls = siteStore.sites.map {
+                    UrlUtils.normalizeUrl(it.url)
+                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store" +
-                        " (${siteStore.sites.size} sites available)"
+                        " - site not found in store." +
+                        " Available sites: $availableSiteUrls"
                 )
-                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
-    }
-
-    fun trackStoringFailed(siteUrl: String?, reason: String) {
-        val properties: MutableMap<String, String?> = HashMap()
-        properties[URL_TAG] = siteUrl
-        properties[REASON_TAG] = reason
-        AnalyticsTracker.track(
-            Stat.APPLICATION_PASSWORD_STORING_FAILED,
-            properties
-        )
-        crashLogging.sendReportWithTag(
-            exception = Exception(
-                "A_P: storing failed for $siteUrl - $reason"
-            ),
-            tag = AppLog.T.DB
-        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -14,6 +15,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -22,6 +24,7 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
+private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -32,7 +35,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -100,6 +104,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
+            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -121,20 +126,34 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                val availableSiteUrls = siteStore.sites.map {
-                    UrlUtils.normalizeUrl(it.url)
-                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store." +
-                        " Available sites: $availableSiteUrls"
+                        " - site not found in store" +
+                        " (${siteStore.sites.size} sites available)"
                 )
+                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
+    }
+
+    fun trackStoringFailed(siteUrl: String?, reason: String) {
+        val properties: MutableMap<String, String?> = HashMap()
+        properties[URL_TAG] = siteUrl
+        properties[REASON_TAG] = reason
+        AnalyticsTracker.track(
+            Stat.APPLICATION_PASSWORD_STORING_FAILED,
+            properties
+        )
+        crashLogging.sendReportWithTag(
+            exception = Exception(
+                "A_P: storing failed for $siteUrl - $reason"
+            ),
+            tag = AppLog.T.DB
+        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -91,7 +91,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             ) {
             appLogWrapper.e(
                 AppLog.T.DB,
-                "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - bad data"
+                "A_P: Cannot save application password credentials" +
+                    " for: ${urlLogin.siteUrl}" +
+                    " - apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
+                    ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
+                    ", password isEmpty=${urlLogin.password.isNullOrEmpty()}" +
+                    ", siteUrl isNull=${urlLogin.siteUrl == null}" +
+                    ", alreadyProcessed=" +
+                    "${urlLogin.siteUrl == processedAppPasswordData}"
             )
             return false
         }
@@ -114,9 +121,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
+                val availableSiteUrls = siteStore.sites.map {
+                    UrlUtils.normalizeUrl(it.url)
+                }
                 appLogWrapper.e(
                     AppLog.T.DB,
-                    "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - null site"
+                    "A_P: Cannot save application password" +
+                        " credentials for: ${urlLogin.siteUrl}" +
+                        " (normalized: $normalizedUrl)" +
+                        " - site not found in store." +
+                        " Available sites: $availableSiteUrls"
                 )
                 false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -93,7 +93,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                             AppLog.T.API,
                             "A_P: Error creating application password" +
                                 " for: ${site.url}" +
-                                " - response: $response"
+                                " - response type: ${response::class.simpleName}"
                         )
                         fallbackToManualLogin(site.url)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -89,12 +89,22 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
 
                     else -> {
-                        appLogWrapper.e(AppLog.T.API, "Error creating application password")
+                        appLogWrapper.e(
+                            AppLog.T.API,
+                            "A_P: Error creating application password" +
+                                " for: ${site.url}" +
+                                " - response: $response"
+                        )
                         fallbackToManualLogin(site.url)
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(AppLog.T.API, "Exception creating application password: ${e.message}")
+                appLogWrapper.e(
+                    AppLog.T.API,
+                    "A_P: Exception creating application password" +
+                        " for: ${site.url}" +
+                        " - ${e.message}"
+                )
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false
@@ -115,7 +125,11 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             val authUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(siteUrl)
             _navigationEvent.emit(NavigationEvent.FallbackToManualLogin(authUrl))
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Failed to get authorization URL: ${e.message}")
+            appLogWrapper.e(
+                AppLog.T.API,
+                "A_P: Failed to get authorization URL" +
+                    " for: $siteUrl - ${e.message}"
+            )
             _navigationEvent.emit(NavigationEvent.Error)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -89,27 +89,24 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
 
                     else -> {
-                        appLogWrapper.e(
-                            AppLog.T.API,
-                            "A_P: Error creating application password" +
-                                " for: ${site.url}" +
-                                " - response type: ${response::class.simpleName}"
-                        )
+                        logCreationError(site.url, "response type: ${response::class.simpleName}")
                         fallbackToManualLogin(site.url)
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(
-                    AppLog.T.API,
-                    "A_P: Exception creating application password" +
-                        " for: ${site.url}" +
-                        " - ${e.message}"
-                )
+                logCreationError(site.url, e.message.orEmpty())
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false
             }
         }
+    }
+
+    private fun logCreationError(siteUrl: String, detail: String) {
+        appLogWrapper.e(
+            AppLog.T.API,
+            "A_P: Error creating application password for: $siteUrl - $detail"
+        )
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -64,9 +63,6 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
-    @Mock
-    lateinit var crashLogging: CrashLogging
-
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -81,8 +77,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper,
-            crashLogging
+            discoverSuccessWrapper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -63,6 +64,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -77,7 +81,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper
+            discoverSuccessWrapper,
+            crashLogging
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -150,7 +150,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore).sites
+            verify(siteStore, times(2)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1125,8 +1125,7 @@ public final class AnalyticsTracker {
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
         WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
         JP_ANDROID_APPLICATION_PASSWORD_LOGIN,
-        APPLICATION_PASSWORD_SET_OFF,
-        APPLICATION_PASSWORD_STORING_FAILED;
+        APPLICATION_PASSWORD_SET_OFF;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1125,7 +1125,8 @@ public final class AnalyticsTracker {
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
         WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
         JP_ANDROID_APPLICATION_PASSWORD_LOGIN,
-        APPLICATION_PASSWORD_SET_OFF;
+        APPLICATION_PASSWORD_SET_OFF,
+        APPLICATION_PASSWORD_STORING_FAILED;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.


### PR DESCRIPTION
## Description

Some users are seeing the "error storing application password credentials" toast. The existing error logs were too generic to diagnose the root cause from logs alone.

This PR improves logging across the application password login flow:

- Adds consistent `A_P:` prefix to all log messages for easy filtering
- Logs field-level boolean diagnostics (e.g., which field is null/empty) instead of generic "bad data" messages
- Logs normalized URL comparison details when site lookup fails, including available site URLs in the store
- Logs response type (class name only) for API failures instead of the full response object, to avoid potential credential exposure
- Removes a pre-existing log that was leaking the raw username value

Files changed:
- `ApplicationPasswordLoginHelper.kt`
- `ApplicationPasswordLoginViewModel.kt`
- `ApplicationPasswordAutoAuthDialogViewModel.kt`

## Testing instructions

Logging-only changes — no behavior changes.

