### PR TITLE
Fix Dependabot label to match existing repo label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "bot: dependencies update"
+      - "dependencies update"
     groups:
       kotlin-ksp:
         applies-to: version-updates


### PR DESCRIPTION
At some point Dependabot stopped automatically assigning a label to its PRs, which caused them to fail the Danger CI check (`PR requires at least one label`). This was due to a recent label "clean up" which accidentally removed some labels we actually use.

This PR resolves this by updating the Dependabot config to auto-assign the  `dependencies update` label.

Clean CI should be enough to test this change.

