### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -62,7 +62,7 @@ jobs:
           echo ::set-output name=title::"$PR_TITLE"
           echo ::set-output name=commit_message::"Update gutenbergMobileVersion to $GUTENBERG_MOBILE_VERSION"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: ${{ steps.vars.outputs.commit_message }}
           title: ${{ steps.vars.outputs.title }}

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@1.2.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
       org-slug: "automattic"
       pipeline-slug: "wordpress-android"

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/dependency-submission@v3
+        uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.1.2
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1
     with:
       label-format-list: '[
-        "^\[.+\]",
+        "^\\[.+\\]",
         "^[[:alnum:]]"
       ]'
       label-error-message: '🚫 Please add a type label (e.g. **[Type] Enhancement**) and a feature label (e.g. **Stats**) to this issue.'


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Upgrade `actions/setup-java` from v3 to v4
- Upgrade `gradle/actions/dependency-submission` from v3 to v4
- Upgrade `peter-evans/create-pull-request` from v3 to v7
- Update dangermattic reusable workflows to `@v1`
- Fix label regex escaping in validate-issues workflow

## Test plan
- [ ] Verify dependency submission workflow runs on next push to trunk
- [ ] Verify automated version update PR workflow works
- [ ] Verify Danger workflow runs on next PR
- [ ] Verify issue label validation workflow works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)