### PR TITLE
Fix Reader post detail content jumping (CMM-2012)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -778,9 +778,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     /**
      * Registers an [View.OnLayoutChangeListener] on [readerWebView] that waits for
      * the WebView to obtain a positive height after rendering HTML content. Once
-     * detected, the listener removes itself and calls [showDeferredContent] so that
-     * tags and comments appear only after the WebView has laid out, preventing them
-     * from briefly showing near the top then jumping below the fold.
+     * detected, the listener sets [hasWebViewContent] to true, removes itself, and
+     * re-invokes [renderUiState] and [manageCommentSnippetUiState] so that tags and
+     * comments appear only after the WebView has laid out, preventing them from
+     * briefly showing near the top then jumping below the fold.
      */
     private fun registerWebViewLayoutListener() {
         removeWebViewLayoutListener()
@@ -789,7 +790,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             if (readerWebView.height > 0 && !hasWebViewContent) {
                 hasWebViewContent = true
                 removeWebViewLayoutListener()
-                showDeferredContent()
+                (viewModel.uiState.value as? ReaderPostDetailsUiState)
+                    ?.let { state ->
+                        binding?.let { renderUiState(state, it) }
+                    }
+                viewModel.commentSnippetState.value?.let {
+                    manageCommentSnippetUiState(it)
+                }
             }
         }
         readerWebView.addOnLayoutChangeListener(webViewLayoutListener)
@@ -800,25 +807,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             readerWebView.removeOnLayoutChangeListener(it)
         }
         webViewLayoutListener = null
