### PR TITLE
Feature branch: AGP 9.x Upgrade

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,5 +1,4 @@
 import io.sentry.android.gradle.extensions.InstrumentationFeature
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
@@ -188,13 +187,12 @@ android {
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
 
-    // Gutenberg's dependency - react-native-video is using
-    // Java API 1.8
+    // Java source/target compatibility (version defined in libs.versions.toml)
     compileOptions {
         // Enables Java 8+ API desugaring support
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
-        targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
     }
 
     flavorDimensions = ['app']
@@ -295,23 +293,16 @@ android {
         }
     }
 
-    packagingOptions {
-        // MPAndroidChart uses androidX - remove this line when we migrate everything to androidX
-        exclude 'META-INF/proguard/androidx-annotations.pro'
-
-        // Exclude React Native's JSC and Fabric JNI
-        exclude '**/libjscexecutor.so'
-        exclude '**/libfabricjni.so'
-
-        // Avoid React Native's JNI duplicated classes
-        pickFirst '**/libc++_shared.so'
-        pickFirst '**/libfbjni.so'
-
-        pickFirst 'META-INF/-no-jdk.kotlin_module'
-
-        // OkHttp 5.x: Pick first OSGI manifest from multi-release JARs
-        pickFirst 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
-
+    packaging {
+        resources {
+            excludes += 'META-INF/proguard/androidx-annotations.pro'
+            excludes += '**/libjscexecutor.so'
+            excludes += '**/libfabricjni.so'
+            pickFirsts += '**/libc++_shared.so'
+            pickFirsts += '**/libfbjni.so'
+            pickFirsts += 'META-INF/-no-jdk.kotlin_module'
+            pickFirsts += 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+        }
     }
 
     bundle {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -651,6 +651,10 @@ androidComponents {
             finalizedBy(deleteTask)
         }
 
+        // TODO: Replace afterEvaluate with AGP artifacts API when a suitable
+        //  hook for post-merge asset tasks becomes available. afterEvaluate is
+        //  needed here because the mergeXxxAssets task doesn't exist yet when
+        //  onVariants runs, and there's no artifact transform for this use case.
         afterEvaluate {
             tasks.named("merge${capitalizedName}Assets").configure {
                 finalizedBy(copyTask)

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.allopen)
@@ -90,6 +89,10 @@ allOpen {
     annotation 'org.wordpress.android.testing.OpenClassAnnotation'
 }
 
+base {
+    archivesName = "org.wordpress.android"
+}
+
 android {
     useLibrary 'android.test.runner'
 
@@ -100,16 +103,16 @@ android {
 
     def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
 
+    compileSdk rootProject.compileSdkVersion
+
     defaultConfig {
         applicationId "org.wordpress.android"
-        archivesBaseName = "$applicationId"
 
         versionName project.findProperty("prototypeBuildVersionName") ?: versionProperties.getProperty("versionName")
         versionCode versionProperties.getProperty("versionCode").toInteger()
 
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
-        compileSdk rootProject.compileSdkVersion
 
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
@@ -250,7 +253,7 @@ android {
             // Proguard is used to shrink our apk, and reduce the number of methods in our final apk,
             // but we don't obfuscate the bytecode.
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard.cfg'
             buildConfigField "boolean", "ENABLE_DEBUG_SETTINGS", "false"
         }
 
@@ -591,14 +594,24 @@ tasks.register("printVersionName") {
     }
 }
 
-tasks.register("printAllVersions") {
-    def versions = android.applicationVariants.collect {
-        [it.name, it.versionName, it.versionCode]
-    }
+def allVariantVersions = []
 
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.each { output ->
+            allVariantVersions.add([
+                name: variant.name,
+                versionName: output.versionName,
+                versionCode: output.versionCode
+            ])
+        }
+    }
+}
+
+tasks.register("printAllVersions") {
     doLast {
-        versions.each { name, versionName, versionCode ->
-            println "$name: $versionName ($versionCode)"
+        allVariantVersions.each { data ->
+            println "${data.name}: ${data.versionName.get()} (${data.versionCode.get()})"
         }
     }
 }
@@ -621,25 +634,36 @@ android {
     androidResources {
         generateLocaleConfig = true
     }
+}
 
-    // Copy React Native JavaScript bundle and source map so they can be upload it to the Crash logging
-    // service during the build process.
-    applicationVariants.configureEach { variant ->
-        def variantAssets = variant.mergeAssetsProvider.get().outputDir.get()
+// Copy React Native JavaScript bundle and source map so they can be uploaded to the Crash logging
+// service during the build process.
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        def capitalizedName = variant.name.capitalize()
+        def assetsDir = variant.artifacts.get(
+            com.android.build.api.artifact.SingleArtifact.ASSETS.INSTANCE
+        )
 
-        tasks.register("delete${variant.name.capitalize()}ReactNativeBundleSourceMap", Delete) {
-            delete(fileTree(dir: variantAssets, includes: ['**/*.bundle.map']))
+        def deleteTask = tasks.register(
+            "delete${capitalizedName}ReactNativeBundleSourceMap", Delete
+        ) {
+            delete(fileTree(dir: assetsDir, includes: ['**/*.bundle.map']))
         }
 
-        tasks.register("copy${variant.name.capitalize()}ReactNativeBundleSourceMap", Copy) {
-            from(variantAssets)
-            into("${buildDir}/react-native-bundle-source-map")
+        def copyTask = tasks.register(
+            "copy${capitalizedName}ReactNativeBundleSourceMap", Copy
+        ) {
+            from(assetsDir)
+            into(layout.buildDirectory.dir("react-native-bundle-source-map"))
             include("*.bundle", "*.bundle.map")
-            finalizedBy("delete${variant.name.capitalize()}ReactNativeBundleSourceMap")
+            finalizedBy(deleteTask)
         }
 
-        variant.mergeAssetsProvider.configure {
-            finalizedBy("copy${variant.name.capitalize()}ReactNativeBundleSourceMap")
+        afterEvaluate {
+            tasks.named("merge${capitalizedName}Assets").configure {
+                finalizedBy(copyTask)
+            }
         }
     }
 }

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -1,4 +1,7 @@
 -dontobfuscate
+# AGP 9 requires proguard-android-optimize.txt, which enables aggressive R8
+# optimizations. Disable until reflection-safe keep rules are fully verified.
+-dontoptimize
 
 ###### OkHttp - begin
 -dontwarn okio.**

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -516,8 +516,6 @@
             android:name=".URISchemeDeepLinkingIntentReceiverActivity"
             android:label="@string/deep_linking_urilinks_alias_label"
             android:targetActivity="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity"
-            android:theme="@style/WordPress.NoActionBar"
-            android:excludeFromRecents="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -541,8 +539,6 @@
             android:name=".WebLinksDeepLinkingIntentReceiverActivity"
             android:label="@string/deep_linking_weblinks_alias_label"
             android:targetActivity="org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity"
-            android:theme="@style/WordPress.NoActionBar"
-            android:excludeFromRecents="true"
             android:exported="true">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.jetpackplugininstall.fullplugin.install
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,13 +46,18 @@ class JetpackFullPluginInstallActivity : BaseAppCompatActivity() {
             }
         }
         observeActionEvents()
-    }
-
-    @Suppress("OVERRIDE_DEPRECATION","MissingSuperCall")
-    override fun onBackPressed() {
-        if (!viewModel.uiState.value.showCloseButton) return
-
-        viewModel.onBackPressed()
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (viewModel.uiState.value.showCloseButton) {
+                        viewModel.onBackPressed()
+                    }
+                    // When showCloseButton is false, consume the
+                    // back event (do nothing)
+                }
+            }
+        )
     }
 
     private fun observeActionEvents() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -421,18 +421,18 @@ fun ReaderTagsFeedPostListItemPreview() {
                             postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
                                     "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl." +
-                                    "Lorem ipsum dolor sit amet consectetur adipiscing elit. Integer" +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl." +
-                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. " +
+                                    "Lorem ipsum dolor sit amet consectetur adipiscing elit. Integer " +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. " +
+                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque " +
                                     "sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor " +
-                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna" +
-                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit" +
-                                    "amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna" +
-                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet," +
-                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum" +
-                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur" +
-                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere." +
+                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna " +
+                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit " +
+                                    "amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna " +
+                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, " +
+                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum " +
+                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur " +
+                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere. " +
                                     "Vivamus in pretium nisl.",
                             postImageUrl = "https://picsum.photos/200/300",
                             postNumberOfLikesText = "15 likes",
@@ -452,23 +452,23 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
-                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
+                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
                                     "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
-                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem" +
+                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem " +
                                     "ipsum dolor sit amet, " +
-                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna" +
-                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet," +
-                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum" +
-                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur" +
-                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere." +
-                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing" +
-                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in" +
-                                    "pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem" +
-                                    "ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque sapien" +
+                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna " +
+                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, " +
+                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum " +
+                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur " +
+                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere. " +
+                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing " +
+                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in " +
+                                    "pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem " +
+                                    "ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque sapien " +
                                     "sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postImageUrl = "",
                             postNumberOfLikesText = "15 likes",
@@ -488,7 +488,7 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
                             postTitle = "Lorem ipsum dolor sit amet.",
                             postExcerpt = "Lorem ipsum dolor sit amet.",
@@ -510,7 +510,7 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
                             postTitle = "Lorem ipsum dolor sit amet.",
                             postExcerpt = "Lorem ipsum dolor sit amet.",
@@ -532,9 +532,9 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
-                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
+                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
                                     "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postExcerpt = "Lorem ipsum dolor sit amet.",
                             postImageUrl = "https://picsum.photos/200/300",
@@ -554,10 +554,10 @@ fun ReaderTagsFeedPostListItemPreview() {
                 item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
-                            siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
+                            siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
                                     "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
-                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit." +
+                            postTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
                                     "Integer pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postExcerpt = "Lorem ipsum dolor sit amet.",
                             postImageUrl = "",
@@ -578,22 +578,22 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
                             postTitle = "Lorem ipsum dolor sit amet.",
-                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl." +
-                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor" +
-                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna" +
-                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet," +
-                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum" +
-                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur" +
-                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere." +
-                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing" +
-                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in" +
-                                    "pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit." +
-                                    "Integer pellentesque sapien sed urna fermentum" +
+                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. " +
+                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque " +
+                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor " +
+                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna " +
+                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, " +
+                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum " +
+                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur " +
+                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere. " +
+                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing " +
+                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in " +
+                                    "pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                                    "Integer pellentesque sapien sed urna fermentum " +
                                     "posuere. Vivamus in pretium nisl.",
                             postImageUrl = "https://picsum.photos/200/300",
                             postNumberOfLikesText = "15 likes",
@@ -613,20 +613,20 @@ fun ReaderTagsFeedPostListItemPreview() {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
+                                    " sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postDateLine = "1h",
                             postTitle = "Lorem ipsum dolor sit amet.",
-                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
-                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl." +
-                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
-                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor" +
-                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna" +
-                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet," +
-                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum" +
-                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur" +
-                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere." +
-                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing" +
-                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in" +
+                            postExcerpt = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " +
+                                    "pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl. " +
+                                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque " +
+                                    "sapien sed urna fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor " +
+                                    "sit amet, consectetur adipiscing elit. Integer pellentesque sapien sed urna " +
+                                    "fermentum posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, " +
+                                    "consectetur adipiscing elit. Integer pellentesque sapien sed urna fermentum " +
+                                    "posuere. Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur " +
+                                    "adipiscing elit. Integer pellentesque sapien sed urna fermentum posuere. " +
+                                    "Vivamus in pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing " +
+                                    "elit. Integer pellentesque sapien sed urna fermentum posuere. Vivamus in " +
                                     "pretium nisl. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
                                     " pellentesque sapien sed urna fermentum posuere. Vivamus in pretium nisl.",
                             postImageUrl = "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -378,7 +378,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
      */
     private void trackUploadMediaEvents(AnalyticsTracker.Stat stat, MediaModel media, Map<String, Object> properties) {
         if (media == null) {
-            AppLog.e(T.MEDIA, "MediaUploadHandler > Cannot track media upload handler events if the original media"
+            AppLog.e(T.MEDIA, "MediaUploadHandler > Cannot track media upload handler events if the original media "
                               + "is null");
             return;
         }

--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,12 @@ plugins {
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.google.services).apply(false)
     alias(libs.plugins.kotlin.allopen).apply(false)
-    alias(libs.plugins.kotlin.android).apply(false)
     alias(libs.plugins.kotlin.compose).apply(false)
     alias(libs.plugins.kotlin.jvm).apply(false)
     alias(libs.plugins.kotlin.parcelize).apply(false)
     alias(libs.plugins.kotlin.serialization).apply(false)
     alias(libs.plugins.ksp).apply(false)
-    alias(libs.plugins.kapt).apply(false)
+    alias(libs.plugins.legacy.kapt).apply(false)
     alias(libs.plugins.room).apply(false)
 }
 
@@ -98,7 +97,7 @@ allprojects {
 subprojects {
     plugins.withType(com.android.build.gradle.AppPlugin) {
         android {
-            lintOptions {
+            lint {
                 warningsAsErrors = true
                 checkDependencies true
                 checkGeneratedSources = true
@@ -114,7 +113,7 @@ subprojects {
     }
     plugins.withType(com.android.build.gradle.LibraryPlugin) {
         android {
-            lintOptions {
+            lint {
                 checkDependencies false
                 lintConfig file("${project.rootDir}/config/lint/lint.xml")
             }

--- a/build.gradle
+++ b/build.gradle
@@ -78,18 +78,18 @@ allprojects {
         debug = false
     }
 
-    tasks.withType(KotlinCompile).all {
-        kotlinOptions {
-            jvmTarget = JvmTarget.fromTarget(libs.versions.java.get()).target
+    tasks.withType(KotlinCompile).configureEach {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget(libs.versions.java.get())
             allWarningsAsErrors = true
-            freeCompilerArgs += [
+            freeCompilerArgs.addAll(
                     "-opt-in=kotlin.RequiresOptIn",
                     "-jvm-default=no-compatibility",
                     "-Xannotation-default-target=param-property",
                     // Suppress Glide KSP codegen visibility warning (bumptech/glide#5601)
                     "-Xwarning-level=" +
                         "EXPOSED_PACKAGE_PRIVATE_TYPE_FROM_INTERNAL_WARNING:disabled"
-            ]
+            )
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,7 @@
 org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
-org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-
-android.enableR8.fullMode=false
 
 # Dependency Analysis Plugin
 dependency.analysis.android.ignored.variants=release,wordpressRelease,jetpackRelease

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,6 @@ org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
-android.nonTransitiveRClass=true
-android.nonFinalResIds=true
 android.enableR8.fullMode=false
 
 # Dependency Analysis Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,6 @@ org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
-android.useAndroidX=true
-android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 android.enableR8.fullMode=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = '8.10.1'
+agp = '9.0.1'
 airbnb-lottie = '6.7.1'
 android-desugar = '2.1.5'
 android-installreferrer = '2.2'
@@ -56,9 +56,9 @@ dependency-analysis = '3.6.1'
 facebook-react = '0.73.3'
 facebook-shimmer = '0.5.0'
 fastlane-screengrab = '2.1.1'
-fladle = '0.19.0'
+fladle = '0.21.0'
 google-autoservice = '1.1.1'
-google-dagger = '2.58'
+google-dagger = '2.59.2'
 google-exoplayer = '2.13.3'
 google-firebase-bom = '34.11.0'
 google-firebase-iid = '21.1.0'
@@ -279,10 +279,9 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 fladle = { id = "com.osacky.fladle", version.ref = "fladle" }
 google-dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "google-dagger" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin-main" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin-main" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-main" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin-main" }
+legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "agp" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-main" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin-main" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin-main" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=296742a352f0b20ec14b143fb684965ad66086c7810b7b255dee216670716175
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
+distributionSha256Sum=b84e04fa845fecba48551f425957641074fcc00a88a84d2aae5808743b35fc85
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -344,7 +344,7 @@ public class AnalyticsTrackerNosara extends Tracker {
                         if (propertiesToJSON.has(key)) {
                             AppLog.w(AppLog.T.STATS,
                                     "The user has defined a property named: '" + key + "' that will override"
-                                    + "the same property pre-defined at event level. This may generate unexpected "
+                                    + " the same property pre-defined at event level. This may generate unexpected "
                                     + "behavior!!");
                             AppLog.w(AppLog.T.STATS,
                                     "User value: " + propertiesToJSON.get(key)

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -1,11 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.dependency.analysis)
 }
 
 java {
-    sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
-    targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 }

--- a/libs/annotations/build.gradle
+++ b/libs/annotations/build.gradle
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.dependency.analysis)
 }
 
-kotlin {
+java {
     sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
     targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
 }

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.parcelize)
@@ -17,17 +15,18 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
-        targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
     }
 
-    // Avoid 'duplicate files during packaging of APK' errors
-    packagingOptions {
-        exclude 'LICENSE.txt'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/NOTICE.txt'
+    packaging {
+        resources {
+            excludes += 'LICENSE.txt'
+            excludes += 'META-INF/LICENSE.txt'
+            excludes += 'META-INF/LICENSE'
+            excludes += 'META-INF/NOTICE'
+            excludes += 'META-INF/NOTICE.txt'
+        }
     }
 
     buildFeatures {
@@ -75,6 +74,7 @@ dependencies {
 
     // This dependency will be substituted if the `local-builds.gradle` file contains
     // `localGutenbergKitPath`. Details for this can be found in the `settings.gradle` file.
+    //noinspection UseTomlInstead - path is dynamic for local/remote substitution
     implementation("$rootProject.gradle.ext.gutenbergKitBinaryPath:${libs.versions.gutenberg.kit.get()}")
 
     implementation(libs.wordpress.utils)

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.dependency.analysis)

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -179,7 +179,7 @@ public class GutenbergContainerFragment extends Fragment {
                 } else {
                     if (isEnabled()) {
                         setEnabled(false); // Disable this callback
-                        requireActivity().onBackPressed(); // Bubble up the onBackPressed event
+                        requireActivity().getOnBackPressedDispatcher().onBackPressed();
                         setEnabled(true); // Re-enable this callback
                     }
                 }

--- a/libs/fluxc-annotations/build.gradle
+++ b/libs/fluxc-annotations/build.gradle
@@ -1,11 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id "java"
     alias(libs.plugins.dependency.analysis)
 }
 
 java {
-    sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
-    targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 }

--- a/libs/fluxc-processor/build.gradle
+++ b/libs/fluxc-processor/build.gradle
@@ -1,13 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id "java"
     alias(libs.plugins.dependency.analysis)
 }
 
 java {
-    sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
-    targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 }
 
 dependencies {

--- a/libs/fluxc/build.gradle
+++ b/libs/fluxc/build.gradle
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -35,8 +34,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
-        targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
     }
 
     testOptions {

--- a/libs/fluxc/build.gradle
+++ b/libs/fluxc/build.gradle
@@ -3,9 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
-    alias(libs.plugins.kapt)
+    alias(libs.plugins.legacy.kapt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.room)
     alias(libs.plugins.kotlinx.kover)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsConfiguration.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsConfiguration.kt
@@ -19,7 +19,7 @@ internal data class ApplicationPasswordsConfiguration @Inject constructor(
         get() = applicationNameOptional.orElseThrow {
             NoSuchElementException(
                 "Please make sure to inject a String instance with " +
-                    "the annotation @${ApplicationPasswordsClientId::class.simpleName} to the Dagger graph" +
+                    "the annotation @${ApplicationPasswordsClientId::class.simpleName} to the Dagger graph " +
                     "to be able to use the Application Passwords feature"
             )
         }

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.androidx.navigation.safeargs)
     alias(libs.plugins.kotlinx.kover)

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.parcelize)
@@ -26,8 +24,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
-        targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
     }
 
     testOptions {

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -11,4 +11,9 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         compileSdk rootProject.compileSdkVersion
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
+    }
 }

--- a/libs/networking/build.gradle
+++ b/libs/networking/build.gradle
@@ -11,6 +11,11 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         compileSdk rootProject.compileSdkVersion
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
+    }
 }
 
 dependencies {

--- a/libs/posttypes/build.gradle
+++ b/libs/posttypes/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
@@ -19,8 +17,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
-        targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
+        sourceCompatibility JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.java.get())
     }
 
     buildFeatures {

--- a/libs/posttypes/build.gradle
+++ b/libs/posttypes/build.gradle
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.google.dagger.hilt)

--- a/libs/posttypes/src/main/AndroidManifest.xml
+++ b/libs/posttypes/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <application
-        android:allowBackup="false"
         android:usesCleartextTraffic="false"
         tools:ignore="UnusedAttribute">
         <activity

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlinx.kover)
@@ -7,8 +5,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
-    targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
 }
 
 dependencies {

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dependency.analysis)
 }
 
-kotlin {
+java {
     sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
     targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
 }


### PR DESCRIPTION
# Feature Branch: AGP 9.x Upgrade

## Summary

This feature branch upgrades the project from **Gradle 8.12.1 / AGP 8.10.1** to **Gradle 9.1.0 / AGP 9.0.1**. The upgrade was executed across six phases, merged as multiple PRs into this branch:

### Phase 1 — Audit (no PR)
- Catalogued all deprecated APIs, removed flags, and breaking changes in AGP 9

### Phase 2 — Gradle/AGP version upgrade (#22705)
- Upgraded Gradle 8.12.1 → 9.1.0 and AGP 8.10.1 → 9.0.1
- Bumped Dagger/Hilt 2.58 → 2.59.2 and Fladle 0.19.0 → 0.21.0 for compatibility
- Migrated deprecated DSL: `archivesBaseName` → `base.archivesName`, `lintOptions` → `lint`, `buildDir` → `layout.buildDirectory`
- Replaced `proguard-android.txt` with `proguard-android-optimize.txt`
- Fixed `kotlin {}` → `java {}` for sourceCompatibility in JVM-only modules
- Removed `allowBackup` from posttypes library manifest

### Phase 3 — Built-in Kotlin adoption (#22705)
- Removed `android.newDsl=false` and `android.builtInKotlin=false` opt-out flags
- Removed `kotlin-android` plugin from all 7 modules (now built into AGP 9)
- Migrated `kapt` → `legacy-kapt` in fluxc (AGP 9 requirement)
- Migrated `applicationVariants` API → `androidComponents.onVariants` (new DSL)
- Kept `kotlin-compose` plugin (still required for Compose compiler)

### Phase 4-5 — Remove obsolete Gradle properties (#22714)
- Removed `android.nonTransitiveRClass=true` (now the default)
- Removed `android.nonFinalResIds=true` (now the default)

### Phase 6-7 — Final cleanup and lint fixes (#22727)
- Replaced deprecated `packagingOptions` with `packaging { resources { ... } }` DSL
- Reverted `compileOptions` to use `JavaVersion.toVersion()` instead of `JvmTarget.fromTarget().target`
- Migrated deprecated `kotlinOptions` → `compilerOptions`, using lazy `.configureEach` instead of eager `.all`
- Removed deprecated `org.gradle.configureondemand=true` (incompatible with configuration cache)
- Removed `android.enableR8.fullMode=false` (property removed in AGP 9)
- Added `-dontoptimize` to `proguard.cfg` to preserve safe R8 behavior (equivalent to old `proguard-android.txt` default)
- Added explicit `compileOptions` to `libs/networking` and `libs/mocks` for consistency
- Suppressed `UseTomlInstead` lint on dynamic GutenbergKit dependency
- Removed invalid `activity-alias` attributes and fixed string concatenation lint errors
- Migrated deprecated `onBackPressed()` to `OnBackPressedCallback` for Android 16+ predictive back gesture support
- Fixed `TextConcatSpace` lint errors across multiple files
- Fixed stale comment referencing Java 1.8 (project uses Java 11)

## Key decisions
- **`-dontoptimize` in proguard.cfg**: AGP 9 requires `proguard-android-optimize.txt` which enables aggressive R8 optimizations that can strip reflection-accessed code (Gson, FluxC, React Native). Adding `-dontoptimize` preserves the safe behavior of the old `proguard-android.txt` default.
- **`kotlin-compose` plugin retained**: Unlike `kotlin-android`, the Compose compiler plugin is not yet built into AGP and must remain explicit.
- **`legacy-kapt` in fluxc**: AGP 9 requires this migration path for modules still using kapt.

## Test plan
- [ ] `./gradlew assembleWordPressDebug` builds successfully
- [ ] `./gradlew assembleJetpackDebug` builds successfully
- [ ] `./gradlew :WordPress:testWordPressDebugUnitTest` passes
- [ ] `./gradlew lintWordPressRelease` passes with no new errors
- [ ] `./gradlew detekt` and `./gradlew checkstyle` pass
- [ ] Smoke test WordPress and Jetpack apps on device
