### PR TITLE
fix: rename cached media files to include extension when missing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -144,6 +144,26 @@ public class FluxCUtils {
             filename += "." + fileExtension;
         }
 
+        // Path resolution can drop the file extension when the filename contains
+        // spaces (e.g. "screenshot_one ui home123.jpg" resolves to a path ending
+        // in "screenshot_one ui home123."). Rename the on-disk file so the path
+        // includes the correct extension, allowing upload consumers to detect the
+        // MIME type from the filename.
+        if (fileExtension != null && !path.endsWith("." + fileExtension)) {
+            String correctedPath = path;
+            while (correctedPath.endsWith(".")) {
+                correctedPath = correctedPath.substring(0, correctedPath.length() - 1);
+            }
+            correctedPath = correctedPath + "." + fileExtension;
+            File renamed = new File(correctedPath);
+            if (file.renameTo(renamed)) {
+                path = correctedPath;
+            } else {
+                AppLog.w(T.UTILS,
+                    "Failed to rename cached file to include extension: " + path);
+            }
+        }
+
         MediaModel media = new MediaModel(
                 localSiteId,
                 DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000),


### PR DESCRIPTION
## Description

Fix CMM-2003. 

When a media file's source filename contains spaces (e.g. Samsung screenshots named `screenshot_20260327_072755_one ui home5107006954197938205.jpg`), Android's path resolution can produce a cached file path that ends with a trailing dot — dropping the file extension entirely.

The existing code in `FluxCUtils.mediaModelFromLocalUri()` already derives the correct extension from the MIME type and appends it to `filename`, but the on-disk file path (`mFilePath`) was left unchanged. Since `MediaRSApiRestClient` passes `mFilePath` to wordpress-rs, and reqwest infers the MIME type from the file extension in the path, the upload request was sent with `Content-Type: application/octet-stream` and a filename without an extension — causing WordPress to reject it with "Sorry, you are not allowed to upload this file type."

This PR adds a step that renames the cached file on disk to include the correct extension when the path doesn't match, keeping `mFilePath` consistent with `mFileName`.

## Testing instructions

Upload a file with spaces in the filename:

1. On a Samsung device, take a screenshot from an app like Samsung Health or One UI Home (these produce filenames with spaces)
2. Open the WordPress/Jetpack app and navigate to Media
3. Tap **+** to upload the screenshot
- [x] Verify the upload succeeds without errors

Alternatively, create a test file manually:

1. Using a file manager, create or rename an image file to include spaces (e.g. `test file upload.jpg`)
2. Share the file to the WordPress/Jetpack app, or upload it via the Media screen
- [ ] Verify the upload succeeds without errors

Regression — files without spaces:

1. Upload a media file with a normal filename (no spaces)
- [x] Verify the upload still succeeds as before