### PR TITLE
CMM-2043: Suggest new Stats experience via one-shot dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -63,6 +63,8 @@ public class AppPrefs {
 
         NEW_STATS_INTRO_SHOWN,
 
+        STATS_NEW_STATS_SUGGESTION_SHOWN,
+
         READER_TAGS_UPDATE_TIMESTAMP,
         // last selected tag in the reader
         READER_TAG_NAME,
@@ -1887,5 +1889,13 @@ public class AppPrefs {
 
     public static void setNewStatsIntroShown(boolean shown) {
         setBoolean(DeletablePrefKey.NEW_STATS_INTRO_SHOWN, shown);
+    }
+
+    public static boolean getStatsNewStatsSuggestionShown() {
+        return getBoolean(DeletablePrefKey.STATS_NEW_STATS_SUGGESTION_SHOWN, false);
+    }
+
+    public static void setStatsNewStatsSuggestionShown(boolean shown) {
+        setBoolean(DeletablePrefKey.STATS_NEW_STATS_SUGGESTION_SHOWN, shown);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -65,6 +65,8 @@ public class AppPrefs {
 
         STATS_NEW_STATS_SUGGESTION_SHOWN,
 
+        STATS_NEW_STATS_SUGGESTION_LAST_DISMISSED_AT,
+
         READER_TAGS_UPDATE_TIMESTAMP,
         // last selected tag in the reader
         READER_TAG_NAME,
@@ -1897,5 +1899,13 @@ public class AppPrefs {
 
     public static void setStatsNewStatsSuggestionShown(boolean shown) {
         setBoolean(DeletablePrefKey.STATS_NEW_STATS_SUGGESTION_SHOWN, shown);
+    }
+
+    public static long getStatsNewStatsSuggestionLastDismissedAt() {
+        return getLong(DeletablePrefKey.STATS_NEW_STATS_SUGGESTION_LAST_DISMISSED_AT, 0L);
+    }
+
+    public static void setStatsNewStatsSuggestionLastDismissedAt(long timestamp) {
+        setLong(DeletablePrefKey.STATS_NEW_STATS_SUGGESTION_LAST_DISMISSED_AT, timestamp);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -530,6 +530,12 @@ class AppPrefsWrapper @Inject constructor(val buildConfigWrapper: BuildConfigWra
     fun setNewStatsIntroShown(shown: Boolean) =
         AppPrefs.setNewStatsIntroShown(shown)
 
+    fun getStatsNewStatsSuggestionShown(): Boolean =
+        AppPrefs.getStatsNewStatsSuggestionShown()
+
+    fun setStatsNewStatsSuggestionShown(shown: Boolean) =
+        AppPrefs.setStatsNewStatsSuggestionShown(shown)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -536,6 +536,12 @@ class AppPrefsWrapper @Inject constructor(val buildConfigWrapper: BuildConfigWra
     fun setStatsNewStatsSuggestionShown(shown: Boolean) =
         AppPrefs.setStatsNewStatsSuggestionShown(shown)
 
+    fun getStatsNewStatsSuggestionLastDismissedAt(): Long =
+        AppPrefs.getStatsNewStatsSuggestionLastDismissedAt()
+
+    fun setStatsNewStatsSuggestionLastDismissedAt(timestamp: Long) =
+        AppPrefs.setStatsNewStatsSuggestionLastDismissedAt(timestamp)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -165,6 +165,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
         requireActivity().finish()
     }
 
+    @Suppress("ReturnCount")
     private fun maybeShowNewStatsSuggestion() {
         if (appPrefsWrapper.getStatsNewStatsSuggestionShown()) return
         // Avoid stacking on top of the Jetpack-powered bottom sheet or the feature-removal overlay,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.MarginPageTransformer
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
@@ -33,6 +34,7 @@ import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.newstats.NewStatsActivity
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.StatsModuleUiModel
@@ -83,6 +85,9 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
     lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Inject
     lateinit var mStatsTrafficSubscribersTabsFeatureConfig: StatsTrafficSubscribersTabsFeatureConfig
 
     private val viewModel: StatsViewModel by activityViewModels()
@@ -119,6 +124,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
             initializeViews()
             setupMenu()
         }
+        maybeShowNewStatsSuggestion()
     }
 
     private fun setupMenu() {
@@ -131,10 +137,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
                 override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
                     return when (menuItem.itemId) {
                         R.id.menu_try_new_stats -> {
-                            analyticsTracker.track(Stat.STATS_NEW_STATS_ENABLED)
-                            experimentalFeatures.setEnabled(Feature.NEW_STATS, true)
-                            NewStatsActivity.start(requireContext())
-                            requireActivity().finish()
+                            switchToNewStats()
                             true
                         }
                         else -> false
@@ -144,6 +147,26 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
             viewLifecycleOwner,
             Lifecycle.State.RESUMED
         )
+    }
+
+    private fun switchToNewStats() {
+        analyticsTracker.track(Stat.STATS_NEW_STATS_ENABLED)
+        experimentalFeatures.setEnabled(Feature.NEW_STATS, true)
+        NewStatsActivity.start(requireContext())
+        requireActivity().finish()
+    }
+
+    private fun maybeShowNewStatsSuggestion() {
+        if (appPrefsWrapper.getStatsNewStatsSuggestionShown()) return
+        appPrefsWrapper.setStatsNewStatsSuggestionShown(true)
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.stats_new_stats_suggestion_title)
+            .setMessage(R.string.stats_new_stats_suggestion_message)
+            .setPositiveButton(R.string.stats_new_stats_suggestion_positive) { _, _ ->
+                switchToNewStats()
+            }
+            .setNegativeButton(R.string.stats_new_stats_suggestion_negative, null)
+            .show()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -29,7 +29,9 @@ import org.wordpress.android.databinding.StatsFragmentBinding
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
+import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.newstats.NewStatsActivity
@@ -89,6 +91,9 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
     @Inject
     lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Inject
+    lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
 
     @Inject
     lateinit var mStatsTrafficSubscribersTabsFeatureConfig: StatsTrafficSubscribersTabsFeatureConfig
@@ -153,6 +158,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
     }
 
     private fun switchToNewStats() {
+        if (!isAdded) return
         analyticsTracker.track(Stat.STATS_NEW_STATS_ENABLED)
         experimentalFeatures.setEnabled(Feature.NEW_STATS, true)
         NewStatsActivity.start(requireContext())
@@ -161,6 +167,13 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
     private fun maybeShowNewStatsSuggestion() {
         if (appPrefsWrapper.getStatsNewStatsSuggestionShown()) return
+        // Avoid stacking on top of the Jetpack-powered bottom sheet or the feature-removal overlay,
+        // both of which may show on a fresh Stats activity launch.
+        if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) return
+        if (jetpackFeatureRemovalOverlayUtil.shouldShowFeatureSpecificJetpackOverlay(
+                JetpackOverlayConnectedFeature.STATS
+            )
+        ) return
         val lastDismissedAt = appPrefsWrapper.getStatsNewStatsSuggestionLastDismissedAt()
         val isSecondAttempt = lastDismissedAt > 0L
         if (isSecondAttempt &&

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -63,7 +63,10 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
 import java.lang.ref.WeakReference
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+
+private val NEW_STATS_SUGGESTION_RESHOW_DELAY_MS = TimeUnit.DAYS.toMillis(7)
 
 private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 private val statsSectionsWithTrafficTab = listOf(TRAFFIC, INSIGHTS, SUBSCRIBERS)
@@ -158,14 +161,29 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
     private fun maybeShowNewStatsSuggestion() {
         if (appPrefsWrapper.getStatsNewStatsSuggestionShown()) return
-        appPrefsWrapper.setStatsNewStatsSuggestionShown(true)
+        val lastDismissedAt = appPrefsWrapper.getStatsNewStatsSuggestionLastDismissedAt()
+        val isSecondAttempt = lastDismissedAt > 0L
+        if (isSecondAttempt &&
+            System.currentTimeMillis() - lastDismissedAt < NEW_STATS_SUGGESTION_RESHOW_DELAY_MS
+        ) {
+            return
+        }
+        val onDismiss = {
+            if (isSecondAttempt) {
+                appPrefsWrapper.setStatsNewStatsSuggestionShown(true)
+            } else {
+                appPrefsWrapper.setStatsNewStatsSuggestionLastDismissedAt(System.currentTimeMillis())
+            }
+        }
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.stats_new_stats_suggestion_title)
             .setMessage(R.string.stats_new_stats_suggestion_message)
             .setPositiveButton(R.string.stats_new_stats_suggestion_positive) { _, _ ->
+                appPrefsWrapper.setStatsNewStatsSuggestionShown(true)
                 switchToNewStats()
             }
-            .setNegativeButton(R.string.stats_new_stats_suggestion_negative, null)
+            .setNegativeButton(R.string.stats_new_stats_suggestion_negative) { _, _ -> onDismiss() }
+            .setOnCancelListener { onDismiss() }
             .show()
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -997,6 +997,10 @@
     <string name="experimental_new_stats_description">Show stats in a more modern and advanced UI</string>
     <string name="stats_try_new_stats">Try new stats</string>
     <string name="stats_switch_to_old_stats">Disable new stats</string>
+    <string name="stats_new_stats_suggestion_title">A new Stats experience</string>
+    <string name="stats_new_stats_suggestion_message">We\'ve built a brand new Stats experience. Want to give it a try? You can always go back to the old one from the Stats menu.</string>
+    <string name="stats_new_stats_suggestion_positive">Try it out</string>
+    <string name="stats_new_stats_suggestion_negative">Maybe later</string>
     <!-- New Stats intro bottom sheet -->
     <string name="new_stats_intro_title">New Stats</string>
     <string name="new_stats_intro_subtitle">A better way to understand your site\'s performance.</string>


### PR DESCRIPTION
## Description

Surfaces the new Stats experience to users still on the legacy Stats screen
via a one-shot Material dialog. The "Try new stats" overflow menu item is
hidden behind the three-dots icon (`showAsAction="never"`), so most users
never discover it; this dialog brings it forward.

Behavior:

- On first visit to the old Stats screen, a Material dialog appears titled
  *"A new Stats experience"* offering **Try it out** or **Maybe later**.
- **Try it out** enables the `NEW_STATS` experimental feature, tracks the
  existing `STATS_NEW_STATS_ENABLED` event, and launches `NewStatsActivity`
  — same flow as the existing menu item (refactored into a shared
  `switchToNewStats()` helper, so analytics parity is preserved).
- **Maybe later** snoozes the dialog for **7 days**.
- A **second** "Maybe later" (or accepting the suggestion) suppresses the
  dialog permanently.
- Back-button / outside-tap go through the same dismiss path as the
  negative button via `setOnCancelListener`.

State is persisted in two new prefs (`STATS_NEW_STATS_SUGGESTION_SHOWN`,
`STATS_NEW_STATS_SUGGESTION_LAST_DISMISSED_AT`) and exposed via
`AppPrefsWrapper`.


## Testing instructions

Show the dialog and accept:

1. Freshly install the app
2. Sign in, open a site, tap **Stats**.
- [ ] Dialog *"A new Stats experience"* appears with **MAYBE LATER** /
      **TRY IT OUT** buttons.
3. Tap **TRY IT OUT**.
- [ ] App switches to the new Stats screen (`NewStatsActivity`).
4. Open the old Stats screen via the new-Stats overflow ("Disable new
   stats") menu, then re-enter Stats.
- [ ] Dialog does **not** reappear.


Cancel paths behave like "Maybe later":

1. With the dialog visible, dismiss it
- [ ] Dialog is dismissed and old stats kept

<img width="451" alt="Screenshot 2026-04-16 at 11 42 40" src="https://github.com/user-attachments/assets/fa5a57af-1ce9-4578-8a75-301ab088f0db" />
<img width="1400"  alt="Screenshot 2026-04-16 at 11 50 41" src="https://github.com/user-attachments/assets/e1713427-76f1-4b20-86f0-4140cc5624db" />
