### PR TITLE
RS Post List: Bridge posts to FluxC for editor opening

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
@@ -1,0 +1,77 @@
+package org.wordpress.android.ui.postsrs
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
+import org.wordpress.android.fluxc.persistence.PostSqlUtils
+import org.wordpress.android.fluxc.store.PostStore
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.PostEndpointType
+import uniffi.wp_api.PostRetrieveParams
+import javax.inject.Inject
+
+/**
+ * Bridges a wordpress-rs post into FluxC's local SQLite database
+ * so the editor (which reads from FluxC) can open it.
+ *
+ * **Fast path**: if the post is already in FluxC's DB, returns it
+ * immediately without a network call.
+ *
+ * **Slow path**: fetches the full post via wordpress-rs, maps it
+ * to a [PostModel], inserts it into FluxC's DB, and re-reads it
+ * to obtain the auto-assigned local ID.
+ */
+@Reusable
+class PostRsFluxCBridge @Inject constructor(
+    private val wpApiClientProvider: WpApiClientProvider,
+    private val postStore: PostStore,
+    private val postSqlUtils: PostSqlUtils,
+    private val mapper: PostRsToFluxCMapper,
+) {
+    /**
+     * Returns a [PostModel] for [remotePostId] that is guaranteed
+     * to exist in FluxC's local database.
+     *
+     * @throws PostBridgeException if the post cannot be fetched
+     *   or inserted.
+     */
+    suspend fun fetchAndBridge(
+        remotePostId: Long,
+        site: SiteModel
+    ): PostModel {
+        // Fast path — already in FluxC
+        postStore.getPostByRemotePostId(remotePostId, site)
+            ?.let { return it }
+
+        // Slow path — fetch via wordpress-rs
+        val client = wpApiClientProvider.getWpApiClient(site)
+        val response = client.request {
+            it.posts().retrieveWithEditContext(
+                PostEndpointType.Posts,
+                remotePostId,
+                PostRetrieveParams()
+            )
+        }
+        val rsPost = when (response) {
+            is WpRequestResult.Success -> response.response.data
+            else -> {
+                val msg = (response as? WpRequestResult.WpError<*>)
+                    ?.errorMessage ?: "Failed to fetch post"
+                throw PostBridgeException(msg)
+            }
+        }
+
+        // Map and insert
+        val postModel = mapper.map(rsPost, site)
+        postSqlUtils.insertOrUpdatePost(postModel, false)
+
+        // Re-read to get the auto-assigned local ID
+        return postStore.getPostByRemotePostId(remotePostId, site)
+            ?: throw PostBridgeException(
+                "Post inserted but not found in FluxC"
+            )
+    }
+}
+
+class PostBridgeException(message: String) : Exception(message)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.postsrs
 
-import dagger.Reusable
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
@@ -22,7 +21,6 @@ import javax.inject.Inject
  * to a [PostModel], inserts it into FluxC's DB, and re-reads it
  * to obtain the auto-assigned local ID.
  */
-@Reusable
 class PostRsFluxCBridge @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
     private val postStore: PostStore,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
