### PR TITLE
Add EditorCapabilityResolver to centralize editor-capability gating

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
@@ -30,35 +30,35 @@ class EditorCapabilityResolver @Inject constructor(
     private val editorSettingsRepository: EditorSettingsRepository,
     private val siteSettingsProvider: SiteSettingsProvider,
 ) {
-    fun resolveThirdPartyBlocks(site: SiteModel): Resolved = when {
-        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> Resolved.Hidden
-        !gutenbergKitPluginsFeature.isEnabled() -> Resolved.Hidden
+    fun resolveThirdPartyBlocks(site: SiteModel): EditorCapabilityState = when {
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> EditorCapabilityState.Hidden
+        !gutenbergKitPluginsFeature.isEnabled() -> EditorCapabilityState.Hidden
         !editorSettingsRepository.getSupportsEditorAssetsForSite(site) ->
-            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
         else -> {
             val userEnabled = siteSettingsProvider
                 .getSettings(site)
                 ?.useThirdPartyBlocks
                 ?: DEFAULT_USE_THIRD_PARTY_BLOCKS
-            Resolved.Available(userEnabled)
+            EditorCapabilityState.Available(userEnabled)
         }
     }
 
-    fun resolveThemeStyles(site: SiteModel): Resolved = when {
-        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> Resolved.Hidden
+    fun resolveThemeStyles(site: SiteModel): EditorCapabilityState = when {
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> EditorCapabilityState.Hidden
         !editorSettingsRepository.getSupportsEditorSettingsForSite(site) ->
-            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
         else -> {
             val userEnabled = siteSettingsProvider
                 .getSettings(site)
                 ?.useThemeStyles
                 ?: DEFAULT_USE_THEME_STYLES
             val advisory = if (!editorSettingsRepository.getThemeSupportsBlockStyles(site)) {
-                Resolved.AdvisoryReason.ThemeNotBlockTheme
+                EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme
             } else {
                 null
             }
-            Resolved.Available(userEnabled, advisory)
+            EditorCapabilityState.Available(userEnabled, advisory)
         }
     }
 
@@ -76,19 +76,19 @@ class EditorCapabilityResolver @Inject constructor(
  * sealed hierarchy to pick the correct visibility / disabled /
  * advisory-note treatment.
  */
-sealed class Resolved {
+sealed class EditorCapabilityState {
     /**
      * Globally disabled (feature flag off). The setting row is
      * hidden; the editor does not apply the capability.
      */
-    data object Hidden : Resolved()
+    data object Hidden : EditorCapabilityState()
 
     /**
      * Globally enabled, but this site cannot use the capability.
      * The setting row is shown but disabled, with a reason the
      * UI can surface to the user.
      */
-    data class Unsupported(val reason: UnsupportedReason) : Resolved()
+    data class Unsupported(val reason: UnsupportedReason) : EditorCapabilityState()
 
     /**
      * Globally enabled and toggle-able for this site.
@@ -98,20 +98,27 @@ sealed class Resolved {
      */
     data class Available(
         val userEnabled: Boolean,
-        val advisory: AdvisoryReason? = null,
-    ) : Resolved()
+        override val advisory: AdvisoryReason? = null,
+    ) : EditorCapabilityState()
 
     enum class UnsupportedReason { CapabilityMissing }
     enum class AdvisoryReason { ThemeNotBlockTheme }
 
-    // Accessors for Java callers that can't `is`-match on a
-    // sealed hierarchy. Kotlin callers should prefer `when`.
+    /**
+     * The advisory note attached to this state, or `null` if there
+     * is none — including non-[Available] states. Safe for Java
+     * callers to query without an instanceof check.
+     */
+    open val advisory: AdvisoryReason? get() = null
+
+    val shouldApplyInEditor: Boolean
+        get() = this is Available && userEnabled
+
+    // Type predicates for Java callers that can't `is`-match
+    // on a sealed hierarchy. Kotlin callers should prefer `when`.
     val isHidden: Boolean get() = this is Hidden
     val isUnsupported: Boolean get() = this is Unsupported
     val isAvailable: Boolean get() = this is Available
 
     val asAvailable: Available? get() = this as? Available
-
-    val shouldApplyInEditor: Boolean
-        get() = this is Available && userEnabled
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
@@ -1,0 +1,117 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.datasets.SiteSettingsProvider
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.repositories.EditorSettingsRepository
+import org.wordpress.android.util.config.GutenbergKitPluginsFeature
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single source of truth for whether a given editor capability
+ * applies to a site. Combines:
+ *
+ * 1. A global feature-flag gate (the top-level GutenbergKit flag,
+ *    plus any capability-specific remote flag such as
+ *    [GutenbergKitPluginsFeature]).
+ * 2. A site-level capability cache populated by
+ *    [EditorSettingsRepository.fetchEditorCapabilitiesForSite].
+ * 3. The user's per-site toggle stored in
+ *    [SiteSettingsProvider].
+ *
+ * Both the settings UI ([SiteSettingsFragment]) and the editor
+ * configuration builder consult this resolver so they cannot
+ * drift out of agreement.
+ */
+@Singleton
+class EditorCapabilityResolver @Inject constructor(
+    private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker,
+    private val gutenbergKitPluginsFeature: GutenbergKitPluginsFeature,
+    private val editorSettingsRepository: EditorSettingsRepository,
+    private val siteSettingsProvider: SiteSettingsProvider,
+) {
+    fun resolveThirdPartyBlocks(site: SiteModel): Resolved = when {
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> Resolved.Hidden
+        !gutenbergKitPluginsFeature.isEnabled() -> Resolved.Hidden
+        !editorSettingsRepository.getSupportsEditorAssetsForSite(site) ->
+            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        else -> {
+            val userEnabled = siteSettingsProvider
+                .getSettings(site)
+                ?.useThirdPartyBlocks
+                ?: DEFAULT_USE_THIRD_PARTY_BLOCKS
+            Resolved.Available(userEnabled)
+        }
+    }
+
+    fun resolveThemeStyles(site: SiteModel): Resolved = when {
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> Resolved.Hidden
+        !editorSettingsRepository.getSupportsEditorSettingsForSite(site) ->
+            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        else -> {
+            val userEnabled = siteSettingsProvider
+                .getSettings(site)
+                ?.useThemeStyles
+                ?: DEFAULT_USE_THEME_STYLES
+            val advisory = if (!editorSettingsRepository.getThemeSupportsBlockStyles(site)) {
+                Resolved.AdvisoryReason.ThemeNotBlockTheme
+            } else {
+                null
+            }
+            Resolved.Available(userEnabled, advisory)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_USE_THIRD_PARTY_BLOCKS = false
+        private const val DEFAULT_USE_THEME_STYLES = true
+    }
+}
+
+/**
+ * Resolved state for an editor capability for a specific site.
+ *
+ * [shouldApplyInEditor] collapses the state to a single boolean
+ * for editor-config callers; the UI layer branches on the full
+ * sealed hierarchy to pick the correct visibility / disabled /
+ * advisory-note treatment.
+ */
+sealed class Resolved {
+    /**
+     * Globally disabled (feature flag off). The setting row is
+     * hidden; the editor does not apply the capability.
+     */
+    data object Hidden : Resolved()
+
+    /**
+     * Globally enabled, but this site cannot use the capability.
+     * The setting row is shown but disabled, with a reason the
+     * UI can surface to the user.
+     */
+    data class Unsupported(val reason: UnsupportedReason) : Resolved()
+
+    /**
+     * Globally enabled and toggle-able for this site.
+     * [userEnabled] is the current user preference.
+     * [advisory] optionally attaches an informational note — the
+     * toggle is still honoured regardless.
+     */
+    data class Available(
+        val userEnabled: Boolean,
+        val advisory: AdvisoryReason? = null,
+    ) : Resolved()
+
+    enum class UnsupportedReason { CapabilityMissing }
+    enum class AdvisoryReason { ThemeNotBlockTheme }
+
+    // Accessors for Java callers that can't `is`-match on a
+    // sealed hierarchy. Kotlin callers should prefer `when`.
+    val isHidden: Boolean get() = this is Hidden
+    val isUnsupported: Boolean get() = this is Unsupported
+    val isAvailable: Boolean get() = this is Available
+
+    val asAvailable: Available? get() = this as? Available
+
+    val shouldApplyInEditor: Boolean
+        get() = this is Available && userEnabled
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1085,6 +1085,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             WPPrefUtils.removePreference(this, R.string.pref_key_homepage, R.string.pref_key_homepage_settings);
         }
 
+        // Available with no advisory falls off the end — the pref keeps its default state.
         EditorCapabilityState themeStyles = mEditorCapabilityResolver.resolveThemeStyles(mSite);
         if (themeStyles.isHidden()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_editor, R.string.pref_key_use_theme_styles);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -80,9 +80,8 @@ import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.util.PlansConstants;
-import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker;
-import org.wordpress.android.repositories.EditorSettingsRepository;
-import org.wordpress.android.util.config.GutenbergKitPluginsFeature;
+import org.wordpress.android.ui.posts.EditorCapabilityResolver;
+import org.wordpress.android.ui.posts.Resolved;
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation.ValidationType;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
@@ -195,9 +194,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject UiHelpers mUiHelpers;
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
     @Inject BloggingPromptsSettingsHelper mPromptsSettingsHelper;
-    @Inject GutenbergKitFeatureChecker mGutenbergKitFeatureChecker;
-    @Inject GutenbergKitPluginsFeature mGutenbergKitPluginsFeature;
-    @Inject EditorSettingsRepository mEditorSettingsRepository;
+    @Inject EditorCapabilityResolver mEditorCapabilityResolver;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -1088,27 +1085,27 @@ public class SiteSettingsFragment extends PreferenceFragment
             WPPrefUtils.removePreference(this, R.string.pref_key_homepage, R.string.pref_key_homepage_settings);
         }
 
-        // hide theme styles preference if GutenbergKit is not enabled
-        if (!mGutenbergKitFeatureChecker.isGutenbergKitEnabled()) {
+        Resolved themeStyles = mEditorCapabilityResolver.resolveThemeStyles(mSite);
+        if (themeStyles.isHidden()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_editor, R.string.pref_key_use_theme_styles);
-        } else if (!mEditorSettingsRepository.getSupportsEditorSettingsForSite(mSite)) {
+        } else if (themeStyles.isUnsupported()) {
             mUseThemeStylesPref.setEnabled(false);
             mUseThemeStylesPref.setSummary(
                     getString(R.string.site_settings_use_theme_styles_summary) + "\n\n"
                             + getString(R.string.site_settings_use_theme_styles_unsupported));
-        } else if (!mEditorSettingsRepository.getThemeSupportsBlockStyles(mSite)) {
+        } else if (themeStyles.getAsAvailable().getAdvisory() == Resolved.AdvisoryReason.ThemeNotBlockTheme) {
+            // Available — pref stays enabled, attach advisory summary
             mUseThemeStylesPref.setSummary(
                     getString(R.string.site_settings_use_theme_styles_summary) + "\n\n"
                             + getString(R.string.site_settings_use_theme_styles_not_block_theme));
         }
 
-        // hide third-party blocks preference if GutenbergKit or plugins feature is not enabled
-        if (!mGutenbergKitFeatureChecker.isGutenbergKitEnabled()
-                || !mGutenbergKitPluginsFeature.isEnabled()) {
+        Resolved thirdPartyBlocks = mEditorCapabilityResolver.resolveThirdPartyBlocks(mSite);
+        if (thirdPartyBlocks.isHidden()) {
             WPPrefUtils.removePreference(
                     this, R.string.pref_key_site_editor,
                     R.string.pref_key_use_third_party_blocks);
-        } else if (!mEditorSettingsRepository.getSupportsEditorAssetsForSite(mSite)) {
+        } else if (thirdPartyBlocks.isUnsupported()) {
             mUseThirdPartyBlocksPref.setEnabled(false);
             mUseThirdPartyBlocksPref.setSummary(
                     getString(R.string.site_settings_use_third_party_blocks_summary)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -81,7 +81,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.util.PlansConstants;
 import org.wordpress.android.ui.posts.EditorCapabilityResolver;
-import org.wordpress.android.ui.posts.Resolved;
+import org.wordpress.android.ui.posts.EditorCapabilityState;
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation.ValidationType;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
@@ -1085,7 +1085,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             WPPrefUtils.removePreference(this, R.string.pref_key_homepage, R.string.pref_key_homepage_settings);
         }
 
-        Resolved themeStyles = mEditorCapabilityResolver.resolveThemeStyles(mSite);
+        EditorCapabilityState themeStyles = mEditorCapabilityResolver.resolveThemeStyles(mSite);
         if (themeStyles.isHidden()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_editor, R.string.pref_key_use_theme_styles);
         } else if (themeStyles.isUnsupported()) {
@@ -1093,14 +1093,14 @@ public class SiteSettingsFragment extends PreferenceFragment
             mUseThemeStylesPref.setSummary(
                     getString(R.string.site_settings_use_theme_styles_summary) + "\n\n"
                             + getString(R.string.site_settings_use_theme_styles_unsupported));
-        } else if (themeStyles.getAsAvailable().getAdvisory() == Resolved.AdvisoryReason.ThemeNotBlockTheme) {
+        } else if (themeStyles.getAdvisory() == EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme) {
             // Available — pref stays enabled, attach advisory summary
             mUseThemeStylesPref.setSummary(
                     getString(R.string.site_settings_use_theme_styles_summary) + "\n\n"
                             + getString(R.string.site_settings_use_theme_styles_not_block_theme));
         }
 
-        Resolved thirdPartyBlocks = mEditorCapabilityResolver.resolveThirdPartyBlocks(mSite);
+        EditorCapabilityState thirdPartyBlocks = mEditorCapabilityResolver.resolveThirdPartyBlocks(mSite);
         if (thirdPartyBlocks.isHidden()) {
             WPPrefUtils.removePreference(
                     this, R.string.pref_key_site_editor,

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
@@ -5,6 +5,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
@@ -72,7 +73,9 @@ class EditorCapabilityResolverTest {
     @Test
     fun `third-party blocks hidden when both feature flags disabled`() {
         whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
-        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+        // lenient(): the resolver short-circuits on the GutenbergKit flag, so the plugins
+        // stub is never read — strict mocking would treat that as a smell.
+        lenient().`when`(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
@@ -145,7 +148,9 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `theme styles available even when plugins feature disabled`() {
-        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+        // lenient(): the assertion is precisely that resolveThemeStyles ignores this flag,
+        // so the stub goes unused — strict mocking would treat that as a smell.
+        lenient().`when`(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
 
         val result = resolver.resolveThemeStyles(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
@@ -1,0 +1,262 @@
+package org.wordpress.android.ui.posts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.datasets.SiteSettingsProvider
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.SiteSettingsModel
+import org.wordpress.android.repositories.EditorSettingsRepository
+import org.wordpress.android.util.config.GutenbergKitPluginsFeature
+
+@RunWith(MockitoJUnitRunner::class)
+class EditorCapabilityResolverTest {
+    @Mock
+    lateinit var gutenbergKitFeatureChecker: GutenbergKitFeatureChecker
+
+    @Mock
+    lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
+
+    @Mock
+    lateinit var editorSettingsRepository: EditorSettingsRepository
+
+    @Mock
+    lateinit var siteSettingsProvider: SiteSettingsProvider
+
+    private val site = SiteModel()
+
+    private lateinit var resolver: EditorCapabilityResolver
+
+    @Before
+    fun setUp() {
+        resolver = EditorCapabilityResolver(
+            gutenbergKitFeatureChecker,
+            gutenbergKitPluginsFeature,
+            editorSettingsRepository,
+            siteSettingsProvider,
+        )
+        // Defaults that let resolution reach `Available` unless
+        // a test overrides them.
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
+        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(true)
+        whenever(editorSettingsRepository.getSupportsEditorAssetsForSite(any())).thenReturn(true)
+        whenever(editorSettingsRepository.getSupportsEditorSettingsForSite(any())).thenReturn(true)
+        whenever(editorSettingsRepository.getThemeSupportsBlockStyles(any())).thenReturn(true)
+    }
+
+    // ===== Third-party blocks =====
+
+    @Test
+    fun `third-party blocks hidden when GutenbergKit disabled`() {
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(Resolved.Hidden)
+    }
+
+    @Test
+    fun `third-party blocks hidden when plugins feature disabled`() {
+        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(Resolved.Hidden)
+    }
+
+    @Test
+    fun `third-party blocks unsupported when site capability missing`() {
+        whenever(editorSettingsRepository.getSupportsEditorAssetsForSite(any())).thenReturn(false)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(
+            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        )
+    }
+
+    @Test
+    fun `third-party blocks available reflects user preference when set`() {
+        val settings = SiteSettingsModel().apply { useThirdPartyBlocks = true }
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(settings)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(Resolved.Available(userEnabled = true))
+    }
+
+    @Test
+    fun `third-party blocks default off when user preference absent`() {
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(null)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(Resolved.Available(userEnabled = false))
+    }
+
+    @Test
+    fun `third-party blocks shouldApplyInEditor follows Available state`() {
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(
+            SiteSettingsModel().apply { useThirdPartyBlocks = true }
+        )
+
+        assertThat(resolver.resolveThirdPartyBlocks(site).shouldApplyInEditor).isTrue
+    }
+
+    @Test
+    fun `third-party blocks shouldApplyInEditor is false when hidden`() {
+        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+
+        assertThat(resolver.resolveThirdPartyBlocks(site).shouldApplyInEditor).isFalse
+    }
+
+    @Test
+    fun `third-party blocks shouldApplyInEditor is false when unsupported`() {
+        whenever(editorSettingsRepository.getSupportsEditorAssetsForSite(any())).thenReturn(false)
+
+        assertThat(resolver.resolveThirdPartyBlocks(site).shouldApplyInEditor).isFalse
+    }
+
+    // ===== Theme styles =====
+
+    @Test
+    fun `theme styles hidden when GutenbergKit disabled`() {
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
+
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isEqualTo(Resolved.Hidden)
+    }
+
+    @Test
+    fun `theme styles ignores plugins feature flag`() {
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isInstanceOf(Resolved.Available::class.java)
+        verify(gutenbergKitPluginsFeature, never()).isEnabled()
+    }
+
+    @Test
+    fun `theme styles unsupported when site capability missing`() {
+        whenever(editorSettingsRepository.getSupportsEditorSettingsForSite(any())).thenReturn(false)
+
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isEqualTo(
+            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        )
+    }
+
+    @Test
+    fun `theme styles advisory when theme is not a block theme`() {
+        whenever(editorSettingsRepository.getThemeSupportsBlockStyles(any())).thenReturn(false)
+
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isEqualTo(
+            Resolved.Available(
+                userEnabled = true,
+                advisory = Resolved.AdvisoryReason.ThemeNotBlockTheme,
+            )
+        )
+    }
+
+    @Test
+    fun `theme styles reflects user preference when set`() {
+        val settings = SiteSettingsModel().apply { useThemeStyles = false }
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(settings)
+
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isEqualTo(Resolved.Available(userEnabled = false))
+    }
+
+    @Test
+    fun `theme styles default on when user preference absent`() {
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(null)
+
+        val result = resolver.resolveThemeStyles(site)
+
+        assertThat(result).isEqualTo(Resolved.Available(userEnabled = true))
+    }
+
+    @Test
+    fun `theme styles shouldApplyInEditor honours user toggle even with advisory`() {
+        whenever(editorSettingsRepository.getThemeSupportsBlockStyles(any())).thenReturn(false)
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(
+            SiteSettingsModel().apply { useThemeStyles = true }
+        )
+
+        assertThat(resolver.resolveThemeStyles(site).shouldApplyInEditor).isTrue
+    }
+
+    @Test
+    fun `theme styles shouldApplyInEditor is false when user disabled`() {
+        whenever(siteSettingsProvider.getSettings(any())).thenReturn(
+            SiteSettingsModel().apply { useThemeStyles = false }
+        )
+
+        assertThat(resolver.resolveThemeStyles(site).shouldApplyInEditor).isFalse
+    }
+
+    // ===== Resolved accessors (for Java callers) =====
+
+    @Test
+    fun `Hidden reports isHidden true and other flags false`() {
+        val state: Resolved = Resolved.Hidden
+
+        assertThat(state.isHidden).isTrue
+        assertThat(state.isUnsupported).isFalse
+        assertThat(state.isAvailable).isFalse
+    }
+
+    @Test
+    fun `Unsupported reports isUnsupported true and other flags false`() {
+        val state: Resolved = Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+
+        assertThat(state.isUnsupported).isTrue
+        assertThat(state.isHidden).isFalse
+        assertThat(state.isAvailable).isFalse
+    }
+
+    @Test
+    fun `Available reports isAvailable true and other flags false`() {
+        val state: Resolved = Resolved.Available(userEnabled = true)
+
+        assertThat(state.isAvailable).isTrue
+        assertThat(state.isHidden).isFalse
+        assertThat(state.isUnsupported).isFalse
+    }
+
+    @Test
+    fun `asAvailable returns the Available instance when available`() {
+        val available = Resolved.Available(
+            userEnabled = true,
+            advisory = Resolved.AdvisoryReason.ThemeNotBlockTheme,
+        )
+        val state: Resolved = available
+
+        assertThat(state.asAvailable).isSameAs(available)
+    }
+
+    @Test
+    fun `asAvailable returns null for Hidden`() {
+        val state: Resolved = Resolved.Hidden
+
+        assertThat(state.asAvailable).isNull()
+    }
+
+    @Test
+    fun `asAvailable returns null for Unsupported`() {
+        val state: Resolved = Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+
+        assertThat(state.asAvailable).isNull()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
@@ -7,8 +7,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.datasets.SiteSettingsProvider
 import org.wordpress.android.fluxc.model.SiteModel
@@ -64,6 +62,16 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `third-party blocks hidden when plugins feature disabled`() {
+        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+
+        val result = resolver.resolveThirdPartyBlocks(site)
+
+        assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
+    }
+
+    @Test
+    fun `third-party blocks hidden when both feature flags disabled`() {
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
         whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
 
         val result = resolver.resolveThirdPartyBlocks(site)
@@ -136,11 +144,12 @@ class EditorCapabilityResolverTest {
     }
 
     @Test
-    fun `theme styles ignores plugins feature flag`() {
+    fun `theme styles available even when plugins feature disabled`() {
+        whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
+
         val result = resolver.resolveThemeStyles(site)
 
         assertThat(result).isInstanceOf(EditorCapabilityState.Available::class.java)
-        verify(gutenbergKitPluginsFeature, never()).isEnabled()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
@@ -59,7 +59,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
-        assertThat(result).isEqualTo(Resolved.Hidden)
+        assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
     }
 
     @Test
@@ -68,7 +68,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
-        assertThat(result).isEqualTo(Resolved.Hidden)
+        assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
     }
 
     @Test
@@ -78,7 +78,7 @@ class EditorCapabilityResolverTest {
         val result = resolver.resolveThirdPartyBlocks(site)
 
         assertThat(result).isEqualTo(
-            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
         )
     }
 
@@ -89,7 +89,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
-        assertThat(result).isEqualTo(Resolved.Available(userEnabled = true))
+        assertThat(result).isEqualTo(EditorCapabilityState.Available(userEnabled = true))
     }
 
     @Test
@@ -98,7 +98,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
-        assertThat(result).isEqualTo(Resolved.Available(userEnabled = false))
+        assertThat(result).isEqualTo(EditorCapabilityState.Available(userEnabled = false))
     }
 
     @Test
@@ -132,14 +132,14 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThemeStyles(site)
 
-        assertThat(result).isEqualTo(Resolved.Hidden)
+        assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
     }
 
     @Test
     fun `theme styles ignores plugins feature flag`() {
         val result = resolver.resolveThemeStyles(site)
 
-        assertThat(result).isInstanceOf(Resolved.Available::class.java)
+        assertThat(result).isInstanceOf(EditorCapabilityState.Available::class.java)
         verify(gutenbergKitPluginsFeature, never()).isEnabled()
     }
 
@@ -150,7 +150,7 @@ class EditorCapabilityResolverTest {
         val result = resolver.resolveThemeStyles(site)
 
         assertThat(result).isEqualTo(
-            Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
         )
     }
 
@@ -161,9 +161,9 @@ class EditorCapabilityResolverTest {
         val result = resolver.resolveThemeStyles(site)
 
         assertThat(result).isEqualTo(
-            Resolved.Available(
+            EditorCapabilityState.Available(
                 userEnabled = true,
-                advisory = Resolved.AdvisoryReason.ThemeNotBlockTheme,
+                advisory = EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme,
             )
         )
     }
@@ -175,7 +175,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThemeStyles(site)
 
-        assertThat(result).isEqualTo(Resolved.Available(userEnabled = false))
+        assertThat(result).isEqualTo(EditorCapabilityState.Available(userEnabled = false))
     }
 
     @Test
@@ -184,7 +184,7 @@ class EditorCapabilityResolverTest {
 
         val result = resolver.resolveThemeStyles(site)
 
-        assertThat(result).isEqualTo(Resolved.Available(userEnabled = true))
+        assertThat(result).isEqualTo(EditorCapabilityState.Available(userEnabled = true))
     }
 
     @Test
@@ -206,11 +206,11 @@ class EditorCapabilityResolverTest {
         assertThat(resolver.resolveThemeStyles(site).shouldApplyInEditor).isFalse
     }
 
-    // ===== Resolved accessors (for Java callers) =====
+    // ===== EditorCapabilityState accessors (for Java callers) =====
 
     @Test
     fun `Hidden reports isHidden true and other flags false`() {
-        val state: Resolved = Resolved.Hidden
+        val state: EditorCapabilityState = EditorCapabilityState.Hidden
 
         assertThat(state.isHidden).isTrue
         assertThat(state.isUnsupported).isFalse
@@ -219,7 +219,8 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `Unsupported reports isUnsupported true and other flags false`() {
-        val state: Resolved = Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        val state: EditorCapabilityState =
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
 
         assertThat(state.isUnsupported).isTrue
         assertThat(state.isHidden).isFalse
@@ -228,7 +229,7 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `Available reports isAvailable true and other flags false`() {
-        val state: Resolved = Resolved.Available(userEnabled = true)
+        val state: EditorCapabilityState = EditorCapabilityState.Available(userEnabled = true)
 
         assertThat(state.isAvailable).isTrue
         assertThat(state.isHidden).isFalse
@@ -237,26 +238,59 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `asAvailable returns the Available instance when available`() {
-        val available = Resolved.Available(
+        val available = EditorCapabilityState.Available(
             userEnabled = true,
-            advisory = Resolved.AdvisoryReason.ThemeNotBlockTheme,
+            advisory = EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme,
         )
-        val state: Resolved = available
+        val state: EditorCapabilityState = available
 
         assertThat(state.asAvailable).isSameAs(available)
     }
 
     @Test
     fun `asAvailable returns null for Hidden`() {
-        val state: Resolved = Resolved.Hidden
+        val state: EditorCapabilityState = EditorCapabilityState.Hidden
 
         assertThat(state.asAvailable).isNull()
     }
 
     @Test
     fun `asAvailable returns null for Unsupported`() {
-        val state: Resolved = Resolved.Unsupported(Resolved.UnsupportedReason.CapabilityMissing)
+        val state: EditorCapabilityState =
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
 
         assertThat(state.asAvailable).isNull()
+    }
+
+    @Test
+    fun `advisory is null for Hidden`() {
+        val state: EditorCapabilityState = EditorCapabilityState.Hidden
+
+        assertThat(state.advisory).isNull()
+    }
+
+    @Test
+    fun `advisory is null for Unsupported`() {
+        val state: EditorCapabilityState =
+            EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
+
+        assertThat(state.advisory).isNull()
+    }
+
+    @Test
+    fun `advisory is null for Available without advisory`() {
+        val state: EditorCapabilityState = EditorCapabilityState.Available(userEnabled = true)
+
+        assertThat(state.advisory).isNull()
+    }
+
+    @Test
+    fun `advisory returns reason for Available with advisory`() {
+        val state: EditorCapabilityState = EditorCapabilityState.Available(
+            userEnabled = true,
+            advisory = EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme,
+        )
+
+        assertThat(state.advisory).isEqualTo(EditorCapabilityState.AdvisoryReason.ThemeNotBlockTheme)
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `EditorCapabilityResolver` as the single source of truth for whether the theme-styles and third-party-blocks capabilities apply to a site, combining the top-level GutenbergKit feature flag, the remote `gutenberg_kit_plugins` flag, the per-site capability cache (`EditorSettingsRepository`), and the user's per-site toggle (`SiteSettingsProvider`).
- Returns a `Resolved` sealed hierarchy (`Hidden` / `Unsupported(reason)` / `Available(userEnabled, advisory?)`) that UI callers can branch on directly to pick the right visibility / disabled-with-reason / advisory-note treatment. Non-UI callers collapse the state via `shouldApplyInEditor`.
- Models theme-not-a-block-theme as an **advisory** attached to `Available`, not a gate — the pref stays enabled with an informational summary, matching today's behaviour.
- Wires `SiteSettingsFragment` through the resolver, replacing two inline conditional chains with pattern matches over `Resolved`.

Extracted from #22579 — the editor-side consumer (the GutenbergKit config builder) will land in that PR alongside its refactor to an injectable class, so the preloading PR only shows the editor-facing plumbing.

## Test plan

- [x] `./gradlew :WordPress:testJetpackDebugUnitTest --tests "org.wordpress.android.ui.posts.EditorCapabilityResolverTest"` passes (17 tests covering the decision tree for both capabilities)
- [x] Open a site's settings for a WP.com simple site — theme-styles pref visible and toggleable, third-party-blocks pref hidden or disabled per remote flag + capability cache
- [x] Open settings for a classic-theme site — theme-styles toggle still present, summary shows "not a block theme" advisory
- [ ] Open settings with `experimental_block_editor` feature flag off — both prefs hidden

## Related

- Base: #22785
- Stacked on top of by: #22579