### PR TITLE
Fix Reader rendering blank lines in excerpts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -99,8 +99,10 @@ public class ReaderPost {
             post.mPseudoId = JSONUtils.getString(json, "global_ID"); // sites/ endpoint
         }
 
-        // remove HTML from the excerpt
-        post.mExcerpt = HtmlUtils.fastStripHtml(JSONUtils.getString(json, "excerpt")).trim();
+        // remove HTML from the excerpt, replacing newlines with spaces so that
+        // <br> and <p> tags don't render as blank lines in the post list
+        post.mExcerpt = HtmlUtils.fastStripHtml(JSONUtils.getString(json, "excerpt"))
+                .replaceAll("\\n+", " ").trim();
 
         post.mText = JSONUtils.getString(json, "content");
         post.mTitle = JSONUtils.getStringDecoded(json, "title");

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderSimplePost.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderSimplePost.java
@@ -48,7 +48,8 @@ public class ReaderSimplePost {
         }
 
         post.mTitle = JSONUtils.getStringDecoded(json, "title");
-        post.mExcerpt = HtmlUtils.fastStripHtml(JSONUtils.getString(json, "excerpt")).trim();
+        post.mExcerpt = HtmlUtils.fastStripHtml(JSONUtils.getString(json, "excerpt"))
+                .replaceAll("\\n+", " ").trim();
         post.mSiteName = JSONUtils.getStringDecoded(json, "site_name");
         post.mFeaturedImageUrl = JSONUtils.getString(json, "featured_image");
 


### PR DESCRIPTION
## Description

`HtmlUtils.fastStripHtml()` converts `<br>` and `<p>` tags to newline characters (`\n`). When the API returns excerpts containing these tags, the newlines render as visible blank lines in the Reader post list.

This collapses consecutive newlines into a single space after stripping HTML from excerpts in both `ReaderPost` and `ReaderSimplePost`.

Fixes the Android equivalent of the iOS issue described in CMM-82.

## Testing instructions

Reader excerpt rendering:

1. Open the Reader and browse posts that have multi-paragraph excerpts (posts with `<br>` or `<p>` tags in their excerpt)
- [ ] Verify excerpts display as continuous text without blank lines
2. Check related posts at the bottom of a Reader post detail
- [ ] Verify related post excerpts also display without blank lines