### PR TITLE
Reader: defer likers row until post body renders (CMM-2049)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -186,7 +186,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private lateinit var readerProgressBar: ProgressBar
 
     private lateinit var likeFacesTrain: View
-    private lateinit var likeProgressBar: ProgressBar
     private lateinit var likeEmptyStateText: TextView
     private lateinit var likeFacesRecycler: RecyclerView
 
@@ -429,7 +428,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun initLikeFacesTrain(view: View) {
         likeFacesTrain = view.findViewById(R.id.liker_faces_container)
         likeFacesRecycler = view.findViewById(R.id.likes_recycler)
-        likeProgressBar = view.findViewById(R.id.progress_bar)
         likeEmptyStateText = view.findViewById(R.id.empty_state_text)
     }
 
@@ -673,17 +671,19 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         with(requireActivity()) {
             if (this.isFinishing) return@with
 
+            // Defer the likers row until the WebView has laid out, so it
+            // doesn't pop in above the body before the content renders.
+            if (!hasWebViewContent) {
+                likeFacesTrain.visibility = View.GONE
+                likeEmptyStateText.visibility = View.GONE
+                return@with
+            }
+
             val shouldSkipAnimation =
                 likeFacesTrain.isGone && state.goingToShowFaces
 
-            setupLikeFacesTrain(
-                state.engageItemsList,
-                state.showLoading,
-                shouldSkipAnimation
-            )
+            setupLikeFacesTrain(state.engageItemsList, shouldSkipAnimation)
 
-            likeProgressBar.visibility =
-                if (state.showLoading) View.VISIBLE else View.GONE
             likeFacesTrain.visibility =
                 if (state.showLikeFacesTrainContainer) {
                     View.VISIBLE
@@ -750,9 +750,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         commentSnippetRecycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 
-    private fun setupLikeFacesTrain(items: List<TrainOfAvatarsItem>, loading: Boolean, shouldSkipAnimation: Boolean) {
-        likeFacesRecycler.visibility = if (loading) View.GONE else View.VISIBLE
-
+    private fun setupLikeFacesTrain(items: List<TrainOfAvatarsItem>, shouldSkipAnimation: Boolean) {
         if (shouldSkipAnimation) {
             likeFacesRecycler.itemAnimator = null
         } else if (likeFacesRecycler.itemAnimator == null) {
@@ -796,6 +794,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     }
                 viewModel.commentSnippetState.value?.let {
                     manageCommentSnippetUiState(it)
+                }
+                if (likesEnhancementsFeatureConfig.isEnabled()) {
+                    viewModel.likesUiState.value?.let { manageLikesUiState(it) }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -194,7 +194,6 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     data class TrainOfFacesUiState(
         val showLikeFacesTrainContainer: Boolean,
-        val showLoading: Boolean,
         val engageItemsList: List<TrainOfAvatarsItem>,
         val showEmptyState: Boolean,
         val emptyStateTitle: UiString? = null,
@@ -791,7 +790,6 @@ class ReaderPostDetailViewModel @Inject constructor(
     private fun buildLikersUiState(updateLikesState: GetLikesState?): TrainOfFacesUiState {
         val (likers, numLikes) = getLikersEssentials(updateLikesState)
 
-        val showLoading = updateLikesState is Loading
         var showEmptyState = false
         var emptyStateTitle: UiString? = null
 
@@ -803,7 +801,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
 
         val showLikeFacesTrainContainer = post?.let {
-            it.isWP && ((numLikes > 0 && (likers.isNotEmpty() || showEmptyState)) || showLoading)
+            it.isWP && numLikes > 0 && (likers.isNotEmpty() || showEmptyState)
         } ?: false
 
         val engageItemsList = if (showLikeFacesTrainContainer) {
@@ -818,7 +816,6 @@ class ReaderPostDetailViewModel @Inject constructor(
 
         return TrainOfFacesUiState(
             showLikeFacesTrainContainer = showLikeFacesTrainContainer,
-            showLoading = showLoading,
             engageItemsList = engageItemsList,
             showEmptyState = showEmptyState,
             emptyStateTitle = emptyStateTitle,

--- a/WordPress/src/main/res/layout/reader_post_likers_faces_list.xml
+++ b/WordPress/src/main/res/layout/reader_post_likers_faces_list.xml
@@ -28,14 +28,6 @@
         tools:listitem="@layout/avatar_item"
         tools:orientation="horizontal" />
 
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/empty_state_text"
         android:layout_width="wrap_content"

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -1032,7 +1032,6 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
 
         assertThat(likeObserver).isNotEmpty
         with(likeObserver.first()) {
-            assertThat(showLoading).isFalse
             assertThat(engageItemsList).isEqualTo(
                 likers + TrailingLabelTextItem(
                     UiStringText(
@@ -1061,7 +1060,6 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
 
         assertThat(likeObserver).isNotEmpty
         with(likeObserver.first()) {
-            assertThat(showLoading).isFalse
             assertThat(engageItemsList).isEqualTo(likers)
             assertThat(showEmptyState).isTrue
             assertThat(emptyStateTitle is UiStringRes).isTrue


### PR DESCRIPTION
## Description

**Fixes CMM-2049.**

When loading a Reader post detail, two progress spinners could briefly appear stacked in the upper portion of the screen — the inline likers-faces spinner in the post header and the WebView content spinner above the body.

This PR defers the likers row until the WebView has laid out (`hasWebViewContent = true`) and ditches the likers progress spinner.

## Testing instructions

1. Open the Reader on the Jetpack app
2. Tap any post in the feed that has likers
- [x] Verify only a single progress spinner is visible during load (centered above the post body)
- [x] Verify the likers row does NOT appear before the post body renders
- [x] Verify the post body renders first, then the likers avatars appear right below the subscribe row
3. Repeat with a post that has zero likes
- [x] Verify no likers row appears at all
4. Repeat with airplane-mode / throttled connectivity so the load is observably slow
- [x] Verify there is never a moment where two spinners are visible simultaneously

**Note:** The merged PR #22807 makes testing this one easier since it gives a quick way to reset the reader DB.

## Before

https://github.com/user-attachments/assets/b0b99b68-0768-4e78-87c1-3794fcc2680a

## After

https://github.com/user-attachments/assets/30085e94-65a4-4618-a91e-33474d3ad244

