### PR TITLE
RS Post Settings: Fetch site post formats from themes API

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
@@ -54,6 +54,7 @@ data class PostRsSettingsUiState(
     val editedAuthor: Long? = null,
     val sitePostFormats: List<PostFormat> =
         PostRsRestClient.DEFAULT_POST_FORMATS,
+    val isLoadingFormats: Boolean = false,
     val isSaving: Boolean = false,
     val dialogState: DialogState = DialogState.None,
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsUiState.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.postsrs
 
+import org.wordpress.android.ui.postsrs.data.PostRsRestClient
 import uniffi.wp_api.PostFormat
 import uniffi.wp_api.PostStatus
 import java.util.Date
@@ -51,6 +52,8 @@ data class PostRsSettingsUiState(
     val editedFormat: PostFormat? = null,
     val editedDate: Date? = null,
     val editedAuthor: Long? = null,
+    val sitePostFormats: List<PostFormat> =
+        PostRsRestClient.DEFAULT_POST_FORMATS,
     val isSaving: Boolean = false,
     val dialogState: DialogState = DialogState.None,
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -1133,8 +1133,7 @@ class PostRsSettingsViewModel @Inject constructor(
             } catch (e: Exception) {
                 AppLog.w(
                     AppLog.T.POSTS,
-                    "resolveSitePostFormats failed: " +
-                        "${e.message}"
+                    "resolveSitePostFormats failed: ${e.message}"
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -943,6 +943,7 @@ class PostRsSettingsViewModel @Inject constructor(
         ) { names ->
             _uiState.update { it.copy(tagNames = names) }
         }
+        resolveSitePostFormats()
     }
 
     @Suppress("ComplexCondition", "CyclomaticComplexMethod")
@@ -1111,6 +1112,30 @@ class PostRsSettingsViewModel @Inject constructor(
         }
     }
 
+    private fun resolveSitePostFormats() {
+        val site = site ?: return
+        viewModelScope.launch {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val formats =
+                    withContext(Dispatchers.IO) {
+                        restClient.fetchSitePostFormats(site)
+                    }
+                _uiState.update {
+                    it.copy(sitePostFormats = formats)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.w(
+                    AppLog.T.POSTS,
+                    "resolveSitePostFormats failed: " +
+                        "${e.message}"
+                )
+            }
+        }
+    }
+
     private fun formatDate(dateGmt: Date): String {
         val fmt = DateFormat.getDateTimeInstance(
             DateFormat.MEDIUM,
@@ -1138,6 +1163,7 @@ class PostRsSettingsViewModel @Inject constructor(
         editedFeaturedImageId = from.editedFeaturedImageId,
         editedCategoryIds = from.editedCategoryIds,
         editedTagIds = from.editedTagIds,
+        sitePostFormats = from.sitePostFormats,
     )
 
     private class PostApiRequestException(message: String) :

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -258,6 +258,11 @@ class PostRsSettingsViewModel @Inject constructor(
     }
 
     fun onFormatClicked() {
+        if (_uiState.value.sitePostFormats ==
+            PostRsRestClient.DEFAULT_POST_FORMATS
+        ) {
+            resolveSitePostFormats()
+        }
         _uiState.update {
             it.copy(dialogState = DialogState.FormatDialog)
         }
@@ -943,7 +948,6 @@ class PostRsSettingsViewModel @Inject constructor(
         ) { names ->
             _uiState.update { it.copy(tagNames = names) }
         }
-        resolveSitePostFormats()
     }
 
     @Suppress("ComplexCondition", "CyclomaticComplexMethod")

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -258,7 +258,9 @@ class PostRsSettingsViewModel @Inject constructor(
     }
 
     fun onFormatClicked() {
-        if (!hasFetchedFormats) {
+        if (!hasFetchedFormats &&
+            !_uiState.value.isLoadingFormats
+        ) {
             resolveSitePostFormats()
         }
         _uiState.update {
@@ -1131,6 +1133,7 @@ class PostRsSettingsViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(sitePostFormats = formats)
                 }
+                hasFetchedFormats = true
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -1139,7 +1142,6 @@ class PostRsSettingsViewModel @Inject constructor(
                     "resolveSitePostFormats failed: ${e.message}"
                 )
             }
-            hasFetchedFormats = true
             _uiState.update {
                 it.copy(isLoadingFormats = false)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -258,13 +258,12 @@ class PostRsSettingsViewModel @Inject constructor(
     }
 
     fun onFormatClicked() {
-        if (_uiState.value.sitePostFormats ==
-            PostRsRestClient.DEFAULT_POST_FORMATS
-        ) {
+        if (!hasFetchedFormats) {
             resolveSitePostFormats()
-        }
-        _uiState.update {
-            it.copy(dialogState = DialogState.FormatDialog)
+        } else {
+            _uiState.update {
+                it.copy(dialogState = DialogState.FormatDialog)
+            }
         }
     }
 
@@ -1116,6 +1115,8 @@ class PostRsSettingsViewModel @Inject constructor(
         }
     }
 
+    private var hasFetchedFormats = false
+
     private fun resolveSitePostFormats() {
         val site = site ?: return
         viewModelScope.launch {
@@ -1134,6 +1135,12 @@ class PostRsSettingsViewModel @Inject constructor(
                 AppLog.w(
                     AppLog.T.POSTS,
                     "resolveSitePostFormats failed: ${e.message}"
+                )
+            }
+            hasFetchedFormats = true
+            _uiState.update {
+                it.copy(
+                    dialogState = DialogState.FormatDialog
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsSettingsViewModel.kt
@@ -260,10 +260,9 @@ class PostRsSettingsViewModel @Inject constructor(
     fun onFormatClicked() {
         if (!hasFetchedFormats) {
             resolveSitePostFormats()
-        } else {
-            _uiState.update {
-                it.copy(dialogState = DialogState.FormatDialog)
-            }
+        }
+        _uiState.update {
+            it.copy(dialogState = DialogState.FormatDialog)
         }
     }
 
@@ -1120,6 +1119,9 @@ class PostRsSettingsViewModel @Inject constructor(
     private fun resolveSitePostFormats() {
         val site = site ?: return
         viewModelScope.launch {
+            _uiState.update {
+                it.copy(isLoadingFormats = true)
+            }
             @Suppress("TooGenericExceptionCaught")
             try {
                 val formats =
@@ -1139,9 +1141,7 @@ class PostRsSettingsViewModel @Inject constructor(
             }
             hasFetchedFormats = true
             _uiState.update {
-                it.copy(
-                    dialogState = DialogState.FormatDialog
-                )
+                it.copy(isLoadingFormats = false)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -15,6 +15,7 @@ import uniffi.wp_api.PostFormat
 import uniffi.wp_api.TermCreateParams
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
+import uniffi.wp_api.SparseThemeFieldWithViewContext
 import uniffi.wp_api.ThemeListParams
 import uniffi.wp_api.ThemeStatus
 import uniffi.wp_api.ThemeSupports
@@ -350,9 +351,13 @@ class PostRsRestClient @Inject constructor(
     ): List<PostFormat> {
         val client = wpApiClientProvider.getWpApiClient(site)
         val response = client.request {
-            it.themes().listWithViewContext(
+            it.themes().filterListWithViewContext(
                 ThemeListParams(
                     status = ThemeStatus.Active
+                ),
+                listOf(
+                    SparseThemeFieldWithViewContext
+                        .THEME_SUPPORTS
                 )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -11,9 +11,14 @@ import org.wordpress.android.util.SiteUtils
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.AnyTermWithViewContext
 import uniffi.wp_api.MediaListParams
+import uniffi.wp_api.PostFormat
 import uniffi.wp_api.TermCreateParams
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
+import uniffi.wp_api.ThemeListParams
+import uniffi.wp_api.ThemeStatus
+import uniffi.wp_api.ThemeSupports
+import uniffi.wp_api.ThemeSupportsData
 import uniffi.wp_api.UserListParams
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -335,6 +340,88 @@ class PostRsRestClient @Inject constructor(
         }
     }
 
+    /**
+     * Fetches the post formats supported by the site's active
+     * theme. Returns [DEFAULT_POST_FORMATS] on failure or when
+     * the theme does not declare format support.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun fetchSitePostFormats(
+        site: SiteModel,
+    ): List<PostFormat> {
+        return try {
+            val client = wpApiClientProvider.getWpApiClient(site)
+            val response = client.request {
+                it.themes().listWithViewContext(
+                    ThemeListParams(
+                        status = ThemeStatus.Active
+                    )
+                )
+            }
+            when (response) {
+                is WpRequestResult.Success -> {
+                    val theme =
+                        response.response.data.firstOrNull()
+                            ?: return DEFAULT_POST_FORMATS
+                    val supports = theme.themeSupports
+                        ?: return DEFAULT_POST_FORMATS
+                    val data = supports[ThemeSupports.Formats]
+                        ?: return DEFAULT_POST_FORMATS
+                    val slugs =
+                        (data as? ThemeSupportsData.VecString)
+                            ?.v1
+                            ?: return DEFAULT_POST_FORMATS
+                    if (slugs.isEmpty()) {
+                        return DEFAULT_POST_FORMATS
+                    }
+                    val formats = slugs
+                        .map { slugToPostFormat(it) }
+                        .toMutableList()
+                    if (formats.none {
+                            it is PostFormat.Standard
+                        }
+                    ) {
+                        formats.add(0, PostFormat.Standard)
+                    }
+                    formats
+                }
+                else -> {
+                    val msg =
+                        (response
+                            as? WpRequestResult.WpError<*>)
+                            ?.errorMessage
+                    AppLog.w(
+                        AppLog.T.POSTS,
+                        "fetchSitePostFormats failed: $msg"
+                    )
+                    DEFAULT_POST_FORMATS
+                }
+            }
+        } catch (e: Exception) {
+            AppLog.w(
+                AppLog.T.POSTS,
+                "fetchSitePostFormats exception: " +
+                    "${e.message}"
+            )
+            DEFAULT_POST_FORMATS
+        }
+    }
+
+    private fun slugToPostFormat(slug: String): PostFormat =
+        when (slug) {
+            "standard" -> PostFormat.Standard
+            "aside" -> PostFormat.Aside
+            "audio" -> PostFormat.Audio
+            "chat" -> PostFormat.Chat
+            "gallery" -> PostFormat.Gallery
+            "image" -> PostFormat.Image
+            "link" -> PostFormat.Link
+            "quote" -> PostFormat.Quote
+            "status" -> PostFormat.Status
+            "video" -> PostFormat.Video
+            else -> PostFormat.Custom(slug)
+        }
+
     private fun toPhotonUrl(
         site: SiteModel,
         sourceUrl: String,
@@ -363,5 +450,18 @@ class PostRsRestClient @Inject constructor(
     companion object {
         internal const val AUTHORS_PER_PAGE: UInt = 20u
         private const val PER_PAGE = 100u
+
+        val DEFAULT_POST_FORMATS = listOf(
+            PostFormat.Standard,
+            PostFormat.Aside,
+            PostFormat.Audio,
+            PostFormat.Chat,
+            PostFormat.Gallery,
+            PostFormat.Image,
+            PostFormat.Link,
+            PostFormat.Quote,
+            PostFormat.Status,
+            PostFormat.Video,
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -16,6 +16,7 @@ import uniffi.wp_api.TermCreateParams
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 import uniffi.wp_api.SparseThemeFieldWithViewContext
+import uniffi.wp_api.SparseThemeWithViewContext
 import uniffi.wp_api.ThemeListParams
 import uniffi.wp_api.ThemeStatus
 import uniffi.wp_api.ThemeSupports
@@ -363,23 +364,8 @@ class PostRsRestClient @Inject constructor(
         }
         return when (response) {
             is WpRequestResult.Success -> {
-                val theme =
-                    response.response.data.firstOrNull()
-                        ?: return DEFAULT_POST_FORMATS
-                val supports = theme.themeSupports
-                    ?: return DEFAULT_POST_FORMATS
-                val data = supports[ThemeSupports.Formats]
-                    ?: return DEFAULT_POST_FORMATS
-                val slugs =
-                    (data as? ThemeSupportsData.VecString)
-                        ?.v1
-                        ?: return DEFAULT_POST_FORMATS
-                if (slugs.isEmpty()) {
-                    return DEFAULT_POST_FORMATS
-                }
-                (listOf(PostFormat.Standard) +
-                    slugs.map { slugToPostFormat(it) })
-                    .distinct()
+                parsePostFormats(response.response.data)
+                    ?: DEFAULT_POST_FORMATS
             }
             else -> {
                 val msg =
@@ -393,6 +379,22 @@ class PostRsRestClient @Inject constructor(
                 DEFAULT_POST_FORMATS
             }
         }
+    }
+
+    private fun parsePostFormats(
+        themes: List<SparseThemeWithViewContext>,
+    ): List<PostFormat>? {
+        val slugs =
+            themes.firstOrNull()
+                ?.themeSupports
+                ?.get(ThemeSupports.Formats)
+                ?.let { it as? ThemeSupportsData.VecString }
+                ?.v1
+                ?.takeIf { it.isNotEmpty() }
+                ?: return null
+        return (listOf(PostFormat.Standard) +
+            slugs.map { slugToPostFormat(it) })
+            .distinct()
     }
 
     private fun slugToPostFormat(slug: String): PostFormat =

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -345,65 +345,48 @@ class PostRsRestClient @Inject constructor(
      * theme. Returns [DEFAULT_POST_FORMATS] on failure or when
      * the theme does not declare format support.
      */
-    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchSitePostFormats(
         site: SiteModel,
     ): List<PostFormat> {
-        return try {
-            val client = wpApiClientProvider.getWpApiClient(site)
-            val response = client.request {
-                it.themes().listWithViewContext(
-                    ThemeListParams(
-                        status = ThemeStatus.Active
-                    )
+        val client = wpApiClientProvider.getWpApiClient(site)
+        val response = client.request {
+            it.themes().listWithViewContext(
+                ThemeListParams(
+                    status = ThemeStatus.Active
                 )
-            }
-            when (response) {
-                is WpRequestResult.Success -> {
-                    val theme =
-                        response.response.data.firstOrNull()
-                            ?: return DEFAULT_POST_FORMATS
-                    val supports = theme.themeSupports
-                        ?: return DEFAULT_POST_FORMATS
-                    val data = supports[ThemeSupports.Formats]
-                        ?: return DEFAULT_POST_FORMATS
-                    val slugs =
-                        (data as? ThemeSupportsData.VecString)
-                            ?.v1
-                            ?: return DEFAULT_POST_FORMATS
-                    if (slugs.isEmpty()) {
-                        return DEFAULT_POST_FORMATS
-                    }
-                    val formats = slugs
-                        .map { slugToPostFormat(it) }
-                        .toMutableList()
-                    if (formats.none {
-                            it is PostFormat.Standard
-                        }
-                    ) {
-                        formats.add(0, PostFormat.Standard)
-                    }
-                    formats
-                }
-                else -> {
-                    val msg =
-                        (response
-                            as? WpRequestResult.WpError<*>)
-                            ?.errorMessage
-                    AppLog.w(
-                        AppLog.T.POSTS,
-                        "fetchSitePostFormats failed: $msg"
-                    )
-                    DEFAULT_POST_FORMATS
-                }
-            }
-        } catch (e: Exception) {
-            AppLog.w(
-                AppLog.T.POSTS,
-                "fetchSitePostFormats exception: " +
-                    "${e.message}"
             )
-            DEFAULT_POST_FORMATS
+        }
+        return when (response) {
+            is WpRequestResult.Success -> {
+                val theme =
+                    response.response.data.firstOrNull()
+                        ?: return DEFAULT_POST_FORMATS
+                val supports = theme.themeSupports
+                    ?: return DEFAULT_POST_FORMATS
+                val data = supports[ThemeSupports.Formats]
+                    ?: return DEFAULT_POST_FORMATS
+                val slugs =
+                    (data as? ThemeSupportsData.VecString)
+                        ?.v1
+                        ?: return DEFAULT_POST_FORMATS
+                if (slugs.isEmpty()) {
+                    return DEFAULT_POST_FORMATS
+                }
+                (listOf(PostFormat.Standard) +
+                    slugs.map { slugToPostFormat(it) })
+                    .distinct()
+            }
+            else -> {
+                val msg =
+                    (response
+                        as? WpRequestResult.WpError<*>)
+                        ?.errorMessage
+                AppLog.w(
+                    AppLog.T.POSTS,
+                    "fetchSitePostFormats failed: $msg"
+                )
+                DEFAULT_POST_FORMATS
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -51,7 +51,7 @@ class PostRsRestClient @Inject constructor(
     /**
      * Fetches media source URLs for the given [mediaIds] in a single
      * network call using the `include` parameter, returning a map of
-     * media ID to Photon-optimised URL. IDs already in the local cache
+     * media ID to Photon-optimized URL. IDs already in the local cache
      * are returned immediately without a network round-trip.
      *
      * @param widthDp target display width in dp for Photon resizing.

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -398,19 +398,7 @@ class PostRsRestClient @Inject constructor(
     }
 
     private fun slugToPostFormat(slug: String): PostFormat =
-        when (slug) {
-            "standard" -> PostFormat.Standard
-            "aside" -> PostFormat.Aside
-            "audio" -> PostFormat.Audio
-            "chat" -> PostFormat.Chat
-            "gallery" -> PostFormat.Gallery
-            "image" -> PostFormat.Image
-            "link" -> PostFormat.Link
-            "quote" -> PostFormat.Quote
-            "status" -> PostFormat.Status
-            "video" -> PostFormat.Video
-            else -> PostFormat.Custom(slug)
-        }
+        SLUG_TO_FORMAT[slug] ?: PostFormat.Custom(slug)
 
     private fun toPhotonUrl(
         site: SiteModel,
@@ -441,17 +429,20 @@ class PostRsRestClient @Inject constructor(
         internal const val AUTHORS_PER_PAGE: UInt = 20u
         private const val PER_PAGE = 100u
 
-        val DEFAULT_POST_FORMATS = listOf(
-            PostFormat.Standard,
-            PostFormat.Aside,
-            PostFormat.Audio,
-            PostFormat.Chat,
-            PostFormat.Gallery,
-            PostFormat.Image,
-            PostFormat.Link,
-            PostFormat.Quote,
-            PostFormat.Status,
-            PostFormat.Video,
+        private val SLUG_TO_FORMAT = mapOf(
+            "standard" to PostFormat.Standard,
+            "aside" to PostFormat.Aside,
+            "audio" to PostFormat.Audio,
+            "chat" to PostFormat.Chat,
+            "gallery" to PostFormat.Gallery,
+            "image" to PostFormat.Image,
+            "link" to PostFormat.Link,
+            "quote" to PostFormat.Quote,
+            "status" to PostFormat.Status,
+            "video" to PostFormat.Video,
         )
+
+        val DEFAULT_POST_FORMATS =
+            SLUG_TO_FORMAT.values.toList()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -1045,6 +1045,7 @@ private fun SettingsDialogs(
             currentFormat = uiState.editedFormat
                 ?: uiState.postFormat,
             formats = uiState.sitePostFormats,
+            isLoading = uiState.isLoadingFormats,
             onFormatSelected = onFormatSelected,
             onDismiss = onDismissDialog,
         )
@@ -1350,9 +1351,34 @@ private fun ExcerptDialog(
 private fun FormatDialog(
     currentFormat: PostFormat?,
     formats: List<PostFormat>,
+    isLoading: Boolean,
     onFormatSelected: (PostFormat) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    if (isLoading) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = {
+                Text(
+                    stringResource(
+                        R.string
+                            .post_rs_settings_format_dialog_title
+                    )
+                )
+            },
+            text = {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            },
+            confirmButton = {},
+        )
+        return
+    }
+
     val labels = formats.map { postFormatLabel(it) }
     val currentIndex = formats.indexOfFirst {
         it == currentFormat

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -1357,29 +1358,31 @@ private fun FormatDialog(
         it == currentFormat
     }.coerceAtLeast(0)
 
-    val selectedIndex = rememberSaveable {
-        mutableIntStateOf(currentIndex)
-    }
+    key(formats) {
+        val selectedIndex = rememberSaveable {
+            mutableIntStateOf(currentIndex)
+        }
 
-    LaunchedEffect(formats) {
-        selectedIndex.intValue = formats.indexOfFirst {
-            it == currentFormat
-        }.coerceAtLeast(0)
+        SingleChoiceAlertDialog(
+            title = stringResource(
+                R.string.post_rs_settings_format_dialog_title
+            ),
+            options = labels,
+            selectedIndex = selectedIndex.intValue,
+            onOptionSelected = {
+                selectedIndex.intValue = it
+            },
+            onConfirm = {
+                onFormatSelected(
+                    formats[selectedIndex.intValue]
+                )
+            },
+            onDismiss = onDismiss,
+            confirmButtonText = stringResource(
+                R.string.ok
+            ),
+        )
     }
-
-    SingleChoiceAlertDialog(
-        title = stringResource(
-            R.string.post_rs_settings_format_dialog_title
-        ),
-        options = labels,
-        selectedIndex = selectedIndex.intValue,
-        onOptionSelected = { selectedIndex.intValue = it },
-        onConfirm = {
-            onFormatSelected(formats[selectedIndex.intValue])
-        },
-        onDismiss = onDismiss,
-        confirmButtonText = stringResource(R.string.ok),
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -1043,6 +1043,7 @@ private fun SettingsDialogs(
         is DialogState.FormatDialog -> FormatDialog(
             currentFormat = uiState.editedFormat
                 ?: uiState.postFormat,
+            formats = uiState.sitePostFormats,
             onFormatSelected = onFormatSelected,
             onDismiss = onDismissDialog,
         )
@@ -1344,27 +1345,13 @@ private fun ExcerptDialog(
     )
 }
 
-@Suppress("ForbiddenComment")
 @Composable
 private fun FormatDialog(
     currentFormat: PostFormat?,
+    formats: List<PostFormat>,
     onFormatSelected: (PostFormat) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    // TODO: Replace hardcoded formats with site-supported
-    //  formats once wordpress-rs exposes that API
-    val formats = listOf(
-        PostFormat.Standard,
-        PostFormat.Aside,
-        PostFormat.Audio,
-        PostFormat.Chat,
-        PostFormat.Gallery,
-        PostFormat.Image,
-        PostFormat.Link,
-        PostFormat.Quote,
-        PostFormat.Status,
-        PostFormat.Video,
-    )
     val labels = formats.map { postFormatLabel(it) }
     val currentIndex = formats.indexOfFirst {
         it == currentFormat

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsSettingsScreen.kt
@@ -1361,6 +1361,12 @@ private fun FormatDialog(
         mutableIntStateOf(currentIndex)
     }
 
+    LaunchedEffect(formats) {
+        selectedIndex.intValue = formats.indexOfFirst {
+            it == currentFormat
+        }.coerceAtLeast(0)
+    }
+
     SingleChoiceAlertDialog(
         title = stringResource(
             R.string.post_rs_settings_format_dialog_title


### PR DESCRIPTION
## Description

The RS post settings `FormatDialog` previously hardcoded all 10 standard post formats. This PR fetches the formats actually supported by the site's active theme using the wordpress-rs themes API (`themes().listWithViewContext()`), falling back to the full default list if the API call fails.

## Testing instructions

Theme with limited format support:

1. View settings for a post on the "Rabbit Of Caribbeans" test site (whose active theme supports only a subset of formats)
2. Tap the Format row to open the format dialog
- [x] Verify the dialog shows only the theme-supported formats plus Standard

<img width="297" height="629" alt="format" src="https://github.com/user-attachments/assets/cf333532-d42e-42fe-9877-ce3b741162d4" />

Fallback on failure:

1. Open a post, then disable network
2. Tap the Format row
- [x] Verify the dialog shows the full default list of 10 formats

<img width="297" height="629" alt="format2" src="https://github.com/user-attachments/assets/549a49ca-7242-459e-a5b4-9efc87b5ab89" />
