### PR TITLE
CMM-2001: Replace previous-period line with stacked bars in Views chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -79,6 +79,7 @@ import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarkerVisibility
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberColumnCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.layer.stacked
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.core.common.Insets
@@ -520,13 +521,21 @@ private fun ViewsStatsChart(
                 }
                 ChartType.BAR -> modelProducer.runTransaction {
                     columnSeries {
-                        series(chartData.currentPeriod.map { it.views.toInt() })
-                    }
-                    if (hasPreviousPeriod) {
-                        lineSeries {
+                        series(
+                            chartData.currentPeriod.map {
+                                it.views.toInt()
+                            }
+                        )
+                        if (hasPreviousPeriod) {
                             series(
-                                chartData.previousPeriod
-                                    .map { it.views.toInt() }
+                                chartData.currentPeriod.zip(
+                                    chartData.previousPeriod
+                                ) { current, previous ->
+                                    maxOf(
+                                        0L,
+                                        previous.views - current.views
+                                    ).toInt()
+                                }
                             )
                         }
                     }
@@ -679,24 +688,18 @@ private fun ViewsStatsChart(
                                     shape = CorneredShape.rounded(
                                         allPercent = 40
                                     )
+                                ),
+                                LineComponent(
+                                    fill = fill(secondaryColor),
+                                    thicknessDp = 16f,
+                                    shape = CorneredShape.rounded(
+                                        allPercent = 40
+                                    )
                                 )
-                            )
-                    ),
-                    rememberLineCartesianLayer(
-                        lineProvider = LineCartesianLayer
-                            .LineProvider.series(
-                                LineCartesianLayer.Line(
-                                    fill = LineCartesianLayer
-                                        .LineFill.single(
-                                            fill(secondaryColor)
-                                        ),
-                                    stroke = LineCartesianLayer
-                                        .LineStroke.Dashed(),
-                                    pointConnector =
-                                        LineCartesianLayer
-                                            .PointConnector.Sharp
-                                )
-                            )
+                            ),
+                        mergeMode = {
+                            ColumnCartesianLayer.MergeMode.stacked()
+                        }
                     ),
                     startAxis = VerticalAxis.rememberStart(
                         line = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -521,12 +521,30 @@ private fun ViewsStatsChart(
                 }
                 ChartType.BAR -> modelProducer.runTransaction {
                     columnSeries {
-                        series(
-                            chartData.currentPeriod.map {
-                                it.views.toInt()
-                            }
-                        )
                         if (hasPreviousPeriod) {
+                            // Series 1: current value when no
+                            // delta (rounded top)
+                            series(
+                                chartData.currentPeriod.zip(
+                                    chartData.previousPeriod
+                                ) { current, previous ->
+                                    if (previous.views <= current.views)
+                                        current.views.toInt()
+                                    else 0
+                                }
+                            )
+                            // Series 2: current value when there
+                            // is a delta (flat top)
+                            series(
+                                chartData.currentPeriod.zip(
+                                    chartData.previousPeriod
+                                ) { current, previous ->
+                                    if (previous.views > current.views)
+                                        current.views.toInt()
+                                    else 0
+                                }
+                            )
+                            // Series 3: delta (rounded top)
                             series(
                                 chartData.currentPeriod.zip(
                                     chartData.previousPeriod
@@ -535,6 +553,12 @@ private fun ViewsStatsChart(
                                         0L,
                                         previous.views - current.views
                                     ).toInt()
+                                }
+                            )
+                        } else {
+                            series(
+                                chartData.currentPeriod.map {
+                                    it.views.toInt()
                                 }
                             )
                         }
@@ -686,14 +710,20 @@ private fun ViewsStatsChart(
                                     fill = fill(primaryColor),
                                     thicknessDp = 16f,
                                     shape = CorneredShape.rounded(
-                                        allPercent = 40
+                                        topLeftPercent = 40,
+                                        topRightPercent = 40,
                                     )
+                                ),
+                                LineComponent(
+                                    fill = fill(primaryColor),
+                                    thicknessDp = 16f,
                                 ),
                                 LineComponent(
                                     fill = fill(secondaryColor),
                                     thicknessDp = 16f,
                                     shape = CorneredShape.rounded(
-                                        allPercent = 40
+                                        topLeftPercent = 40,
+                                        topRightPercent = 40,
                                     )
                                 )
                             ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -710,8 +710,8 @@ private fun ViewsStatsChart(
                                     fill = fill(primaryColor),
                                     thicknessDp = 16f,
                                     shape = CorneredShape.rounded(
-                                        topLeftPercent = 40,
-                                        topRightPercent = 40,
+                                        topLeftPercent = 20,
+                                        topRightPercent = 20,
                                     )
                                 ),
                                 LineComponent(
@@ -722,8 +722,8 @@ private fun ViewsStatsChart(
                                     fill = fill(secondaryColor),
                                     thicknessDp = 16f,
                                     shape = CorneredShape.rounded(
-                                        topLeftPercent = 40,
-                                        topRightPercent = 40,
+                                        topLeftPercent = 20,
+                                        topRightPercent = 20,
                                     )
                                 )
                             ),


### PR DESCRIPTION
## Description

Replaces the dashed line overlay for previous period data in the Views bar chart with stacked grey bars.

- When the previous period value is less than or equal to the current: only the primary bar is shown (rounded top)
- When the previous period value exceeds the current: a grey bar stacks on top (flat primary bar, rounded grey bar)
- Uses three stacked series to conditionally apply rounded corners only to the topmost visible bar
- Reduces corner rounding from 40% to 20%

## Testing instructions

Stacked bars in Views chart:

1. Open the app and navigate to Stats > Traffic tab
2. Look at the Views card and switch to bar chart mode

This is how it looked before and after

<img width="444" height="479" alt="Screenshot 2026-03-27 at 13 04 41" src="https://github.com/user-attachments/assets/2f943e15-2439-4298-b769-d9f955440601" />
<img width="349" height="373" alt="Screenshot 2026-03-27 at 12 59 13" src="https://github.com/user-attachments/assets/c3aaa7cf-dfd8-4bf8-8cd0-c795f6fc258a" />