-    }
-
-    /**
-     * Makes tags and comments snippet visible once the WebView has rendered its
-     * content. Called by the layout listener registered in
-     * [registerWebViewLayoutListener].
-     */
-    private fun showDeferredContent() {
-        binding?.expandableTagsView?.let { tagsView ->
-            val uiState = viewModel.uiState.value
-            if (uiState is ReaderPostDetailsUiState &&
-                uiState.headerUiState.tagItems.isNotEmpty()
-            ) {
-                tagsView.setVisible(true)
-            }
-        }
-        if (commentsSnippetFeatureConfig.isEnabled()) {
-            commentsSnippetContainer.visibility = View.VISIBLE
-        }
     }
 
     private fun renderUiState(state: ReaderPostDetailsUiState, binding: ReaderFragmentPostDetailBinding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -775,6 +775,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         likeFacesRecycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 
+    /**
+     * Registers an [View.OnLayoutChangeListener] on [readerWebView] that waits for
+     * the WebView to obtain a positive height after rendering HTML content. Once
+     * detected, the listener removes itself and calls [showDeferredContent] so that
+     * tags and comments appear only after the WebView has laid out, preventing them
+     * from briefly showing near the top then jumping below the fold.
+     */
     private fun registerWebViewLayoutListener() {
         removeWebViewLayoutListener()
         webViewLayoutListener = View.OnLayoutChangeListener {
@@ -795,6 +802,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         webViewLayoutListener = null
     }
 
+    /**
+     * Makes tags and comments snippet visible once the WebView has rendered its
+     * content. Called by the layout listener registered in
+     * [registerWebViewLayoutListener].
+     */
     private fun showDeferredContent() {
         binding?.expandableTagsView?.let { tagsView ->
             val uiState = viewModel.uiState.value

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -211,6 +211,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private var postSlugsResolutionUnderway: Boolean = false
     private var hasAlreadyUpdatedPost: Boolean = false
     private var isWebViewPaused: Boolean = false
+    private var hasWebViewContent: Boolean = false
+    private var webViewLayoutListener: View.OnLayoutChangeListener? = null
 
     private var isRelatedPost: Boolean = false
 
@@ -724,7 +726,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         with(requireActivity()) {
             if (this.isFinishing) return@with
 
-            uiHelpers.updateVisibility(commentsSnippetContainer, commentsSnippetFeatureConfig.isEnabled())
+            uiHelpers.updateVisibility(
+                commentsSnippetContainer,
+                hasWebViewContent && commentsSnippetFeatureConfig.isEnabled()
+            )
             uiHelpers.updateVisibility(followConversationContainer, state.showFollowConversation)
             commentsNumTitle.text = readerUtilsWrapper.getTextForCommentSnippet(state.commentsNumber)
 
@@ -770,6 +775,40 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         likeFacesRecycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 
+    private fun registerWebViewLayoutListener() {
+        removeWebViewLayoutListener()
+        webViewLayoutListener = View.OnLayoutChangeListener {
+                _, _, _, _, _, _, _, _, _ ->
+            if (readerWebView.height > 0 && !hasWebViewContent) {
+                hasWebViewContent = true
+                removeWebViewLayoutListener()
+                showDeferredContent()
+            }
+        }
+        readerWebView.addOnLayoutChangeListener(webViewLayoutListener)
+    }
+
+    private fun removeWebViewLayoutListener() {
+        webViewLayoutListener?.let {
+            readerWebView.removeOnLayoutChangeListener(it)
+        }
+        webViewLayoutListener = null
+    }
+
+    private fun showDeferredContent() {
+        binding?.expandableTagsView?.let { tagsView ->
+            val uiState = viewModel.uiState.value
+            if (uiState is ReaderPostDetailsUiState &&
+                uiState.headerUiState.tagItems.isNotEmpty()
+            ) {
+                tagsView.setVisible(true)
+            }
+        }
+        if (commentsSnippetFeatureConfig.isEnabled()) {
+            commentsSnippetContainer.visibility = View.VISIBLE
+        }
+    }
+
     private fun renderUiState(state: ReaderPostDetailsUiState, binding: ReaderFragmentPostDetailBinding) {
         onPostExecuteShowPost()
 
@@ -794,7 +833,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             viewModel::handleHeaderAction
         )
 
-        binding.expandableTagsView.setVisible(state.headerUiState.tagItems.isNotEmpty())
+        binding.expandableTagsView.setVisible(
+            hasWebViewContent && state.headerUiState.tagItems.isNotEmpty()
+        )
         binding.expandableTagsView.updateUi(
             state.headerUiState.tagItems, getReadingPreferences()
         )
@@ -1039,6 +1080,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     override fun onDestroyView() {
         super.onDestroyView()
+        removeWebViewLayoutListener()
         binding = null
     }
 
@@ -1242,6 +1284,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (commentsSnippetFeatureConfig.isEnabled()) {
             commentsSnippetContainer.visibility = View.GONE
         }
+
+        hasWebViewContent = false
+        removeWebViewLayoutListener()
+        binding?.expandableTagsView?.setVisible(false)
 
         // clear the webView - otherwise it will remain scrolled to where the user scrolled to
         readerWebView.clearContent()
@@ -1708,6 +1754,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         readerProgressBar.visibility = View.GONE
         injectFragmentLinkInterceptor(view)
+
+        if (!hasWebViewContent) {
+            registerWebViewLayoutListener()
+        }
 
         if (url != null && url == "about:blank") {
             // brief delay before showing related posts to give page time to render


### PR DESCRIPTION
## Description

When opening a Reader post detail, tags and comments briefly appear near the top of the screen (because the WebView has 0 height), then jump below the fold when the WebView content loads and expands.

This PR fixes this by using a`View.OnLayoutChangeListener` on the `readerWebView` to detect when its height transitions from 0 to a positive value — the reliable signal that content has rendered and tags/comments will be at their final position. Tags and comments are hidden until this occurs, eliminating the visual jump.

## Testing instructions

I recommend testing this PR while using `trunk` on another device and noticing the improvements in jumpiness.

## Before and after videos

https://github.com/user-attachments/assets/6c1e1be3-1445-498d-9f9b-c067d5a98c66

https://github.com/user-attachments/assets/2f4d6880-a96c-4b41-9f67-930ccb16e887