@@ -65,8 +65,6 @@ class PostRsFluxCBridge @Inject constructor(
 
         // Re-read to get the auto-assigned local ID
         return postStore.getPostByRemotePostId(remotePostId, site)
-            ?: throw IllegalStateException(
-                "Post inserted but not found in FluxC"
-            )
+            ?: error("Post inserted but not found in FluxC")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
@@ -33,8 +33,7 @@ class PostRsFluxCBridge @Inject constructor(
      * Returns a [PostModel] for [remotePostId] that is guaranteed
      * to exist in FluxC's local database.
      *
-     * @throws PostBridgeException if the post cannot be fetched
-     *   or inserted.
+     * @throws IllegalStateException if the post cannot be fetched or inserted.
      */
     suspend fun fetchAndBridge(
         remotePostId: Long,
@@ -58,7 +57,7 @@ class PostRsFluxCBridge @Inject constructor(
             else -> {
                 val msg = (response as? WpRequestResult.WpError<*>)
                     ?.errorMessage ?: "Failed to fetch post"
-                throw PostBridgeException(msg)
+                throw IllegalStateException(msg)
             }
         }
 
@@ -68,10 +67,8 @@ class PostRsFluxCBridge @Inject constructor(
 
         // Re-read to get the auto-assigned local ID
         return postStore.getPostByRemotePostId(remotePostId, site)
-            ?: throw PostBridgeException(
+            ?: throw IllegalStateException(
                 "Post inserted but not found in FluxC"
             )
     }
 }
-
-class PostBridgeException(message: String) : Exception(message)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsFluxCBridge.kt
@@ -29,17 +29,26 @@ class PostRsFluxCBridge @Inject constructor(
 ) {
     /**
      * Returns a [PostModel] for [remotePostId] that is guaranteed
-     * to exist in FluxC's local database.
+     * to exist in FluxC's local database. If [lastModified] is
+     * provided and differs from the cached row's
+     * `remoteLastModified`, the cache is considered
+     * stale and the post is re-fetched from the server.
      *
      * @throws IllegalStateException if the post cannot be fetched or inserted.
      */
     suspend fun fetchAndBridge(
         remotePostId: Long,
-        site: SiteModel
+        site: SiteModel,
+        lastModified: String? = null
     ): PostModel {
-        // Fast path — already in FluxC
-        postStore.getPostByRemotePostId(remotePostId, site)
-            ?.let { return it }
+        // Fast path — already in FluxC and still fresh
+        postStore.getPostByRemotePostId(remotePostId, site)?.let { cached ->
+            if (lastModified == null ||
+                lastModified == cached.remoteLastModified
+            ) {
+                return cached
+            }
+        }
 
         // Slow path — fetch via wordpress-rs
         val client = wpApiClientProvider.getWpApiClient(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListActivity.kt
@@ -46,6 +46,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
         setContent {
             val tabStates by viewModel.tabStates.collectAsState()
             val isSearchActive by viewModel.isSearchActive.collectAsState()
+            val isOpeningPost by viewModel.isOpeningPost.collectAsState()
             val searchQuery by viewModel.searchQuery.collectAsState()
             val authorFilter by viewModel.authorFilter.collectAsState()
             val confirmation by viewModel.pendingConfirmation.collectAsState()
@@ -53,6 +54,7 @@ class PostRsListActivity : BaseAppCompatActivity() {
                 PostRsListScreen(
                     tabStates = tabStates,
                     isSearchActive = isSearchActive,
+                    isOpeningPost = isOpeningPost,
                     searchQuery = searchQuery,
                     authorFilter = authorFilter,
                     isAuthorFilterSupported = viewModel.isAuthorFilterSupported,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.postsrs
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import uniffi.wp_api.AnyPostWithEditContext
 import uniffi.wp_api.PostCommentStatus
@@ -51,6 +52,7 @@ data class PostRsUiModel(
     val title: String,
     val excerpt: String,
     val date: String,
+    val lastModified: String = "",
     val link: String = "",
     val hasPassword: Boolean = false,
     val commentsOpen: Boolean = false,
@@ -165,6 +167,9 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
             ).let { HtmlUtils.fastStripHtml(it).trim() },
         date = PostRsDateFormatter.format(
             post.dateGmt, post.status
+        ),
+        lastModified = DateTimeUtils.iso8601UTCFromDate(
+            post.modifiedGmt
         ),
         link = post.link,
         authorId = post.author ?: 0L,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus as FluxCPostStatus
 import org.wordpress.android.fluxc.store.AccountStore
@@ -373,46 +372,21 @@ class PostRsListViewModel @Inject constructor(
                         postStatusUpdate(PostStatus.Draft)
                     )
                 }
-                val post = try {
-                    withContext(Dispatchers.IO) {
-                        fluxCBridge.fetchAndBridge(postId, site)
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    AppLog.e(
-                        AppLog.T.POSTS, "Bridge post failed", e
-                    )
-                    _snackbarMessages.trySend(
-                        SnackbarMessage(
-                            friendlyErrorMessage(
-                                e, R.string.post_not_found
-                            )
-                        )
-                    )
-                    null
-                }
+                val post = bridgePostOrNull(postId)
                 if (post != null) {
                     _events.trySend(PostRsListEvent.EditPost(site, post))
                 } else {
                     _events.trySend(
-                        PostRsListEvent.ShowToast(
-                            R.string.post_rs_moved_to_draft
-                        )
+                        PostRsListEvent.ShowToast(R.string.post_rs_moved_to_draft)
                     )
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                AppLog.e(
-                    AppLog.T.POSTS,
-                    "Move to draft and edit failed", e
-                )
+                AppLog.e(AppLog.T.POSTS, "Move to draft failed", e)
                 _snackbarMessages.trySend(
                     SnackbarMessage(
-                        friendlyErrorMessage(
-                            e, R.string.post_rs_error_update_status
-                        )
+                        friendlyErrorMessage(e, R.string.post_rs_error_update_status)
                     )
                 )
             } finally {
@@ -421,6 +395,21 @@ class PostRsListViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun bridgePostOrNull(remotePostId: Long) = try {
+        withContext(Dispatchers.IO) {
+            fluxCBridge.fetchAndBridge(remotePostId, site)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        AppLog.e(AppLog.T.POSTS, "Bridge post failed", e)
+        _snackbarMessages.trySend(
+            SnackbarMessage(friendlyErrorMessage(e, R.string.post_not_found))
+        )
+        null
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -140,6 +140,7 @@ class PostRsListViewModel @Inject constructor(
      */
     @MainThread
     fun openPost(remotePostId: Long, tab: PostRsListTab) {
+        if (_isOpeningPost.value) return
         if (tab == PostRsListTab.TRASHED) {
             analyticsTracker.track(
                 Stat.POST_LIST_ITEM_SELECTED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -54,6 +54,7 @@ class PostRsListViewModel @Inject constructor(
     private val restClient: PostRsRestClient,
     private val resourceProvider: ResourceProvider,
     private val postStore: PostStore,
+    private val fluxCBridge: PostRsFluxCBridge,
     private val blazeFeatureUtils: BlazeFeatureUtils,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val accountStore: AccountStore,
@@ -62,6 +63,9 @@ class PostRsListViewModel @Inject constructor(
 ) : ViewModel() {
     private val _tabStates = MutableStateFlow<Map<PostRsListTab, PostTabUiState>>(emptyMap())
     val tabStates: StateFlow<Map<PostRsListTab, PostTabUiState>> = _tabStates.asStateFlow()
+
+    private val _isOpeningPost = MutableStateFlow(false)
+    val isOpeningPost: StateFlow<Boolean> = _isOpeningPost.asStateFlow()
 
     private val _isSearchActive = MutableStateFlow(false)
     val isSearchActive: StateFlow<Boolean> = _isSearchActive.asStateFlow()
@@ -131,8 +135,8 @@ class PostRsListViewModel @Inject constructor(
     }
 
     /**
-     * Looks up a post in the local FluxC database and emits
-     * an [PostRsListEvent.EditPost] to open the editor.
+     * Bridges the post into FluxC's database and emits an
+     * [PostRsListEvent.EditPost] to open the editor.
      * If the post is trashed, shows a confirmation dialog first.
      */
     @MainThread
@@ -158,8 +162,7 @@ class PostRsListViewModel @Inject constructor(
                 TRACKS_POST_ID to remotePostId
             )
         )
-        val post = getFluxCPost(remotePostId) ?: return
-        _events.trySend(PostRsListEvent.EditPost(site, post))
+        bridgeAndOpen(remotePostId)
     }
 
     /**
@@ -284,10 +287,7 @@ class PostRsListViewModel @Inject constructor(
                 }
                 _events.trySend(PostRsListEvent.SharePost(url, post.title))
             }
-            PostRsMenuAction.BLAZE -> {
-                val post = getFluxCPost(remotePostId) ?: return
-                _events.trySend(PostRsListEvent.PromoteWithBlaze(site, post))
-            }
+            PostRsMenuAction.BLAZE -> bridgeAndOpen(remotePostId, blaze = true)
             PostRsMenuAction.STATS -> _events.trySend(
                 PostRsListEvent.ViewStats(
                     site = site, postId = remotePostId,
@@ -373,21 +373,46 @@ class PostRsListViewModel @Inject constructor(
                         postStatusUpdate(PostStatus.Draft)
                     )
                 }
-                val post = getFluxCPost(postId)
+                val post = try {
+                    withContext(Dispatchers.IO) {
+                        fluxCBridge.fetchAndBridge(postId, site)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    AppLog.e(
+                        AppLog.T.POSTS, "Bridge post failed", e
+                    )
+                    _snackbarMessages.trySend(
+                        SnackbarMessage(
+                            friendlyErrorMessage(
+                                e, R.string.post_not_found
+                            )
+                        )
+                    )
+                    null
+                }
                 if (post != null) {
                     _events.trySend(PostRsListEvent.EditPost(site, post))
                 } else {
                     _events.trySend(
-                        PostRsListEvent.ShowToast(R.string.post_rs_moved_to_draft)
+                        PostRsListEvent.ShowToast(
+                            R.string.post_rs_moved_to_draft
+                        )
                     )
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                AppLog.e(AppLog.T.POSTS, "Move to draft and edit failed", e)
+                AppLog.e(
+                    AppLog.T.POSTS,
+                    "Move to draft and edit failed", e
+                )
                 _snackbarMessages.trySend(
                     SnackbarMessage(
-                        friendlyErrorMessage(e, R.string.post_rs_error_update_status)
+                        friendlyErrorMessage(
+                            e, R.string.post_rs_error_update_status
+                        )
                     )
                 )
             } finally {
@@ -400,22 +425,42 @@ class PostRsListViewModel @Inject constructor(
 
     /**
      * Duplicates a post by creating a new draft with the same content.
-     * The FluxC dependency is temporary and will be removed once the
-     * editor supports loading posts via wordpress-rs.
+     * Bridges the source post into FluxC first so we can read its
+     * content, then creates a new local draft from it.
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun duplicatePost(remotePostId: Long) {
-        val postToCopy = getFluxCPost(remotePostId) ?: return
-        val newPost = postStore.instantiatePostModel(
-            site,
-            false,
-            postToCopy.title,
-            postToCopy.content,
-            FluxCPostStatus.DRAFT.toString(),
-            postToCopy.categoryIdList,
-            postToCopy.postFormat,
-            true
-        )
-        _events.trySend(PostRsListEvent.EditPost(site, newPost))
+        if (!checkNetwork()) return
+        _isOpeningPost.value = true
+        viewModelScope.launch {
+            try {
+                val postToCopy = withContext(Dispatchers.IO) {
+                    fluxCBridge.fetchAndBridge(remotePostId, site)
+                }
+                val newPost = postStore.instantiatePostModel(
+                    site,
+                    false,
+                    postToCopy.title,
+                    postToCopy.content,
+                    FluxCPostStatus.DRAFT.toString(),
+                    postToCopy.categoryIdList,
+                    postToCopy.postFormat,
+                    true
+                )
+                _events.trySend(PostRsListEvent.EditPost(site, newPost))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e(AppLog.T.POSTS, "Duplicate post failed", e)
+                _snackbarMessages.trySend(
+                    SnackbarMessage(
+                        friendlyErrorMessage(e, R.string.post_not_found)
+                    )
+                )
+            } finally {
+                _isOpeningPost.value = false
+            }
+        }
     }
 
     private fun checkNetwork(): Boolean {
@@ -479,18 +524,44 @@ class PostRsListViewModel @Inject constructor(
     }
 
     /**
-     * Looks up a post in the local FluxC database and shows a toast if not found.
-     * This FluxC dependency is temporary and will be removed once the editor
-     * supports loading posts via wordpress-rs.
+     * Fetches the post via the bridge (fast path from FluxC cache
+     * or slow path via wordpress-rs), then opens the editor or
+     * Blaze promotion screen.
      */
-    private fun getFluxCPost(remotePostId: Long): PostModel? {
-        val post = postStore.getPostByRemotePostId(remotePostId, site)
-        if (post == null) {
-            _snackbarMessages.trySend(
-                SnackbarMessage(resourceProvider.getString(R.string.post_not_found))
-            )
+    @Suppress("TooGenericExceptionCaught")
+    private fun bridgeAndOpen(
+        remotePostId: Long,
+        blaze: Boolean = false
+    ) {
+        if (!checkNetwork()) return
+        _isOpeningPost.value = true
+        viewModelScope.launch {
+            try {
+                val post = withContext(Dispatchers.IO) {
+                    fluxCBridge.fetchAndBridge(remotePostId, site)
+                }
+                if (blaze) {
+                    _events.trySend(
+                        PostRsListEvent.PromoteWithBlaze(site, post)
+                    )
+                } else {
+                    _events.trySend(
+                        PostRsListEvent.EditPost(site, post)
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e(AppLog.T.POSTS, "Bridge post failed", e)
+                _snackbarMessages.trySend(
+                    SnackbarMessage(
+                        friendlyErrorMessage(e, R.string.post_not_found)
+                    )
+                )
+            } finally {
+                _isOpeningPost.value = false
+            }
         }
-        return post
     }
 
     private fun getMenuActions(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -400,8 +400,9 @@ class PostRsListViewModel @Inject constructor(
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun bridgePostOrNull(remotePostId: Long) = try {
+        val lastModified = findPost(remotePostId)?.lastModified
         withContext(Dispatchers.IO) {
-            fluxCBridge.fetchAndBridge(remotePostId, site)
+            fluxCBridge.fetchAndBridge(remotePostId, site, lastModified)
         }
     } catch (e: CancellationException) {
         throw e
@@ -424,8 +425,11 @@ class PostRsListViewModel @Inject constructor(
         _isOpeningPost.value = true
         viewModelScope.launch {
             try {
+                val lastModified = findPost(remotePostId)?.lastModified
                 val postToCopy = withContext(Dispatchers.IO) {
-                    fluxCBridge.fetchAndBridge(remotePostId, site)
+                    fluxCBridge.fetchAndBridge(
+                        remotePostId, site, lastModified
+                    )
                 }
                 val newPost = postStore.instantiatePostModel(
                     site,
@@ -527,8 +531,11 @@ class PostRsListViewModel @Inject constructor(
         _isOpeningPost.value = true
         viewModelScope.launch {
             try {
+                val lastModified = findPost(remotePostId)?.lastModified
                 val post = withContext(Dispatchers.IO) {
-                    fluxCBridge.fetchAndBridge(remotePostId, site)
+                    fluxCBridge.fetchAndBridge(
+                        remotePostId, site, lastModified
+                    )
                 }
                 if (blaze) {
                     _events.trySend(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsToFluxCMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsToFluxCMapper.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.postsrs
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.DateTimeUtils
+import uniffi.wp_api.AnyPostWithEditContext
+import uniffi.wp_api.PostFormat
+import uniffi.wp_api.PostStatus
+import javax.inject.Inject
+
+/**
+ * Maps a wordpress-rs [AnyPostWithEditContext] to a FluxC [PostModel]
+ * so the editor can load it from FluxC's local database.
+ */
+@Reusable
+class PostRsToFluxCMapper @Inject constructor() {
+    fun map(post: AnyPostWithEditContext, site: SiteModel): PostModel {
+        val modified = DateTimeUtils.iso8601UTCFromDate(
+            post.modifiedGmt
+        )
+        return PostModel().apply {
+            setRemotePostId(post.id)
+            setLocalSiteId(site.id)
+            setRemoteSiteId(site.siteId)
+
+            setTitle(
+                post.title?.raw?.takeIf { it.isNotBlank() }
+                    ?: post.title?.rendered ?: ""
+            )
+            setContent(
+                post.content.raw?.takeIf { it.isNotBlank() }
+                    ?: post.content.rendered
+            )
+            setExcerpt(
+                post.excerpt?.raw?.takeIf { it.isNotBlank() }
+                    ?: post.excerpt?.rendered ?: ""
+            )
+
+            setStatus(mapStatus(post.status))
+            setLink(post.link)
+            setSlug(post.slug)
+            setPassword(post.password ?: "")
+            setSticky(post.sticky ?: false)
+
+            setAuthorId(post.author ?: 0L)
+            setFeaturedImageId(post.featuredMedia ?: 0L)
+            setPostFormat(mapFormat(post.format))
+
+            setDateCreated(
+                DateTimeUtils.iso8601UTCFromDate(post.dateGmt)
+            )
+            setLastModified(modified)
+            setRemoteLastModified(modified)
+
+            setCategoryIdList(post.categories ?: emptyList())
+
+            setIsPage(false)
+            setIsLocalDraft(false)
+            setIsLocallyChanged(false)
+        }
+    }
+
+    private fun mapStatus(status: PostStatus?): String =
+        when (status) {
+            is PostStatus.Publish -> "publish"
+            is PostStatus.Draft -> "draft"
+            is PostStatus.Pending -> "pending"
+            is PostStatus.Private -> "private"
+            is PostStatus.Future -> "future"
+            is PostStatus.Trash -> "trash"
+            else -> "draft"
+        }
+
+    private fun mapFormat(format: PostFormat?): String =
+        when (format) {
+            is PostFormat.Standard -> "standard"
+            is PostFormat.Aside -> "aside"
+            is PostFormat.Audio -> "audio"
+            is PostFormat.Chat -> "chat"
+            is PostFormat.Gallery -> "gallery"
+            is PostFormat.Image -> "image"
+            is PostFormat.Link -> "link"
+            is PostFormat.Quote -> "quote"
+            is PostFormat.Status -> "status"
+            is PostFormat.Video -> "video"
+            is PostFormat.Custom -> format.v1
+            null -> "standard"
+        }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsToFluxCMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsToFluxCMapper.kt
@@ -1,21 +1,26 @@
 package org.wordpress.android.ui.postsrs
 
-import dagger.Reusable
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.postsrs.data.PostRsRestClient
 import org.wordpress.android.util.DateTimeUtils
 import uniffi.wp_api.AnyPostWithEditContext
 import uniffi.wp_api.PostFormat
 import uniffi.wp_api.PostStatus
+import uniffi.wp_api.TermEndpointType
 import javax.inject.Inject
 
 /**
  * Maps a wordpress-rs [AnyPostWithEditContext] to a FluxC [PostModel]
  * so the editor can load it from FluxC's local database.
  */
-@Reusable
-class PostRsToFluxCMapper @Inject constructor() {
-    fun map(post: AnyPostWithEditContext, site: SiteModel): PostModel {
+class PostRsToFluxCMapper @Inject constructor(
+    private val restClient: PostRsRestClient,
+) {
+    suspend fun map(
+        post: AnyPostWithEditContext,
+        site: SiteModel
+    ): PostModel {
         val modified = DateTimeUtils.iso8601UTCFromDate(
             post.modifiedGmt
         )
@@ -54,11 +59,23 @@ class PostRsToFluxCMapper @Inject constructor() {
             setRemoteLastModified(modified)
 
             setCategoryIdList(post.categories ?: emptyList())
+            setTagNameList(resolveTagNames(post.tags, site))
 
             setIsPage(false)
             setIsLocalDraft(false)
             setIsLocallyChanged(false)
         }
+    }
+
+    private suspend fun resolveTagNames(
+        ids: List<Long>?,
+        site: SiteModel
+    ): List<String> {
+        if (ids.isNullOrEmpty()) return emptyList()
+        val nameMap = restClient.fetchTermNames(
+            site, ids, TermEndpointType.Tags
+        )
+        return ids.mapNotNull { nameMap[it] }
     }
 
     private fun mapStatus(status: PostStatus?): String =

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -76,6 +78,7 @@ import org.wordpress.android.ui.postsrs.PostTabUiState
 fun PostRsListScreen(
     tabStates: Map<PostRsListTab, PostTabUiState>,
     isSearchActive: Boolean,
+    isOpeningPost: Boolean,
     searchQuery: String,
     authorFilter: AuthorFilterSelection,
     isAuthorFilterSupported: Boolean,
@@ -279,6 +282,15 @@ fun PostRsListScreen(
             onDismiss = confirmationDialog.onDismiss
         )
         null -> {}
+    }
+
+    if (isOpeningPost) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -73,6 +73,7 @@ import org.wordpress.android.ui.postsrs.PostRsListViewModel.Companion.MIN_SEARCH
 import org.wordpress.android.ui.postsrs.PostRsMenuAction
 import org.wordpress.android.ui.postsrs.PostTabUiState
 
+@Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostRsListScreen(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.postsrs.screens
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -287,7 +289,14 @@ fun PostRsListScreen(
 
     if (isOpeningPost) {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    indication = null,
+                    interactionSource = remember {
+                        MutableInteractionSource()
+                    }
+                ) { },
             contentAlignment = Alignment.Center
         ) {
             CircularProgressIndicator()

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsListViewModelTest.kt
@@ -38,6 +38,7 @@ class PostRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     @Mock lateinit var restClient: PostRsRestClient
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var postStore: PostStore
+    @Mock lateinit var fluxCBridge: PostRsFluxCBridge
     @Mock lateinit var blazeFeatureUtils: BlazeFeatureUtils
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
     @Mock lateinit var accountStore: AccountStore
@@ -72,6 +73,7 @@ class PostRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         restClient = restClient,
         resourceProvider = resourceProvider,
         postStore = postStore,
+        fluxCBridge = fluxCBridge,
         blazeFeatureUtils = blazeFeatureUtils,
         networkUtilsWrapper = networkUtilsWrapper,
         accountStore = accountStore,
@@ -222,14 +224,15 @@ class PostRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `openPost emits EditPost when FluxC post found`() = test {
+    fun `openPost emits EditPost when bridge succeeds`() = test {
         val postModel = PostModel()
-        whenever(postStore.getPostByRemotePostId(42L, site))
+        whenever(fluxCBridge.fetchAndBridge(42L, site))
             .thenReturn(postModel)
         val viewModel = createViewModel()
 
         viewModel.events.test {
             viewModel.openPost(42L, PostRsListTab.PUBLISHED)
+            advanceUntilIdle()
 
             val event = awaitItem()
             assertThat(event)
@@ -242,18 +245,25 @@ class PostRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `openPost shows snackbar when FluxC post not found`() = test {
-        whenever(postStore.getPostByRemotePostId(42L, site))
-            .thenReturn(null)
+    fun `openPost shows snackbar when bridge fails`() = test {
+        whenever(fluxCBridge.fetchAndBridge(42L, site))
+            .thenAnswer { throw PostBridgeException("not found") }
         val viewModel = createViewModel()
 
         viewModel.snackbarMessages.test {
             viewModel.openPost(42L, PostRsListTab.PUBLISHED)
+            advanceUntilIdle()
 
             val message = awaitItem()
             assertThat(message.message).isNotEmpty()
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `isOpeningPost is false on init`() {
+        val viewModel = createViewModel()
+        assertThat(viewModel.isOpeningPost.value).isFalse()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsListViewModelTest.kt
@@ -247,7 +247,7 @@ class PostRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     @Test
     fun `openPost shows snackbar when bridge fails`() = test {
         whenever(fluxCBridge.fetchAndBridge(42L, site))
-            .thenAnswer { throw PostBridgeException("not found") }
+            .thenAnswer { throw IllegalStateException("not found") }
         val viewModel = createViewModel()
 
         viewModel.snackbarMessages.test {


### PR DESCRIPTION
## Description

When a user taps a post in the RS post list, the editor loads the post from FluxC's local SQLite database. Since RS posts are fetched via `wordpress-rs` and never go through FluxC, the editor can't find them. This PR bridges the gap by:

1. **Fast path**: Checking if FluxC already has the post (no network call)
2. **Slow path**: Fetching the full post via wordpress-rs `retrieveWithEditContext`, mapping it to a FluxC `PostModel`, and inserting it into FluxC's DB
3. Showing a loading indicator during the fetch

## Testing instructions

Open post for editing:

1. Clear storage then login
2. Enable the the RS post list experimental feature
3. Open the RS post list
5. Tap a published post
- [x] Verify a brief loading indicator appears, then the editor opens with the post content
6. Go back and tap the same post again
- [x] Verify the editor opens immediately (fast path, no loading indicator)

Offline:

1. Turn off network connectivity
2. Tap a post that hasn't been cached
- [x] Verify an error snackbar appears