### PR TITLE
Add logging and tracking for application password login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -64,13 +64,13 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
             )
             intent.setData(null)
         } else {
-            ToastUtils.showToast(
-                this,
-                getString(
-                    R.string.application_password_credentials_storing_error,
-                    navigationActionData.siteUrl
-                )
+            val detail = navigationActionData.errorMessage
+            val baseMessage = getString(
+                R.string.application_password_credentials_storing_error,
+                navigationActionData.siteUrl
             )
+            val message = if (detail != null) "$baseMessage\n$detail" else baseMessage
+            ToastUtils.showToast(this, message)
         }
 
         if (navigationActionData.isError) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -64,13 +64,13 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
             )
             intent.setData(null)
         } else {
-            val detail = navigationActionData.errorMessage
-            val baseMessage = getString(
-                R.string.application_password_credentials_storing_error,
-                navigationActionData.siteUrl
+            ToastUtils.showToast(
+                this,
+                getString(
+                    R.string.application_password_credentials_storing_error,
+                    navigationActionData.siteUrl
+                )
             )
-            val message = if (detail != null) "$baseMessage\n$detail" else baseMessage
-            ToastUtils.showToast(this, message)
         }
 
         if (navigationActionData.isError) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -93,9 +93,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun storeCredentials(urlLogin: UriLogin): Boolean = withContext(ioDispatcher) {
         try {
-            // TODO: Remove this line before merging — used to force
-            //  the error path for testing Sentry/analytics reporting
-            // throw RuntimeException("Forced error for Sentry testing")
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
             appLogWrapper.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -93,6 +93,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun storeCredentials(urlLogin: UriLogin): Boolean = withContext(ioDispatcher) {
         try {
+            // TODO: Remove this line before merging — used to force
+            //  the error path for testing Sentry/analytics reporting
+            // throw RuntimeException("Forced error for Sentry testing")
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
             appLogWrapper.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -22,8 +22,8 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.Ur
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import com.automattic.android.tracks.crashlogging.CrashLogging
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -251,17 +251,17 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     errorMessage = errorMessage
                 )
             } else {
-                val nonNullSite = site!!
+                val resolvedSite = site ?: return@launch
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(nonNullSite.id) != true,
+                                oldSitesIDs?.contains(resolvedSite.id) != true,
                         showPostSignupInterstitial = !siteStore.hasSite()
                                 && appPrefsWrapper.shouldShowPostSignupInterstitial,
                         siteUrl = currentUrlLogin?.siteUrl,
                         oldSitesIDs = oldSitesIDs,
                         isError = false,
-                        newSiteLocalId = nonNullSite.id
+                        newSiteLocalId = resolvedSite.id
                     )
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -63,6 +63,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             if (rawData.isEmpty()) {
                 appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
+                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -120,6 +121,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    siteUrl, "empty_fetch_params"
+                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -139,6 +143,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                siteUrl, "fetch_sites_exception"
             )
             emitErrorFetching(siteUrl)
         }
@@ -173,6 +180,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                                     .siteHasBadCredentials(it)
                             }
                         }"
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 _onFinishedEvent.emit(
                     NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -22,6 +22,8 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.Ur
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -34,6 +36,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     private val siteStore: SiteStore,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val appLogWrapper: AppLogWrapper,
+    private val crashLogging: CrashLogging,
 ) : ViewModel() {
     private val _onFinishedEvent = MutableSharedFlow<NavigationActionData>()
     /**
@@ -141,11 +144,18 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
             )
-            emitError(siteUrl = siteUrl, errorMessage = e.message)
+            emitError(siteUrl = siteUrl, errorMessage = e.message, cause = e)
         }
     }
 
-    private suspend fun emitError(siteUrl: String, errorMessage: String? = null) =
+    private suspend fun emitError(
+        siteUrl: String,
+        errorMessage: String? = null,
+        cause: Throwable? = null
+    ) {
+        val exception = cause
+            ?: Exception("Application password login failed: $errorMessage")
+        crashLogging.sendReportWithTag(exception, AppLog.T.MAIN)
         _onFinishedEvent.emit(
             NavigationActionData(
                 showSiteSelector = false,
@@ -156,6 +166,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 errorMessage = errorMessage
             )
         )
+    }
 
     @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
@@ -192,7 +203,8 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "Failed to read sites: ${e.message}"
+                    errorMessage = "Failed to read sites: ${e.message}",
+                    cause = e
                 )
                 return@launch
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -11,6 +11,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -175,97 +176,109 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
     }
 
-    @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {
-            val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
-
             if (event.isError) {
-                val error = event.error
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: " +
-                        "SiteStore error ${error?.type}: ${error?.message}"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "SiteStore error: " +
-                        "${error?.type} — ${error?.message}"
-                )
-                return@launch
-            }
-
-            val site = try {
-                siteStore.sites.firstOrNull {
-                    UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl
-                }
-            } catch (e: Exception) {
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: " +
-                        "exception reading sites from DB: " +
-                        e.stackTraceToString()
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = "Failed to read sites: ${e.message}",
-                    cause = e
-                )
-                return@launch
-            }
-
-            val errorMessage = when {
-                event.rowsAffected < 1 -> {
-                    "No rows affected (rowsAffected=${event.rowsAffected})"
-                }
-                site == null -> {
-                    "Site not found for URL: $currentNormalizedUrl"
-                }
-                applicationPasswordLoginHelper.siteHasBadCredentials(site) -> {
-                    "Credentials are empty for site: $currentNormalizedUrl"
-                }
-                else -> null
-            }
-
-            if (errorMessage != null) {
-                appLogWrapper.e(
-                    AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed: $errorMessage"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
-                )
-                emitError(
-                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-                    errorMessage = errorMessage
-                )
+                handleSiteChangedError(event)
             } else {
-                val resolvedSite = site ?: return@launch
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(resolvedSite.id) != true,
-                        showPostSignupInterstitial = !siteStore.hasSite()
-                                && appPrefsWrapper.shouldShowPostSignupInterstitial,
-                        siteUrl = currentUrlLogin?.siteUrl,
-                        oldSitesIDs = oldSitesIDs,
-                        isError = false,
-                        newSiteLocalId = resolvedSite.id
-                    )
-                )
+                handleSiteChangedSuccess(event)
             }
         }
+    }
+
+    private suspend fun handleSiteChangedError(event: OnSiteChanged) {
+        val error = event.error
+        appLogWrapper.e(
+            AppLog.T.MAIN,
+            "A_P: onSiteChanged failed: " +
+                "SiteStore error ${error?.type}: ${error?.message}"
+        )
+        applicationPasswordLoginHelper.trackStoringFailed(
+            currentUrlLogin?.siteUrl,
+            "site_changed_failed"
+        )
+        emitError(
+            siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+            errorMessage = "SiteStore error: " +
+                "${error?.type} — ${error?.message}"
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handleSiteChangedSuccess(event: OnSiteChanged) {
+        val normalizedUrl =
+            UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
+
+        val site = try {
+            siteStore.sites.firstOrNull {
+                UrlUtils.normalizeUrl(it.url) == normalizedUrl
+            }
+        } catch (e: Exception) {
+            logAndEmitSiteChangedError(
+                "exception reading sites from DB: " +
+                    e.stackTraceToString(),
+                "Failed to read sites: ${e.message}",
+                e
+            )
+            return
+        }
+
+        val errorMessage = validateSiteChanged(
+            event, site, normalizedUrl
+        )
+        if (errorMessage != null) {
+            logAndEmitSiteChangedError(errorMessage, errorMessage)
+        } else {
+            val resolvedSite = site ?: return
+            _onFinishedEvent.emit(
+                NavigationActionData(
+                    showSiteSelector = siteStore.hasSite() &&
+                        oldSitesIDs?.contains(resolvedSite.id) != true,
+                    showPostSignupInterstitial = !siteStore.hasSite()
+                        && appPrefsWrapper.shouldShowPostSignupInterstitial,
+                    siteUrl = currentUrlLogin?.siteUrl,
+                    oldSitesIDs = oldSitesIDs,
+                    isError = false,
+                    newSiteLocalId = resolvedSite.id
+                )
+            )
+        }
+    }
+
+    private fun validateSiteChanged(
+        event: OnSiteChanged,
+        site: SiteModel?,
+        normalizedUrl: String?
+    ): String? = when {
+        event.rowsAffected < 1 ->
+            "No rows affected (rowsAffected=${event.rowsAffected})"
+        site == null ->
+            "Site not found for URL: $normalizedUrl"
+        applicationPasswordLoginHelper.siteHasBadCredentials(site) ->
+            "Credentials are empty for site: $normalizedUrl"
+        else -> null
+    }
+
+    private suspend fun logAndEmitSiteChangedError(
+        logMessage: String,
+        errorMessage: String,
+        cause: Throwable? = null
+    ) {
+        appLogWrapper.e(
+            AppLog.T.MAIN,
+            "A_P: onSiteChanged failed: $logMessage"
+        )
+        applicationPasswordLoginHelper.trackStoringFailed(
+            currentUrlLogin?.siteUrl,
+            "site_changed_failed"
+        )
+        emitError(
+            siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+            errorMessage = errorMessage,
+            cause = cause
+        )
     }
 
     data class NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -71,7 +71,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: Cannot store credentials: rawData is empty"
                 )
                 applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
-                emitError(siteUrl = "", errorMessage = "Callback data was empty")
+                emitError(siteUrl = "", errorMessage = "empty_raw_data")
                 return@launch
             }
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
@@ -99,6 +99,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.DB,
                 "A_P: Error storing credentials: ${e.stackTraceToString()}"
             )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                urlLogin.siteUrl, "store_credentials_exception"
+            )
+            crashLogging.sendReportWithTag(e, AppLog.T.DB)
             false
         }
     }
@@ -125,10 +129,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
                 emitError(
                     siteUrl = siteUrl,
-                    errorMessage = "Missing login data — " +
-                        "username empty: ${username.isEmpty()}, " +
-                        "password empty: ${password.isEmpty()}, " +
-                        "apiRootUrl empty: ${apiRootUrl.isEmpty()}"
+                    errorMessage = "empty_fetch_params"
                 )
             } else {
                 val xmlRpcEndpoint =
@@ -201,8 +202,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
         emitError(
             siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-            errorMessage = "SiteStore error: " +
-                "${error?.type} — ${error?.message}"
+            errorMessage = "site_store_error"
         )
     }
 
@@ -217,19 +217,20 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             }
         } catch (e: Exception) {
             logAndEmitSiteChangedError(
-                "exception reading sites from DB: " +
+                logMessage = "exception reading sites from DB: " +
                     e.stackTraceToString(),
-                "Failed to read sites: ${e.message}",
-                e
+                errorCode = "db_read_exception",
+                cause = e
             )
             return
         }
 
-        val errorMessage = validateSiteChanged(
-            event, site, normalizedUrl
-        )
-        if (errorMessage != null) {
-            logAndEmitSiteChangedError(errorMessage, errorMessage)
+        val validationError = validateSiteChanged(event, site)
+        if (validationError != null) {
+            logAndEmitSiteChangedError(
+                logMessage = validationError.logMessage,
+                errorCode = validationError.errorCode
+            )
         } else {
             val resolvedSite = site ?: return
             _onFinishedEvent.emit(
@@ -249,21 +250,33 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
 
     private fun validateSiteChanged(
         event: OnSiteChanged,
-        site: SiteModel?,
-        normalizedUrl: String?
-    ): String? = when {
-        event.rowsAffected < 1 ->
-            "No rows affected (rowsAffected=${event.rowsAffected})"
-        site == null ->
-            "Site not found for URL: $normalizedUrl"
-        applicationPasswordLoginHelper.siteHasBadCredentials(site) ->
-            "Credentials are empty for site: $normalizedUrl"
+        site: SiteModel?
+    ): SiteChangedValidationError? = when {
+        event.rowsAffected < 1 -> SiteChangedValidationError(
+            logMessage = "No rows affected " +
+                "(rowsAffected=${event.rowsAffected})",
+            errorCode = "no_rows_affected"
+        )
+        site == null -> SiteChangedValidationError(
+            logMessage = "Site not found after update",
+            errorCode = "site_not_found"
+        )
+        applicationPasswordLoginHelper
+            .siteHasBadCredentials(site) -> SiteChangedValidationError(
+            logMessage = "Credentials are empty after store",
+            errorCode = "empty_credentials"
+        )
         else -> null
     }
 
+    private data class SiteChangedValidationError(
+        val logMessage: String,
+        val errorCode: String
+    )
+
     private suspend fun logAndEmitSiteChangedError(
         logMessage: String,
-        errorMessage: String,
+        errorCode: String,
         cause: Throwable? = null
     ) {
         appLogWrapper.e(
@@ -276,7 +289,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
         emitError(
             siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
-            errorMessage = errorMessage,
+            errorMessage = errorCode,
             cause = cause
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -62,7 +62,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     fun setupSite(rawData: String) {
         viewModelScope.launch {
             if (rawData.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "Cannot store credentials: rawData is empty")
+                appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -95,7 +95,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         try {
             applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.stackTraceToString()}")
+            appLogWrapper.e(
+                AppLog.T.DB,
+                "A_P: Error storing credentials: ${e.stackTraceToString()}"
+            )
             false
         }
     }
@@ -109,9 +112,14 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         ) = withContext(ioDispatcher) {
         try {
             if (username.isEmpty() || password.isEmpty() || siteUrl.isEmpty() || apiRootUrl.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "Cannot fetch sites for credential storing: " +
-                        "Username: $username, Password: ${password.isEmpty()}, SiteUrl: $siteUrl, " +
-                        "API Root URL: $apiRootUrl")
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: Cannot fetch sites for credential storing" +
+                        " - username isEmpty=${username.isEmpty()}" +
+                        ", password isEmpty=${password.isEmpty()}" +
+                        ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
+                        ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
+                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -128,7 +136,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.stackTraceToString()}")
+            appLogWrapper.e(
+                AppLog.T.API,
+                "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
             emitErrorFetching(siteUrl)
         }
     }
@@ -150,7 +161,19 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
             if (event.rowsAffected < 1 || site == null || applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
-                appLogWrapper.e(AppLog.T.MAIN, "Site not found or credentials are empty.")
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed" +
+                        " for: ${currentUrlLogin?.siteUrl}" +
+                        " - rowsAffected=${event.rowsAffected}" +
+                        ", siteFound=${site != null}" +
+                        ", badCredentials=${
+                            site?.let {
+                                applicationPasswordLoginHelper
+                                    .siteHasBadCredentials(it)
+                            }
+                        }"
+                )
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -69,6 +69,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     AppLog.T.MAIN,
                     "A_P: Cannot store credentials: rawData is empty"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 emitError(siteUrl = "", errorMessage = "Callback data was empty")
                 return@launch
             }
@@ -118,6 +119,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    siteUrl, "empty_fetch_params"
+                )
                 emitError(
                     siteUrl = siteUrl,
                     errorMessage = "Missing login data — " +
@@ -143,6 +147,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
+            )
+            applicationPasswordLoginHelper.trackStoringFailed(
+                siteUrl, "fetch_sites_exception"
             )
             emitError(siteUrl = siteUrl, errorMessage = e.message, cause = e)
         }
@@ -182,6 +189,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: onSiteChanged failed: " +
                         "SiteStore error ${error?.type}: ${error?.message}"
                 )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
+                )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
                     errorMessage = "SiteStore error: " +
@@ -200,6 +211,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     "A_P: onSiteChanged failed: " +
                         "exception reading sites from DB: " +
                         e.stackTraceToString()
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
@@ -226,6 +241,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 appLogWrapper.e(
                     AppLog.T.MAIN,
                     "A_P: onSiteChanged failed: $errorMessage"
+                )
+                applicationPasswordLoginHelper.trackStoringFailed(
+                    currentUrlLogin?.siteUrl,
+                    "site_changed_failed"
                 )
                 emitError(
                     siteUrl = currentUrlLogin?.siteUrl.orEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -63,7 +63,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             if (rawData.isEmpty()) {
                 appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
-                applicationPasswordLoginHelper.trackStoringFailed("", "empty_raw_data")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -121,9 +120,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    siteUrl, "empty_fetch_params"
-                )
                 emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
@@ -143,9 +139,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             appLogWrapper.e(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
-            )
-            applicationPasswordLoginHelper.trackStoringFailed(
-                siteUrl, "fetch_sites_exception"
             )
             emitErrorFetching(siteUrl)
         }
@@ -180,10 +173,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                                     .siteHasBadCredentials(it)
                             }
                         }"
-                )
-                applicationPasswordLoginHelper.trackStoringFailed(
-                    currentUrlLogin?.siteUrl,
-                    "site_changed_failed"
                 )
                 _onFinishedEvent.emit(
                     NavigationActionData(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -62,16 +62,11 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     fun setupSite(rawData: String) {
         viewModelScope.launch {
             if (rawData.isEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "A_P: Cannot store credentials: rawData is empty")
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = false,
-                        showPostSignupInterstitial = false,
-                        siteUrl = "",
-                        oldSitesIDs = oldSitesIDs,
-                        isError = true
-                    )
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: Cannot store credentials: rawData is empty"
                 )
+                emitError(siteUrl = "", errorMessage = "Callback data was empty")
                 return@launch
             }
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
@@ -120,7 +115,13 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         ", siteUrl isEmpty=${siteUrl.isEmpty()}" +
                         ", apiRootUrl isEmpty=${apiRootUrl.isEmpty()}"
                 )
-                emitErrorFetching(siteUrl)
+                emitError(
+                    siteUrl = siteUrl,
+                    errorMessage = "Missing login data — " +
+                        "username empty: ${username.isEmpty()}, " +
+                        "password empty: ${password.isEmpty()}, " +
+                        "apiRootUrl empty: ${apiRootUrl.isEmpty()}"
+                )
             } else {
                 val xmlRpcEndpoint =
                     selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(siteUrl)
@@ -140,60 +141,96 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 AppLog.T.API,
                 "A_P: Error fetching sites: ${e.stackTraceToString()}"
             )
-            emitErrorFetching(siteUrl)
+            emitError(siteUrl = siteUrl, errorMessage = e.message)
         }
     }
 
-    private suspend fun emitErrorFetching(siteUrl: String) =  _onFinishedEvent.emit(
-        NavigationActionData(
-            showSiteSelector = false,
-            showPostSignupInterstitial = false,
-            siteUrl = siteUrl,
-            oldSitesIDs = oldSitesIDs,
-            isError = true
+    private suspend fun emitError(siteUrl: String, errorMessage: String? = null) =
+        _onFinishedEvent.emit(
+            NavigationActionData(
+                showSiteSelector = false,
+                showPostSignupInterstitial = false,
+                siteUrl = siteUrl,
+                oldSitesIDs = oldSitesIDs,
+                isError = true,
+                errorMessage = errorMessage
+            )
         )
-    )
 
+    @Suppress("TooGenericExceptionCaught")
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
-            val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-            if (event.rowsAffected < 1 || site == null || applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
+
+            if (event.isError) {
+                val error = event.error
                 appLogWrapper.e(
                     AppLog.T.MAIN,
-                    "A_P: onSiteChanged failed" +
-                        " for: ${currentUrlLogin?.siteUrl}" +
-                        " - rowsAffected=${event.rowsAffected}" +
-                        ", siteFound=${site != null}" +
-                        ", badCredentials=${
-                            site?.let {
-                                applicationPasswordLoginHelper
-                                    .siteHasBadCredentials(it)
-                            }
-                        }"
+                    "A_P: onSiteChanged failed: " +
+                        "SiteStore error ${error?.type}: ${error?.message}"
                 )
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = false,
-                        showPostSignupInterstitial = false,
-                        siteUrl = currentUrlLogin?.siteUrl,
-                        oldSitesIDs = oldSitesIDs,
-                        isError = true
-                    )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = "SiteStore error: " +
+                        "${error?.type} — ${error?.message}"
+                )
+                return@launch
+            }
+
+            val site = try {
+                siteStore.sites.firstOrNull {
+                    UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl
+                }
+            } catch (e: Exception) {
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed: " +
+                        "exception reading sites from DB: " +
+                        e.stackTraceToString()
+                )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = "Failed to read sites: ${e.message}"
+                )
+                return@launch
+            }
+
+            val errorMessage = when {
+                event.rowsAffected < 1 -> {
+                    "No rows affected (rowsAffected=${event.rowsAffected})"
+                }
+                site == null -> {
+                    "Site not found for URL: $currentNormalizedUrl"
+                }
+                applicationPasswordLoginHelper.siteHasBadCredentials(site) -> {
+                    "Credentials are empty for site: $currentNormalizedUrl"
+                }
+                else -> null
+            }
+
+            if (errorMessage != null) {
+                appLogWrapper.e(
+                    AppLog.T.MAIN,
+                    "A_P: onSiteChanged failed: $errorMessage"
+                )
+                emitError(
+                    siteUrl = currentUrlLogin?.siteUrl.orEmpty(),
+                    errorMessage = errorMessage
                 )
             } else {
+                val nonNullSite = site!!
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = siteStore.hasSite() &&
-                                oldSitesIDs?.contains(site.id) != true, // null or false
+                                oldSitesIDs?.contains(nonNullSite.id) != true,
                         showPostSignupInterstitial = !siteStore.hasSite()
                                 && appPrefsWrapper.shouldShowPostSignupInterstitial,
                         siteUrl = currentUrlLogin?.siteUrl,
                         oldSitesIDs = oldSitesIDs,
                         isError = false,
-                        newSiteLocalId = site.id
+                        newSiteLocalId = nonNullSite.id
                     )
                 )
             }
@@ -206,6 +243,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         val siteUrl: String?,
         val oldSitesIDs: ArrayList<Int>?,
         val isError: Boolean,
-        val newSiteLocalId: Int? = null
+        val newSiteLocalId: Int? = null,
+        val errorMessage: String? = null
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -121,16 +121,13 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                val availableSiteUrls = siteStore.sites.map {
-                    UrlUtils.normalizeUrl(it.url)
-                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store." +
-                        " Available sites: $availableSiteUrls"
+                        " - site not found in store" +
+                        " (${siteStore.sites.size} sites available)"
                 )
                 false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -88,41 +88,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     @Suppress("ComplexCondition")
-    suspend fun storeApplicationPasswordCredentialsFrom(urlLogin: UriLogin): Boolean {
+    suspend fun storeApplicationPasswordCredentialsFrom(
+        urlLogin: UriLogin
+    ): Boolean {
         if (urlLogin.apiRootUrl == null ||
             urlLogin.user.isNullOrEmpty() ||
             urlLogin.password.isNullOrEmpty() ||
             urlLogin.siteUrl == null ||
             urlLogin.siteUrl == processedAppPasswordData
-            ) {
-            appLogWrapper.e(
-                AppLog.T.DB,
-                "A_P: Cannot save application password credentials" +
-                    " for: ${urlLogin.siteUrl}" +
-                    " - apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
-                    ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
-                    ", password isEmpty=${urlLogin.password.isNullOrEmpty()}" +
-                    ", siteUrl isNull=${urlLogin.siteUrl == null}" +
-                    ", alreadyProcessed=" +
-                    "${urlLogin.siteUrl == processedAppPasswordData}"
-            )
-            trackStoringFailed(urlLogin.siteUrl, "bad_data")
-            crashLogging.sendReportWithTag(
-                Exception(
-                    "A_P: bad_data for ${urlLogin.siteUrl}" +
-                        " — apiRootUrl isNull=" +
-                        "${urlLogin.apiRootUrl == null}" +
-                        ", user isEmpty=" +
-                        "${urlLogin.user.isNullOrEmpty()}" +
-                        ", password isEmpty=" +
-                        "${urlLogin.password.isNullOrEmpty()}" +
-                        ", siteUrl isNull=" +
-                        "${urlLogin.siteUrl == null}" +
-                        ", alreadyProcessed=" +
-                        "${urlLogin.siteUrl == processedAppPasswordData}"
-                ),
-                AppLog.T.DB
-            )
+        ) {
+            logAndReportBadData(urlLogin)
             return false
         }
 
@@ -144,24 +119,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                appLogWrapper.e(
-                    AppLog.T.DB,
-                    "A_P: Cannot save application password" +
-                        " credentials for: ${urlLogin.siteUrl}" +
-                        " (normalized: $normalizedUrl)" +
-                        " - site not found in store" +
-                        " (${siteStore.sites.size} sites available)"
-                )
-                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
-                crashLogging.sendReportWithTag(
-                    Exception(
-                        "A_P: site_not_found for " +
-                            "${urlLogin.siteUrl}" +
-                            " (normalized: $normalizedUrl)" +
-                            " — ${siteStore.sites.size} sites" +
-                            " available"
-                    ),
-                    AppLog.T.DB
+                logAndReportSiteNotFound(
+                    urlLogin.siteUrl, normalizedUrl
                 )
                 false
             }
@@ -176,6 +135,49 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             Stat.APPLICATION_PASSWORD_STORING_FAILED,
             properties
         )
+    }
+
+    private fun reportStoringFailedToSentry(
+        reason: String,
+        detail: String
+    ) {
+        crashLogging.sendReportWithTag(
+            Exception("A_P: $reason — $detail"),
+            AppLog.T.DB
+        )
+    }
+
+    private fun logAndReportBadData(urlLogin: UriLogin) {
+        val detail =
+            "apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
+                ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
+                ", password isEmpty=" +
+                "${urlLogin.password.isNullOrEmpty()}" +
+                ", siteUrl isNull=${urlLogin.siteUrl == null}" +
+                ", alreadyProcessed=" +
+                "${urlLogin.siteUrl == processedAppPasswordData}"
+        appLogWrapper.e(
+            AppLog.T.DB,
+            "A_P: Cannot save credentials" +
+                " for: ${urlLogin.siteUrl} - $detail"
+        )
+        trackStoringFailed(urlLogin.siteUrl, "bad_data")
+        reportStoringFailedToSentry("bad_data", detail)
+    }
+
+    private fun logAndReportSiteNotFound(
+        siteUrl: String?,
+        normalizedUrl: String?
+    ) {
+        val detail = "$siteUrl (normalized: $normalizedUrl)" +
+            " — ${siteStore.sites.size} sites available"
+        appLogWrapper.e(
+            AppLog.T.DB,
+            "A_P: Cannot save credentials" +
+                " - site not found: $detail"
+        )
+        trackStoringFailed(siteUrl, "site_not_found")
+        reportStoringFailedToSentry("site_not_found", detail)
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -15,7 +14,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -24,7 +22,6 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
-private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -35,8 +32,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
-    private val crashLogging: CrashLogging
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -104,7 +100,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
-            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -126,34 +121,20 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
+                val availableSiteUrls = siteStore.sites.map {
+                    UrlUtils.normalizeUrl(it.url)
+                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store" +
-                        " (${siteStore.sites.size} sites available)"
+                        " - site not found in store." +
+                        " Available sites: $availableSiteUrls"
                 )
-                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
-    }
-
-    fun trackStoringFailed(siteUrl: String?, reason: String) {
-        val properties: MutableMap<String, String?> = HashMap()
-        properties[URL_TAG] = siteUrl
-        properties[REASON_TAG] = reason
-        AnalyticsTracker.track(
-            Stat.APPLICATION_PASSWORD_STORING_FAILED,
-            properties
-        )
-        crashLogging.sendReportWithTag(
-            exception = Exception(
-                "A_P: storing failed for $siteUrl - $reason"
-            ),
-            tag = AppLog.T.DB
-        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -14,6 +15,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -22,6 +24,7 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
+private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -32,7 +35,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -100,6 +104,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
+            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -121,20 +126,34 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
-                val availableSiteUrls = siteStore.sites.map {
-                    UrlUtils.normalizeUrl(it.url)
-                }
                 appLogWrapper.e(
                     AppLog.T.DB,
                     "A_P: Cannot save application password" +
                         " credentials for: ${urlLogin.siteUrl}" +
                         " (normalized: $normalizedUrl)" +
-                        " - site not found in store." +
-                        " Available sites: $availableSiteUrls"
+                        " - site not found in store" +
+                        " (${siteStore.sites.size} sites available)"
                 )
+                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
+    }
+
+    fun trackStoringFailed(siteUrl: String?, reason: String) {
+        val properties: MutableMap<String, String?> = HashMap()
+        properties[URL_TAG] = siteUrl
+        properties[REASON_TAG] = reason
+        AnalyticsTracker.track(
+            Stat.APPLICATION_PASSWORD_STORING_FAILED,
+            properties
+        )
+        crashLogging.sendReportWithTag(
+            exception = Exception(
+                "A_P: storing failed for $siteUrl - $reason"
+            ),
+            tag = AppLog.T.DB
+        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,6 +17,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -35,7 +37,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -104,6 +107,22 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
             trackStoringFailed(urlLogin.siteUrl, "bad_data")
+            crashLogging.sendReportWithTag(
+                Exception(
+                    "A_P: bad_data for ${urlLogin.siteUrl}" +
+                        " — apiRootUrl isNull=" +
+                        "${urlLogin.apiRootUrl == null}" +
+                        ", user isEmpty=" +
+                        "${urlLogin.user.isNullOrEmpty()}" +
+                        ", password isEmpty=" +
+                        "${urlLogin.password.isNullOrEmpty()}" +
+                        ", siteUrl isNull=" +
+                        "${urlLogin.siteUrl == null}" +
+                        ", alreadyProcessed=" +
+                        "${urlLogin.siteUrl == processedAppPasswordData}"
+                ),
+                AppLog.T.DB
+            )
             return false
         }
 
@@ -134,6 +153,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         " (${siteStore.sites.size} sites available)"
                 )
                 trackStoringFailed(urlLogin.siteUrl, "site_not_found")
+                crashLogging.sendReportWithTag(
+                    Exception(
+                        "A_P: site_not_found for " +
+                            "${urlLogin.siteUrl}" +
+                            " (normalized: $normalizedUrl)" +
+                            " — ${siteStore.sites.size} sites" +
+                            " available"
+                    ),
+                    AppLog.T.DB
+                )
                 false
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
+import com.automattic.android.tracks.crashlogging.CrashLogging
+import org.wordpress.android.R
+import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -14,6 +17,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -22,6 +26,7 @@ import javax.inject.Named
 
 private const val URL_TAG = "url"
 private const val SUCCESS_TAG = "success"
+private const val REASON_TAG = "reason"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -32,7 +37,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
+    private val crashLogging: CrashLogging
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -100,6 +106,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     ", alreadyProcessed=" +
                     "${urlLogin.siteUrl == processedAppPasswordData}"
             )
+            trackStoringFailed(urlLogin.siteUrl, "bad_data")
             return false
         }
 
@@ -129,9 +136,26 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         " - site not found in store" +
                         " (${siteStore.sites.size} sites available)"
                 )
+                trackStoringFailed(urlLogin.siteUrl, "site_not_found")
                 false
             }
         }
+    }
+
+    fun trackStoringFailed(siteUrl: String?, reason: String) {
+        val properties: MutableMap<String, String?> = HashMap()
+        properties[URL_TAG] = siteUrl
+        properties[REASON_TAG] = reason
+        AnalyticsTracker.track(
+            Stat.APPLICATION_PASSWORD_STORING_FAILED,
+            properties
+        )
+        crashLogging.sendReportWithTag(
+            exception = Exception(
+                "A_P: storing failed for $siteUrl - $reason"
+            ),
+            tag = AppLog.T.DB
+        )
     }
 
     private fun trackSuccessful(siteUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import org.wordpress.android.R
-import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.accounts.login
 
 import androidx.core.net.toUri
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,7 +16,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.UrlUtils
-import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
@@ -37,8 +35,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
     private val apiRootUrlCache: ApiRootUrlCache,
-    private val discoverSuccessWrapper: DiscoverSuccessWrapper,
-    private val crashLogging: CrashLogging
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -149,12 +146,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         AnalyticsTracker.track(
             Stat.APPLICATION_PASSWORD_STORING_FAILED,
             properties
-        )
-        crashLogging.sendReportWithTag(
-            exception = Exception(
-                "A_P: storing failed for $siteUrl - $reason"
-            ),
-            tag = AppLog.T.DB
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -91,7 +91,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             ) {
             appLogWrapper.e(
                 AppLog.T.DB,
-                "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - bad data"
+                "A_P: Cannot save application password credentials" +
+                    " for: ${urlLogin.siteUrl}" +
+                    " - apiRootUrl isNull=${urlLogin.apiRootUrl == null}" +
+                    ", user isEmpty=${urlLogin.user.isNullOrEmpty()}" +
+                    ", password isEmpty=${urlLogin.password.isNullOrEmpty()}" +
+                    ", siteUrl isNull=${urlLogin.siteUrl == null}" +
+                    ", alreadyProcessed=" +
+                    "${urlLogin.siteUrl == processedAppPasswordData}"
             )
             return false
         }
@@ -114,9 +121,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
+                val availableSiteUrls = siteStore.sites.map {
+                    UrlUtils.normalizeUrl(it.url)
+                }
                 appLogWrapper.e(
                     AppLog.T.DB,
-                    "A_P: Cannot save application password credentials for: ${urlLogin.siteUrl} - null site"
+                    "A_P: Cannot save application password" +
+                        " credentials for: ${urlLogin.siteUrl}" +
+                        " (normalized: $normalizedUrl)" +
+                        " - site not found in store." +
+                        " Available sites: $availableSiteUrls"
                 )
                 false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -93,7 +93,7 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                             AppLog.T.API,
                             "A_P: Error creating application password" +
                                 " for: ${site.url}" +
-                                " - response: $response"
+                                " - response type: ${response::class.simpleName}"
                         )
                         fallbackToManualLogin(site.url)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -89,12 +89,22 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
 
                     else -> {
-                        appLogWrapper.e(AppLog.T.API, "Error creating application password")
+                        appLogWrapper.e(
+                            AppLog.T.API,
+                            "A_P: Error creating application password" +
+                                " for: ${site.url}" +
+                                " - response: $response"
+                        )
                         fallbackToManualLogin(site.url)
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(AppLog.T.API, "Exception creating application password: ${e.message}")
+                appLogWrapper.e(
+                    AppLog.T.API,
+                    "A_P: Exception creating application password" +
+                        " for: ${site.url}" +
+                        " - ${e.message}"
+                )
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false
@@ -115,7 +125,11 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
             val authUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(siteUrl)
             _navigationEvent.emit(NavigationEvent.FallbackToManualLogin(authUrl))
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Failed to get authorization URL: ${e.message}")
+            appLogWrapper.e(
+                AppLog.T.API,
+                "A_P: Failed to get authorization URL" +
+                    " for: $siteUrl - ${e.message}"
+            )
             _navigationEvent.emit(NavigationEvent.Error)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordAutoAuthDialogViewModel.kt
@@ -89,27 +89,24 @@ class ApplicationPasswordAutoAuthDialogViewModel @Inject constructor(
                     }
 
                     else -> {
-                        appLogWrapper.e(
-                            AppLog.T.API,
-                            "A_P: Error creating application password" +
-                                " for: ${site.url}" +
-                                " - response type: ${response::class.simpleName}"
-                        )
+                        logCreationError(site.url, "response type: ${response::class.simpleName}")
                         fallbackToManualLogin(site.url)
                     }
                 }
             } catch (e: Exception) {
-                appLogWrapper.e(
-                    AppLog.T.API,
-                    "A_P: Exception creating application password" +
-                        " for: ${site.url}" +
-                        " - ${e.message}"
-                )
+                logCreationError(site.url, e.message.orEmpty())
                 fallbackToManualLogin(site.url)
             } finally {
                 _isLoading.value = false
             }
         }
+    }
+
+    private fun logCreationError(siteUrl: String, detail: String) {
+        appLogWrapper.e(
+            AppLog.T.API,
+            "A_P: Error creating application password for: $siteUrl - $detail"
+        )
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -84,7 +84,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             siteUrl = "",
             oldSitesIDs = null,
             isError = true,
-            errorMessage = "Callback data was empty"
+            errorMessage = "empty_raw_data"
         )
 
         // When
@@ -112,10 +112,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 siteUrl = "",
                 oldSitesIDs = null,
                 isError = true,
-                errorMessage = "Missing login data — " +
-                    "username empty: true, " +
-                    "password empty: true, " +
-                    "apiRootUrl empty: true"
+                errorMessage = "empty_fetch_params"
             )
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(malformedRawData))
                 .thenReturn(
@@ -186,9 +183,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val finishedEvent = awaitItem()
                 assertTrue(finishedEvent.isError)
-                assertTrue(
-                    finishedEvent.errorMessage
-                        ?.contains("Site not found") == true
+                assertEquals(
+                    "site_not_found", finishedEvent.errorMessage
                 )
                 verify(selfHostedEndpointFinder, times(1))
                     .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
@@ -335,10 +331,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertEquals(
-                    "SiteStore error: GENERIC_ERROR — encryption failed",
-                    result.errorMessage
-                )
+                assertEquals("site_store_error", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -359,9 +352,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertTrue(
-                    result.errorMessage?.contains("No rows affected") == true
-                )
+                assertEquals("no_rows_affected", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -389,10 +380,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertTrue(
-                    result.errorMessage
-                        ?.contains("Credentials are empty") == true
-                )
+                assertEquals("empty_credentials", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -415,10 +403,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val result = awaitItem()
                 assertTrue(result.isError)
-                assertEquals(
-                    "Failed to read sites: DB corrupted",
-                    result.errorMessage
-                )
+                assertEquals("db_read_exception", result.errorMessage)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -1,26 +1,28 @@
 package org.wordpress.android.ui.accounts.applicationpassword
 
 import app.cash.turbine.test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
-import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
-import org.wordpress.android.fluxc.store.SiteStore
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 @Suppress("MaxLineLength")
@@ -43,6 +45,9 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var viewModel: ApplicationPasswordLoginViewModel
 
     private val rawData = "url=callback?site_url=https://example.com&user_login=user&password=pass"
@@ -63,7 +68,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             selfHostedEndpointFinder,
             siteStore,
             appPrefsWrapper,
-            appLogWrapper
+            appLogWrapper,
+            crashLogging
         )
         whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)).thenReturn(urlLogin)
     }
@@ -77,7 +83,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             showPostSignupInterstitial = false,
             siteUrl = "",
             oldSitesIDs = null,
-            isError = true
+            isError = true,
+            errorMessage = "Callback data was empty"
         )
 
         // When
@@ -104,7 +111,11 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = "",
                 oldSitesIDs = null,
-                isError = true
+                isError = true,
+                errorMessage = "Missing login data — " +
+                    "username empty: true, " +
+                    "password empty: true, " +
+                    "apiRootUrl empty: true"
             )
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(malformedRawData))
                 .thenReturn(
@@ -132,7 +143,8 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 showPostSignupInterstitial = false,
                 siteUrl = urlLogin.siteUrl,
                 oldSitesIDs = null,
-                isError = true
+                isError = true,
+                errorMessage = null
             )
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any())).thenThrow(RuntimeException())
@@ -154,31 +166,32 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
         runTest {
             // Given
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
-            val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
-                showSiteSelector = false,
-                showPostSignupInterstitial = false,
-                siteUrl = urlLogin.siteUrl,
-                oldSitesIDs = null,
-                isError = true
-            )
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
-            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
-                .thenReturn(xmlRpcEndpoint)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+            ).thenReturn(false)
+            whenever(
+                selfHostedEndpointFinder
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+            ).thenReturn(xmlRpcEndpoint)
 
             // When
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
                 viewModel.onSiteChanged(
-                    SiteStore.OnSiteChanged(
-                        rowsAffected = 1,
-                    )
+                    SiteStore.OnSiteChanged(rowsAffected = 1)
                 )
 
                 // Then
                 val finishedEvent = awaitItem()
-                assertEquals(expectedResult, finishedEvent)
-                verify(selfHostedEndpointFinder, times(1)).verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                assertTrue(finishedEvent.isError)
+                assertTrue(
+                    finishedEvent.errorMessage
+                        ?.contains("Site not found") == true
+                )
+                verify(selfHostedEndpointFinder, times(1))
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
                 verify(siteStore, times(1)).sites
                 cancelAndIgnoreRemainingEvents()
             }
@@ -275,9 +288,14 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             )
             whenever(siteStore.hasSite()).thenReturn(true)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
-            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
-                .thenReturn(xmlRpcEndpoint)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+            ).thenReturn(false)
+            whenever(
+                selfHostedEndpointFinder
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+            ).thenReturn(xmlRpcEndpoint)
 
             // When
             viewModel.onFinishedEvent.test {
@@ -293,34 +311,74 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 // Then
                 val finishedEvent = awaitItem()
                 assertEquals(expectedResult, finishedEvent)
-                verify(selfHostedEndpointFinder, times(1)).verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                verify(selfHostedEndpointFinder, times(1))
+                    .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no interstitial by preferences`() =
+    fun `given onSiteChanged with error, then emit error with SiteStore details`() =
         runTest {
             // Given
-            val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
-            val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
-                showSiteSelector = false,
-                showPostSignupInterstitial = false,
-                siteUrl = urlLogin.siteUrl,
-                oldSitesIDs = null,
-                isError = false,
-                newSiteLocalId = testSite.id
+            setupFetchSitesFlow()
+            val siteError = SiteStore.SiteError(
+                SiteStore.SiteErrorType.GENERIC_ERROR, "encryption failed"
             )
-            whenever(siteStore.sites).thenReturn(listOf(testSite))
-            whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(false)
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
-            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
-                .thenReturn(xmlRpcEndpoint)
+            val errorEvent = SiteStore.OnSiteChanged(0, siteError)
 
             // When
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
-                // Mock onSiteChanged event
+                viewModel.onSiteChanged(errorEvent)
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertEquals(
+                    "SiteStore error: GENERIC_ERROR — encryption failed",
+                    result.errorMessage
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given onSiteChanged with no rows affected, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(rowsAffected = 0)
+                )
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertTrue(
+                    result.errorMessage?.contains("No rows affected") == true
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given onSiteChanged with bad credentials, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
+            whenever(
+                applicationPasswordLoginHelper.siteHasBadCredentials(any())
+            ).thenReturn(true)
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
                 viewModel.onSiteChanged(
                     SiteStore.OnSiteChanged(
                         rowsAffected = 1,
@@ -329,10 +387,68 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 )
 
                 // Then
-                val finishedEvent = awaitItem()
-                assertEquals(expectedResult, finishedEvent)
-                verify(selfHostedEndpointFinder, times(1)).verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertTrue(
+                    result.errorMessage
+                        ?.contains("Credentials are empty") == true
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `given onSiteChanged with DB exception, then emit error`() =
+        runTest {
+            // Given
+            setupFetchSitesFlow()
+            whenever(siteStore.sites)
+                .thenThrow(RuntimeException("DB corrupted"))
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(rowsAffected = 1)
+                )
+
+                // Then
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertEquals(
+                    "Failed to read sites: DB corrupted",
+                    result.errorMessage
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given error emitted, then crash report is sent`() = runTest {
+        // Given & When
+        viewModel.onFinishedEvent.test {
+            viewModel.setupSite("")
+
+            // Then
+            awaitItem()
+            verify(crashLogging).sendReport(
+                exception = any(),
+                tags = eq(mapOf("tag" to "MAIN")),
+                message = eq(null)
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private suspend fun setupFetchSitesFlow() {
+        val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
+        whenever(
+            applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
+        ).thenReturn(false)
+        whenever(
+            selfHostedEndpointFinder
+                .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
+        ).thenReturn(xmlRpcEndpoint)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -64,9 +63,6 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
-    @Mock
-    lateinit var crashLogging: CrashLogging
-
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -81,8 +77,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper,
-            crashLogging
+            discoverSuccessWrapper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -156,7 +156,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore, times(3)).sites
+            verify(siteStore, times(2)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
+import android.content.Context
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -63,6 +65,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -77,7 +82,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper
+            discoverSuccessWrapper,
+            crashLogging
         )
     }
 
@@ -150,7 +156,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore, times(2)).sites
+            verify(siteStore, times(3)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts.login
 
-import android.content.Context
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
@@ -63,6 +64,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var apiRootUrlCache: ApiRootUrlCache
 
+    @Mock
+    lateinit var crashLogging: CrashLogging
+
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Before
@@ -77,7 +81,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             wpLoginClient,
             appLogWrapper,
             apiRootUrlCache,
-            discoverSuccessWrapper
+            discoverSuccessWrapper,
+            crashLogging
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -150,7 +150,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore).sites
+            verify(siteStore, times(2)).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
         }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1125,8 +1125,7 @@ public final class AnalyticsTracker {
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
         WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
         JP_ANDROID_APPLICATION_PASSWORD_LOGIN,
-        APPLICATION_PASSWORD_SET_OFF,
-        APPLICATION_PASSWORD_STORING_FAILED;
+        APPLICATION_PASSWORD_SET_OFF;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1134,7 +1134,7 @@ public final class AnalyticsTracker {
 
         private String mEventName;
 
-        Stat(String eventName) {
+        Stat(@Nullable String eventName) {
             this.mEventName = eventName;
         }
 

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1125,7 +1125,8 @@ public final class AnalyticsTracker {
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
         WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
         JP_ANDROID_APPLICATION_PASSWORD_LOGIN,
-        APPLICATION_PASSWORD_SET_OFF;
+        APPLICATION_PASSWORD_SET_OFF,
+        APPLICATION_PASSWORD_STORING_FAILED;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1480,18 +1480,24 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchSitesXmlRpcFromApplicationPassword(
         payload: RefreshSitesXMLRPCApplicationPasswordCredentialsPayload
     ): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
-            updateSites(
-                siteXMLRPCClient.fetchSitesFromApplicationPassword(
-                    payload.url,
-                    payload.apiRootUrl,
-                    payload.username,
-                    payload.password
+            try {
+                updateSites(
+                    siteXMLRPCClient.fetchSitesFromApplicationPassword(
+                        payload.url,
+                        payload.apiRootUrl,
+                        payload.username,
+                        payload.password
+                    )
                 )
-            )
+            } catch (e: Exception) {
+                AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
+                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+            }
         }
     }
 
@@ -1547,7 +1553,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
     private fun updateApplicationPassword(siteModel: SiteModel): OnSiteChanged {
         return try {
             val siteFromDB = getSiteByLocalId(siteModel.id)
@@ -1569,6 +1575,13 @@ open class SiteStore @Inject constructor(
             OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteToStore))
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
+        } catch (e: Exception) {
+            AppLog.e(
+                T.DB,
+                "Failed to update application password: ${e.message}",
+                e
+            )
+            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,8 +1495,9 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
-                AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
-                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+                val errorMsg = e.message ?: e.javaClass.simpleName
+                AppLog.e(T.API, "Failed to fetch/store sites: $errorMsg", e)
+                OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, errorMsg))
             }
         }
     }
@@ -1576,12 +1577,13 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
+            val errorMsg = e.message ?: e.javaClass.simpleName
             AppLog.e(
                 T.DB,
-                "Failed to update application password: ${e.message}",
+                "Failed to update application password: $errorMsg",
                 e
             )
-            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
+            OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, errorMsg))
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,8 +1495,6 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
-                // TODO: Narrow to specific exception type once Android 16
-                //  KeyStore root cause is identified (CMM-1949)
                 AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
                 OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
             }
@@ -1578,8 +1576,6 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
-            // TODO: Narrow to specific exception type once Android 16
-            //  KeyStore root cause is identified (CMM-1949)
             AppLog.e(
                 T.DB,
                 "Failed to update application password: ${e.message}",

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1495,6 +1495,8 @@ open class SiteStore @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
+                // TODO: Narrow to specific exception type once Android 16
+                //  KeyStore root cause is identified (CMM-1949)
                 AppLog.e(T.API, "Failed to fetch/store sites: ${e.message}", e)
                 OnSiteChanged(SiteError(SiteErrorType.GENERIC_ERROR, e.message))
             }
@@ -1576,6 +1578,8 @@ open class SiteStore @Inject constructor(
         } catch (e: DuplicateSiteException) {
             OnSiteChanged(SiteError(DUPLICATE_SITE))
         } catch (e: Exception) {
+            // TODO: Narrow to specific exception type once Android 16
+            //  KeyStore root cause is identified (CMM-1949)
             AppLog.e(
                 T.DB,
                 "Failed to update application password: ${e.message}",


### PR DESCRIPTION
## Description

Cherry-picks from #22694 and #22702 into `release/26.7`.

Adds comprehensive logging, analytics tracking, and crash reporting for the
application password login flow:

- **Diagnostic logging**: Improved error logs during application password
  storing, avoiding PII exposure (site URLs) and full response object leaks
- **Analytics tracking**: Added Tracks events for application password storing
  failures with error context
- **Crash reporting**: Sentry reports on login failures and storeCredentials
  false-return paths
- **Error handling**: Internal errors are hidden from user-facing toasts,
  non-null assertions fixed
- **Code quality**: Extracted log helper and refactored long methods to fix
  detekt LongMethod violations

### Files changed
- `ApplicationPasswordLoginViewModel.kt` — error handling, Sentry/Tracks
  integration, refactored `onSiteChanged`
- `ApplicationPasswordLoginHelper.kt` — Sentry reports on storeCredentials
  failures, refactored for detekt
- `ApplicationPasswordAutoAuthDialogViewModel.kt` — PII-safe logging
- `SiteStore.kt` — logging improvements
- Tests updated accordingly

## Testing instructions

NOTE: MORE IMPORTANT THAN THE LOGS IS THE LOGIN FLOW IS NOT BROKEN, SO PLEASE PAY ATTENTION TO THAT

Application password login success:

1. Log in with a self-hosted site using application passwords
- [x] Verify login completes successfully
- [x] No unexpected error toasts shown

1. Add a self-hosted site using application passwords
- [x] Verify login completes successfully
- [x] No unexpected error toasts shown

1. For this step, be sure that the AP FF is enabled.
2. Revoke credentials from the wp-admin and try to open a screen that users APs. E.g: Media
- [x] Verify login completes successfully
- [x] No unexpected error toasts shown


Application password login failure:

1. Simulate a login failure (e.g., invalid credentials, network error)
- [x] Verify a human-friendly toast is shown
- [x] Verify detailed logs (Use "A_P" tag)