### PR TITLE
Fix crash in RS post list analytics tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -141,7 +141,7 @@ class PostRsListViewModel @Inject constructor(
             analyticsTracker.track(
                 Stat.POST_LIST_ITEM_SELECTED,
                 site,
-                mapOf(
+                mutableMapOf(
                     TRACKS_ACTION to "move_to_draft",
                     TRACKS_POST_ID to remotePostId
                 )
@@ -153,7 +153,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_ITEM_SELECTED,
             site,
-            mapOf(
+            mutableMapOf(
                 TRACKS_ACTION to "edit",
                 TRACKS_POST_ID to remotePostId
             )
@@ -182,7 +182,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_TAB_CHANGED,
             site,
-            mapOf(TRACKS_SELECTED_TAB to tab.name.lowercase())
+            mutableMapOf(TRACKS_SELECTED_TAB to tab.name.lowercase())
         )
     }
 
@@ -192,7 +192,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_CREATE_POST_TAPPED,
             site,
-            mapOf(TRACKS_ACTION to TRACKS_CREATE_NEW_POST)
+            mutableMapOf(TRACKS_ACTION to TRACKS_CREATE_NEW_POST)
         )
         _events.trySend(PostRsListEvent.CreatePost(site))
     }
@@ -241,7 +241,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_AUTHOR_FILTER_CHANGED,
             site,
-            mapOf(TRACKS_SELECTED_AUTHOR_FILTER to selection.toString())
+            mutableMapOf(TRACKS_SELECTED_AUTHOR_FILTER to selection.toString())
         )
         appPrefsWrapper.postListAuthorSelection = selection
         _authorFilter.value = selection
@@ -256,7 +256,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_BUTTON_PRESSED,
             site,
-            mapOf(
+            mutableMapOf(
                 TRACKS_ACTION to action.toAnalyticsAction(),
                 TRACKS_POST_ID to remotePostId
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -141,7 +141,7 @@ class PostRsListViewModel @Inject constructor(
             analyticsTracker.track(
                 Stat.POST_LIST_ITEM_SELECTED,
                 site,
-                mutableMapOf(
+                mapOf(
                     TRACKS_ACTION to "move_to_draft",
                     TRACKS_POST_ID to remotePostId
                 )
@@ -153,7 +153,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_ITEM_SELECTED,
             site,
-            mutableMapOf(
+            mapOf(
                 TRACKS_ACTION to "edit",
                 TRACKS_POST_ID to remotePostId
             )
@@ -182,7 +182,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_TAB_CHANGED,
             site,
-            mutableMapOf(TRACKS_SELECTED_TAB to tab.name.lowercase())
+            mapOf(TRACKS_SELECTED_TAB to tab.name.lowercase())
         )
     }
 
@@ -192,7 +192,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_CREATE_POST_TAPPED,
             site,
-            mutableMapOf(TRACKS_ACTION to TRACKS_CREATE_NEW_POST)
+            mapOf(TRACKS_ACTION to TRACKS_CREATE_NEW_POST)
         )
         _events.trySend(PostRsListEvent.CreatePost(site))
     }
@@ -241,7 +241,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_AUTHOR_FILTER_CHANGED,
             site,
-            mutableMapOf(TRACKS_SELECTED_AUTHOR_FILTER to selection.toString())
+            mapOf(TRACKS_SELECTED_AUTHOR_FILTER to selection.toString())
         )
         appPrefsWrapper.postListAuthorSelection = selection
         _authorFilter.value = selection
@@ -256,7 +256,7 @@ class PostRsListViewModel @Inject constructor(
         analyticsTracker.track(
             Stat.POST_LIST_BUTTON_PRESSED,
             site,
-            mutableMapOf(
+            mapOf(
                 TRACKS_ACTION to action.toAnalyticsAction(),
                 TRACKS_POST_ID to remotePostId
             )

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -44,7 +44,11 @@ class AnalyticsTrackerWrapper
 
     @JvmOverloads
     fun track(stat: Stat, site: SiteModel?, properties: Map<String, Any?>? = null) {
-        AnalyticsUtils.trackWithSiteDetails(this, stat, site, properties)
+        // Copy to a mutable map because the Java trackWithSiteDetails method
+        // mutates the map to add site properties.
+        AnalyticsUtils.trackWithSiteDetails(
+            this, stat, site, properties?.toMutableMap()
+        )
     }
 
     fun track(stat: Stat, site: SiteModel?, feature: FeatureConfig) {


### PR DESCRIPTION
## Description

All analytics calls in `PostRsListViewModel` passed Kotlin's immutable `mapOf()` to `AnalyticsTrackerWrapper.track()`, which delegates to `AnalyticsUtils.trackWithSiteDetails()`. That Java method calls `properties.put()` to add site details, which throws `UnsupportedOperationException` on an immutable map.

Replaced `mapOf()` with `mutableMapOf()` at all six call sites:
- FAB tap (create new post)
- Post item tap (edit / move to draft)
- Tab change
- Author filter change
- Post menu action

## Testing instructions

Enable the experimental RS post list then verify the above actions don't crash.