### PR TITLE
Fix VideoPress videos not appearing in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -265,6 +265,16 @@ class ReaderPostRenderer(
         }
         content = removeInlineStyles(content)
 
+        // strip videopress-iframe.js which can permanently hide iframes on error
+        content = content.replace(
+            Regex(
+                "<script[^>]*videopress-iframe\\.js[^>]*>"
+                    + "\\s*</script>",
+                RegexOption.IGNORE_CASE
+            ),
+            ""
+        )
+
         // some content (such as Vimeo embeds) don't have "http:" before links
         content = content.replace("src=\"//", "src=\"http://")
 
@@ -525,7 +535,7 @@ class ReaderPostRenderer(
             .append(" font-family: sans-serif;")
             .append(" }")
             // horizontally center iframes
-            .append(" iframe { display: block; margin: 0 auto; }")
+            .append(" iframe { display: block; margin: 0 auto; max-width: 100%; }")
             // hide forms, form-related elements, legacy RSS sharing links and other ad-related content
             // http://bit.ly/2FUTvsP
             .append(" form, input, select, button textarea { display: none; }")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -436,6 +436,8 @@ class ReaderPostRenderer(
             .append(" display: block; margin-left: auto; margin-right: auto;")
             .append(" background-color: var(--color-neutral-0);")
             .append(" margin-bottom: ").append(resourceVars.marginMediumPx).append("px; }")
+            // make sure videos aren't wider than the display
+            .append(" video { display: block; max-width: 100%; height: auto; }")
 
         if (renderAsTiledGallery) {
             // tiled-gallery related styles

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.kt
@@ -30,7 +30,7 @@ class ReaderIframeScanner(private val content: String) {
 
     companion object {
         private val IFRAME_TAG_PATTERN: Pattern = Pattern.compile(
-            "<iframe[^>]* src=\\\'([^\\\']*)\\\'[^>]*>",
+            "<iframe[^>]* src=['\"]([^'\"]*)['\"][^>]*>",
             Pattern.CASE_INSENSITIVE
         )
     }


### PR DESCRIPTION
## Description

VideoPress videos in Reader posts don't appear at all. Three compounding issues prevent these videos from rendering:

1. **`videopress-iframe.js` permanently hides iframes** — The external script sets `display: none` on iframes to measure parent width, but has no error protection. If measurement fails, iframes stay hidden forever. Fix: strip the script since the renderer handles iframe sizing via `resizeIframes()`.

2. **Iframe regex only matches single-quoted `src`** — `ReaderIframeScanner` uses a regex that only matches `src='...'`, but `removeInlineStyles()` passes content through JSoup which converts all quotes to double quotes. After JSoup processing, no iframes are matched and `resizeIframes()` silently skips them all. Fix: update regex to match both `'` and `"`.

3. **Iframe CSS lacks `max-width` constraint** — VideoPress iframes with hardcoded `width="500"` overflow on narrower viewports. Fix: add `max-width: 100%` to iframe CSS rule.

## Testing instructions

VideoPress embed rendering:

1. Open the Reader and navigate to a post with VideoPress embeds (e.g., https://rich.blog/pages-and-layers/)
- [ ] Verify VideoPress videos appear and are playable
- [ ] Verify videos are properly sized within the screen width (no horizontal overflow)

2. Open a Reader post with YouTube or Vimeo embeds
- [ ] Verify YouTube/Vimeo iframes still render correctly

3. Open a Reader post with images
- [ ] Verify images are unaffected by the changes