### PR TITLE
Add diagnostic error handling for application password login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -67,13 +67,13 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
             )
             intent.setData(null)
         } else {
-            val detail = navigationActionData.errorMessage
-            val baseMessage = getString(
-                R.string.application_password_credentials_storing_error,
-                navigationActionData.siteUrl
+            ToastUtils.showToast(
+                this,
+                getString(
+                    R.string.application_password_credentials_storing_error,
+                    navigationActionData.siteUrl
+                )
             )
-            val message = if (detail != null) "$baseMessage\n$detail" else baseMessage
-            ToastUtils.showToast(this, message)
         }
 
         // Check if we're in a share flow - if so, just finish and return to LoginActivity

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -67,13 +67,13 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
             )
             intent.setData(null)
         } else {
-            ToastUtils.showToast(
-                this,
-                getString(
-                    R.string.application_password_credentials_storing_error,
-                    navigationActionData.siteUrl
-                )
+            val detail = navigationActionData.errorMessage
+            val baseMessage = getString(
+                R.string.application_password_credentials_storing_error,
+                navigationActionData.siteUrl
             )
+            val message = if (detail != null) "$baseMessage\n$detail" else baseMessage
+            ToastUtils.showToast(this, message)
         }
 
         // Check if we're in a share flow - if so, just finish and return to LoginActivity

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -69,7 +69,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: Cannot store credentials: rawData is empty"
                 )
                 applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
-                emitError(siteUrl = "", errorMessage = "Callback data was empty")
+                emitError(siteUrl = "", errorMessage = "empty_raw_data")
                 return@launch
             }
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
@@ -97,6 +97,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.DB,
                 "A_P: Error storing credentials: ${e.stackTraceToString()}"
             )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                urlLogin.siteUrl, "store_credentials_exception"
+            )
+            crashLogging.sendReportWithTag(e, AppLog.T.DB)
             false
         }
     }
@@ -123,10 +127,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
                 emitError(
                     siteUrl = siteUrl,
-                    errorMessage = "Missing login data — " +
-                        "username empty: ${username.isEmpty()}, " +
-                        "password empty: ${password.isEmpty()}, " +
-                        "apiRootUrl empty: ${apiRootUrl.isEmpty()}"
+                    errorMessage = "empty_fetch_params"
                 )
             } else {
                 val xmlRpcEndpoint =
@@ -198,8 +199,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
         emitError(
             siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-            errorMessage = "SiteStore error: " +
-                "${error?.type} — ${error?.message}"
+            errorMessage = "site_store_error"
         )
     }
 
@@ -214,19 +214,20 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             }
         } catch (e: Exception) {
             logAndEmitSiteChangedError(
-                "exception reading sites from DB: " +
+                logMessage = "exception reading sites from DB: " +
                     e.stackTraceToString(),
-                "Failed to read sites: ${e.message}",
-                e
+                errorCode = "db_read_exception",
+                cause = e
             )
             return
         }
 
