### PR TITLE
Polish new Stats Traffic tab defaults and UTM card headers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsCardType.kt
@@ -31,11 +31,7 @@ enum class StatsCardType(
             TODAYS_STATS,
             VIEWS_STATS,
             MOST_VIEWED_POSTS_AND_PAGES,
-            MOST_VIEWED_REFERRERS,
-            LOCATIONS,
-            AUTHORS,
-            DEVICES,
-            UTM
+            LOCATIONS
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/utm/UtmCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/utm/UtmCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.newstats.components.CardPosition
@@ -33,7 +34,6 @@ import org.wordpress.android.ui.newstats.components.StatsCardContainer
 import org.wordpress.android.ui.newstats.components.StatsCardEmptyContent
 import org.wordpress.android.ui.newstats.components.StatsCardErrorContent
 import org.wordpress.android.ui.newstats.components.StatsCardHeader
-import org.wordpress.android.ui.newstats.components.StatsListHeader
 import org.wordpress.android.ui.newstats.util.ShimmerBox
 
 private val CardPadding = 16.dp
@@ -131,11 +131,6 @@ private fun LoadingContent(
             onSelected = onCategoryChanged
         )
         Spacer(modifier = Modifier.height(12.dp))
-        StatsListHeader(
-            leftHeaderResId =
-                selectedCategory.labelResId
-        )
-        Spacer(modifier = Modifier.height(8.dp))
         repeat(LOADING_ITEM_COUNT) { index ->
             Row(
                 modifier = Modifier
@@ -199,9 +194,14 @@ private fun LoadedContent(
         if (state.items.isEmpty()) {
             StatsCardEmptyContent()
         } else {
-            StatsListHeader(
-                leftHeaderResId =
-                    selectedCategory.labelResId
+            Text(
+                text = stringResource(
+                    R.string.stats_countries_views_header
+                ),
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.End,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(modifier = Modifier.height(8.dp))
 


### PR DESCRIPTION
## Description

Two small polish changes to the new stats screen:

1. **Reduce default Traffic tab cards** — Show only 4 cards by default (Today's Stats, Views, Most Viewed Posts & Pages, Locations) instead of 8, so the initial experience is less overwhelming.

2. **Clean up UTM card column headers** — Remove the redundant left column title (already visible in the category dropdown selector) and hide column headers entirely during loading state.

## Testing instructions

Default cards:

1. Clear app data or log in to a site that has never configured stats cards
2. Navigate to Stats > Traffic tab
- [ ] Verify only 4 cards are shown: Today's Stats, Views, Most Viewed Posts & Pages, Locations
- [ ] Verify the remaining cards (Referrers, Authors, Clicks, etc.) can still be added via card configuration

UTM card headers:

1. Navigate to Stats > Traffic tab and add the UTM card if not visible
2. Observe the UTM card while it loads
- [ ] Verify no column headers are shown during the loading/shimmer state
