### PR TITLE
Fix application password site_not_found by adding fallback URL matching

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.accounts.login
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
-import java.net.URI
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
@@ -24,6 +23,7 @@ import org.wordpress.android.util.crashlogging.sendReportWithTag
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.applicationPasswordsUrl
+import java.net.URI
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -270,12 +270,15 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             null
         } ?: return url
         val dotIndex = host.lastIndexOf('.')
-        if (dotIndex < MIN_MASK_LENGTH) return url
+        if (dotIndex <= 0) return url
         val domain = host.substring(0, dotIndex)
         val tld = host.substring(dotIndex)
-        val maskedDomain = domain.first() +
-            "x".repeat(domain.length - 2) +
-            domain.last()
+        val maskedDomain = when {
+            domain.length <= 2 -> "x".repeat(domain.length)
+            else -> domain.first() +
+                "x".repeat(domain.length - 2) +
+                domain.last()
+        }
         return url.replaceFirst(host, maskedDomain + tld)
     }
 
@@ -337,7 +340,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     companion object {
         private const val JETPACK_SUCCESS_URL = "jetpack://app-pass-authorize"
         private const val WORDPRESS_SUCCESS_URL = "wordpress://app-pass-authorize"
-        private const val MIN_MASK_LENGTH = 3
     }
 
     data class UriLogin(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts.login
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
+import java.net.URI
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
 import org.wordpress.android.util.DeviceUtils
@@ -264,7 +265,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun maskUrl(url: String): String {
         val host = try {
-            java.net.URI(url).host
+            URI(url).host
         } catch (_: Exception) {
             null
         } ?: url
@@ -273,7 +274,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         val maskedHost = host.replaceRange(
             dotIndex - MASK_LENGTH, dotIndex, "X".repeat(MASK_LENGTH)
         )
-        return url.replace(host, maskedHost)
+        return url.replaceFirst(host, maskedHost)
     }
 
     private fun SiteModel.hasRegularCredentials(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -262,6 +262,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             .removePrefix("www.")
     }
 
+    @Suppress("ReturnCount")
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun maskUrl(url: String): String {
         val host = try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -268,13 +268,15 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             URI(url).host
         } catch (_: Exception) {
             null
-        } ?: url
+        } ?: return url
         val dotIndex = host.lastIndexOf('.')