-        val errorMessage = validateSiteChanged(
-            event, site, normalizedUrl
-        )
-        if (errorMessage != null) {
-            logAndEmitSiteChangedError(errorMessage, errorMessage)
+        val validationError = validateSiteChanged(event, site)
+        if (validationError != null) {
+            logAndEmitSiteChangedError(
+                logMessage = validationError.logMessage,
+                errorCode = validationError.errorCode
+            )
         } else {
             val resolvedSite = site ?: return
             _onFinishedEvent.emit(
@@ -244,21 +245,33 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
 
     private fun validateSiteChanged(
         event: OnSiteChanged,
-        site: SiteModel?,
-        normalizedUrl: String?
-    ): String? = when {
-        event.rowsAffected < 1 ->
-            "No rows affected (rowsAffected=${event.rowsAffected})"
-        site == null ->
-            "Site not found for URL: $normalizedUrl"
-        applicationPasswordLoginHelper.siteHasBadCredentials(site) ->
-            "Credentials are empty for site: $normalizedUrl"
+        site: SiteModel?
+    ): SiteChangedValidationError? = when {
+        event.rowsAffected < 1 -> SiteChangedValidationError(
+            logMessage = "No rows affected " +
+                "(rowsAffected=${event.rowsAffected})",
+            errorCode = "no_rows_affected"
+        )
+        site == null -> SiteChangedValidationError(
+            logMessage = "Site not found after update",
+            errorCode = "site_not_found"
+        )
+        applicationPasswordLoginHelper
+            .siteHasBadCredentials(site) -> SiteChangedValidationError(
+            logMessage = "Credentials are empty after store",
+            errorCode = "empty_credentials"
+        )
         else -> null
     }
 
+    private data class SiteChangedValidationError(
+        val logMessage: String,
+        val errorCode: String
+    )
+
     private suspend fun logAndEmitSiteChangedError(
         logMessage: String,
-        errorMessage: String,
+        errorCode: String,
         cause: Throwable? = null
     ) {
         appLogWrapper.e(
@@ -271,7 +284,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
         emitError(
             siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-            errorMessage = errorMessage,
+            errorMessage = errorCode,
             cause = cause
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -91,6 +91,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun storeCredentials(urlLogin: UriLogin): Boolean = withContext(ioDispatcher) {
         try {
+            // TODO: Remove this line before merging — used to force
+            //  the error path for testing Sentry/analytics reporting
+            // throw RuntimeException("Forced error for Sentry testing")
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
             appLogWrapper.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -21,6 +21,8 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.UriLogin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -32,6 +34,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     private val selfHostedEndpointFinder: SelfHostedEndpointFinder,
     private val siteStore: SiteStore,
     private val appLogWrapper: AppLogWrapper,
+    private val crashLogging: CrashLogging,
 ) : ViewModel() {
     private val _onFinishedEvent = MutableSharedFlow<NavigationActionData>()
     /**
@@ -139,11 +142,18 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
             )
-            emitError(siteUrl = siteUrl, errorMessage = e.message)
+            emitError(siteUrl = siteUrl, errorMessage = e.message, cause = e)
         }
     }
 
-    private suspend fun emitError(siteUrl: String, errorMessage: String? = null) =
+    private suspend fun emitError(
+        siteUrl: String,
+        errorMessage: String? = null,
+        cause: Throwable? = null
+    ) {
+        val exception = cause
+            ?: Exception("Application password login failed: $errorMessage")
+        crashLogging.sendReportWithTag(exception, AppLog.T.MAIN)
         _onFinishedEvent.emit(
             NavigationActionData(
                 showSiteSelector = false,
@@ -153,6 +163,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 errorMessage = errorMessage
             )
         )
+    }
 
     @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
@@ -189,7 +200,8 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "Failed to read sites: ${e.message}"
+                    errorMessage = "Failed to read sites: ${e.message}",
+                    cause = e
                 )
                 return@launch
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -67,6 +67,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     AppLog.T.MAIN,
                     "A_P: Cannot store credentials: rawData is empty"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 emitError(siteUrl = "", errorMessage = "Callback data was empty")
                 return@launch
             }
@@ -116,6 +117,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    siteUrl, "empty_fetch_params"
+                )
                 emitError(
                     siteUrl = siteUrl,
                     errorMessage = "Missing login data — " +
@@ -141,6 +145,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                siteUrl, "fetch_sites_exception"
             )
             emitError(siteUrl = siteUrl, errorMessage = e.message, cause = e)
         }
@@ -179,6 +186,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: onSiteChanged failed: " +
                         "SiteStore error ${error?.type}: ${error?.message}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
+                )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
                     errorMessage = "SiteStore error: " +
@@ -197,6 +208,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: onSiteChanged failed: " +
                         "exception reading sites from DB: " +
                         e.stackTraceToString()
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
@@ -223,6 +238,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 appLogWrapper.e(
                     AppLog.T.MAIN,
                     "A_P: onSiteChanged failed: $errorMessage"
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -11,6 +11,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -172,95 +173,107 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
     }
 
-    @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {
-            val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
-
             if (event.isError) {
-                val error = event.error
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: " +
-                        "SiteStore error ${error?.type}: ${error?.message}"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "SiteStore error: " +
-                        "${error?.type} — ${error?.message}"
-                )
-                return@launch
-            }
-
-            val site = try {
-                siteStore.sites.firstOrNull {
-                    UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl
-                }
-            } catch (e: Exception) {
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: " +
-                        "exception reading sites from DB: " +
-                        e.stackTraceToString()
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "Failed to read sites: ${e.message}",
-                    cause = e
-                )
-                return@launch
-            }
-
-            val errorMessage = when {
-                event.rowsAffected < 1 -> {
-                    "No rows affected (rowsAffected=${event.rowsAffected})"
-                }
-                site == null -> {
-                    "Site not found for URL: $currentNormalizedUrl"
-                }
-                applicationPasswordLoginHelper.siteHasBadCredentials(site) -> {
-                    "Credentials are empty for site: $currentNormalizedUrl"
-                }
-                else -> null
-            }
-
-            if (errorMessage != null) {
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: $errorMessage"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = errorMessage
-                )
+                handleSiteChangedError(event)
             } else {
-                val resolvedSite = site ?: return@launch
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(resolvedSite.id) != true,
-                        siteUrl = currentUrlLogin?.siteUrl,
-                        oldSitesIDs = oldSitesIDs,
-                        isError = false,
-                        newSiteLocalId = resolvedSite.id
-                    )
-                )
+                handleSiteChangedSuccess(event)
             }
         }
+    }
+
+    private suspend fun handleSiteChangedError(event: OnSiteChanged) {
+        val error = event.error
+        appLogWrapper.e(
+            AppLog.T.MAIN,
+            "A_P: onSiteChanged failed: " +
+                "SiteStore error ${error?.type}: ${error?.message}"
+        )
+        applicationPasswordLoginHelper.trackStoringFailed(
+            currentUrlLogin?.siteUrl,
+            "site_changed_failed"
+        )
+        emitError(
+            siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+            errorMessage = "SiteStore error: " +
+                "${error?.type} — ${error?.message}"
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handleSiteChangedSuccess(event: OnSiteChanged) {
+        val normalizedUrl =
+            UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
+
+        val site = try {
+            siteStore.sites.firstOrNull {
+                UrlUtils.normalizeUrl(it.url) == normalizedUrl
+            }
+        } catch (e: Exception) {
+            logAndEmitSiteChangedError(
+                "exception reading sites from DB: " +
+                    e.stackTraceToString(),
+                "Failed to read sites: ${e.message}",
+                e
+            )
+            return
+        }
+
+        val errorMessage = validateSiteChanged(
+            event, site, normalizedUrl
+        )
+        if (errorMessage != null) {
+            logAndEmitSiteChangedError(errorMessage, errorMessage)
+        } else {
+            val resolvedSite = site ?: return
+            _onFinishedEvent.emit(
+                NavigationActionData(
+                    showSiteSelector = siteStore.hasSite() &&
+                        oldSitesIDs?.contains(resolvedSite.id) != true,
+                    siteUrl = currentUrlLogin?.siteUrl,
+                    oldSitesIDs = oldSitesIDs,
+                    isError = false,
+                    newSiteLocalId = resolvedSite.id
+                )
+            )
+        }
+    }
+
+    private fun validateSiteChanged(
+        event: OnSiteChanged,
+        site: SiteModel?,
+        normalizedUrl: String?
+    ): String? = when {
+        event.rowsAffected < 1 ->
+            "No rows affected (rowsAffected=${event.rowsAffected})"
+        site == null ->
+            "Site not found for URL: $normalizedUrl"
+        applicationPasswordLoginHelper.siteHasBadCredentials(site) ->
+            "Credentials are empty for site: $normalizedUrl"
+        else -> null
+    }
+
+    private suspend fun logAndEmitSiteChangedError(
+        logMessage: String,
+        errorMessage: String,
+        cause: Throwable? = null
+    ) {
+        appLogWrapper.e(
+            AppLog.T.MAIN,
+            "A_P: onSiteChanged failed: $logMessage"
+        )
+        applicationPasswordLoginHelper.trackStoringFailed(
+            currentUrlLogin?.siteUrl,
+            "site_changed_failed"
+        )
+        emitError(
+            siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+            errorMessage = errorMessage,
+            cause = cause
+        )
     }
 
     data class NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -91,9 +91,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun storeCredentials(urlLogin: UriLogin): Boolean = withContext(ioDispatcher) {
         try {
-            // TODO: Remove this line before merging — used to force
-            //  the error path for testing Sentry/analytics reporting
-            // throw RuntimeException("Forced error for Sentry testing")
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
             appLogWrapper.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -21,8 +21,8 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.UriLogin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import com.automattic.android.tracks.crashlogging.CrashLogging
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -248,15 +248,15 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     errorMessage = errorMessage
                 )
             } else {
-                val nonNullSite = site!!
+                val resolvedSite = site ?: return@launch
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(nonNullSite.id) != true,
+                                oldSitesIDs?.contains(resolvedSite.id) != true,
                         siteUrl = currentUrlLogin?.siteUrl,
                         oldSitesIDs = oldSitesIDs,
                         isError = false,
-                        newSiteLocalId = nonNullSite.id
+                        newSiteLocalId = resolvedSite.id
                     )
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -60,15 +60,11 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     fun setupSite(rawData: String) {
         viewModelScope.launch {
             if (rawData.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = false,
-                        siteUrl = "",
-                        oldSitesIDs = oldSitesIDs,
-                        isError = true
-                    )
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: Cannot store credentials: rawData is empty"
                 )
+                emitError(siteUrl = "", errorMessage = "Callback data was empty")
                 return@launch
             }
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
@@ -117,7 +113,13 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
-                emitErrorFetching(siteUrl)
+                emitError(
+                    siteUrl = siteUrl,
+                    errorMessage = "Missing login data — " +
+                        "username empty: ${username.isEmpty()}, " +
+                        "password empty: ${password.isEmpty()}, " +
+                        "apiRootUrl empty: ${apiRootUrl.isEmpty()}"
+                )
             } else {
                 val xmlRpcEndpoint =
                     selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(siteUrl)
@@ -137,56 +139,93 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
             )
-            emitErrorFetching(siteUrl)
+            emitError(siteUrl = siteUrl, errorMessage = e.message)
         }
     }
 
-    private suspend fun emitErrorFetching(siteUrl: String) =  _onFinishedEvent.emit(
-        NavigationActionData(
-            showSiteSelector = false,
-            siteUrl = siteUrl,
-            oldSitesIDs = oldSitesIDs,
-            isError = true
+    private suspend fun emitError(siteUrl: String, errorMessage: String? = null) =
+        _onFinishedEvent.emit(
+            NavigationActionData(
+                showSiteSelector = false,
+                siteUrl = siteUrl,
+                oldSitesIDs = oldSitesIDs,
+                isError = true,
+                errorMessage = errorMessage
+            )
         )
-    )
 
+    @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
-            val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-            if (event.rowsAffected < 1 || site == null || applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
+
+            if (event.isError) {
+                val error = event.error
                 appLogWrapper.e(
                     AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed" +
-                        " for: ${currentUrlLogin?.siteUrl}" +
-                        " - rowsAffected=${event.rowsAffected}" +
-                        ", siteFound=${site != null}" +
-                        ", badCredentials=${
-                            site?.let {
-                                applicationPasswordLoginHelper
-                                    .siteHasBadCredentials(it)
-                            }
-                        }"
+                    "A_P: onSiteChanged failed: " +
+                        "SiteStore error ${error?.type}: ${error?.message}"
                 )
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = false,
-                        siteUrl = currentUrlLogin?.siteUrl,
-                        oldSitesIDs = oldSitesIDs,
-                        isError = true
-                    )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = "SiteStore error: " +
+                        "${error?.type} — ${error?.message}"
+                )
+                return@launch
+            }
+
+            val site = try {
+                siteStore.sites.firstOrNull {
+                    UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl
+                }
+            } catch (e: Exception) {
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed: " +
+                        "exception reading sites from DB: " +
+                        e.stackTraceToString()
+                )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = "Failed to read sites: ${e.message}"
+                )
+                return@launch
+            }
+
+            val errorMessage = when {
+                event.rowsAffected < 1 -> {
+                    "No rows affected (rowsAffected=${event.rowsAffected})"
+                }
+                site == null -> {
+                    "Site not found for URL: $currentNormalizedUrl"
+                }
+                applicationPasswordLoginHelper.siteHasBadCredentials(site) -> {
+                    "Credentials are empty for site: $currentNormalizedUrl"
+                }
+                else -> null
+            }
+
+            if (errorMessage != null) {
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed: $errorMessage"
+                )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = errorMessage
                 )
             } else {
+                val nonNullSite = site!!
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(site.id) != true, // null or false
+                                oldSitesIDs?.contains(nonNullSite.id) != true,
                         siteUrl = currentUrlLogin?.siteUrl,
                         oldSitesIDs = oldSitesIDs,
                         isError = false,
-                        newSiteLocalId = site.id
+                        newSiteLocalId = nonNullSite.id
                     )
                 )
             }
@@ -198,6 +237,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         val siteUrl: String?,
         val oldSitesIDs: ArrayList<Int>?,
         val isError: Boolean,
-        val newSiteLocalId: Int? = null
+        val newSiteLocalId: Int? = null,
+        val errorMessage: String? = null
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,6 +18,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -36,7 +38,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -105,6 +108,22 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
             trackStoringFailed(urlLogin.siteUrl, "bad_data")
+            crashLogging.sendReportWithTag(
+                Exception(
+                    "A_P: bad_data for ${urlLogin.siteUrl}" +
+                        " — apiRootUrl isNull=" +
+                        "${urlLogin.apiRootUrl == null}" +
+                        ", user isEmpty=" +
+                        "${urlLogin.user.isNullOrEmpty()}" +
+                        ", password isEmpty=" +
+                        "${urlLogin.password.isNullOrEmpty()}" +
+                        ", siteUrl isNull=" +
+                        "${urlLogin.siteUrl == null}" +
+                        ", alreadyProcessed=" +
+                        "${urlLogin.siteUrl == processedAppPasswordData}"
+                ),
+                AppLog.T.DB
+            )
             return false
         }
 
@@ -135,6 +154,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         " (${siteStore.sites.size} sites available)"
                 )
                 trackStoringFailed(urlLogin.siteUrl, "site_not_found")
+                crashLogging.sendReportWithTag(
+                    Exception(
+                        "A_P: site_not_found for " +
+                            "${urlLogin.siteUrl}" +
+                            " (normalized: $normalizedUrl)" +
+                            " — ${siteStore.sites.size} sites" +
+                            " available"
+                    ),
+                    AppLog.T.DB
+                )
                 false
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
 import androidx.core.net.toUri
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -18,7 +17,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -38,8 +36,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
-    private val crashLogging: CrashLogging
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -150,12 +147,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         AnalyticsTracker.track(
             Stat.APPLICATION_PASSWORD_STORING_FAILED,
             properties
-        )
-        crashLogging.sendReportWithTag(
-            exception = Exception(
-                "A_P: storing failed for $siteUrl - $reason"
-            ),
-            tag = AppLog.T.DB
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -89,41 +89,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     @Suppress("ComplexCondition")
-    suspend fun storeApplicationPasswordCredentialsFrom(urlLogin: UriLogin): Boolean {
+    suspend fun storeApplicationPasswordCredentialsFrom(
+        urlLogin: UriLogin
+    ): Boolean {
         if (urlLogin.apiRootUrl == null ||
             urlLogin.user.isNullOrEmpty() ||
             urlLogin.password.isNullOrEmpty() ||
             urlLogin.siteUrl == null ||
             urlLogin.siteUrl == processedAppPasswordData
-            ) {
-            appLogWrapper.e(
-                AppLog.T.DB,
-                "A_P: Cannot save application password credentials" +
-                    " for: ${urlLogin.siteUrl}" +
-                    " - apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
-                    ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
-                    ", password isEmpty=${urlLogin.password.isNullOrEmpty()}" +
-                    ", siteUrl isNull=${urlLogin.siteUrl == null}" +
-                    ", alreadyProcessed=" +
-                    "${urlLogin.siteUrl == processedAppPasswordData}"
-            )
-            trackStoringFailed(urlLogin.siteUrl, "bad_data")
-            crashLogging.sendReportWithTag(
-                Exception(
-                    "A_P: bad_data for ${urlLogin.siteUrl}" +
-                        " — apiRootUrl isNull=" +
-                        "${urlLogin.apiRootUrl == null}" +
-                        ", user isEmpty=" +
-                        "${urlLogin.user.isNullOrEmpty()}" +
-                        ", password isEmpty=" +
-                        "${urlLogin.password.isNullOrEmpty()}" +
-                        ", siteUrl isNull=" +
-                        "${urlLogin.siteUrl == null}" +
-                        ", alreadyProcessed=" +
-                        "${urlLogin.siteUrl == processedAppPasswordData}"
-                ),
-                AppLog.T.DB
-            )
+        ) {
+            logAndReportBadData(urlLogin)
             return false
         }
 
@@ -145,24 +120,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                appLogWrapper.e(
-                    AppLog.T.DB,
-                    "A_P: Cannot save application password" +
-                        " credentials for: ${urlLogin.siteUrl}" +
-                        " (normalized: $normalizedUrl)" +
-                        " - site not found in store" +
-                        " (${siteStore.sites.size} sites available)"
-                )
-                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
-                crashLogging.sendReportWithTag(
-                    Exception(
-                        "A_P: site_not_found for " +
-                            "${urlLogin.siteUrl}" +
-                            " (normalized: $normalizedUrl)" +
-                            " — ${siteStore.sites.size} sites" +
-                            " available"
-                    ),
-                    AppLog.T.DB
+                logAndReportSiteNotFound(
+                    urlLogin.siteUrl, normalizedUrl
                 )
                 false
             }
@@ -177,6 +136,49 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             Stat.APPLICATION_PASSWORD_STORING_FAILED,
             properties
         )
+    }
+
+    private fun reportStoringFailedToSentry(
+        reason: String,
+        detail: String
+    ) {
+        crashLogging.sendReportWithTag(
+            Exception("A_P: $reason — $detail"),
+            AppLog.T.DB
+        )
+    }
+
+    private fun logAndReportBadData(urlLogin: UriLogin) {
+        val detail =
+            "apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
+                ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
+                ", password isEmpty=" +
+                "${urlLogin.password.isNullOrEmpty()}" +
+                ", siteUrl isNull=${urlLogin.siteUrl == null}" +
+                ", alreadyProcessed=" +
+                "${urlLogin.siteUrl == processedAppPasswordData}"
+        appLogWrapper.e(
+            AppLog.T.DB,
+            "A_P: Cannot save credentials" +
+                " for: ${urlLogin.siteUrl} - $detail"
+        )
+        trackStoringFailed(urlLogin.siteUrl, "bad_data")
+        reportStoringFailedToSentry("bad_data", detail)
+    }
+
+    private fun logAndReportSiteNotFound(
+        siteUrl: String?,
+        normalizedUrl: String?
+    ) {
+        val detail = "$siteUrl (normalized: $normalizedUrl)" +
+            " — ${siteStore.sites.size} sites available"
+        appLogWrapper.e(
+            AppLog.T.DB,
+            "A_P: Cannot save credentials" +
+                " - site not found: $detail"
+        )
+        trackStoringFailed(siteUrl, "site_not_found")
+        reportStoringFailedToSentry("site_not_found", detail)
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,6 +18,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -25,6 +27,7 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
+private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -35,7 +38,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -103,6 +107,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
+            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -132,9 +137,26 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         " - site not found in store" +
                         " (${siteStore.sites.size} sites available)"
                 )
+                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
+    }
+
+    fun trackStoringFailed(siteUrl: String?, reason: String) {
+        val properties: MutableMap<String, String?> = HashMap()
+        properties[URL_TAG] = siteUrl
+        properties[REASON_TAG] = reason
+        AnalyticsTracker.track(
+            Stat.APPLICATION_PASSWORD_STORING_FAILED,
+            properties
+        )
+        crashLogging.sendReportWithTag(
+            exception = Exception(
+                "A_P: storing failed for $siteUrl - $reason"
+            ),
+            tag = AppLog.T.DB
+        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -1,25 +1,27 @@
 package org.wordpress.android.ui.accounts.applicationpassword
 
 import app.cash.turbine.test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
-import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
-import org.wordpress.android.fluxc.store.SiteStore
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 @Suppress("MaxLineLength")
@@ -38,6 +40,9 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
+
+    @Mock
+    lateinit var crashLogging: CrashLogging
 
     private lateinit var viewModel: ApplicationPasswordLoginViewModel
 
@@ -63,7 +68,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             applicationPasswordLoginHelper,
             selfHostedEndpointFinder,
             siteStore,
-            appLogWrapper
+            appLogWrapper,
+            crashLogging
         )
         whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)).thenReturn(urlLogin)
     }
@@ -76,7 +82,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             showSiteSelector = false,
             siteUrl = "",
             oldSitesIDs = null,
-            isError = true
+            isError = true,
+            errorMessage = "Callback data was empty"
         )
 
         // When
@@ -102,7 +109,11 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showSiteSelector = false,
                 siteUrl = "",
                 oldSitesIDs = null,
-                isError = true
+                isError = true,
+                errorMessage = "Missing login data — " +
+                    "username empty: true, " +
+                    "password empty: true, " +
+                    "apiRootUrl empty: true"
             )
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(malformedRawData))
                 .thenReturn(
@@ -129,7 +140,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showSiteSelector = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = true
+                isError = true,
+                errorMessage = null
             )
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin)))
                 .thenReturn(false)
@@ -152,31 +164,32 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
         runTest {
             // Given
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
-            val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
-                showSiteSelector = false,
-                siteUrl = urlLogin.siteUrl,
-                oldSitesIDs = null,
-                isError = true
-            )
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin)))
-                .thenReturn(false)
-            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
-                .thenReturn(xmlRpcEndpoint)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+            ).thenReturn(false)
+            whenever(
+                selfHostedEndpointFinder
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+            ).thenReturn(xmlRpcEndpoint)
 
             // When
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
                 viewModel.onSiteChanged(
-                    SiteStore.OnSiteChanged(
-                        rowsAffected = 1,
-                    )
+                    SiteStore.OnSiteChanged(rowsAffected = 1)
                 )
 
                 // Then
                 val finishedEvent = awaitItem()
-                assertEquals(expectedResult, finishedEvent)
-                verify(selfHostedEndpointFinder, times(1)).verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                assertTrue(finishedEvent.isError)
+                assertTrue(
+                    finishedEvent.errorMessage
+                        ?.contains("Site not found") == true
+                )
+                verify(selfHostedEndpointFinder, times(1))
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
                 verify(siteStore, times(1)).sites
                 cancelAndIgnoreRemainingEvents()
             }
@@ -272,10 +285,14 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             )
             whenever(siteStore.hasSite()).thenReturn(true)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin)))
-                .thenReturn(false)
-            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
-                .thenReturn(xmlRpcEndpoint)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+            ).thenReturn(false)
+            whenever(
+                selfHostedEndpointFinder
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+            ).thenReturn(xmlRpcEndpoint)
 
             // When
             viewModel.onFinishedEvent.test {
@@ -291,8 +308,144 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val finishedEvent = awaitItem()
                 assertEquals(expectedResult, finishedEvent)
-                verify(selfHostedEndpointFinder, times(1)).verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                verify(selfHostedEndpointFinder, times(1))
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `given onSiteChanged with error, then emit error with SiteStore details`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+            val siteError = SiteStore.SiteError(
+                SiteStore.SiteErrorType.GENERIC_ERROR, "encryption failed"
+            )
+            val errorEvent = SiteStore.OnSiteChanged(0, siteError)
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(errorEvent)
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertEquals(
+                    "SiteStore error: GENERIC_ERROR — encryption failed",
+                    result.errorMessage
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given onSiteChanged with no rows affected, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(rowsAffected = 0)
+                )
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertTrue(
+                    result.errorMessage?.contains("No rows affected") == true
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given onSiteChanged with bad credentials, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
+            whenever(
+                applicationPasswordLoginHelper.siteHasBadCredentials(any())
+            ).thenReturn(true)
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(
+                        rowsAffected = 1,
+                        updatedSites = listOf(testSite)
+                    )
+                )
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertTrue(
+                    result.errorMessage
+                        ?.contains("Credentials are empty") == true
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given onSiteChanged with DB exception, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+            whenever(siteStore.sites)
+                .thenThrow(RuntimeException("DB corrupted"))
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(rowsAffected = 1)
+                )
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertEquals(
+                    "Failed to read sites: DB corrupted",
+                    result.errorMessage
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given error emitted, then crash report is sent`() = runTest {
+        // Given & When
+        viewModel.onFinishedEvent.test {
+            viewModel.setupSite("")
+
+            // Then
+            awaitItem()
+            verify(crashLogging).sendReport(
+                exception = any(),
+                tags = eq(mapOf("tag" to "MAIN")),
+                message = eq(null)
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private suspend fun setupFetchSitesFlow() {
+        val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
+        whenever(
+            applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+        ).thenReturn(false)
+        whenever(
+            selfHostedEndpointFinder
+                .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+        ).thenReturn(xmlRpcEndpoint)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -83,7 +83,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             siteUrl = "",
             oldSitesIDs = null,
             isError = true,
-            errorMessage = "Callback data was empty"
+            errorMessage = "empty_raw_data"
         )
 
         // When
@@ -110,10 +110,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 siteUrl = "",
                 oldSitesIDs = null,
                 isError = true,
-                errorMessage = "Missing login data — " +
-                    "username empty: true, " +
-                    "password empty: true, " +
-                    "apiRootUrl empty: true"
+                errorMessage = "empty_fetch_params"
             )
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(malformedRawData))
                 .thenReturn(
@@ -184,9 +181,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val finishedEvent = awaitItem()
                 assertTrue(finishedEvent.isError)
-                assertTrue(
-                    finishedEvent.errorMessage
-                        ?.contains("Site not found") == true
+                assertEquals(
+                    "site_not_found", finishedEvent.errorMessage
                 )
                 verify(selfHostedEndpointFinder, times(1))
                     .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
@@ -332,10 +328,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertEquals(
-                    "SiteStore error: GENERIC_ERROR — encryption failed",
-                    result.errorMessage
-                )
+                assertEquals("site_store_error", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -356,9 +349,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertTrue(
-                    result.errorMessage?.contains("No rows affected") == true
-                )
+                assertEquals("no_rows_affected", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -386,10 +377,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertTrue(
-                    result.errorMessage
-                        ?.contains("Credentials are empty") == true
-                )
+                assertEquals("empty_credentials", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -412,10 +400,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertEquals(
-                    "Failed to read sites: DB corrupted",
-                    result.errorMessage
-                )
+                assertEquals("db_read_exception", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -159,7 +159,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore, times(3)).sites
+            verify(siteStore, times(2)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -67,6 +68,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -81,7 +85,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper
+            discoverSuccessWrapper,
+            crashLogging
         )
     }
 
@@ -154,7 +159,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore, times(2)).sites
+            verify(siteStore, times(3)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -67,6 +68,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -81,7 +85,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper
+            discoverSuccessWrapper,
+            crashLogging
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -68,9 +67,6 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
-    @Mock
-    lateinit var crashLogging: CrashLogging
-
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -85,8 +81,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper,
-            crashLogging
+            discoverSuccessWrapper
         )
     }
 

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1094,7 +1094,8 @@ public final class AnalyticsTracker {
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
         WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
         JP_ANDROID_APPLICATION_PASSWORD_LOGIN,
-        APPLICATION_PASSWORD_SET_OFF;
+        APPLICATION_PASSWORD_SET_OFF,
+        APPLICATION_PASSWORD_STORING_FAILED;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1480,18 +1480,24 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchSitesXmlRpcFromApplicationPassword(
         payload: RefreshSitesXMLRPCApplicationPasswordCredentialsPayload
     ): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
-            updateSites(
-                siteXMLRPCClient.fetchSitesFromApplicationPassword(
-                    payload.url,
-                    payload.apiRootUrl,
-                    payload.username,
-                    payload.password
+            try {
+                updateSites(
+                    siteXMLRPCClient.fetchSitesFromApplicationPassword(
+                        payload.url,
+                        payload.apiRootUrl,
+                        payload.username,
+                        payload.password
+                    )
                 )
-            )
+            } catch (e: Exception) {
+                AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
+                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+            }
         }
     }
 
@@ -1547,7 +1553,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
     private fun updateApplicationPassword(siteModel: SiteModel): OnSiteChanged {
         return try {
             val siteFromDB = getSiteByLocalId(siteModel.id)
@@ -1569,6 +1575,13 @@ open class SiteStore @Inject constructor(
             OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteToStore))
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
+        } catch (e: Exception) {
+            AppLog.e(
+                T.DB,
+                "Failed to update application password: ${e.message}",
+                e
+            )
+            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,8 +1495,9 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
-                AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
-                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+                val errorMsg = e.message ?: e.javaClass.simpleName
+                AppLog.e(T.API, "Failed to fetch/store sites: $errorMsg", e)
+                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, errorMsg))
             }
         }
     }
@@ -1576,12 +1577,13 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
+            val errorMsg = e.message ?: e.javaClass.simpleName
             AppLog.e(
                 T.DB,
-                "Failed to update application password: ${e.message}",
+                "Failed to update application password: $errorMsg",
                 e
             )
-            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, errorMsg))
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,8 +1495,6 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
-                // TODO: Narrow to specific exception type once Android 16
-                //  KeyStore root cause is identified (CMM-1949)
                 AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
                 OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
             }
@@ -1578,8 +1576,6 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
-            // TODO: Narrow to specific exception type once Android 16
-            //  KeyStore root cause is identified (CMM-1949)
             AppLog.e(
                 T.DB,
                 "Failed to update application password: ${e.message}",

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,6 +1495,8 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
+                // TODO: Narrow to specific exception type once Android 16
+                //  KeyStore root cause is identified (CMM-1949)
                 AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
                 OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
             }
@@ -1576,6 +1578,8 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
+            // TODO: Narrow to specific exception type once Android 16
+            //  KeyStore root cause is identified (CMM-1949)
             AppLog.e(
                 T.DB,
                 "Failed to update application password: ${e.message}",


### PR DESCRIPTION
## Summary
- Add diagnostic error handling for application password login on self-hosted sites — catches exceptions in `SiteStore` encryption/decryption paths and returns `OnSiteChanged` with an error instead of crashing the coroutine (infinite spinner or app crash)
- Split the compound `onSiteChanged` error check into distinct conditions (SiteStore error, no rows affected, site not found, empty credentials) with detailed logging and Sentry crash reports for each path
- Add analytics tracking (`APPLICATION_PASSWORD_STORING_FAILED`) and crash logging via `CrashLogging.sendReportWithTag` for all error paths
- Keep toast user-friendly (no internal error details leaked to UI); detailed diagnostics go only to logcat and Sentry

## Test plan

### Normal flow (credentials stored successfully)
1. Ensure the `throw` line in `ApplicationPasswordLoginViewModel.storeCredentials` is **commented out** (default state)
2. Install on a device and attempt application password login to a self-hosted site
3. Verify the success toast is shown and login completes normally

### Error reporting flow
1. **Uncomment** the `throw RuntimeException(...)` line in `ApplicationPasswordLoginViewModel.storeCredentials` (marked with a TODO)
2. Install and attempt application password login
3. Verify in logcat (filter `A_P:`) that:
   - `A_P: Error storing credentials:` appears with the stack trace
   - The `store_credentials_exception` analytics event is tracked
4. The login will still succeed because `fetchSites` runs as fallback after `storeCredentials` fails — this is expected behavior
5. **Re-comment** the line after testing

### Note on Sentry verification
> `WPCrashLoggingDataProvider.crashLoggingEnabled()` returns `false` for debug builds, so Sentry reports will **not** appear in the Sentry web UI during local testing. The `sendReportWithTag` call is confirmed reachable via logcat. Sentry reports will only be visible in production/release builds.

### Unit tests
- [x] Run `ApplicationPasswordLoginViewModelTest` — 12 tests pass
- [x] Run `ApplicationPasswordLoginHelperTest` — 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)