### PR TITLE
Update compileSdk and targetSdk to 36

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -236,7 +236,7 @@
 
         <activity
             android:name=".support.SupportWebViewActivity"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge" />
+            android:theme="@style/WordPress.NoActionBar" />
 
         <!-- empty title -->
 
@@ -304,7 +304,7 @@
             android:label="@string/edit_comment"/>
         <activity
             android:name=".ui.comments.CommentsDetailActivity"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="adjustResize"
             android:label="@string/comments"/>
         <activity
@@ -317,7 +317,7 @@
         <activity
             android:name=".ui.posts.EditPostActivity"
             android:configChanges="locale|orientation|screenSize"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">
             <meta-data
@@ -859,7 +859,7 @@
         <activity
             android:name=".ui.reader.ReaderCommentListActivity"
             android:label="@string/reader_title_comments"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="adjustResize|stateHidden" />
         <activity
             android:name=".ui.reader.NoSiteToReblogActivity"
@@ -873,7 +873,7 @@
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.reader.ReaderSubsActivity"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name=".ui.reader.ReaderPhotoViewerActivity"
@@ -957,7 +957,7 @@
         <!-- Notifications activities -->
         <activity
             android:name=".ui.notifications.NotificationsDetailActivity"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge" />
+            android:theme="@style/WordPress.NoActionBar" />
 
         <!--People Management-->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -1,12 +1,14 @@
 package org.wordpress.android
 
 import android.app.Application
+import android.os.Build
 import coil.decode.VideoFrameDecoder
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
 import okhttp3.OkHttpClient
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
 import org.wordpress.android.modules.AppComponent
+import org.wordpress.android.ui.main.EdgeToEdgeActivityLifecycleCallbacks
 
 /**
  * An abstract class to be extended by {@link WordPressApp} for real application and WordPressTest for UI test
@@ -14,6 +16,15 @@ import org.wordpress.android.modules.AppComponent
  */
 abstract class WordPress : Application(), coil.ImageLoaderFactory {
     abstract fun initializer(): AppInitializer
+
+    override fun onCreate() {
+        super.onCreate()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            registerActivityLifecycleCallbacks(
+                EdgeToEdgeActivityLifecycleCallbacks()
+            )
+        }
+    }
 
     fun component(): AppComponent = EntryPoints.get(this, AppComponent::class.java)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -162,6 +162,7 @@ class ActionableEmptyView : LinearLayout {
             subtitle.isVisible
         } ?: ""
 
+        @Suppress("DEPRECATION")
         announceForAccessibility("${title.text}.$subTitle")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1480,10 +1480,11 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
                     .OnNoteCommentLikeChanged(mNote, actionBinding.btnLike.isActivated()));
         }
 
