### PR TITLE
Fix issues introduced by login lib removal

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -382,6 +382,16 @@ public class LoginActivity extends BaseAppCompatActivity implements
         }
     }
 
+    private void hideLoadingOverlay() {
+        if (mLoadingOverlay != null) {
+            mLoadingOverlay.setVisibility(View.GONE);
+        }
+        View fragmentContainer = findViewById(mFragmentContainerId);
+        if (fragmentContainer != null) {
+            fragmentContainer.setVisibility(View.VISIBLE);
+        }
+    }
+
     private void showLoginError(@NonNull Exception error) {
         AppLog.e(T.MAIN, "OAuth login failed", error);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -88,6 +89,7 @@ public class LoginActivity extends BaseAppCompatActivity implements
     private static final String KEY_SHARE_FLOW_LOGIN_LAUNCHED = "KEY_SHARE_FLOW_LOGIN_LAUNCHED";
 
     private int mFragmentContainerId;
+    private View mLoadingOverlay;
 
     /**
      * Check if there's a pending share flow. Used by
@@ -156,15 +158,27 @@ public class LoginActivity extends BaseAppCompatActivity implements
 
         LoginFlowThemeHelper.injectMissingCustomAttributes(getTheme());
 
+        ViewGroup.LayoutParams matchParent = new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        );
+
+        FrameLayout rootContainer = new FrameLayout(this);
+        rootContainer.setLayoutParams(matchParent);
+
         FrameLayout fragmentContainer = new FrameLayout(this);
         mFragmentContainerId = R.id.fragment_container;
         fragmentContainer.setId(mFragmentContainerId);
         fragmentContainer.setFitsSystemWindows(false);
-        fragmentContainer.setLayoutParams(new ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
-        setContentView(fragmentContainer);
+        fragmentContainer.setLayoutParams(matchParent);
+        rootContainer.addView(fragmentContainer);
+
+        mLoadingOverlay = LayoutInflater.from(this)
+                .inflate(R.layout.login_loading, rootContainer, false);
+        mLoadingOverlay.setVisibility(View.GONE);
+        rootContainer.addView(mLoadingOverlay);
+
+        setContentView(rootContainer);
 
         if (savedInstanceState == null) {
             mLoginAnalyticsListener.trackLoginAccessed();
@@ -179,7 +193,10 @@ public class LoginActivity extends BaseAppCompatActivity implements
                     showWPcomLoginScreen(this);
                     break;
                 case SELF_HOSTED:
-                    showFragment(new LoginSiteApplicationPasswordFragment(), LoginSiteApplicationPasswordFragment.TAG);
+                    showFragment(
+                            new LoginSiteApplicationPasswordFragment(),
+                            LoginSiteApplicationPasswordFragment.TAG
+                    );
                     break;
             }
         } else {
@@ -194,9 +211,9 @@ public class LoginActivity extends BaseAppCompatActivity implements
         }
 
         // If we're waiting for sites (e.g. after config change during post-OAuth fetch),
-        // show the loading screen instead of the fragment container
+        // show the loading overlay instead of the fragment container
         if (mIsWaitingForSitesToLoad) {
-            setContentView(R.layout.login_loading);
+            showLoadingOverlay();
         }
 
         initViewModel();
@@ -233,12 +250,17 @@ public class LoginActivity extends BaseAppCompatActivity implements
     protected void onNewIntent(@NonNull Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
+        mLoginFlow = null;
 
         // Handle OAuth callback when activity is reused (singleTop)
         String dataString = intent.getDataString();
         if (mLoginHelper.hasOAuthCallback(dataString)) {
             intent.setData(null);
-            setContentView(R.layout.login_loading);
+            if (mLoadingOverlay != null) {
+                showLoadingOverlay();
+            } else {
+                setContentView(R.layout.login_loading);
+            }
             mLoginHelper.tryLoginWithDataString(
                     dataString,
                     () -> loggedInAndFinish(new ArrayList<>(), true),
@@ -348,6 +370,16 @@ public class LoginActivity extends BaseAppCompatActivity implements
                 new LoginPrologueRevampedFragment(),
                 LoginPrologueRevampedFragment.TAG
         );
+    }
+
+    private void showLoadingOverlay() {
+        if (mLoadingOverlay != null) {
+            mLoadingOverlay.setVisibility(View.VISIBLE);
+        }
+        View fragmentContainer = findViewById(mFragmentContainerId);
+        if (fragmentContainer != null) {
+            fragmentContainer.setVisibility(View.GONE);
+        }
     }
 
     private void showLoginError(@NonNull Exception error) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/WPcomLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/WPcomLoginHelper.kt
@@ -139,7 +139,11 @@ class ServiceConnection(
     }
 
     fun unbind() {
-        boundContext?.unbindService(this)
+        try {
+            boundContext?.unbindService(this)
+        } catch (_: IllegalArgumentException) {
+            // Already unbound or never bound
+        }
         boundContext = null
         client = null
         session = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordFragment.kt
@@ -62,7 +62,6 @@ class LoginSiteApplicationPasswordFragment : Fragment() {
 
                 AppThemeM3 {
                     LoginSiteApplicationPasswordScreen(
-                        isLoading = isLoading,
                         errorMessage = errorMessage,
                         onBackClick = {
                             requireActivity().onBackPressedDispatcher.onBackPressed()
@@ -76,6 +75,11 @@ class LoginSiteApplicationPasswordFragment : Fragment() {
                         },
                         onErrorDismissed = {
                             viewModel.clearError()
+                        },
+                        onCancelLoading = if (isLoading) {
+                            { viewModel.cancelDiscovery() }
+                        } else {
+                            null
                         }
                     )
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordScreen.kt
@@ -49,22 +49,25 @@ import org.wordpress.android.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginSiteApplicationPasswordScreen(
-    isLoading: Boolean,
     errorMessage: String?,
     onBackClick: () -> Unit,
     onHelpClick: (cleanedAddress: String) -> Unit,
     onContinueClick: (cleanedAddress: String) -> Unit,
     onErrorDismissed: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onCancelLoading: (() -> Unit)? = null
 ) {
     var siteAddress by rememberSaveable { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
+    val isLoading = onCancelLoading != null
 
     val cleanedAddress = siteAddress.trim().replace(Regex("[\r\n]"), "")
-    val isValid = cleanedAddress.isNotEmpty() && Patterns.WEB_URL.matcher(cleanedAddress).matches()
+    val isValid = cleanedAddress.isNotEmpty()
+        && cleanedAddress.contains(".")
+        && Patterns.WEB_URL.matcher(cleanedAddress).matches()
 
-    if (isLoading) {
-        LoadingDialog()
+    if (onCancelLoading != null) {
+        LoadingDialog(onDismiss = onCancelLoading)
     }
 
     Scaffold(
@@ -157,8 +160,8 @@ fun LoginSiteApplicationPasswordScreen(
 }
 
 @Composable
-private fun LoadingDialog() {
-    Dialog(onDismissRequest = { }) {
+private fun LoadingDialog(onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.medium,
             tonalElevation = 8.dp

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts.login.applicationpassword
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,19 +20,28 @@ class LoginSiteApplicationPasswordViewModel @Inject constructor(
     val discoveryURL = _discoveryURL.receiveAsFlow()
 
     private val _loadingStateFlow = MutableStateFlow(false)
-    val loadingStateFlow get() = _loadingStateFlow.asStateFlow()
+    val loadingStateFlow = _loadingStateFlow.asStateFlow()
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage = _errorMessage.asStateFlow()
 
+    private var discoveryJob: Job? = null
+
     fun runApiDiscovery(siteUrl: String) {
         _errorMessage.value = null
         _loadingStateFlow.value = true
-        viewModelScope.launch {
-            val discoveryUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(siteUrl)
+        discoveryJob = viewModelScope.launch {
+            val discoveryUrl = applicationPasswordLoginHelper
+                .getAuthorizationUrlComplete(siteUrl)
             _discoveryURL.send(discoveryUrl)
             _loadingStateFlow.value = false
         }
+    }
+
+    fun cancelDiscovery() {
+        discoveryJob?.cancel()
+        discoveryJob = null
+        _loadingStateFlow.value = false
     }
 
     fun setError(message: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -134,7 +134,6 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                     AppLog.T.MAIN,
                     "A_P: Exception validating credentials for ${site.url}: ${e::class.simpleName}: ${e.message}"
                 )
-                e.printStackTrace()
                 uiModelMutable.postValue(null)
             }
         }


### PR DESCRIPTION
## Summary

This PR addresses the remaining issues introduced in #22564.

- Fix multiple `setContentView()` calls in `LoginActivity` that orphan fragments by using a single root layout with a loading overlay and toggling visibility
- Wrap `unbindService()` in try-catch to prevent `IllegalArgumentException` crashes
- Reset cached `mLoginFlow` in `onNewIntent()` to prevent stale login flow when activity is reused via `singleTop`
- Remove custom `get()` on `loadingStateFlow` that recreated the `StateFlow` wrapper on every access
- Remove redundant `e.printStackTrace()` (already logged via `appLogWrapper`)
- Require a dot in site URL validation to reject single-word inputs like `example`
- Make the site address loading dialog dismissible so users aren't stuck if the request hangs

## Test plan

Test the various login flows and verify everything works as expected.