### PR TITLE
CMM-1991: Add CSS styling for button blocks in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -545,7 +545,7 @@ class ReaderPostRenderer(
             .append(" figure { display: block; margin-inline-start: 0px; margin-inline-end: 0px; }")
             // button block styles
             .append(" .wp-block-buttons {")
-            .append(" display: flex; flex-wrap: wrap;")
+            .append(" display: flex; flex-wrap: wrap; align-items: flex-start;")
             .append(" gap: ").append(resourceVars.marginMediumPx).append("px;")
             .append(" margin-top: ").append(resourceVars.marginMediumPx).append("px;")
             .append(" margin-bottom: ").append(resourceVars.marginMediumPx).append("px;")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -545,7 +545,8 @@ class ReaderPostRenderer(
             .append(" figure { display: block; margin-inline-start: 0px; margin-inline-end: 0px; }")
             // button block styles
             .append(" .wp-block-buttons {")
-            .append(" display: flex; flex-wrap: wrap; gap: 8px;")
+            .append(" display: flex; flex-wrap: wrap;")
+            .append(" gap: ").append(resourceVars.marginMediumPx).append("px;")
             .append(" margin-top: ").append(resourceVars.marginMediumPx).append("px;")
             .append(" margin-bottom: ").append(resourceVars.marginMediumPx).append("px;")
             .append(" border: none !important;")
@@ -567,7 +568,7 @@ class ReaderPostRenderer(
             // outline button variant
             .append(" .is-style-outline a.wp-block-button__link {")
             .append(" background-color: transparent !important;")
-            .append(" border: 2px solid var(--main-link-color);")
+            .append(" border: 2px solid var(--main-link-color) !important;")
             .append(" color: var(--main-link-color) !important;")
             .append(" }")
             .append("</style>")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -555,7 +555,7 @@ class ReaderPostRenderer(
             .append(" display: block; border: none !important;")
             .append(" }")
             .append(" a.wp-block-button__link {")
-            .append(" display: block;")
+            .append(" display: inline-block;")
             .append(" background-color: var(--main-link-color) !important;")
             .append(" color: var(--color-background) !important;")
             .append(" padding: 12px 24px;")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -538,7 +538,7 @@ class ReaderPostRenderer(
             .append(" iframe { display: block; margin: 0 auto; max-width: 100%; }")
             // hide forms, form-related elements, legacy RSS sharing links and other ad-related content
             // http://bit.ly/2FUTvsP
-            .append(" form, input, select, button textarea { display: none; }")
+            .append(" form, input, select, button, textarea { display: none; }")
             .append(" div.feedflare { display: none; }")
             .append(" .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, ")
             .append(" .OUTBRAIN, .adsbygoogle { display: none; }")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.kt
@@ -543,6 +543,33 @@ class ReaderPostRenderer(
             .append(" .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, ")
             .append(" .OUTBRAIN, .adsbygoogle { display: none; }")
             .append(" figure { display: block; margin-inline-start: 0px; margin-inline-end: 0px; }")
+            // button block styles
+            .append(" .wp-block-buttons {")
+            .append(" display: flex; flex-wrap: wrap; gap: 8px;")
+            .append(" margin-top: ").append(resourceVars.marginMediumPx).append("px;")
+            .append(" margin-bottom: ").append(resourceVars.marginMediumPx).append("px;")
+            .append(" border: none !important;")
+            .append(" }")
+            .append(" .wp-block-button {")
+            .append(" display: block; border: none !important;")
+            .append(" }")
+            .append(" a.wp-block-button__link {")
+            .append(" display: block;")
+            .append(" background-color: var(--main-link-color) !important;")
+            .append(" color: var(--color-background) !important;")
+            .append(" padding: 12px 24px;")
+            .append(" border-radius: 4px;")
+            .append(" text-decoration: none !important;")
+            .append(" font-size: inherit;")
+            .append(" line-height: 1.2em;")
+            .append(" text-align: center;")
+            .append(" }")
+            // outline button variant
+            .append(" .is-style-outline a.wp-block-button__link {")
+            .append(" background-color: transparent !important;")
+            .append(" border: 2px solid var(--main-link-color);")
+            .append(" color: var(--main-link-color) !important;")
+            .append(" }")
             .append("</style>")
 
         // add a custom CSS class to (any) tiled gallery elements to make them easier selectable for various rules
@@ -588,6 +615,7 @@ class ReaderPostRenderer(
             .append("--color-neutral-50: ").append(readingPreferencesTheme.cssTextLightColor).append("; ")
             .append("--color-neutral-70: ").append(readingPreferencesTheme.cssTextColor).append("; ")
             .append("--main-link-color: ").append(readingPreferencesTheme.cssLinkColor).append("; ")
+            .append("--color-background: ").append(readingPreferencesTheme.cssBackgroundColor).append("; ")
             .append("} ")
     }
 


### PR DESCRIPTION
## Description

Button blocks (`wp-block-button`) in Reader posts were rendering as plain unstyled text/links instead of proper buttons. This is the Android counterpart of CMM-945 (iOS).

**Root cause:** `removeInlineStyles()` strips all inline `style` attributes from post HTML for safety, but no fallback CSS existed for button block classes. This left button links completely unstyled.

**Changes:**
- Add theme-aware CSS rules for `.wp-block-buttons`, `.wp-block-button`, and `a.wp-block-button__link` in `ReaderPostRenderer`
- Add CSS for the `.is-style-outline` button variant
- Add `--color-background` CSS variable to support contrasting button text color
- Fix pre-existing missing comma in CSS selector (`button textarea` → `button, textarea`)

**Trade-off:** Author-chosen button colors are lost since inline styles are stripped globally. Buttons use theme-consistent colors instead.

## Testing instructions

Button block rendering:

1. Open the Reader and navigate to https://wordpress.com/blog/2026/03/23/encircle-technologies-agency-story/
2. Scroll to the bottom of the post
- [ ] Verify "Explore WordPress.com for Agencies" button at the bottom renders as a styled button with background color, padding, and rounded corners (not as plain text/link)
- [ ] Verify tapping the button opens the correct URL

Reader themes:

1. Open the post from the previous test case
2. Tap the reading preferences icon (Aa) in the Reader toolbar
3. Switch between each theme: System, Soft, Sepia, Evening, OLED, H4x0r, Candy
- [ ] Verify the button adapts to each theme (background uses the theme's link color, text uses the theme's background color)
- [ ] Verify the button remains readable with good contrast in all themes

Dark mode:

1. Enable system dark mode (Settings → Display → Dark theme)
2. Open the same post in Reader with "System" theme selected

Before:
<img width="450" height="2400" alt="Screenshot_20260325-175937" src="https://github.com/user-attachments/assets/a4a5c815-8824-41da-9e33-7005d2a5386a" />

After:
<img width="450" height="2400" alt="Screenshot_20260325-191549" src="https://github.com/user-attachments/assets/0c6f40ce-75b8-4a29-8b3a-bef562d9a7ac" />
<img width="450" height="2400" alt="Screenshot_20260325-191605" src="https://github.com/user-attachments/assets/9ce3dea3-4b73-44f9-b8a4-48fb5848028e" />
<img width="450" height="2400" alt="Screenshot_20260325-191614" src="https://github.com/user-attachments/assets/848f9962-ab64-4108-aa67-65609ffc9421" />
