### PR TITLE
RS Post Settings: Fix dialog selection lost on rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -1086,7 +1086,7 @@ private fun StatusDialog(
         it == currentStatus
     }.coerceAtLeast(0)
 
-    val selectedIndex = remember {
+    val selectedIndex = rememberSaveable {
         mutableIntStateOf(currentIndex)
     }
 
@@ -1359,7 +1359,7 @@ private fun FormatDialog(
         it == currentFormat
     }.coerceAtLeast(0)
 
-    val selectedIndex = remember {
+    val selectedIndex = rememberSaveable {
         mutableIntStateOf(currentIndex)
     }
 
@@ -1522,7 +1522,7 @@ private fun AuthorDialog(
         it.id == currentAuthorId
     }.coerceAtLeast(0)
 
-    val selectedIndex = remember {
+    val selectedIndex = rememberSaveable {
         mutableIntStateOf(currentIndex)
     }
 


### PR DESCRIPTION
## Description

When a user selects a new author, status, or format in the RS Post Settings dialogs and then rotates the device, the selection reverts to the original value. This happens because the dialog's local selection state uses `remember` which doesn't survive configuration changes.

This PR changes `remember` to `rememberSaveable` in `StatusDialog`, `FormatDialog`, and `AuthorDialog` so the selected index is preserved across configuration changes. The other dialogs (`PasswordDialog`, `TextFieldDialog`) already used `rememberSaveable` correctly.

## Testing instructions

Dialog selection survives rotation:

1. Open a post's RS Post Settings screen
2. Tap on Status and select a different status (e.g., Draft → Pending)
3. Before tapping OK, rotate the device
- [x] Verify the selection is still on the newly chosen status
4. Repeat for the Format dialog
- [x] Verify the format selection persists through rotation
5. Repeat for the Author dialog
- [x] Verify the author selection persists through rotation