### PR TITLE
Reader: optimize ReaderPostTable.comparePosts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -421,18 +421,18 @@ public class ReaderPostTable {
             return ReaderActions.UpdateResult.UNCHANGED;
         }
 
-        // Fetch all existing rows that match any of the incoming (blog_id, post_id) pairs in a
-        // single query, keyed by "blogId|postId". Mirrors ReaderPost.isSamePost, but reads the
-        // comparison fields directly from the cursor to avoid building full ReaderPost instances.
-        Map<String, PostComparisonRow> existing = loadPostComparisonRows(posts);
+        // Fetch all existing rows for the incoming (blog_id, post_id) pairs in a single query,
+        // keyed by "blogId|postId", so the comparison loop can probe the map instead of issuing
+        // one SELECT per post. Text column is excluded, matching the prior per-post lookup.
+        Map<String, ReaderPost> existing = loadExistingPostsForComparison(posts);
 
         boolean hasChanges = false;
         for (ReaderPost post : posts) {
-            PostComparisonRow row = existing.get(postComparisonKey(post.blogId, post.postId));
-            if (row == null) {
+            ReaderPost existingPost = existing.get(post.blogId + "|" + post.postId);
+            if (existingPost == null) {
                 return ReaderActions.UpdateResult.HAS_NEW;
             }
-            if (!hasChanges && !row.matches(post)) {
+            if (!hasChanges && !post.isSamePost(existingPost)) {
                 hasChanges = true;
             }
         }
@@ -440,12 +440,8 @@ public class ReaderPostTable {
         return (hasChanges ? ReaderActions.UpdateResult.CHANGED : ReaderActions.UpdateResult.UNCHANGED);
     }
 
-    private static String postComparisonKey(long blogId, long postId) {
-        return blogId + "|" + postId;
-    }
-
-    private static Map<String, PostComparisonRow> loadPostComparisonRows(ReaderPostList posts) {
-        Map<String, PostComparisonRow> map = new LinkedHashMap<>(posts.size());
+    private static Map<String, ReaderPost> loadExistingPostsForComparison(ReaderPostList posts) {
+        Map<String, ReaderPost> map = new LinkedHashMap<>(posts.size());
         StringBuilder where = new StringBuilder(posts.size() * 28);
         String[] args = new String[posts.size() * 2];
         int argIdx = 0;
@@ -458,87 +454,18 @@ public class ReaderPostTable {
             args[argIdx++] = Long.toString(post.postId);
         }
 
-        String sql = "SELECT blog_id, post_id, feed_id, feed_item_id, num_likes, num_replies,"
-                + " is_liked, is_followed, is_comments_open, use_excerpt, title, excerpt"
-                + " FROM tbl_posts WHERE " + where;
-
+        String sql = "SELECT " + COLUMN_NAMES_NO_TEXT + " FROM tbl_posts WHERE " + where;
         Cursor c = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
-            if (!c.moveToFirst()) {
-                return map;
-            }
-            int idxBlogId = c.getColumnIndexOrThrow("blog_id");
-            int idxPostId = c.getColumnIndexOrThrow("post_id");
-            int idxFeedId = c.getColumnIndexOrThrow("feed_id");
-            int idxFeedItemId = c.getColumnIndexOrThrow("feed_item_id");
-            int idxNumLikes = c.getColumnIndexOrThrow("num_likes");
-            int idxNumReplies = c.getColumnIndexOrThrow("num_replies");
-            int idxIsLiked = c.getColumnIndexOrThrow("is_liked");
-            int idxIsFollowed = c.getColumnIndexOrThrow("is_followed");
-            int idxIsCommentsOpen = c.getColumnIndexOrThrow("is_comments_open");
-            int idxUseExcerpt = c.getColumnIndexOrThrow("use_excerpt");
-            int idxTitle = c.getColumnIndexOrThrow("title");
-            int idxExcerpt = c.getColumnIndexOrThrow("excerpt");
-            do {
-                long blogId = c.getLong(idxBlogId);
-                long postId = c.getLong(idxPostId);
-                String key = postComparisonKey(blogId, postId);
+            while (c.moveToNext()) {
+                ReaderPost existing = getPostFromCursor(c);
                 // the same post can appear multiple times (one row per tag) - keep the first row
-                if (map.containsKey(key)) {
-                    continue;
-                }
-                PostComparisonRow row = new PostComparisonRow();
-                row.blogId = blogId;
-                row.postId = postId;
-                row.feedId = c.getLong(idxFeedId);
-                row.feedItemId = c.getLong(idxFeedItemId);
-                row.numLikes = c.getInt(idxNumLikes);
-                row.numReplies = c.getInt(idxNumReplies);
-                row.isLiked = SqlUtils.sqlToBool(c.getInt(idxIsLiked));
-                row.isFollowed = SqlUtils.sqlToBool(c.getInt(idxIsFollowed));
-                row.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(idxIsCommentsOpen));
-                row.useExcerpt = SqlUtils.sqlToBool(c.getInt(idxUseExcerpt));
-                row.title = c.getString(idxTitle);
-                row.excerpt = c.getString(idxExcerpt);
-                map.put(key, row);
-            } while (c.moveToNext());
+                map.putIfAbsent(existing.blogId + "|" + existing.postId, existing);
+            }
         } finally {
             SqlUtils.closeCursor(c);
         }
         return map;
-    }
-
-    private static final class PostComparisonRow {
-        long blogId;
-        long postId;
-        long feedId;
-        long feedItemId;
-        int numLikes;
-        int numReplies;
-        boolean isLiked;
-        boolean isFollowed;
-        boolean isCommentsOpen;
-        boolean useExcerpt;
-        String title;
-        String excerpt;
-
-        // mirrors ReaderPost.isSamePost; the text column is intentionally omitted to match the
-        // prior behavior of loading the existing row with excludeTextColumn=true
-        boolean matches(ReaderPost post) {
-            return post.blogId == blogId
-                    && post.postId == postId
-                    && post.feedId == feedId
-                    && post.feedItemId == feedItemId
-                    && post.numLikes == numLikes
-                    && post.numReplies == numReplies
-                    && post.isFollowedByCurrentUser == isFollowed
-                    && post.isLikedByCurrentUser == isLiked
-                    && post.isCommentsOpen == isCommentsOpen
-                    && post.useExcerpt == useExcerpt
-                    && post.getTitle().equals(title == null ? "" : title)
-                    && post.getExcerpt().equals(excerpt == null ? "" : excerpt)
-                    && post.getText().isEmpty();
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SqlUtils;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -421,9 +422,6 @@ public class ReaderPostTable {
             return ReaderActions.UpdateResult.UNCHANGED;
         }
 
-        // Fetch all existing rows for the incoming (blog_id, post_id) pairs in a single query,
-        // keyed by "blogId|postId", so the comparison loop can probe the map instead of issuing
-        // one SELECT per post. Text column is excluded, matching the prior per-post lookup.
         Map<String, ReaderPost> existing = loadExistingPostsForComparison(posts);
 
         boolean hasChanges = false;
@@ -442,14 +440,10 @@ public class ReaderPostTable {
 
     private static Map<String, ReaderPost> loadExistingPostsForComparison(ReaderPostList posts) {
         Map<String, ReaderPost> map = new LinkedHashMap<>(posts.size());
-        StringBuilder where = new StringBuilder(posts.size() * 28);
+        String where = String.join(" OR ", Collections.nCopies(posts.size(), "(blog_id=? AND post_id=?)"));
         String[] args = new String[posts.size() * 2];
         int argIdx = 0;
         for (ReaderPost post : posts) {
-            if (where.length() > 0) {
-                where.append(" OR ");
-            }
-            where.append("(blog_id=? AND post_id=?)");
             args[argIdx++] = Long.toString(post.blogId);
             args[argIdx++] = Long.toString(post.postId);
         }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -430,7 +430,8 @@ public class ReaderPostTable {
             if (existingPost == null) {
                 return ReaderActions.UpdateResult.HAS_NEW;
             }
-            if (!hasChanges && !post.isSamePost(existingPost)) {
+            // existingPost was loaded without the text column, so skip comparing text
+            if (!hasChanges && !post.isSamePost(existingPost, false)) {
                 hasChanges = true;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -421,17 +421,124 @@ public class ReaderPostTable {
             return ReaderActions.UpdateResult.UNCHANGED;
         }
 
+        // Fetch all existing rows that match any of the incoming (blog_id, post_id) pairs in a
+        // single query, keyed by "blogId|postId". Mirrors ReaderPost.isSamePost, but reads the
+        // comparison fields directly from the cursor to avoid building full ReaderPost instances.
+        Map<String, PostComparisonRow> existing = loadPostComparisonRows(posts);
+
         boolean hasChanges = false;
         for (ReaderPost post : posts) {
-            ReaderPost existingPost = getBlogPost(post.blogId, post.postId, true);
-            if (existingPost == null) {
+            PostComparisonRow row = existing.get(postComparisonKey(post.blogId, post.postId));
+            if (row == null) {
                 return ReaderActions.UpdateResult.HAS_NEW;
-            } else if (!hasChanges && !post.isSamePost(existingPost)) {
+            }
+            if (!hasChanges && !row.matches(post)) {
                 hasChanges = true;
             }
         }
 
         return (hasChanges ? ReaderActions.UpdateResult.CHANGED : ReaderActions.UpdateResult.UNCHANGED);
+    }
+
+    private static String postComparisonKey(long blogId, long postId) {
+        return blogId + "|" + postId;
+    }
+
+    private static Map<String, PostComparisonRow> loadPostComparisonRows(ReaderPostList posts) {
+        Map<String, PostComparisonRow> map = new LinkedHashMap<>(posts.size());
+        StringBuilder where = new StringBuilder(posts.size() * 28);
+        String[] args = new String[posts.size() * 2];
+        int argIdx = 0;
+        for (ReaderPost post : posts) {
+            if (where.length() > 0) {
+                where.append(" OR ");
+            }
+            where.append("(blog_id=? AND post_id=?)");
+            args[argIdx++] = Long.toString(post.blogId);
+            args[argIdx++] = Long.toString(post.postId);
+        }
+
+        String sql = "SELECT blog_id, post_id, feed_id, feed_item_id, num_likes, num_replies,"
+                + " is_liked, is_followed, is_comments_open, use_excerpt, title, excerpt"
+                + " FROM tbl_posts WHERE " + where;
+
+        Cursor c = ReaderDatabase.getReadableDb().rawQuery(sql, args);
+        try {
+            if (!c.moveToFirst()) {
+                return map;
+            }
+            int idxBlogId = c.getColumnIndexOrThrow("blog_id");
+            int idxPostId = c.getColumnIndexOrThrow("post_id");
+            int idxFeedId = c.getColumnIndexOrThrow("feed_id");
+            int idxFeedItemId = c.getColumnIndexOrThrow("feed_item_id");
+            int idxNumLikes = c.getColumnIndexOrThrow("num_likes");
+            int idxNumReplies = c.getColumnIndexOrThrow("num_replies");
+            int idxIsLiked = c.getColumnIndexOrThrow("is_liked");
+            int idxIsFollowed = c.getColumnIndexOrThrow("is_followed");
+            int idxIsCommentsOpen = c.getColumnIndexOrThrow("is_comments_open");
+            int idxUseExcerpt = c.getColumnIndexOrThrow("use_excerpt");
+            int idxTitle = c.getColumnIndexOrThrow("title");
+            int idxExcerpt = c.getColumnIndexOrThrow("excerpt");
+            do {
+                long blogId = c.getLong(idxBlogId);
+                long postId = c.getLong(idxPostId);
+                String key = postComparisonKey(blogId, postId);
+                // the same post can appear multiple times (one row per tag) - keep the first row
+                if (map.containsKey(key)) {
+                    continue;
+                }
+                PostComparisonRow row = new PostComparisonRow();
+                row.blogId = blogId;
+                row.postId = postId;
+                row.feedId = c.getLong(idxFeedId);
+                row.feedItemId = c.getLong(idxFeedItemId);
+                row.numLikes = c.getInt(idxNumLikes);
+                row.numReplies = c.getInt(idxNumReplies);
+                row.isLiked = SqlUtils.sqlToBool(c.getInt(idxIsLiked));
+                row.isFollowed = SqlUtils.sqlToBool(c.getInt(idxIsFollowed));
+                row.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(idxIsCommentsOpen));
+                row.useExcerpt = SqlUtils.sqlToBool(c.getInt(idxUseExcerpt));
+                row.title = c.getString(idxTitle);
+                row.excerpt = c.getString(idxExcerpt);
+                map.put(key, row);
+            } while (c.moveToNext());
+        } finally {
+            SqlUtils.closeCursor(c);
+        }
+        return map;
+    }
+
+    private static final class PostComparisonRow {
+        long blogId;
+        long postId;
+        long feedId;
+        long feedItemId;
+        int numLikes;
+        int numReplies;
+        boolean isLiked;
+        boolean isFollowed;
+        boolean isCommentsOpen;
+        boolean useExcerpt;
+        String title;
+        String excerpt;
+
+        // mirrors ReaderPost.isSamePost; the text column is intentionally omitted to match the
+        // prior behavior of loading the existing row with excludeTextColumn=true
+        boolean matches(ReaderPost post) {
+            return post.blogId == blogId
+                    && post.postId == postId
+                    && post.feedId == feedId
+                    && post.feedItemId == feedItemId
+                    && post.numLikes == numLikes
+                    && post.numReplies == numReplies
+                    && post.isFollowedByCurrentUser == isFollowed
+                    && post.isLikedByCurrentUser == isLiked
+                    && post.isCommentsOpen == isCommentsOpen
+                    && post.useExcerpt == useExcerpt
+                    && post.getTitle().equals(title == null ? "" : title)
+                    && post.getExcerpt().equals(excerpt == null ? "" : excerpt)
+                    && post.getText().isEmpty();
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -662,6 +662,14 @@ public class ReaderPost {
      * retrieved to determine which ones are new/changed/unchanged
      */
     public boolean isSamePost(ReaderPost post) {
+        return isSamePost(post, true);
+    }
+
+    /*
+     * pass compareText=false when either side was loaded without the text column, since an
+     * absent text would otherwise be compared against the incoming post's body and always differ
+     */
+    public boolean isSamePost(ReaderPost post, boolean compareText) {
         return post != null
                && post.blogId == this.blogId
                && post.postId == this.postId
@@ -675,7 +683,7 @@ public class ReaderPost {
                && post.useExcerpt == this.useExcerpt
                && post.getTitle().equals(this.getTitle())
                && post.getExcerpt().equals(this.getExcerpt())
-               && post.getText().equals(this.getText());
+               && (!compareText || post.getText().equals(this.getText()));
     }
 
     public boolean hasIds(ReaderBlogIdPostId ids) {

--- a/WordPress/src/test/java/org/wordpress/android/models/ReaderPostTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/ReaderPostTest.kt
@@ -65,4 +65,32 @@ class ReaderPostTest {
         method.isAccessible = true
         return method.invoke(null, imageUrl) as String?
     }
+
+    @Test
+    fun `GIVEN different useExcerpt WHEN isSamePost THEN returns false`() {
+        val a = samplePost()
+        val b = samplePost().apply { useExcerpt = true }
+
+        assertThat(a.isSamePost(b)).isFalse()
+    }
+
+    @Test
+    fun `GIVEN different text and compareText true WHEN isSamePost THEN returns false`() {
+        val a = samplePost()
+        val b = samplePost().apply { text = "Different body" }
+
+        assertThat(a.isSamePost(b, true)).isFalse()
+    }
+
+    @Test
+    fun `GIVEN different text and compareText false WHEN isSamePost THEN returns true`() {
+        val a = samplePost()
+        val b = samplePost().apply { text = "Different body" }
+
+        assertThat(a.isSamePost(b, false)).isTrue()
+    }
+
+    private fun samplePost(): ReaderPost = ReaderPost().apply {
+        text = "A body"
+    }
 }


### PR DESCRIPTION
## Background

`ReaderPostTable.comparePosts()` is the gate that `ReaderPostLocalSource.saveUpdatedPosts` uses to decide what to do after the Reader fetches posts from the server. Its three-valued result drives three distinct behaviors in the caller:

- **`HAS_NEW` / `CHANGED`** — runs the full write path: gap detection, delete-and-reinsert for `REQUEST_REFRESH`, `addOrUpdatePosts`, bookmark pseudo-id fixups, gap-marker placement, and the UI change events those trigger.
- **`UNCHANGED`** — skips the write path entirely, avoiding re-inserting rows we already have and suppressing UI refreshes when nothing has actually changed.
- **`UNCHANGED` + `REQUEST_OLDER_THAN_GAP`** — a special case where a gap-fill request returned nothing new, signalling that the gap marker was bogus and should be removed.

In short, `comparePosts` answers "does the server response differ from what's already stored?" — used to short-circuit writes and UI refreshes on no-op refreshes, and to distinguish "gap filled nothing" from a real update.

## Description

`ReaderPostTable.comparePosts()` previously ran one `getBlogPost()` SQL query per incoming post, each materializing a full `ReaderPost` that was thrown away after the `isSamePost` check. For a typical Reader refresh of ~20 posts that's 20 round-trips to SQLite.

This change replaces those N queries with a single `SELECT` keyed by `(blog_id, post_id)` via `OR` clauses, loads the matching rows into an in-memory map (using the existing `COLUMN_NAMES_NO_TEXT` projection and `getPostFromCursor`), and has the comparison loop probe the map.

### Fix to `isSamePost` text comparison

While optimizing this, we noticed `comparePosts` was also effectively never returning `UNCHANGED` for full-text streams. It loads existing rows with `excludeTextColumn=true`, but `ReaderPost.isSamePost` unconditionally compared `post.getText().equals(existingPost.getText())`. Since the stored side was always empty, any incoming post with a non-empty body was reported as `CHANGED` — forcing `saveUpdatedPosts` down the full write path on every refresh.

To fix this, `isSamePost` now has an overload with a `compareText` flag so `UNCHANGED` now fires correctly - and more often - on true no-op refreshes and the caller can skip re-inserting rows and firing UI change events.

## Testing instructions

Reader refresh smoke test:

1. Open the Reader and pull to refresh a followed tag / site stream.
- [ ] Verify posts load and any new/changed posts are reflected in the list.
2. Scroll to trigger paging / background refresh of the same stream.
- [ ] Verify no duplicate or missing posts appear compared to prior behavior.