-        if (dotIndex < MASK_LENGTH) return url
-        val maskedHost = host.replaceRange(
-            dotIndex - MASK_LENGTH, dotIndex, "X".repeat(MASK_LENGTH)
-        )
-        return url.replaceFirst(host, maskedHost)
+        if (dotIndex < MIN_MASK_LENGTH) return url
+        val domain = host.substring(0, dotIndex)
+        val tld = host.substring(dotIndex)
+        val maskedDomain = domain.first() +
+            "x".repeat(domain.length - 2) +
+            domain.last()
+        return url.replaceFirst(host, maskedDomain + tld)
     }
 
     private fun SiteModel.hasRegularCredentials(): Boolean {
@@ -335,7 +337,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     companion object {
         private const val JETPACK_SUCCESS_URL = "jetpack://app-pass-authorize"
         private const val WORDPRESS_SUCCESS_URL = "wordpress://app-pass-authorize"
-        private const val MASK_LENGTH = 3
+        private const val MIN_MASK_LENGTH = 3
     }
 
     data class UriLogin(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -133,7 +133,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
     fun trackStoringFailed(siteUrl: String?, reason: String) {
         val properties: MutableMap<String, String?> = HashMap()
-        properties[URL_TAG] = siteUrl
+        properties[URL_TAG] = maskUrl(siteUrl.orEmpty())
         properties[REASON_TAG] = reason
         AnalyticsTracker.track(
             Stat.APPLICATION_PASSWORD_STORING_FAILED,
@@ -192,7 +192,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
     private fun trackSuccessful(siteUrl: String) {
         val properties: MutableMap<String, String?> = HashMap()
-        properties[URL_TAG] = siteUrl
+        properties[URL_TAG] = maskUrl(siteUrl)
         properties[SUCCESS_TAG] = "true"
         AnalyticsTracker.track(
             if (buildConfigWrapper.isJetpackApp) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -104,7 +104,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
         return withContext(bgDispatcher) {
             val normalizedUrl = UrlUtils.normalizeUrl(urlLogin.siteUrl)
-            val site = findSiteByUrl(normalizedUrl)
+            val sites = siteStore.sites
+            val site = findSiteByUrl(normalizedUrl, sites)
             if (site != null) {
                 site.apply {
                     apiRestUsernameEncrypted = ""
@@ -121,7 +122,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 true
             } else {
                 logAndReportSiteNotFound(
-                    urlLogin.siteUrl, normalizedUrl
+                    urlLogin.siteUrl, normalizedUrl, sites
                 )
                 false
             }
@@ -168,11 +169,12 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
     private fun logAndReportSiteNotFound(
         siteUrl: String?,
-        normalizedUrl: String?
+        normalizedUrl: String?,
+        sites: List<SiteModel>
     ) {
-        val availableSiteUrls = siteStore.sites.joinToString { it.url }
+        val availableSiteUrls = sites.joinToString { it.url }
         val detail = "$siteUrl (normalized: $normalizedUrl)" +
-            " — ${siteStore.sites.size} sites available: [$availableSiteUrls]"
+            " — ${sites.size} sites available: [$availableSiteUrls]"
         appLogWrapper.e(
             AppLog.T.DB,
             "A_P: Cannot save credentials" +
@@ -233,15 +235,18 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         }
     }
 
-    private fun findSiteByUrl(normalizedUrl: String?): SiteModel? {
+    private fun findSiteByUrl(
+        normalizedUrl: String?,
+        sites: List<SiteModel>
+    ): SiteModel? {
         // Exact match first
-        siteStore.sites.firstOrNull {
+        sites.firstOrNull {
             UrlUtils.normalizeUrl(it.url) == normalizedUrl
         }?.let { return it }
 
         // Fallback: compare ignoring scheme and www prefix
         val strippedUrl = normalizedUrl?.stripSchemeAndWww()
-        return siteStore.sites.firstOrNull {
+        return sites.firstOrNull {
             UrlUtils.normalizeUrl(it.url)?.stripSchemeAndWww() == strippedUrl
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import org.wordpress.android.R
@@ -243,13 +244,15 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         normalizedUrl: String?,
         sites: List<SiteModel>
     ): SiteModel? {
+        if (normalizedUrl.isNullOrEmpty()) return null
+
         // Exact match first
         sites.firstOrNull {
             UrlUtils.normalizeUrl(it.url) == normalizedUrl
         }?.let { return it }
 
         // Fallback: compare ignoring scheme and www prefix
-        val strippedUrl = normalizedUrl?.stripSchemeAndWww()
+        val strippedUrl = normalizedUrl.stripSchemeAndWww()
         return sites.firstOrNull {
             UrlUtils.normalizeUrl(it.url)?.stripSchemeAndWww() == strippedUrl
         }
@@ -261,12 +264,19 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             .removePrefix("www.")
     }
 
-    private fun maskUrl(url: String): String {
-        val dotIndex = url.lastIndexOf('.')
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun maskUrl(url: String): String {
+        val host = try {
+            java.net.URI(url).host
+        } catch (_: Exception) {
+            null
+        } ?: url
+        val dotIndex = host.lastIndexOf('.')
         if (dotIndex < MASK_LENGTH) return url
-        return url.replaceRange(
+        val maskedHost = host.replaceRange(
             dotIndex - MASK_LENGTH, dotIndex, "X".repeat(MASK_LENGTH)
         )
+        return url.replace(host, maskedHost)
     }
 
     private fun SiteModel.hasRegularCredentials(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -246,14 +246,11 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     ): SiteModel? {
         if (normalizedUrl.isNullOrEmpty()) return null
 
-        // Exact match first
-        sites.firstOrNull {
-            UrlUtils.normalizeUrl(it.url) == normalizedUrl
-        }?.let { return it }
-
-        // Fallback: compare ignoring scheme and www prefix
+        // Exact match first, fallback: compare ignoring scheme and www prefix
         val strippedUrl = normalizedUrl.stripSchemeAndWww()
         return sites.firstOrNull {
+            UrlUtils.normalizeUrl(it.url) == normalizedUrl
+        } ?: sites.firstOrNull {
             UrlUtils.normalizeUrl(it.url)?.stripSchemeAndWww() == strippedUrl
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -104,7 +104,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
         return withContext(bgDispatcher) {
             val normalizedUrl = UrlUtils.normalizeUrl(urlLogin.siteUrl)
-            val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
+            val site = findSiteByUrl(normalizedUrl)
             if (site != null) {
                 site.apply {
                     apiRestUsernameEncrypted = ""
@@ -231,6 +231,25 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             )
             sitesToReset.size
         }
+    }
+
+    private fun findSiteByUrl(normalizedUrl: String?): SiteModel? {
+        // Exact match first
+        siteStore.sites.firstOrNull {
+            UrlUtils.normalizeUrl(it.url) == normalizedUrl
+        }?.let { return it }
+
+        // Fallback: compare ignoring scheme and www prefix
+        val strippedUrl = normalizedUrl?.stripSchemeAndWww()
+        return siteStore.sites.firstOrNull {
+            UrlUtils.normalizeUrl(it.url)?.stripSchemeAndWww() == strippedUrl
+        }
+    }
+
+    private fun String.stripSchemeAndWww(): String {
+        return removePrefix("https://")
+            .removePrefix("http://")
+            .removePrefix("www.")
     }
 
     private fun SiteModel.hasRegularCredentials(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -170,8 +170,9 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         siteUrl: String?,
         normalizedUrl: String?
     ) {
+        val availableSiteUrls = siteStore.sites.joinToString { it.url }
         val detail = "$siteUrl (normalized: $normalizedUrl)" +
-            " — ${siteStore.sites.size} sites available"
+            " — ${siteStore.sites.size} sites available: [$availableSiteUrls]"
         appLogWrapper.e(
             AppLog.T.DB,
             "A_P: Cannot save credentials" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -173,15 +173,19 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         sites: List<SiteModel>
     ) {
         val availableSiteUrls = sites.joinToString { it.url }
-        val detail = "$siteUrl (normalized: $normalizedUrl)" +
+        val logDetail = "$siteUrl (normalized: $normalizedUrl)" +
             " — ${sites.size} sites available: [$availableSiteUrls]"
         appLogWrapper.e(
             AppLog.T.DB,
             "A_P: Cannot save credentials" +
-                " - site not found: $detail"
+                " - site not found: $logDetail"
         )
         trackStoringFailed(siteUrl, "site_not_found")
-        reportStoringFailedToSentry("site_not_found", detail)
+        val maskedSiteUrls = sites.joinToString { maskUrl(it.url) }
+        val sentryDetail =
+            "${maskUrl(siteUrl.orEmpty())} (normalized: ${maskUrl(normalizedUrl.orEmpty())})" +
+                " — ${sites.size} sites available: [$maskedSiteUrls]"
+        reportStoringFailedToSentry("site_not_found", sentryDetail)
     }
 
     private fun trackSuccessful(siteUrl: String) {
@@ -257,6 +261,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             .removePrefix("www.")
     }
 
+    private fun maskUrl(url: String): String {
+        val dotIndex = url.lastIndexOf('.')
+        if (dotIndex < MASK_LENGTH) return url
+        return url.replaceRange(
+            dotIndex - MASK_LENGTH, dotIndex, "X".repeat(MASK_LENGTH)
+        )
+    }
+
     private fun SiteModel.hasRegularCredentials(): Boolean {
         return !username.isNullOrEmpty() && !password.isNullOrEmpty()
     }
@@ -315,6 +327,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     companion object {
         private const val JETPACK_SUCCESS_URL = "jetpack://app-pass-authorize"
         private const val WORDPRESS_SUCCESS_URL = "wordpress://app-pass-authorize"
+        private const val MASK_LENGTH = 3
     }
 
     data class UriLogin(

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -507,7 +507,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `maskUrl with standard domain masks characters before TLD`() {
+    fun `maskUrl with standard domain masks middle characters`() {
         val result = applicationPasswordLoginHelper.maskUrl("https://example.com")
         assertEquals("https://exxxxxe.com", result)
     }
@@ -526,9 +526,21 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `maskUrl with short host returns url unmasked`() {
+    fun `maskUrl with three char domain masks middle character`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://abc.com")
+        assertEquals("https://axc.com", result)
+    }
+
+    @Test
+    fun `maskUrl with single char domain replaces it with x`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://a.com")
+        assertEquals("https://x.com", result)
+    }
+
+    @Test
+    fun `maskUrl with two char domain replaces both with x`() {
         val result = applicationPasswordLoginHelper.maskUrl("https://ab.com")
-        assertEquals("https://ab.com", result)
+        assertEquals("https://xx.com", result)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -509,20 +509,20 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Test
     fun `maskUrl with standard domain masks characters before TLD`() {
         val result = applicationPasswordLoginHelper.maskUrl("https://example.com")
-        assertEquals("https://examXXX.com", result)
+        assertEquals("https://exxxxxe.com", result)
     }
 
     @Test
     fun `maskUrl with port preserves port`() {
         val result = applicationPasswordLoginHelper.maskUrl("https://test.com:8080")
-        assertEquals("https://tXXX.com:8080", result)
+        assertEquals("https://txxt.com:8080", result)
     }
 
     @Test
     fun `maskUrl with dot in path masks only host`() {
         val result = applicationPasswordLoginHelper
             .maskUrl("https://example.com/wp-content/image.jpg")
-        assertEquals("https://examXXX.com/wp-content/image.jpg", result)
+        assertEquals("https://exxxxxe.com/wp-content/image.jpg", result)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -483,6 +483,37 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     }
 
     @Test
+    fun `maskUrl with no dot returns url unmasked`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://localhost")
+        assertEquals("https://localhost", result)
+    }
+
+    @Test
+    fun `maskUrl with standard domain masks characters before TLD`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://example.com")
+        assertEquals("https://examXXX.com", result)
+    }
+
+    @Test
+    fun `maskUrl with port preserves port`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://test.com:8080")
+        assertEquals("https://tXXX.com:8080", result)
+    }
+
+    @Test
+    fun `maskUrl with dot in path masks only host`() {
+        val result = applicationPasswordLoginHelper
+            .maskUrl("https://example.com/wp-content/image.jpg")
+        assertEquals("https://examXXX.com/wp-content/image.jpg", result)
+    }
+
+    @Test
+    fun `maskUrl with short host returns url unmasked`() {
+        val result = applicationPasswordLoginHelper.maskUrl("https://ab.com")
+        assertEquals("https://ab.com", result)
+    }
+
+    @Test
     fun `getResettableApplicationPasswordSitesCount returns count of sites with regular credentials`() {
         val siteWithRegularCredentials = SiteModel().apply {
             id = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -159,9 +159,84 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
-            verify(siteStore, times(2)).sites
+            verify(siteStore).sites
             verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
             verify(dispatcherWrapper, times(0)).removeApplicationPassword(any())
+        }
+
+    @Test
+    fun `storeApplicationPasswordCredentialsFrom matches site with different scheme`() =
+        runTest {
+            val siteModel = SiteModel().apply {
+                url = "http://test.com"
+            }
+            whenever(siteStore.sites).thenReturn(listOf(siteModel))
+            val httpsLogin = UriLogin(
+                "https://test.com", TEST_USER, TEST_PASSWORD, TEST_API_ROOT_URL
+            )
+
+            val result = applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(httpsLogin)
+
+            assertTrue(result)
+            verify(dispatcherWrapper).updateApplicationPassword(eq(siteModel))
+        }
+
+    @Test
+    fun `storeApplicationPasswordCredentialsFrom matches site with www mismatch`() =
+        runTest {
+            val siteModel = SiteModel().apply {
+                url = "https://www.test.com"
+            }
+            whenever(siteStore.sites).thenReturn(listOf(siteModel))
+            val noWwwLogin = UriLogin(
+                "https://test.com", TEST_USER, TEST_PASSWORD, TEST_API_ROOT_URL
+            )
+
+            val result = applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(noWwwLogin)
+
+            assertTrue(result)
+            verify(dispatcherWrapper).updateApplicationPassword(eq(siteModel))
+        }
+
+    @Test
+    fun `storeApplicationPasswordCredentialsFrom matches site with scheme and www mismatch`() =
+        runTest {
+            val siteModel = SiteModel().apply {
+                url = "http://www.test.com"
+            }
+            whenever(siteStore.sites).thenReturn(listOf(siteModel))
+            val httpsNoWwwLogin = UriLogin(
+                "https://test.com", TEST_USER, TEST_PASSWORD, TEST_API_ROOT_URL
+            )
+
+            val result = applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(httpsNoWwwLogin)
+
+            assertTrue(result)
+            verify(dispatcherWrapper).updateApplicationPassword(eq(siteModel))
+        }
+
+    @Test
+    fun `storeApplicationPasswordCredentialsFrom prefers exact match over fallback`() =
+        runTest {
+            val exactSite = SiteModel().apply {
+                url = TEST_URL
+                id = 1
+            }
+            val fallbackSite = SiteModel().apply {
+                url = "https://test.com"
+                id = 2
+            }
+            whenever(siteStore.sites)
+                .thenReturn(listOf(fallbackSite, exactSite))
+
+            val result = applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(testUriLogin)
+
+            assertTrue(result)
+            verify(dispatcherWrapper).updateApplicationPassword(eq(exactSite))
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -165,6 +165,24 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
         }
 
     @Test
+    fun `storeApplicationPasswordCredentialsFrom with empty url does not match site with empty url`() =
+        runTest {
+            val siteWithEmptyUrl = SiteModel().apply {
+                url = ""
+            }
+            whenever(siteStore.sites).thenReturn(listOf(siteWithEmptyUrl))
+            val emptyUrlLogin = UriLogin(
+                "", TEST_USER, TEST_PASSWORD, TEST_API_ROOT_URL
+            )
+
+            val result = applicationPasswordLoginHelper
+                .storeApplicationPasswordCredentialsFrom(emptyUrlLogin)
+
+            assertFalse(result)
+            verify(dispatcherWrapper, times(0)).updateApplicationPassword(any())
+        }
+
+    @Test
     fun `storeApplicationPasswordCredentialsFrom matches site with different scheme`() =
         runTest {
             val siteModel = SiteModel().apply {


### PR DESCRIPTION
## Description

Some users hit a `site_not_found` error when storing Application Password credentials after authorization. The root cause is a URL mismatch between the callback URL and the stored site URL (e.g., `https://` vs `http://`, or `www.` prefix differences).

This PR:
- Adds diagnostic logging that includes the actual stored site URLs in the error report, making it easier to identify the exact mismatch from Sentry
- Adds fallback URL matching that strips scheme (`http`/`https`) and `www.` prefix when the exact normalized match fails
- Caches `siteStore.sites` to avoid redundant list access during lookup and error reporting
- Adds tests for scheme mismatch, www mismatch, combined mismatch, and exact match priority

## Testing instructions

- [ ] Test that you are able to log in with Application Password.