### PR TITLE
Reader: Preserve editorial date on post detail refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -301,9 +301,7 @@ public class ReaderPostActions {
                     ReaderPost existingPost =
                             ReaderPostTable.getBlogPost(
                                     post.blogId, post.postId, true);
-                    if (existingPost != null
-                            && !TextUtils.isEmpty(
-                            existingPost.getDatePublished())) {
+                    if (existingPost != null) {
                         post.setDatePublished(
                                 existingPost.getDatePublished());
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -293,6 +293,21 @@ public class ReaderPostActions {
                 new Thread(() -> {
                     ReaderPost post = ReaderPost.fromJson(jsonObject);
 
+                    // Preserve the existing date_published if the post
+                    // already exists in the DB. This prevents editorial
+                    // dates (e.g. Freshly Pressed "displayed_on") from
+                    // being overwritten when the detail endpoint response
+                    // lacks the editorial section.
+                    ReaderPost existingPost =
+                            ReaderPostTable.getBlogPost(
+                                    post.blogId, post.postId, true);
+                    if (existingPost != null
+                            && !TextUtils.isEmpty(
+                            existingPost.getDatePublished())) {
+                        post.setDatePublished(
+                                existingPost.getDatePublished());
+                    }
+
                     ReaderPostTable.addPost(post);
                     handlePostLikes(post, jsonObject);
 


### PR DESCRIPTION
## Description

**Resolves CMM-2036** 

Fixes a long-standing bug where the Reader post date changes after the detail screen loads. In Freshly Pressed, posts use `editorial.displayed_on` as their publication date. When the detail screen fetches the individual post from `read/sites/{blogId}/posts/{postId}`, the response lacks the `editorial` section, so the raw `date` field overwrites the correct date in the DB.

The fix preserves the existing `date_published` from the DB when saving a freshly-fetched post, so editorial dates are not lost.

## Testing instructions

Freshly Pressed date preservation:

1. Open Reader → Freshly Pressed
2. Note the date displayed on a post in the list
3. Tap the post to open the detail screen
- [x] Verify the date does NOT change after the detail content loads
4. Go back to the list
- [x] Verify the date is still the same as before

## Video

This video shows the problem - note the publication date in post detail originally shows "Mar 30" then quickly changes to "2hr. ago":

https://github.com/user-attachments/assets/6c9d16b1-44d3-4de2-bad6-6136aafd1b29