-        actionBinding.btnLike.announceForAccessibility(
-                getText(actionBinding.btnLike.isActivated() ? R.string.comment_liked_talkback
-                        : R.string.comment_unliked_talkback)
-        );
+        @SuppressWarnings("deprecation")
+        CharSequence announcement = getText(actionBinding.btnLike.isActivated()
+                ? R.string.comment_liked_talkback
+                : R.string.comment_unliked_talkback);
+        actionBinding.btnLike.announceForAccessibility(announcement);
     }
 
     private void toggleLikeButton(
@@ -1667,6 +1668,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void announceCommentStatusChangeForAccessibility(CommentStatus newStatus) {
         int resId = -1;
         switch (newStatus) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -1,8 +1,3 @@
-/**
- * This suppression is so we can include deprecated activities (CommentsDetailActivity)
- */
-@file:Suppress("DEPRECATION")
-
 package org.wordpress.android.ui.main
 
 import android.os.Build
@@ -11,11 +6,9 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import org.wordpress.android.support.SupportWebViewActivity
 import org.wordpress.android.ui.accounts.applicationpassword.ApplicationPasswordsListActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListActivity
-import org.wordpress.android.ui.comments.CommentsDetailActivity
 import org.wordpress.android.ui.debug.preferences.DebugSharedPreferenceFlagsActivity
 import org.wordpress.android.ui.domains.management.DomainManagementActivity
 import org.wordpress.android.ui.domains.management.newdomainsearch.NewDomainSearchActivity
@@ -27,17 +20,13 @@ import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.navmenus.NavMenusActivity
-import org.wordpress.android.ui.notifications.NotificationsDetailActivity
-import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.GutenbergKitActivity
 import org.wordpress.android.ui.postsrs.PostRsListActivity
 import org.wordpress.android.ui.postsrs.PostRsSettingsActivity
 import org.wordpress.android.ui.postsrs.terms.TermSelectionActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity
-import org.wordpress.android.ui.reader.ReaderCommentListActivity
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity
-import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 import org.wordpress.android.ui.subscribers.SubscribersActivity
@@ -110,19 +99,10 @@ private val excludedActivities = listOf(
     SubscribersActivity::class.java.name,
     TermsDataViewActivity::class.java.name,
     ApplicationPasswordsListActivity::class.java.name,
-    SupportWebViewActivity::class.java.name,
 
     // these are excluded because they explicitly enable edge-to-edge
     MediaSettingsActivity::class.java.name,
     ReaderPostPagerActivity::class.java.name,
-
-    // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping
-    // their editors
-    CommentsDetailActivity::class.java.name,
-    EditPostActivity::class.java.name,
-    NotificationsDetailActivity::class.java.name,
-    ReaderCommentListActivity::class.java.name,
-    ReaderSubsActivity::class.java.name,
 
     // these are excluded because they implement custom IME inset handling for proper
     // keyboard management with edge-to-edge support

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -54,6 +54,7 @@ open class BaseAppCompatActivity : AppCompatActivity() {
             val innerPadding = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars()
                         or WindowInsetsCompat.Type.displayCutout()
+                        or WindowInsetsCompat.Type.ime()
             )
 
             view.setPadding(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
@@ -13,7 +13,6 @@ import androidx.core.view.WindowInsetsCompat
  */
 class EdgeToEdgeActivityLifecycleCallbacks :
     Application.ActivityLifecycleCallbacks {
-
     private val targetActivities = setOf(
         "zendesk.support.guide.HelpCenterActivity",
         "zendesk.support.guide.ViewArticleActivity",

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
@@ -24,10 +24,7 @@ class EdgeToEdgeActivityLifecycleCallbacks :
         activity: Activity,
         savedInstanceState: Bundle?
     ) {
-        if (targetActivities.contains(
-                activity::class.java.name
-            )
-        ) {
+        if (activity::class.java.name in targetActivities) {
             applyInsetOffsets(activity)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
@@ -36,6 +36,7 @@ class EdgeToEdgeActivityLifecycleCallbacks :
             val padding = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars()
                     or WindowInsetsCompat.Type.displayCutout()
+                    or WindowInsetsCompat.Type.ime()
             )
             view.setPadding(
                 padding.left,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.ui.main
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Applies edge-to-edge inset padding to third-party activities (e.g. Zendesk)
+ * that don't extend [BaseAppCompatActivity] and therefore don't get
+ * inset handling from [BaseAppCompatActivity.applyInsetOffsets].
+ */
+class EdgeToEdgeActivityLifecycleCallbacks :
+    Application.ActivityLifecycleCallbacks {
+
+    private val targetActivities = setOf(
+        "zendesk.support.guide.HelpCenterActivity",
+        "zendesk.support.guide.ViewArticleActivity",
+        "zendesk.support.request.RequestActivity",
+        "zendesk.support.requestlist.RequestListActivity"
+    )
+
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?
+    ) {
+        if (targetActivities.contains(
+                activity::class.java.name
+            )
+        ) {
+            applyInsetOffsets(activity)
+        }
+    }
+
+    private fun applyInsetOffsets(activity: Activity) {
+        ViewCompat.setOnApplyWindowInsetsListener(
+            activity.window.decorView
+        ) { view, insets ->
+            val padding = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout()
+            )
+            view.setPadding(
+                padding.left,
+                padding.top,
+                padding.right,
+                padding.bottom
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle
+    ) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/EdgeToEdgeActivityLifecycleCallbacks.kt
@@ -13,6 +13,7 @@ import androidx.core.view.WindowInsetsCompat
  */
 class EdgeToEdgeActivityLifecycleCallbacks :
     Application.ActivityLifecycleCallbacks {
+    // Zendesk Support SDK 5.5.3 activity class names
     private val targetActivities = setOf(
         "zendesk.support.guide.HelpCenterActivity",
         "zendesk.support.guide.ViewArticleActivity",

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1140,6 +1140,7 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                   .show();
     }
 
+    @SuppressWarnings("deprecation")
     private void announceTitleForAccessibility(PageType pageType) {
         getWindow().getDecorView().announceForAccessibility(mBottomNav.getContentDescriptionForPageType(pageType));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationBanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationBanner.kt
@@ -68,6 +68,7 @@ fun EmailVerificationBanner(
         val announcementString = stringResource(stringRes)
         val view = LocalView.current
         LaunchedEffect(verificationState.value) {
+            @Suppress("DEPRECATION")
             view.announceForAccessibility(announcementString)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.kt
@@ -120,7 +120,7 @@ class NotificationsSettingsActivity : BaseAppCompatActivity(), MainSwitchToolbar
         hideDisabledView(isMainChecked)
     }
 
-    override fun onMainSwitchCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
+    override fun onMainSwitchCheckedChanged(buttonView: CompoundButton, isChecked: Boolean) {
         applicationScope.launch { updateNotificationSettingsUseCase.updateNotificationSettings(isChecked) }
 
         hideDisabledView(isChecked)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/PrefMainSwitchToolbarView.kt
@@ -79,7 +79,7 @@ class PrefMainSwitchToolbarView @JvmOverloads constructor(
          * @param buttonView The main switch whose state has changed.
          * @param isChecked The new checked state of main switch.
          */
-        fun onMainSwitchCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean)
+        fun onMainSwitchCheckedChanged(buttonView: CompoundButton, isChecked: Boolean)
     }
 
     init {
@@ -296,7 +296,7 @@ class PrefMainSwitchToolbarView @JvmOverloads constructor(
     /*
      * User toggled the main switch
      */
-    override fun onCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
+    override fun onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean) {
         setToolbarTitle(isChecked)
         mainSwitchToolbarListener?.onMainSwitchCheckedChanged(buttonView, isChecked)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -1972,6 +1972,7 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
 
     private fun announceListStateForAccessibility() {
         if (view != null) {
+            @Suppress("DEPRECATION")
             requireView().announceForAccessibility(
                 getString(
                     R.string.reader_acessibility_list_loaded,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -113,6 +113,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         (recyclerView.adapter as SiteCreationDomainsAdapter).update(contentState.items)
 
         if (contentState.items.isNotEmpty()) {
+            @Suppress("DEPRECATION")
             view?.announceForAccessibility(getString(R.string.suggestions_updated_content_description))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -129,6 +129,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         }
         if (isFirstContent) {
             animateContentTransition()
+            @Suppress("DEPRECATION")
             view?.announceForAccessibility(getString(R.string.new_site_creation_site_preview_content_description))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
@@ -93,6 +93,7 @@ class SiteCreationProgressFragment : Fragment(R.layout.site_creation_progress_sc
             }
         }
         viewModel.onFreeSiteCreated.observe(viewLifecycleOwner) {
+            @Suppress("DEPRECATION")
             view?.announceForAccessibility(getString(R.string.new_site_creation_preview_title))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ChipsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ChipsViewHolder.kt
@@ -19,6 +19,7 @@ class ChipsViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         chipGroup.setOnCheckedStateChangeListener { group, checkedIds ->
             checkedIds.forEach { checkedId ->
                 val checkedChip = group.findViewById<Chip>(checkedId)
+                @Suppress("DEPRECATION")
                 checkedChip?.announceForAccessibility(group.resources.getString(R.string.stats_graph_updated))
                 item.onColumnSelected?.invoke(group.indexOfChild(checkedChip))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ExpandableItemViewHolder.kt
@@ -68,6 +68,7 @@ class ExpandableItemViewHolder(parent: ViewGroup, val imageManager: ImageManager
             } else {
                 itemView.resources.getString(R.string.stats_item_expanded)
             }
+            @Suppress("DEPRECATION")
             itemView.announceForAccessibility(announcement)
             expandableItem.onExpandClicked(!expandableItem.isExpanded)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/FourColumnsViewHolder.kt
@@ -40,6 +40,7 @@ class FourColumnsViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             else -> {
                 columnLayouts.forEachIndexed { index, layout ->
                     layout.setOnClickListener {
+                        @Suppress("DEPRECATION")
                         it.announceForAccessibility(it.resources.getString(R.string.stats_graph_updated))
                         item.onColumnSelected?.invoke(index)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/QuickScanItemViewHolder.kt
@@ -55,6 +55,7 @@ class QuickScanItemViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         column.tooltip?.let {
             TooltipCompat.setTooltipText(container, column.tooltip)
             container.setOnClickListener {
+                @Suppress("DEPRECATION")
                 container.announceForAccessibility(column.tooltip)
                 it.performLongClick()
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/ContentDescriptionListAnnouncer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ContentDescriptionListAnnouncer.kt
@@ -51,14 +51,17 @@ class ContentDescriptionListAnnouncer {
 
         targetView.setOnClickListener {
             if (contentDescriptions.isEmpty()) {
+                @Suppress("DEPRECATION")
                 it.announceForAccessibility(it.context.getString(emptyListText))
                 return@setOnClickListener
             }
 
             if (currentIndex == contentDescriptions.size) {
+                @Suppress("DEPRECATION")
                 it.announceForAccessibility(it.context.getString(endOfListText))
                 currentIndex = 0
             } else {
+                @Suppress("DEPRECATION")
                 it.announceForAccessibility(contentDescriptions[currentIndex])
                 currentIndex++
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.kt
@@ -58,9 +58,9 @@ object LocaleManager {
         // Attempt to parse language and region codes.
         val opts = LANGUAGE_SPLITTER.split(languageCode, 0)
         return if (opts.size > 1) {
-            Locale(opts[0], opts[1])
+            Locale.Builder().setLanguage(opts[0]).setRegion(opts[1]).build()
         } else {
-            Locale(opts[0])
+            Locale.Builder().setLanguage(opts[0]).build()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaPickerUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaPickerUtils.java
@@ -8,6 +8,7 @@ import androidx.annotation.StringRes;
 import org.wordpress.android.R;
 
 public class MediaPickerUtils {
+    @SuppressWarnings("deprecation")
     public static void announceSelectedMediaForAccessibility(@NonNull ImageView imageThumbnail,
                                                              boolean isVideo,
                                                              boolean itemSelected) {

--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <!-- statusBarColor is ignored with edge-to-edge on API 35+ but still applies on older APIs -->
         <item name="android:statusBarColor">@color/primary_dark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="toolbarNavigationButtonStyle">

--- a/WordPress/src/main/res/values-night/styles_zendesk.xml
+++ b/WordPress/src/main/res/values-night/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">@color/primary_dark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Base.Wordpress" parent="Theme.MaterialComponents.DayNight">
         <!-- Material theme -->
@@ -289,10 +289,6 @@
     <style name="WordPress.NoActionBar" parent="WordPress">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-    </style>
-
-    <style name="WordPress.NoActionBar.NoEdgeToEdge" parent="WordPress.NoActionBar">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="WordPress.Media.Preview" parent="Theme.MaterialComponents.DayNight.NoActionBar">

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -2,6 +2,7 @@
 <resources>
     <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <!-- statusBarColor is ignored with edge-to-edge on API 35+ but still applies on older APIs -->
         <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="toolbarNavigationButtonStyle">

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar.NoEdgeToEdge">
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
         <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
         <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles_zendesk.xml
+++ b/WordPress/src/main/res/values/styles_zendesk.xml
@@ -7,7 +7,7 @@
         <item name="toolbarNavigationButtonStyle">
             @style/Widget.AppCompat.Toolbar.Button.Navigation
         </item>
-        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightStatusBar">true</item>
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 

--- a/WordPress/src/test/java/org/wordpress/android/util/MediaPickerUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/MediaPickerUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.util
 
 import android.content.Context

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ plugins {
 
 ext {
     minSdkVersion = 26
-    compileSdkVersion = 35
-    targetSdkVersion = 35
+    compileSdkVersion = 36
+    targetSdkVersion = 36
 }
 
 static def loadPropertiesFromFile(File inputFile) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergUtils.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergUtils.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.LocaleList;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -36,13 +37,13 @@ class GutenbergUtils {
                 .createConfigurationContext(currentResources.getConfiguration());
         // if the current locale of the app is english stop here and return an empty map
         Configuration currentConfiguration = localizedContextCurrent.getResources().getConfiguration();
-        if (currentConfiguration.locale.equals(defaultLocale)) {
+        if (defaultLocale.equals(currentConfiguration.getLocales().get(0))) {
             return translations;
         }
 
         // Let's create a Resources object for the default locale (english) to get the original values for our strings
         Configuration defaultLocaleConfiguration = new Configuration(currentConfiguration);
-        defaultLocaleConfiguration.setLocale(defaultLocale);
+        defaultLocaleConfiguration.setLocales(new LocaleList(defaultLocale));
         Context localizedContextDefault = activity
                 .createConfigurationContext(defaultLocaleConfiguration);
         Resources englishResources = localizedContextDefault.getResources();

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergUtils.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergUtils.java
@@ -30,7 +30,7 @@ class GutenbergUtils {
     @SuppressLint("AppBundleLocaleChanges")
     public static Bundle getTranslations(Activity activity) {
         Bundle translations = new Bundle();
-        Locale defaultLocale = new Locale("en");
+        Locale defaultLocale = new Locale.Builder().setLanguage("en").build();
         Resources currentResources = activity.getResources();
         Context localizedContextCurrent = activity
                 .createConfigurationContext(currentResources.getConfiguration());


### PR DESCRIPTION
## Description

Updates `compileSdkVersion` and `targetSdkVersion` from 35 to 36 and addresses all resulting compilation errors, deprecation warnings, and behavioral changes:

- **Edge-to-edge enforcement**: SDK 36 enforces edge-to-edge by default. Removed the `NoEdgeToEdge` opt-out from the manifest and added `EdgeToEdgeActivityLifecycleCallbacks` to apply inset padding to third-party activities (e.g. Zendesk) that don't extend `BaseAppCompatActivity`.
- **IME inset handling**: Added `WindowInsetsCompat.Type.ime()` to both `BaseAppCompatActivity` and `EdgeToEdgeActivityLifecycleCallbacks` so the keyboard doesn't overlap editors — replacing the old `adjustResize` behavior that edge-to-edge disables.
- **Zendesk status bar fix**: Set `windowLightStatusBar` to `true` in the day Zendesk style so status bar icons are visible (dark on light background) now that `statusBarColor` is ignored.
- **Deprecation fixes (Kotlin)**: Replaced deprecated `Configuration.locale` with `ConfigurationCompat.getLocales()` in `LocaleManager`, updated `PrefMainSwitchToolbarView` and `NotificationsSettingsActivity` for SDK 36 API changes.
- **Deprecation fixes (Java)**: Updated `CommentDetailFragment`, `MediaPickerUtils`, and `GutenbergUtils` to use non-deprecated alternatives.
- **announceForAccessibility suppressions**: Added @Suppress("DEPRECATION") to all call sites (replacement with live regions is a separate effort).

## Testing instructions

Build verification:

1. Build the app: ./gradlew assembleWordPressDebug
- [x] Verify build succeeds with no errors

Edge-to-edge on SDK 36:

1. Run the app on an API 36 emulator or device
2. Navigate through the app — check the main screen, reader, stats, posts
- [x] Verify content is not obscured by status bar, navigation bar, or display cutout
3. Open a Zendesk help screen (Help & Support)
- [x] Verify Zendesk screens also have correct inset padding
- [x] Verify the status bar is visible in both light and dark modes

Keyboard overlap:

1. Run the app on an API 35 emulator or device
2. Make sure the keyboard overlap issues haven't re-appeared
- [x] Open the post editor and verify the keyboard doesn't cover the bottom of the editor (#21731)
- [x] Test the comment editor and notification comment editor (#21733)
- [x] Test the Zendesk "Contact us" screen — keyboard should not overlap the text input

General regression:

1. Test basic flows: login, browse reader, view stats, create/edit a post
- [x] Verify no visual regressions or crashes