### PR TITLE
Fix empty Reader post list on first visit (CMM-2023)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.kt
@@ -894,16 +894,18 @@ class ReaderPostListFragment : ViewPagerFragment(), OnPostSelectedListener, OnFo
         if (isAdded && recyclerView.adapter == null) {
             recyclerView.adapter = getPostAdapter()
             refreshPosts()
-            if (!hasRequestedPosts && NetworkUtils.isNetworkAvailable(
-                    activity
+        }
+        if (isAdded && !hasRequestedPosts && NetworkUtils.isNetworkAvailable(
+                activity
+            )
+        ) {
+            hasRequestedPosts = true
+            if (getPostListType().isTagType) {
+                updateCurrentTagIfTime()
+            } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
+                updatePostsInCurrentBlogOrFeed(
+                    ReaderPostServiceStarter.UpdateAction.REQUEST_NEWER
                 )
-            ) {
-                hasRequestedPosts = true
-                if (getPostListType().isTagType) {
-                    updateCurrentTagIfTime()
-                } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
-                    updatePostsInCurrentBlogOrFeed(ReaderPostServiceStarter.UpdateAction.REQUEST_NEWER)
-                }
             }
         }
     }


### PR DESCRIPTION
## Description

**Fixes CMM-2023**

Prior to this PR, a race condition could cause the Reader post list to be empty on first visit, like this:

<img width="297" height="629" alt="empty" src="https://github.com/user-attachments/assets/e26ce7c6-adc2-47cc-b658-6083faefa3e5" />


## Testing instructions

Empty list on first visit:

1. Fresh login → open Reader → Following tab
- [x] Verify posts load immediately (list is not empty)

Regression — no duplicate requests:

1. Navigate away from Reader and back
- [x] Verify posts still display correctly, no duplicate loading