### PR TITLE
Fix ANR caused by WebView init on main thread in UserAgent

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -6,11 +6,13 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
-class UserAgent(
+class UserAgent @JvmOverloads constructor(
     private val appContext: Context,
-    private val appName: String
+    private val appName: String,
+    defaultUserAgentExecutor: Executor = SINGLE_THREAD_EXECUTOR
 ) {
     private val appVersionName by lazy {
         "$appName/${PackageUtils.getVersionName(appContext)}"
@@ -40,7 +42,7 @@ class UserAgent(
                     )
                 }.getOrNull().orEmpty()
             },
-            SINGLE_THREAD_EXECUTOR
+            defaultUserAgentExecutor
         )
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -5,6 +5,7 @@ import android.webkit.WebSettings
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 
 class UserAgent(
@@ -46,7 +47,16 @@ class UserAgent(
      * User-Agent string to be used in WebView.
      */
     val webViewUserAgent: String by lazy {
-        val systemUserAgent = defaultWebViewUserAgentFuture.get()
+        val systemUserAgent = try {
+            defaultWebViewUserAgentFuture.get()
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            AppLog.e(AppLog.T.UTILS, "Interrupted while getting default user agent", e)
+            ""
+        } catch (e: ExecutionException) {
+            AppLog.e(AppLog.T.UTILS, "Error getting default user agent", e)
+            ""
+        }
         "$systemUserAgent $appVersionName".trim()
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.webkit.WebSettings
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 
 class UserAgent(
     private val appContext: Context,
@@ -22,18 +24,38 @@ class UserAgent(
         "$systemUserAgent $appVersionName".trim()
     }
 
+    // Eagerly compute the default WebView user agent on a background
+    // thread to avoid blocking the main thread with WebView JNI init.
+    private val defaultWebViewUserAgentFuture: CompletableFuture<String> =
+        CompletableFuture.supplyAsync(
+            {
+                runCatching {
+                    WebSettings.getDefaultUserAgent(appContext)
+                }.onFailure {
+                    AppLog.e(
+                        AppLog.T.UTILS,
+                        "Error getting default user agent",
+                        it
+                    )
+                }.getOrNull().orEmpty()
+            },
+            SINGLE_THREAD_EXECUTOR
+        )
+
     /**
      * User-Agent string to be used in WebView.
      */
     val webViewUserAgent: String by lazy {
-        val systemUserAgent = runCatching {
-            WebSettings.getDefaultUserAgent(appContext)
-        }.onFailure {
-            // `getDefaultUserAgent()` can throw an Exception
-            // see: https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187
-            AppLog.e(AppLog.T.UTILS, "Error getting default user agent", it)
-        }.getOrNull().orEmpty()
-
+        val systemUserAgent = defaultWebViewUserAgentFuture.get()
         "$systemUserAgent $appVersionName".trim()
+    }
+
+    companion object {
+        private val SINGLE_THREAD_EXECUTOR =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "user-agent-init").apply {
+                    isDaemon = true
+                }
+            }
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.wordpress.android.util.PackageUtils
+import java.util.concurrent.Executor
 import kotlin.test.assertEquals
 
 private const val APP_NAME = "App Name"
@@ -17,12 +18,13 @@ private const val APP_VERSION = "1.0"
 @RunWith(RobolectricTestRunner::class)
 class UserAgentTest {
     private val context = RuntimeEnvironment.getApplication().applicationContext
+    private val directExecutor = Executor { it.run() }
 
     @Test
     fun testUserAgent() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenReturn(USER_AGENT)
-            val result = UserAgent(context, APP_NAME)
+            val result = UserAgent(context, APP_NAME, directExecutor)
             assertEquals("$USER_AGENT $APP_NAME/$APP_VERSION", result.webViewUserAgent)
         }
     }
@@ -31,7 +33,7 @@ class UserAgentTest {
     fun testDefaultUserAgentFailure() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenThrow(RuntimeException(""))
-            val result = UserAgent(context, APP_NAME)
+            val result = UserAgent(context, APP_NAME, directExecutor)
             assertEquals("$APP_NAME/$APP_VERSION", result.webViewUserAgent)
         }
     }


### PR DESCRIPTION
## Description

The `webViewUserAgent` lazy property in `UserAgent.kt` triggers
`WebSettings.getDefaultUserAgent()` on first access, which performs
heavy WebView JNI initialization. When this first access happens on the
main thread (e.g., from `EditPostActivity` or `StatsFragment`), it can
block long enough to cause a Background ANR — the main thread stalls on
the ART runtime lock during a `JNI::FindClass` call triggered by
WebView provider init.

This PR moves the `getDefaultUserAgent()` call to a background thread
using `CompletableFuture.supplyAsync()` that starts eagerly at
`UserAgent` construction time. By the time `webViewUserAgent` is first
accessed, the result is typically already available, eliminating the
main-thread block. If the main thread does get there first, it only
waits for the remaining work — never the full WebView initialization.

## Testing instructions

Editor flow:

1. Open the app and navigate to write/edit a post (`EditPostActivity`)
- [ ] Verify the editor loads without freezing
2. While the editor is loading, quickly navigate back and re-open
- [ ] Verify no ANR dialog appears
3. Trigger a background transition (screen off) during editor load
- [ ] Verify no ANR dialog appears

WebView user-agent consumers:

1. Open a layout preview (Site Creation → Preview / Layout Picker)
- [ ] Verify WebView content loads correctly

- [ ] Smoke test the app