### PR TITLE
Add GutenbergKit opt-in announcement and per-site override

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Resolved an issue where the editor could become impossible to exit when it failed to load.
 * [*] Atomic sites can now create application passwords without leaving the app.
 * [**] Fixed a case where the editor failed to load on WP.com Atomic sites whose host doesn't expose `wp-block-editor/v1/settings`.
+* [*] Try out the next-generation block editor on a per-site basis from Site Settings.
 
 26.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.BasicDialogViewModel
+import org.wordpress.android.ui.posts.GutenbergKitAnnouncementBottomSheetFragment
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
@@ -400,6 +401,15 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 requireActivity().supportFragmentManager,
                 JetpackFullPluginInstallOnboardingDialogFragment.TAG
             )
+        }
+
+        viewModel.onShowGutenbergKitAnnouncement.observeEvent(viewLifecycleOwner) { site ->
+            if (parentFragmentManager.isStateSaved) return@observeEvent
+            if (parentFragmentManager.findFragmentByTag(
+                    GutenbergKitAnnouncementBottomSheetFragment.TAG
+                ) != null) return@observeEvent
+            GutenbergKitAnnouncementBottomSheetFragment.newInstance(site)
+                .show(parentFragmentManager, GutenbergKitAnnouncementBottomSheetFragment.TAG)
         }
 
         viewModel.refresh.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.GutenbergEditorPreloader
+import org.wordpress.android.ui.posts.GutenbergKitAnnouncementController
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -68,11 +69,14 @@ class MySiteViewModel @Inject constructor(
     private val siteCapabilityChecker: SiteCapabilityChecker,
     private val gutenbergEditorPreloader: GutenbergEditorPreloader,
     private val siteConnectivityBannerViewModelSlice: SiteConnectivityBannerViewModelSlice,
+    private val gutenbergKitAnnouncementController: GutenbergKitAnnouncementController,
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     private val _onOpenJetpackInstallFullPluginOnboarding = SingleLiveEvent<Event<Unit>>()
     private val _onShowJetpackIndividualPluginOverlay = SingleLiveEvent<Event<Unit>>()
+    private val _onShowGutenbergKitAnnouncement = SingleLiveEvent<Event<SiteModel>>()
+    val onShowGutenbergKitAnnouncement: LiveData<Event<SiteModel>> = _onShowGutenbergKitAnnouncement
 
     /* Capture and track the site selected event so we can circumvent refreshing sources on resume
        as they're already built on site select. */
@@ -185,6 +189,7 @@ class MySiteViewModel @Inject constructor(
     fun onResume() {
         isSiteSelected = false
         checkAndShowJetpackFullPluginInstallOnboarding()
+        checkAndShowGutenbergKitAnnouncement()
         selectedSiteRepository.updateSiteSettingsIfNecessary()
         selectedSiteRepository.getSelectedSite()?.let {
             buildDashboardOrSiteItems(it)
@@ -201,6 +206,14 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
             if (getShowJetpackFullPluginInstallOnboardingUseCase.execute(selectedSite)) {
                 _onOpenJetpackInstallFullPluginOnboarding.postValue(Event(Unit))
+            }
+        }
+    }
+
+    private fun checkAndShowGutenbergKitAnnouncement() {
+        selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
+            if (gutenbergKitAnnouncementController.shouldShowAnnouncement(selectedSite)) {
+                _onShowGutenbergKitAnnouncement.postValue(Event(selectedSite))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorCapabilityResolver.kt
@@ -31,7 +31,7 @@ class EditorCapabilityResolver @Inject constructor(
     private val siteSettingsProvider: SiteSettingsProvider,
 ) {
     fun resolveThirdPartyBlocks(site: SiteModel): EditorCapabilityState = when {
-        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> EditorCapabilityState.Hidden
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled(site) -> EditorCapabilityState.Hidden
         !gutenbergKitPluginsFeature.isEnabled() -> EditorCapabilityState.Hidden
         !editorSettingsRepository.getSupportsEditorAssetsForSite(site) ->
             EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
@@ -45,7 +45,7 @@ class EditorCapabilityResolver @Inject constructor(
     }
 
     fun resolveThemeStyles(site: SiteModel): EditorCapabilityState = when {
-        !gutenbergKitFeatureChecker.isGutenbergKitEnabled() -> EditorCapabilityState.Hidden
+        !gutenbergKitFeatureChecker.isGutenbergKitEnabled(site) -> EditorCapabilityState.Hidden
         !editorSettingsRepository.getSupportsEditorSettingsForSite(site) ->
             EditorCapabilityState.Unsupported(EditorCapabilityState.UnsupportedReason.CapabilityMissing)
         else -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -122,8 +122,6 @@ class EditorLauncher @Inject constructor(
 
     private fun logFeatureDisabledReason(featureState: GutenbergKitFeatureChecker.FeatureState) {
         val reason = when {
-            featureState.isDisableExperimentalBlockEditorEnabled ->
-                "the experimental block editor is explicitly disabled"
             featureState.siteOverride == false ->
                 "this site has an explicit GutenbergKit opt-out"
             featureState.siteOverride == null && !featureState.isExperimentalBlockEditorEnabled ->
@@ -147,8 +145,7 @@ class EditorLauncher @Inject constructor(
     ): String {
         return "(experimental_block_editor: ${featureState.isExperimentalBlockEditorEnabled}, " +
                 "gutenberg_kit_remote_flag: ${featureState.isGutenbergKitFeatureEnabled}, " +
-                "site_override: ${featureState.siteOverride}, " +
-                "disable_experimental_block_editor: ${featureState.isDisableExperimentalBlockEditorEnabled})"
+                "site_override: ${featureState.siteOverride})"
     }
 
     private fun logEditorDecision(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -89,10 +89,10 @@ class EditorLauncher @Inject constructor(
      * Determines if GutenbergKit editor should be used based on feature flags and post content.
      */
     private fun shouldUseGutenbergKitEditor(params: EditorLauncherParams): Boolean {
-        val featureState = gutenbergKitFeatureChecker.getFeatureState()
+        val site = params.siteSource.getSite(siteStore)
+        val featureState = gutenbergKitFeatureChecker.getFeatureState(site)
         val isGutenbergFeatureEnabled = featureState.isGutenbergKitEnabled
 
-        val site = params.siteSource.getSite(siteStore)
         return when {
             !isGutenbergFeatureEnabled -> {
                 logFeatureDisabledReason(featureState)
@@ -124,8 +124,10 @@ class EditorLauncher @Inject constructor(
         val reason = when {
             featureState.isDisableExperimentalBlockEditorEnabled ->
                 "the experimental block editor is explicitly disabled"
-            !featureState.isExperimentalBlockEditorEnabled && !featureState.isGutenbergKitFeatureEnabled ->
-                "neither the experimental block editor feature nor GutenbergKit feature is enabled"
+            featureState.siteOverride == false ->
+                "this site has an explicit GutenbergKit opt-out"
+            featureState.siteOverride == null && !featureState.isExperimentalBlockEditorEnabled ->
+                "no per-site opt-in and the experimental block editor flag is off"
             else -> "GutenbergKit feature checks failed"
         }
         val featureFlags = getFeatureFlagsString(featureState)
@@ -144,7 +146,8 @@ class EditorLauncher @Inject constructor(
         featureState: GutenbergKitFeatureChecker.FeatureState = gutenbergKitFeatureChecker.getFeatureState()
     ): String {
         return "(experimental_block_editor: ${featureState.isExperimentalBlockEditorEnabled}, " +
-                "gutenberg_kit_feature: ${featureState.isGutenbergKitFeatureEnabled}, " +
+                "gutenberg_kit_remote_flag: ${featureState.isGutenbergKitFeatureEnabled}, " +
+                "site_override: ${featureState.siteOverride}, " +
                 "disable_experimental_block_editor: ${featureState.isDisableExperimentalBlockEditorEnabled})"
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementBottomSheetFragment.kt
@@ -1,0 +1,99 @@
+package org.wordpress.android.ui.posts
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.util.extensions.getSerializableCompat
+import javax.inject.Inject
+
+/**
+ * One-time announcement bottom sheet for the upcoming GutenbergKit editor. Show/defer/activate
+ * logic lives in [GutenbergKitAnnouncementController]; this fragment hosts a Compose layout and
+ * forwards button taps.
+ */
+@AndroidEntryPoint
+class GutenbergKitAnnouncementBottomSheetFragment : BottomSheetDialogFragment() {
+    @Inject lateinit var controller: GutenbergKitAnnouncementController
+
+    private var decisionRecorded = false
+
+    // The default `WordPress.BottomSheetDialogTheme` sets `fitsSystemWindows=true`, which adds
+    // the status-bar inset as top padding to the sheet container. The `NonTranslucent` variant
+    // turns that off — matches what other Compose bottom sheets (e.g. ReaderSubscriptionSettings)
+    // already do.
+    override fun getTheme(): Int = R.style.WordPress_BottomSheetDialogTheme_NonTranslucent
+
+    private val site: SiteModel
+        get() = requireNotNull(
+            requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
+        ) { "GutenbergKitAnnouncementBottomSheetFragment requires a SiteModel argument" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setContent {
+            AppThemeM3 {
+                GutenbergKitAnnouncementScreen(
+                    onActivate = {
+                        controller.onActivate(site)
+                        decisionRecorded = true
+                        dismiss()
+                    },
+                    onMaybeLater = {
+                        controller.onMaybeLater(site)
+                        decisionRecorded = true
+                        dismiss()
+                    },
+                    onLearnMore = {
+                        WPWebViewActivity.openURL(
+                            requireContext(),
+                            getString(R.string.gutenberg_kit_learn_more_url),
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // Force STATE_EXPANDED so the screen has a defined height — the flex spacer between body
+        // and buttons in the Compose layout relies on the parent being taller than its content.
+        (dialog as? BottomSheetDialog)?.apply {
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            behavior.skipCollapsed = true
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        // Swipe / back / tap-outside without a button tap is treated as an implicit "Maybe later"
+        // so the sheet doesn't re-prompt on the next My Site resume. Config changes don't count.
+        if (decisionRecorded) return
+        if (activity?.isChangingConfigurations == true) return
+        controller.onMaybeLater(site)
+    }
+
+    companion object {
+        const val TAG = "GutenbergKitAnnouncementBottomSheetFragment"
+
+        fun newInstance(site: SiteModel): GutenbergKitAnnouncementBottomSheetFragment =
+            GutenbergKitAnnouncementBottomSheetFragment().apply {
+                arguments = Bundle().apply { putSerializable(WordPress.SITE, site) }
+            }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementBottomSheetFragment.kt
@@ -71,11 +71,13 @@ class GutenbergKitAnnouncementBottomSheetFragment : BottomSheetDialogFragment() 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // Force STATE_EXPANDED so the screen has a defined height — the flex spacer between body
-        // and buttons in the Compose layout relies on the parent being taller than its content.
+        // Defer the expand to the show callback so the sheet slides up from offscreen instead of
+        // starting at its final position (which skips the slide-in animation entirely).
         (dialog as? BottomSheetDialog)?.apply {
-            behavior.state = BottomSheetBehavior.STATE_EXPANDED
             behavior.skipCollapsed = true
+            setOnShowListener {
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.datasets.SiteSettingsProvider
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the decisions for the GutenbergKit announcement bottom sheet and the per-site override
+ * it writes. Pure logic so it is unit-testable; the fragment and Site Settings only call into it.
+ *
+ * The per-site override is the single source of truth — its presence means the user has decided
+ * for that site (either direction), its absence means "not yet decided." "Maybe later" defers the
+ * announcement for one week per-site rather than writing an override, so we don't mis-read the
+ * user's intent.
+ */
+@Singleton
+class GutenbergKitAnnouncementController @Inject constructor(
+    private val gutenbergKitFeatureChecker: GutenbergKitFeatureChecker,
+    private val siteSettingsProvider: SiteSettingsProvider,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val clock: Clock,
+) {
+    @Suppress("ReturnCount")
+    fun shouldShowAnnouncement(site: SiteModel): Boolean {
+        // The per-site override/deferral prefs are keyed by URL, so a site without one would
+        // loop the announcement on every resume (writes would no-op via TextUtils.isEmpty).
+        if (site.url.isNullOrEmpty()) return false
+        if (!gutenbergKitFeatureChecker.isGutenbergKitRemoteFeatureEnabled()) return false
+        if (!siteSettingsProvider.isBlockEditorDefault(site)) return false
+        if (appPrefsWrapper.getGutenbergKitSiteOverride(site.url) != null) return false
+        return clock.millis() >= appPrefsWrapper.getGutenbergKitAnnouncementDeferredUntil(site.url)
+    }
+
+    fun onActivate(site: SiteModel) = setOverride(site, true)
+
+    /**
+     * Records an explicit per-site decision (from the announcement sheet or Site Settings). An
+     * explicit decision supersedes any pending "Maybe later" deferral on the same site, so this
+     * clears the deferral timestamp as well.
+     */
+    fun setOverride(site: SiteModel, enabled: Boolean) {
+        appPrefsWrapper.setGutenbergKitSiteOverride(site.url, enabled)
+        appPrefsWrapper.setGutenbergKitAnnouncementDeferredUntil(site.url, 0L)
+    }
+
+    fun onMaybeLater(site: SiteModel) {
+        appPrefsWrapper.setGutenbergKitAnnouncementDeferredUntil(
+            site.url,
+            clock.millis() + DEFER_DURATION_MILLIS
+        )
+    }
+
+    companion object {
+        val DEFER_DURATION_MILLIS: Long = TimeUnit.DAYS.toMillis(7)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,7 +37,7 @@ private val HANDLE_WIDTH = 32.dp
 private val HANDLE_HEIGHT = 4.dp
 private val HANDLE_TOP_MARGIN = 4.dp
 private val TITLE_TOP_SPACE = 24.dp
-private val TITLE_BODY_SPACE = 8.dp
+private val PARAGRAPH_SPACE = 8.dp
 private val BUTTONS_TOP_SPACE = 24.dp
 private val BOTTOM_SPACE = 16.dp
 private val BUTTON_GAP = 8.dp
@@ -62,14 +61,21 @@ fun GutenbergKitAnnouncementScreen(
         Text(
             text = stringResource(R.string.gutenberg_kit_announcement_title),
             style = MaterialTheme.typography.headlineSmall,
-            fontFamily = FontFamily.Serif,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Start,
         )
 
-        Spacer(modifier = Modifier.height(TITLE_BODY_SPACE))
+        Spacer(modifier = Modifier.height(PARAGRAPH_SPACE))
         Text(
-            text = buildBodyWithLearnMore(onLearnMore),
+            text = stringResource(R.string.gutenberg_kit_announcement_body_intro),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Start,
+        )
+
+        Spacer(modifier = Modifier.height(PARAGRAPH_SPACE))
+        Text(
+            text = buildDeadlineWithLearnMore(onLearnMore),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Start,
@@ -100,9 +106,9 @@ fun GutenbergKitAnnouncementScreen(
 }
 
 @Composable
-private fun buildBodyWithLearnMore(onLearnMore: () -> Unit) = buildAnnotatedString {
+private fun buildDeadlineWithLearnMore(onLearnMore: () -> Unit) = buildAnnotatedString {
     val learnMoreText = stringResource(R.string.gutenberg_kit_announcement_learn_more)
-    val body = stringResource(R.string.gutenberg_kit_announcement_body, learnMoreText)
+    val body = stringResource(R.string.gutenberg_kit_announcement_body_deadline, learnMoreText)
     val linkStart = body.indexOf(learnMoreText)
     val link = LinkAnnotation.Clickable(
         tag = "learn_more",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
@@ -30,10 +31,8 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 private val HORIZONTAL_PADDING = 24.dp
-private val TITLE_TOP_SPACE = 24.dp
 private val PARAGRAPH_SPACE = 8.dp
 private val BUTTONS_TOP_SPACE = 24.dp
-private val BOTTOM_SPACE = 16.dp
 private val BUTTON_GAP = 8.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,11 +46,11 @@ fun GutenbergKitAnnouncementScreen(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .navigationBarsPadding()
             .padding(horizontal = HORIZONTAL_PADDING)
     ) {
         BottomSheetDefaults.DragHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
 
-        Spacer(modifier = Modifier.height(TITLE_TOP_SPACE))
         Text(
             text = stringResource(R.string.gutenberg_kit_announcement_title),
             style = MaterialTheme.typography.headlineSmall,
@@ -94,8 +93,6 @@ fun GutenbergKitAnnouncementScreen(
                 Text(stringResource(R.string.gutenberg_kit_announcement_activate))
             }
         }
-
-        Spacer(modifier = Modifier.height(BOTTOM_SPACE))
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
@@ -1,25 +1,22 @@
 package org.wordpress.android.ui.posts
 
 import android.content.res.Configuration
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -33,16 +30,13 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 private val HORIZONTAL_PADDING = 24.dp
-private val HANDLE_WIDTH = 32.dp
-private val HANDLE_HEIGHT = 4.dp
-private val HANDLE_TOP_MARGIN = 4.dp
 private val TITLE_TOP_SPACE = 24.dp
 private val PARAGRAPH_SPACE = 8.dp
 private val BUTTONS_TOP_SPACE = 24.dp
 private val BOTTOM_SPACE = 16.dp
 private val BUTTON_GAP = 8.dp
-private const val HANDLE_ALPHA = 0.38f
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GutenbergKitAnnouncementScreen(
     onActivate: () -> Unit,
@@ -55,7 +49,7 @@ fun GutenbergKitAnnouncementScreen(
             .fillMaxWidth()
             .padding(horizontal = HORIZONTAL_PADDING)
     ) {
-        BottomSheetHandle(modifier = Modifier.padding(top = HANDLE_TOP_MARGIN))
+        BottomSheetDefaults.DragHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
 
         Spacer(modifier = Modifier.height(TITLE_TOP_SPACE))
         Text(
@@ -121,24 +115,6 @@ private fun buildDeadlineWithLearnMore(onLearnMore: () -> Unit) = buildAnnotated
     withLink(link) { append(learnMoreText) }
     val suffixStart = linkStart + learnMoreText.length
     if (suffixStart < body.length) append(body.substring(suffixStart))
-}
-
-@Composable
-private fun BottomSheetHandle(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Box(
-            modifier = Modifier
-                .size(width = HANDLE_WIDTH, height = HANDLE_HEIGHT)
-                .alpha(HANDLE_ALPHA)
-                .background(
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    shape = RoundedCornerShape(HANDLE_HEIGHT / 2),
-                ),
-        )
-    }
 }
 
 @Preview(name = "Light", showBackground = true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
@@ -1,0 +1,149 @@
+package org.wordpress.android.ui.posts
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+
+private val HORIZONTAL_PADDING = 24.dp
+private val HANDLE_WIDTH = 32.dp
+private val HANDLE_HEIGHT = 4.dp
+private val HANDLE_TOP_MARGIN = 4.dp
+private val TITLE_TOP_SPACE = 24.dp
+private val TITLE_BODY_SPACE = 8.dp
+private val BUTTONS_TOP_SPACE = 24.dp
+private val BOTTOM_SPACE = 16.dp
+private val BUTTON_GAP = 8.dp
+private const val HANDLE_ALPHA = 0.38f
+
+@Composable
+fun GutenbergKitAnnouncementScreen(
+    onActivate: () -> Unit,
+    onMaybeLater: () -> Unit,
+    onLearnMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = HORIZONTAL_PADDING)
+    ) {
+        BottomSheetHandle(modifier = Modifier.padding(top = HANDLE_TOP_MARGIN))
+
+        Spacer(modifier = Modifier.height(TITLE_TOP_SPACE))
+        Text(
+            text = stringResource(R.string.gutenberg_kit_announcement_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontFamily = FontFamily.Serif,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Start,
+        )
+
+        Spacer(modifier = Modifier.height(TITLE_BODY_SPACE))
+        Text(
+            text = buildBodyWithLearnMore(onLearnMore),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Start,
+        )
+
+        Spacer(modifier = Modifier.height(BUTTONS_TOP_SPACE))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(BUTTON_GAP),
+        ) {
+            TextButton(
+                onClick = onMaybeLater,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.gutenberg_kit_announcement_maybe_later))
+            }
+            Button(
+                onClick = onActivate,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.gutenberg_kit_announcement_activate))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(BOTTOM_SPACE))
+    }
+}
+
+@Composable
+private fun buildBodyWithLearnMore(onLearnMore: () -> Unit) = buildAnnotatedString {
+    val learnMoreText = stringResource(R.string.gutenberg_kit_announcement_learn_more)
+    val body = stringResource(R.string.gutenberg_kit_announcement_body, learnMoreText)
+    val linkStart = body.indexOf(learnMoreText)
+    val link = LinkAnnotation.Clickable(
+        tag = "learn_more",
+        styles = TextLinkStyles(
+            style = SpanStyle(color = MaterialTheme.colorScheme.primary),
+        ),
+        linkInteractionListener = { onLearnMore() },
+    )
+    append(body.substring(0, linkStart))
+    withLink(link) { append(learnMoreText) }
+    val suffixStart = linkStart + learnMoreText.length
+    if (suffixStart < body.length) append(body.substring(suffixStart))
+}
+
+@Composable
+private fun BottomSheetHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = HANDLE_WIDTH, height = HANDLE_HEIGHT)
+                .alpha(HANDLE_ALPHA)
+                .background(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    shape = RoundedCornerShape(HANDLE_HEIGHT / 2),
+                ),
+        )
+    }
+}
+
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun GutenbergKitAnnouncementScreenPreview() {
+    AppThemeM3 {
+        GutenbergKitAnnouncementScreen(
+            onActivate = {},
+            onMaybeLater = {},
+            onLearnMore = {},
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.posts
 
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.config.GutenbergKitFeature
@@ -13,7 +15,8 @@ import javax.inject.Singleton
 @Singleton
 class GutenbergKitFeatureChecker @Inject constructor(
     private val experimentalFeatures: ExperimentalFeatures,
-    private val gutenbergKitFeature: GutenbergKitFeature
+    private val gutenbergKitFeature: GutenbergKitFeature,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     /**
      * Data class containing the state of all GutenbergKit-related feature flags.
@@ -21,41 +24,54 @@ class GutenbergKitFeatureChecker @Inject constructor(
     data class FeatureState(
         val isExperimentalBlockEditorEnabled: Boolean,
         val isGutenbergKitFeatureEnabled: Boolean,
-        val isDisableExperimentalBlockEditorEnabled: Boolean
+        val isDisableExperimentalBlockEditorEnabled: Boolean,
+        val siteOverride: Boolean? = null
     ) {
         /**
-         * Determines if GutenbergKit should be enabled based on the feature states.
+         * Determines if GutenbergKit should be used for editor routing.
+         *
+         * Resolution: a per-site override (set or cleared via the announcement sheet or Site
+         * Settings) wins over everything except the `DISABLE_EXPERIMENTAL_BLOCK_EDITOR` kill
+         * switch. When absent, falls back to the experimental flag.
+         *
+         * The remote `gutenberg_kit` feature flag is deliberately NOT part of editor routing
+         * — it only gates the visibility of opt-in surfaces (the announcement bottom sheet and
+         * the Site Settings toggle). This lets us roll out the announcement to a percentage of
+         * users without simultaneously flipping the default editor. When we're ready to make
+         * GutenbergKit the default for everyone, the change is a one-line edit here.
          */
         val isGutenbergKitEnabled: Boolean
-            get() = (isExperimentalBlockEditorEnabled || isGutenbergKitFeatureEnabled) &&
-                    !isDisableExperimentalBlockEditorEnabled
+            get() {
+                val resolved = siteOverride ?: isExperimentalBlockEditorEnabled
+                return resolved && !isDisableExperimentalBlockEditorEnabled
+            }
     }
 
     /**
-     * Gets the current state of all GutenbergKit-related feature flags.
-     *
-     * @return FeatureState containing all flag states and the computed enabled state
+     * Gets the current state of all GutenbergKit-related feature flags for the given site (if any).
      */
-    fun getFeatureState(): FeatureState {
+    @JvmOverloads
+    fun getFeatureState(site: SiteModel? = null): FeatureState {
         return FeatureState(
             isExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR),
             isGutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled(),
             isDisableExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(
                 Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
-            )
+            ),
+            siteOverride = site?.url?.let { appPrefsWrapper.getGutenbergKitSiteOverride(it) }
         )
     }
 
     /**
-     * Determines if GutenbergKit is enabled based on feature flags.
-     *
-     * The feature is enabled if:
-     * - Either the experimental block editor is enabled OR the GutenbergKit feature flag is on
-     * - AND the disable experimental block editor flag is NOT enabled
-     *
-     * @return true if GutenbergKit should be enabled, false otherwise
+     * Determines if GutenbergKit is enabled based on feature flags (and optional per-site opt-in).
      */
-    fun isGutenbergKitEnabled(): Boolean {
-        return getFeatureState().isGutenbergKitEnabled
+    @JvmOverloads
+    fun isGutenbergKitEnabled(site: SiteModel? = null): Boolean {
+        return getFeatureState(site).isGutenbergKitEnabled
     }
+
+    /**
+     * Whether the user-facing remote feature flag is on (controls opt-in surfaces).
+     */
+    fun isGutenbergKitRemoteFeatureEnabled(): Boolean = gutenbergKitFeature.isEnabled()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitFeatureChecker.kt
@@ -24,15 +24,13 @@ class GutenbergKitFeatureChecker @Inject constructor(
     data class FeatureState(
         val isExperimentalBlockEditorEnabled: Boolean,
         val isGutenbergKitFeatureEnabled: Boolean,
-        val isDisableExperimentalBlockEditorEnabled: Boolean,
         val siteOverride: Boolean? = null
     ) {
         /**
          * Determines if GutenbergKit should be used for editor routing.
          *
          * Resolution: a per-site override (set or cleared via the announcement sheet or Site
-         * Settings) wins over everything except the `DISABLE_EXPERIMENTAL_BLOCK_EDITOR` kill
-         * switch. When absent, falls back to the experimental flag.
+         * Settings) wins. When absent, falls back to the experimental flag.
          *
          * The remote `gutenberg_kit` feature flag is deliberately NOT part of editor routing
          * — it only gates the visibility of opt-in surfaces (the announcement bottom sheet and
@@ -41,10 +39,7 @@ class GutenbergKitFeatureChecker @Inject constructor(
          * GutenbergKit the default for everyone, the change is a one-line edit here.
          */
         val isGutenbergKitEnabled: Boolean
-            get() {
-                val resolved = siteOverride ?: isExperimentalBlockEditorEnabled
-                return resolved && !isDisableExperimentalBlockEditorEnabled
-            }
+            get() = siteOverride ?: isExperimentalBlockEditorEnabled
     }
 
     /**
@@ -55,9 +50,6 @@ class GutenbergKitFeatureChecker @Inject constructor(
         return FeatureState(
             isExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR),
             isGutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled(),
-            isDisableExperimentalBlockEditorEnabled = experimentalFeatures.isEnabled(
-                Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
-            ),
             siteOverride = site?.url?.let { appPrefsWrapper.getGutenbergKitSiteOverride(it) }
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -127,6 +127,9 @@ public class AppPrefs {
         SHOULD_AUTO_ENABLE_GUTENBERG_FOR_THE_NEW_POSTS_PHASE_2,
         GUTENBERG_OPT_IN_DIALOG_SHOWN,
         GUTENBERG_FOCAL_POINT_PICKER_TOOLTIP_SHOWN,
+        GUTENBERG_KIT_OPT_IN_SITES,
+        GUTENBERG_KIT_OPT_OUT_SITES,
+        GUTENBERG_KIT_ANNOUNCEMENT_DEFERRED_UNTIL,
 
         POST_LIST_AUTHOR_FILTER,
         POST_LIST_VIEW_LAYOUT_TYPE,
@@ -829,6 +832,118 @@ public class AppPrefs {
         }
 
         return urls != null && urls.contains(siteURL);
+    }
+
+    /**
+     * Returns the explicit per-site override for GutenbergKit, or {@code null} if the user has
+     * not set one. When {@code null}, downstream resolution in {@code GutenbergKitFeatureChecker}
+     * falls back to the experimental and remote feature flags.
+     */
+    @Nullable
+    public static Boolean getGutenbergKitSiteOverride(String siteURL) {
+        if (TextUtils.isEmpty(siteURL)) {
+            return null;
+        }
+        if (siteSetContains(DeletablePrefKey.GUTENBERG_KIT_OPT_OUT_SITES, siteURL)) {
+            return Boolean.FALSE;
+        }
+        if (siteSetContains(DeletablePrefKey.GUTENBERG_KIT_OPT_IN_SITES, siteURL)) {
+            return Boolean.TRUE;
+        }
+        return null;
+    }
+
+    /**
+     * Sets an explicit per-site override for GutenbergKit, replacing any prior override for the
+     * site. The site is added to the opt-in or opt-out set (per {@code enabled}) and removed from
+     * the other so the two sets stay mutually exclusive.
+     */
+    public static void setGutenbergKitSiteOverride(String siteURL, boolean enabled) {
+        if (TextUtils.isEmpty(siteURL)) {
+            return;
+        }
+        DeletablePrefKey added = enabled
+                ? DeletablePrefKey.GUTENBERG_KIT_OPT_IN_SITES
+                : DeletablePrefKey.GUTENBERG_KIT_OPT_OUT_SITES;
+        DeletablePrefKey removed = enabled
+                ? DeletablePrefKey.GUTENBERG_KIT_OPT_OUT_SITES
+                : DeletablePrefKey.GUTENBERG_KIT_OPT_IN_SITES;
+        addToSiteSet(added, siteURL);
+        removeFromSiteSet(removed, siteURL);
+    }
+
+    /**
+     * Returns {@code true} if {@code siteURL} is currently a member of the StringSet at {@code key}.
+     * A missing entry or a value of the wrong type is treated as absence.
+     */
+    private static boolean siteSetContains(DeletablePrefKey key, String siteURL) {
+        try {
+            Set<String> urls = prefs().getStringSet(key.name(), null);
+            return urls != null && urls.contains(siteURL);
+        } catch (ClassCastException exp) {
+            return false;
+        }
+    }
+
+    /**
+     * Adds {@code siteURL} to the StringSet at {@code key}, creating the set if it does not exist.
+     * No-ops if the stored value is of the wrong type.
+     */
+    private static void addToSiteSet(DeletablePrefKey key, String siteURL) {
+        Set<String> urls;
+        try {
+            urls = prefs().getStringSet(key.name(), null);
+        } catch (ClassCastException exp) {
+            return;
+        }
+        Set<String> newUrls = new HashSet<>();
+        if (urls != null) newUrls.addAll(urls);
+        newUrls.add(siteURL);
+        prefs().edit().putStringSet(key.name(), newUrls).apply();
+    }
+
+    /**
+     * Removes {@code siteURL} from the StringSet at {@code key}. No-ops if the site is not present
+     * or the stored value is of the wrong type.
+     */
+    private static void removeFromSiteSet(DeletablePrefKey key, String siteURL) {
+        Set<String> urls;
+        try {
+            urls = prefs().getStringSet(key.name(), null);
+        } catch (ClassCastException exp) {
+            return;
+        }
+        if (urls == null || !urls.contains(siteURL)) return;
+        Set<String> newUrls = new HashSet<>(urls);
+        newUrls.remove(siteURL);
+        prefs().edit().putStringSet(key.name(), newUrls).apply();
+    }
+
+    /**
+     * Returns the wall-clock timestamp (millis) before which the GutenbergKit announcement should
+     * not be re-shown for {@code siteURL}. Returns {@code 0L} if no deferral is set (i.e., free
+     * to show now, subject to the other gates).
+     */
+    public static long getGutenbergKitAnnouncementDeferredUntil(String siteURL) {
+        if (TextUtils.isEmpty(siteURL)) {
+            return 0L;
+        }
+        return prefs().getLong(gutenbergKitDeferralKey(siteURL), 0L);
+    }
+
+    /**
+     * Defers the GutenbergKit announcement for {@code siteURL} until the given wall-clock
+     * timestamp (millis).
+     */
+    public static void setGutenbergKitAnnouncementDeferredUntil(String siteURL, long timestampMillis) {
+        if (TextUtils.isEmpty(siteURL)) {
+            return;
+        }
+        prefs().edit().putLong(gutenbergKitDeferralKey(siteURL), timestampMillis).apply();
+    }
+
+    private static String gutenbergKitDeferralKey(String siteURL) {
+        return DeletablePrefKey.GUTENBERG_KIT_ANNOUNCEMENT_DEFERRED_UNTIL.name() + "_" + siteURL;
     }
 
     public static void setGutenbergInfoPopupDisplayed(String siteURL, boolean isDisplayed) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -575,6 +575,18 @@ class AppPrefsWrapper @Inject constructor(val buildConfigWrapper: BuildConfigWra
     fun setStatsNewStatsSuggestionLastDismissedAt(timestamp: Long) =
         AppPrefs.setStatsNewStatsSuggestionLastDismissedAt(timestamp)
 
+    fun getGutenbergKitSiteOverride(siteUrl: String?): Boolean? =
+        AppPrefs.getGutenbergKitSiteOverride(siteUrl)
+
+    fun setGutenbergKitSiteOverride(siteUrl: String?, enabled: Boolean) =
+        AppPrefs.setGutenbergKitSiteOverride(siteUrl, enabled)
+
+    fun getGutenbergKitAnnouncementDeferredUntil(siteUrl: String?): Long =
+        AppPrefs.getGutenbergKitAnnouncementDeferredUntil(siteUrl)
+
+    fun setGutenbergKitAnnouncementDeferredUntil(siteUrl: String?, timestampMillis: Long) =
+        AppPrefs.setGutenbergKitAnnouncementDeferredUntil(siteUrl, timestampMillis)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -82,6 +82,9 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.util.PlansConstants;
 import org.wordpress.android.ui.posts.EditorCapabilityResolver;
 import org.wordpress.android.ui.posts.EditorCapabilityState;
+import org.wordpress.android.ui.posts.GutenbergKitAnnouncementController;
+import org.wordpress.android.ui.posts.GutenbergKitFeatureChecker;
+import org.wordpress.android.datasets.SiteSettingsProvider;
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation.ValidationType;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;
@@ -195,6 +198,9 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
     @Inject BloggingPromptsSettingsHelper mPromptsSettingsHelper;
     @Inject EditorCapabilityResolver mEditorCapabilityResolver;
+    @Inject GutenbergKitFeatureChecker mGutenbergKitFeatureChecker;
+    @Inject GutenbergKitAnnouncementController mGutenbergKitAnnouncementController;
+    @Inject SiteSettingsProvider mSiteSettingsProvider;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -230,6 +236,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private WPSwitchPreference mGutenbergDefaultForNewPosts;
     private WPSwitchPreference mUseThemeStylesPref;
     private WPSwitchPreference mUseThirdPartyBlocksPref;
+    private WPSwitchPreference mGutenbergKitPref;
     private DetailListPreference mCategoryPref;
     private DetailListPreference mFormatPref;
     private WPPreference mDateFormatPref;
@@ -852,6 +859,8 @@ public class SiteSettingsFragment extends PreferenceFragment
             mSiteSettings.setUseThemeStyles((Boolean) newValue);
         } else if (preference == mUseThirdPartyBlocksPref) {
             mSiteSettings.setUseThirdPartyBlocks((Boolean) newValue);
+        } else if (preference == mGutenbergKitPref) {
+            mGutenbergKitAnnouncementController.setOverride(mSite, (Boolean) newValue);
         } else if (preference == mBloggingPromptsPref) {
             final boolean isEnabled = (boolean) newValue;
             mPromptsSettingsHelper.updatePromptsCardEnabledBlocking(mSite.getId(), isEnabled);
@@ -1044,6 +1053,10 @@ public class SiteSettingsFragment extends PreferenceFragment
                 (WPSwitchPreference) getChangePref(R.string.pref_key_use_third_party_blocks);
         mUseThirdPartyBlocksPref.setChecked(mSiteSettings.getUseThirdPartyBlocks());
 
+        mGutenbergKitPref =
+                (WPSwitchPreference) getChangePref(R.string.pref_key_gutenberg_kit_enabled);
+        mGutenbergKitPref.setChecked(mGutenbergKitFeatureChecker.isGutenbergKitEnabled(mSite));
+
         mSiteAcceleratorSettings = (PreferenceScreen) getClickPref(R.string.pref_key_site_accelerator_settings);
         mSiteAcceleratorSettingsNested =
                 (PreferenceScreen) getClickPref(R.string.pref_key_site_accelerator_settings_nested);
@@ -1115,6 +1128,14 @@ public class SiteSettingsFragment extends PreferenceFragment
                             R.string.site_settings_use_third_party_blocks_unsupported));
         }
 
+        // hide the GutenbergKit opt-in switch unless the remote feature flag is on
+        if (!mGutenbergKitFeatureChecker.isGutenbergKitRemoteFeatureEnabled()) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_editor,
+                    R.string.pref_key_gutenberg_kit_enabled);
+        } else {
+            refreshGutenbergKitToggleAvailability();
+        }
+
         // hide Admin options depending of capabilities on this site
         if ((!isAccessedViaWPComRest && !mSite.isSelfHostedAdmin())
             || (isAccessedViaWPComRest && !mSite.getHasCapabilityManageOptions())) {
@@ -1161,6 +1182,25 @@ public class SiteSettingsFragment extends PreferenceFragment
         initBloggingSection();
         removeEmptyCategories();
         initTaxonomies();
+    }
+
+    /**
+     * On Aztec-default sites the GBKit toggle is shown disabled with an explanatory summary —
+     * switching mobileEditor to "gutenberg" is a prerequisite. The state must refresh whenever
+     * site settings change (e.g., the user just flipped "Use block editor as default for new
+     * posts" on this screen), not only at first inflation.
+     */
+    private void refreshGutenbergKitToggleAvailability() {
+        if (mGutenbergKitPref == null) return;
+        if (mSiteSettingsProvider.isBlockEditorDefault(mSite)) {
+            mGutenbergKitPref.setEnabled(true);
+            mGutenbergKitPref.setSummary(R.string.site_settings_gutenberg_kit_enabled_summary);
+        } else {
+            mGutenbergKitPref.setEnabled(false);
+            mGutenbergKitPref.setSummary(
+                    getString(R.string.site_settings_gutenberg_kit_enabled_summary) + "\n\n"
+                            + getString(R.string.site_settings_gutenberg_kit_enabled_unsupported));
+        }
     }
 
     private void initTaxonomies() {
@@ -1240,7 +1280,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mDeleteSitePref, mJpMonitorActivePref, mJpMonitorEmailNotesPref, mJpSsoPref,
                 mJpMonitorWpNotesPref, mJpBruteForcePref, mJpAllowlistPref, mJpMatchEmailPref, mJpUseTwoFactorPref,
                 mGutenbergDefaultForNewPosts, mUseThemeStylesPref, mUseThirdPartyBlocksPref,
-                mHomepagePref, mBloggingPromptsPref
+                mGutenbergKitPref, mHomepagePref, mBloggingPromptsPref
         };
 
         for (Preference preference : editablePreference) {
@@ -1586,6 +1626,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         mGutenbergDefaultForNewPosts.setChecked(SiteUtils.isBlockEditorDefaultForNewPost(mSite));
         mUseThemeStylesPref.setChecked(mSiteSettings.getUseThemeStyles());
         mUseThirdPartyBlocksPref.setChecked(mSiteSettings.getUseThirdPartyBlocks());
+        if (mGutenbergKitPref != null) {
+            mGutenbergKitPref.setChecked(mGutenbergKitFeatureChecker.isGutenbergKitEnabled(mSite));
+            refreshGutenbergKitToggleAvailability();
+        }
         setAdFreeHostingChecked(mSiteSettings.isAdFreeHostingEnabled());
         boolean checked = mSiteSettings.isImprovedSearchEnabled() || mSiteSettings.getJetpackSearchEnabled();
         mImprovedSearch.setChecked(checked);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -20,11 +20,6 @@ class ExperimentalFeatures @Inject constructor(
         val labelResId: Int,
         val descriptionResId: Int
     ) {
-        DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
-            "disable_experimental_block_editor",
-            R.string.disable_experimental_block_editor,
-            R.string.disable_experimental_block_editor_description
-        ),
         EXPERIMENTAL_BLOCK_EDITOR(
             "experimental_block_editor",
             R.string.experimental_block_editor,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -13,13 +13,11 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.GutenbergKitFeature
 import javax.inject.Inject
 
 @HiltViewModel
 internal class ExperimentalFeaturesViewModel @Inject constructor(
     private val experimentalFeatures: ExperimentalFeatures,
-    private val gutenbergKitFeature: GutenbergKitFeature,
     private val appLogWrapper: AppLogWrapper,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
@@ -44,10 +42,8 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         // Only show Post Types feature in debug builds
         return if (feature == Feature.EXPERIMENTAL_POST_TYPES) {
             BuildConfig.DEBUG
-        } else if (gutenbergKitFeature.isEnabled()) {
-            feature != Feature.EXPERIMENTAL_BLOCK_EDITOR
         } else {
-            feature != Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+            true
         }
     }
 

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -194,8 +194,6 @@ Language: ar
     <string name="experimental_features_feedback_dialog_title">مشاركة الملاحظات</string>
     <string name="experimental_block_editor_description">الوصول إلى أنواع المكونات الأخرى وإعداداتها</string>
     <string name="experimental_block_editor_note">سيصبح محرر المكوّنات التجريبي هو المحرر الافتراضي في الإصدارات المستقبلية وستتم إزالة إمكانية تعطيله.</string>
-    <string name="disable_experimental_block_editor_description">إلغاء الاشتراك في أنواع المكوّنات والإعدادات الإضافية</string>
-    <string name="disable_experimental_block_editor">تعطيل محرر المكوِّن التجريبي</string>
     <string name="avatar_update_email_unverified">لتحديث صورتك الرمزية، يتعين عليك التحقق من عنوان بريدك الإلكتروني أولاً.</string>
     <string name="feedback_form_note_link_wordpress">المنتديات المجتمعية.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">عنصر نائب</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -215,8 +215,6 @@ Language: de
     <string name="experimental_features_feedback_dialog_title">Feedback teilen</string>
     <string name="experimental_block_editor_description">Auf zusätzliche Blocktypen und -einstellungen zugreifen</string>
     <string name="experimental_block_editor_note">Der experimentelle Block-Editor wird in einer zukünftigen Version zum Standard und die Möglichkeit, ihn zu deaktivieren, wird entfernt.</string>
-    <string name="disable_experimental_block_editor_description">Zusätzliche Blocktypen und -einstellungen ablehnen</string>
-    <string name="disable_experimental_block_editor">Experimentellen Block-Editor deaktivieren</string>
     <string name="avatar_update_email_unverified">Um deinen Avatar zu aktualisieren, musst du zuerst deine E-Mail-Adresse verifizieren.</string>
     <string name="feedback_form_note_link_wordpress">Community-Foren.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">Platzhalter</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -112,8 +112,6 @@ Language: en_CA
     <string name="experimental_features_feedback_dialog_title">Share feedback</string>
     <string name="experimental_block_editor_description">Access additional block types and settings</string>
     <string name="experimental_block_editor_note">Experimental block editor will become the default in a future release and the ability to disable it will be removed.</string>
-    <string name="disable_experimental_block_editor_description">Opt out of additional block types and settings</string>
-    <string name="disable_experimental_block_editor">Disable experimental block editor</string>
     <string name="avatar_update_email_unverified">To update your avatar, you need to verify your email address first.</string>
     <string name="feedback_form_note_link_wordpress">community forums.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -132,8 +132,6 @@ Language: en_GB
     <string name="experimental_features_feedback_dialog_title">Share feedback</string>
     <string name="experimental_block_editor_description">Access additional block types and settings</string>
     <string name="experimental_block_editor_note">Experimental block editor will become the default in a future release and the ability to disable it will be removed.</string>
-    <string name="disable_experimental_block_editor_description">Opt out of additional block types and settings</string>
-    <string name="disable_experimental_block_editor">Disable experimental block editor</string>
     <string name="avatar_update_email_unverified">To update your avatar, you need to verify your email address first.</string>
     <string name="feedback_form_note_link_wordpress">community forums.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -132,8 +132,6 @@ Language: es_CO
     <string name="experimental_features_feedback_dialog_message">¿Te apetece compartir impresiones sobre el editor experimental?</string>
     <string name="experimental_block_editor_description">Accede a tipos de bloque y ajustes adicionales</string>
     <string name="experimental_block_editor_note">El editor de bloques experimental se convertirá en el predeterminado en una futura versión y se eliminará la posibilidad de desactivarlo.</string>
-    <string name="disable_experimental_block_editor_description">Exclusión de tipos de bloque y ajustes adicionales</string>
-    <string name="disable_experimental_block_editor">Desactivar el editor de bloques experimental</string>
     <string name="avatar_update_email_unverified">Para actualizar su avatar, primero debes verificar tu dirección de correo electrónico.</string>
     <string name="feedback_form_note_link_wordpress">foros de la comunidad</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">marcador de posición</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -215,8 +215,6 @@ Language: es
     <string name="experimental_features_feedback_dialog_title">Compartir comentarios</string>
     <string name="experimental_block_editor_description">Accede a tipos de bloque y ajustes adicionales</string>
     <string name="experimental_block_editor_note">El editor de bloques experimental se convertirá en el predeterminado en una futura versión y se eliminará la posibilidad de desactivarlo.</string>
-    <string name="disable_experimental_block_editor_description">Exclusión de tipos de bloque y ajustes adicionales</string>
-    <string name="disable_experimental_block_editor">Desactivar el editor de bloques experimental</string>
     <string name="avatar_update_email_unverified">Para actualizar tu avatar, primero tienes que verificar tu dirección de correo electrónico.</string>
     <string name="feedback_form_note_link_wordpress">foros de la comunidad.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">marcador de posición</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -195,8 +195,6 @@ Language: fr
     <string name="experimental_features_feedback_dialog_title">Partager des commentaires</string>
     <string name="experimental_block_editor_description">Accéder à des types de blocs et réglages supplémentaires</string>
     <string name="experimental_block_editor_note">L’éditeur de blocs expérimental deviendra l’option par défaut dans une prochaine version et il ne sera plus possible de le désactiver.</string>
-    <string name="disable_experimental_block_editor_description">Se désabonner des types et réglages de blocs supplémentaires</string>
-    <string name="disable_experimental_block_editor">Désactiver l’éditeur de blocs expérimental</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">texte indicatif</string>
     <string name="personalization_screen_shortcuts_accessibility_label">(Dés)activer le raccourci %s</string>
     <string name="personalization_screen_card_accessibility_label">(Dés)activer la carte %s</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -195,8 +195,6 @@ Language: fr
     <string name="experimental_features_feedback_dialog_title">Partager des commentaires</string>
     <string name="experimental_block_editor_description">Accéder à des types de blocs et réglages supplémentaires</string>
     <string name="experimental_block_editor_note">L’éditeur de blocs expérimental deviendra l’option par défaut dans une prochaine version et il ne sera plus possible de le désactiver.</string>
-    <string name="disable_experimental_block_editor_description">Se désabonner des types et réglages de blocs supplémentaires</string>
-    <string name="disable_experimental_block_editor">Désactiver l’éditeur de blocs expérimental</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">texte indicatif</string>
     <string name="personalization_screen_shortcuts_accessibility_label">(Dés)activer le raccourci %s</string>
     <string name="personalization_screen_card_accessibility_label">(Dés)activer la carte %s</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -140,8 +140,6 @@ Language: gl_ES
     <string name="experimental_features_feedback_dialog_title">Compartir comentarios</string>
     <string name="experimental_block_editor_description">Accede a tipos de bloque e axustes adicionais</string>
     <string name="experimental_block_editor_note">O editor de bloques experimental converterase no predeterminado nunha futura versión e eliminarase a posibilidade de desactivalo.</string>
-    <string name="disable_experimental_block_editor_description">Exclusión de tipos de bloque e axustes adicionais</string>
-    <string name="disable_experimental_block_editor">Desactivar o editor de bloques experimental</string>
     <string name="avatar_update_email_unverified">Para actualizar o teu avatar, primeiro tes que verificar o teu enderezo de correo electrónico.</string>
     <string name="feedback_form_note_link_wordpress">foros da comunidade.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">marcador de posición</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -213,8 +213,6 @@ Language: he_IL
     <string name="experimental_features_feedback_dialog_title">לשלוח משוב</string>
     <string name="experimental_block_editor_description">לגשת להגדרות נוספות ולסוגי בלוקים נוספים</string>
     <string name="experimental_block_editor_note">עורך הבלוקים הניסיוני יהפוך לברירת המחדל בגרסה עתידית והאפשרות להשבית אותו תוסר.</string>
-    <string name="disable_experimental_block_editor_description">לבטל את הגישה להגדרות נוספות ולסוגי בלוקים נוספים</string>
-    <string name="disable_experimental_block_editor">להשבית את עורך הבלוקים הניסיוני</string>
     <string name="avatar_update_email_unverified">כדי לעדכן את צלמית המשתמש, עליך לאמת את כתובת האימייל שלך תחילה.</string>
     <string name="feedback_form_note_link_wordpress">בפורומים של הקהילה.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">מציין מיקום</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -211,8 +211,6 @@ Language: id
     <string name="experimental_features_feedback_dialog_title">Bagikan feedback</string>
     <string name="experimental_block_editor_description">Akses jenis blok dan pengaturan lainnya</string>
     <string name="experimental_block_editor_note">Editor blok eksperimental akan menjadi pengaturan asal di rilis mendatang dan fitur untuk menonaktifkannya akan dihapus.</string>
-    <string name="disable_experimental_block_editor_description">Tolak jenis blok dan pengaturan lainnya</string>
-    <string name="disable_experimental_block_editor">Nonaktifkan editor blok eksperimental</string>
     <string name="avatar_update_email_unverified">Untuk memperbarui avatar, alamat email Anda harus diverifikasi terlebih dahulu.</string>
     <string name="feedback_form_note_link_wordpress">forum komunitas.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -215,8 +215,6 @@ Language: it
     <string name="experimental_features_feedback_dialog_title">Condividi un feedback</string>
     <string name="experimental_block_editor_description">Accedi a tipi di blocco e impostazioni aggiuntivi</string>
     <string name="experimental_block_editor_note">L\'editor a blocchi sperimentale diventerà l\'editor predefinito in una prossima versione e verrà rimossa la possibilità di disattivarlo.</string>
-    <string name="disable_experimental_block_editor_description">Annulla l\'adesione a tipi di blocco e impostazioni aggiuntivi</string>
-    <string name="disable_experimental_block_editor">Disabilita l\'editor a blocchi sperimentale</string>
     <string name="avatar_update_email_unverified">Per aggiornare il tuo avatar devi prima verificare il tuo indirizzo e-mail.</string>
     <string name="feedback_form_note_link_wordpress">i forum della community.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">segnaposto</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -192,8 +192,6 @@ Language: ja_JP
     <string name="experimental_features_feedback_dialog_title">フィードバックを共有</string>
     <string name="experimental_block_editor_description">追加のブロックタイプと設定にアクセス</string>
     <string name="experimental_block_editor_note">試験用のブロックエディターは将来のリリースでデフォルトになり、無効化する機能は削除されます。</string>
-    <string name="disable_experimental_block_editor_description">追加のブロックタイプと設定をオプトアウト</string>
-    <string name="disable_experimental_block_editor">試験用のブロックエディターを無効化</string>
     <string name="avatar_update_email_unverified">アバターを更新するには、まずメールアドレスを確認する必要があります。</string>
     <string name="feedback_form_note_link_wordpress">コミュニティフォーラム。</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">プレースホルダー</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -215,8 +215,6 @@ Language: ko_KR
     <string name="experimental_features_feedback_dialog_title">피드백 공유</string>
     <string name="experimental_block_editor_description">추가 블록 유형 및 설정에 접근</string>
     <string name="experimental_block_editor_note">실험 버전 블록 편집기가 향후 릴리스에서 기본값이 되며 비활성화하는 기능은 제거될 예정입니다.</string>
-    <string name="disable_experimental_block_editor_description">추가 블록 유형 및 설정 수신 거부</string>
-    <string name="disable_experimental_block_editor">실험 버전 블록 편집기 비활성화</string>
     <string name="avatar_update_email_unverified">아바타를 업데이트하려면 먼저 이메일 주소를 확인해야 합니다.</string>
     <string name="feedback_form_note_link_wordpress">커뮤니티 포럼\"을 사용해 주세요.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">플레이스홀더</string>

--- a/WordPress/src/main/res/values-lv/strings.xml
+++ b/WordPress/src/main/res/values-lv/strings.xml
@@ -27,8 +27,6 @@ Language: lv
     <string name="experimental_features_feedback_dialog_title">Kopīgot atsauksmes</string>
     <string name="experimental_block_editor_description">Piekļūstiet papildu bloku veidiem un iestatījumiem</string>
     <string name="experimental_block_editor_note">Eksperimentālais bloku redaktors kļūs par noklusējuma redaktoru nākamajā laidienā, un iespēja to atspējot tiks noņemta.</string>
-    <string name="disable_experimental_block_editor_description">Atteikties no papildu bloķēšanas veidiem un iestatījumiem</string>
-    <string name="disable_experimental_block_editor">Atspējot eksperimentālo bloku redaktoru</string>
     <string name="avatar_update_email_unverified">Lai atjauninātu savu avatāru, vispirms ir jāapstiprina sava e-pasta adrese.</string>
     <string name="feedback_form_note_link_wordpress">kopienas forumos.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">vietturis</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -215,8 +215,6 @@ Language: nl
     <string name="experimental_features_feedback_dialog_title">Feedback delen</string>
     <string name="experimental_block_editor_description">Toegang tot extra bloktypen en instellingen</string>
     <string name="experimental_block_editor_note">De experimentele blok-editor wordt de standaard in een toekomstige release en de mogelijkheid om deze uit te schakelen wordt verwijderd.</string>
-    <string name="disable_experimental_block_editor_description">Afmelden voor extra bloktypen en instellingen</string>
-    <string name="disable_experimental_block_editor">Experimentele blok-editor uitschakelen</string>
     <string name="avatar_update_email_unverified">Om je avatar te updaten, moet je eerst je e-mailadres verifiëren.</string>
     <string name="feedback_form_note_link_wordpress">community forums.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">plaatshouder</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -132,8 +132,6 @@ Language: pl
     <string name="experimental_features_feedback_dialog_title">Podziel się swoją informacją zwrotną</string>
     <string name="experimental_block_editor_description">Uzyskaj dostęp do dodatkowych rodzajów bloków oraz ustawień</string>
     <string name="experimental_block_editor_note">Eksperymentalny edytor bloków stanie się domyślny w przyszłych wydaniach, a funkcjonalność umożliwiająca wyłączenie go będzie usunięta.</string>
-    <string name="disable_experimental_block_editor_description">Zrezygnuj z dodatkowych rodzajów bloków oraz ustawień</string>
-    <string name="disable_experimental_block_editor">Wyłącz eksperymentalny edytor blokowy</string>
     <string name="avatar_update_email_unverified">Aby zaktualizować swój awatar, musisz najpierw zweryfikować swój adres e-mail.</string>
     <string name="feedback_form_note_link_wordpress">fora społecznościowe.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">symbol zastępczy</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -215,8 +215,6 @@ Language: pt_BR
     <string name="experimental_features_feedback_dialog_title">Compartilhar feedback</string>
     <string name="experimental_block_editor_description">Acesse configurações e tipos de bloco adicionais</string>
     <string name="experimental_block_editor_note">O editor de blocos experimental se tornará o padrão em uma versão futura, e a capacidade de desativá-lo será removida.</string>
-    <string name="disable_experimental_block_editor_description">Desative as configurações e tipos de bloco adicionais</string>
-    <string name="disable_experimental_block_editor">Desativar editor de blocos experimental</string>
     <string name="avatar_update_email_unverified">Para atualizar o seu avatar, você precisa confirmar o seu endereço de e-mail primeiro.</string>
     <string name="feedback_form_note_link_wordpress">fóruns da comunidade.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">espaço reservado</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -215,8 +215,6 @@ Language: ro
     <string name="experimental_features_feedback_dialog_title">Împărtășește impresiile</string>
     <string name="experimental_block_editor_description">Ai acces la tipuri de blocuri și setări suplimentare</string>
     <string name="experimental_block_editor_note">Editorul de blocuri experimental va deveni implicit într-o versiune viitoare și posibilitatea de a-l dezactiva va fi înlăturată.</string>
-    <string name="disable_experimental_block_editor_description">Renunță la tipuri de bloc și setările suplimentare</string>
-    <string name="disable_experimental_block_editor">Dezactivează editorul de blocuri experimental</string>
     <string name="avatar_update_email_unverified">Pentru a-ți actualiza avatarul, mai întâi trebuie să-ți confirmi adresa de email.</string>
     <string name="feedback_form_note_link_wordpress">forumuri pentru comunitate.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">substituent</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -215,8 +215,6 @@ Language: ru
     <string name="experimental_features_feedback_dialog_title">Отправить отзыв</string>
     <string name="experimental_block_editor_description">Доступ к дополнительным типам блоков и настройкам</string>
     <string name="experimental_block_editor_note">Экспериментальный редактор блоков станет редактором блоков по умолчанию в следующей версии, и его нельзя будет отключить.</string>
-    <string name="disable_experimental_block_editor_description">Отказаться от дополнительных типов блоков и настроек</string>
-    <string name="disable_experimental_block_editor">Отключить экспериментальный редактор блоков</string>
     <string name="avatar_update_email_unverified">Чтобы обновить аватар, необходимо подтвердить адрес электронной почты.</string>
     <string name="feedback_form_note_link_wordpress">форумы сообщества.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">заполнитель</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -215,8 +215,6 @@ Language: sq_AL
     <string name="experimental_features_feedback_dialog_title">Jepni përshtypje</string>
     <string name="experimental_block_editor_description">Përdorni lloje blloqesh dhe rregullime shtesë</string>
     <string name="experimental_block_editor_note">Përpunuesi eksprerimental me blloqe do të bëhet parazgjedhja, në një hedhje të ardhshme në qarkullim dhe aftësia për ta aktivizuar do të hiqet.</string>
-    <string name="disable_experimental_block_editor_description">Zgjidhni lënien jashtë nga lloje blloqesh dhe rregullime shtesë</string>
-    <string name="disable_experimental_block_editor">Çaktivizo përpunues eksperimental me blloqe</string>
     <string name="avatar_update_email_unverified">Që të përditësoni avatarin tuaj, lypset të verifikohet adresa juaj email së pari.</string>
     <string name="feedback_form_note_link_wordpress">forume bashkësie.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">vendmbajtëse</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -214,8 +214,6 @@ Language: sv_SE
     <string name="experimental_features_feedback_dialog_title">Dela feedback</string>
     <string name="experimental_block_editor_description">Få åtkomst till ytterligare blocktyper och inställningar</string>
     <string name="experimental_block_editor_note">Den experimentella blockredigeraren kommer att bli standard i en framtida version och möjligheten att inaktivera den kommer att tas bort.</string>
-    <string name="disable_experimental_block_editor_description">Tacka nej till ytterligare blocktyper och inställningar</string>
-    <string name="disable_experimental_block_editor">Inaktivera den experimentella blockredigeraren</string>
     <string name="avatar_update_email_unverified">För att uppdatera din profilbild måste du först verifiera din e-postadress.</string>
     <string name="feedback_form_note_link_wordpress">community-forum.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">platshållare</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -215,8 +215,6 @@ Language: tr
     <string name="experimental_features_feedback_dialog_title">Görüşlerinizi paylaşın</string>
     <string name="experimental_block_editor_description">Ek blok türlerine ve ayarlarına erişin</string>
     <string name="experimental_block_editor_note">Deneysel blok düzenleyici gelecekteki bir sürümde varsayılan olacak ve bunu devre dışı bırakma özelliği kaldırılacak.</string>
-    <string name="disable_experimental_block_editor_description">Ek blok türlerini ve ayarlarını devre dışı bırakın</string>
-    <string name="disable_experimental_block_editor">Deneysel blok düzenleyiciyi devre dışı bırakın</string>
     <string name="avatar_update_email_unverified">Avatarınızı güncellemek için öncelikle e-posta adresinizi doğrulamanız gerekir.</string>
     <string name="feedback_form_note_link_wordpress">topluluk forumları.</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">yer tutucu</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -214,8 +214,6 @@ Language: zh_CN
     <string name="experimental_features_feedback_dialog_title">分享反馈</string>
     <string name="experimental_block_editor_description">启用更多区块类型和设置</string>
     <string name="experimental_block_editor_note">实验性区块编辑器将在今后的版本中成为默认设置，并且将无法禁用。</string>
-    <string name="disable_experimental_block_editor_description">停用更多区块类型和设置</string>
-    <string name="disable_experimental_block_editor">禁用实验性区块编辑器</string>
     <string name="avatar_update_email_unverified">要更新您的头像，请先验证您的电子邮件地址。</string>
     <string name="feedback_form_note_link_wordpress">社区论坛。</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">占位符</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -131,8 +131,6 @@ Language: zh_TW
     <string name="experimental_features_feedback_dialog_title">分享意見！</string>
     <string name="experimental_block_editor_description">存取額外的區塊類型和設定</string>
     <string name="experimental_block_editor_note">試用版區塊編輯器將在未來版本中成為預設選項，屆時將無法停用。</string>
-    <string name="disable_experimental_block_editor_description">選擇不啟用額外區塊類型與設定</string>
-    <string name="disable_experimental_block_editor">停用試用版區塊編輯器</string>
     <string name="avatar_update_email_unverified">若想更新大頭貼，請先驗證電子郵件地址。</string>
     <string name="feedback_form_note_link_wordpress">社群論壇。</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">預留位置</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -131,8 +131,6 @@ Language: zh_TW
     <string name="experimental_features_feedback_dialog_title">分享意見！</string>
     <string name="experimental_block_editor_description">存取額外的區塊類型和設定</string>
     <string name="experimental_block_editor_note">試用版區塊編輯器將在未來版本中成為預設選項，屆時將無法停用。</string>
-    <string name="disable_experimental_block_editor_description">選擇不啟用額外區塊類型與設定</string>
-    <string name="disable_experimental_block_editor">停用試用版區塊編輯器</string>
     <string name="avatar_update_email_unverified">若想更新大頭貼，請先驗證電子郵件地址。</string>
     <string name="feedback_form_note_link_wordpress">社群論壇。</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">預留位置</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -57,6 +57,7 @@
     <string name="pref_key_gutenberg_default_for_new_posts" translatable="false">wp_pref_key_gutenberg_default_for_new_posts</string>
     <string name="pref_key_use_theme_styles" translatable="false">wp_pref_key_use_theme_styles</string>
     <string name="pref_key_use_third_party_blocks" translatable="false">wp_pref_key_use_third_party_blocks</string>
+    <string name="pref_key_gutenberg_kit_enabled" translatable="false">wp_pref_key_gutenberg_kit_enabled</string>
     <string name="pref_key_site_video_width" translatable="false">wp_pref_site_default_video_width</string>
     <string name="pref_key_site_video_encoder_bitrate" translatable="false">wp_pref_site_default_encoder_bitrate</string>
     <string name="pref_key_site_discussion" translatable="false">wp_pref_site_discussion</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -712,7 +712,7 @@
 
     <!-- GutenbergKit announcement -->
     <string name="gutenberg_kit_announcement_title">A better block editor is coming</string>
-    <string name="gutenberg_kit_announcement_body">The next-generation block editor is ready, and it brings more new features.\n\nStarting in June 2026, it will become the default editor for everyone. %1$s</string>
+    <string name="gutenberg_kit_announcement_body">The next-generation block editor is ready, and it brings more new features.\n\nBy the end of June 2026, it will become the default editor for everyone. %1$s</string>
     <string name="gutenberg_kit_announcement_activate">Activate</string>
     <string name="gutenberg_kit_announcement_maybe_later">Maybe later</string>
     <string name="gutenberg_kit_announcement_learn_more">Learn more</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -981,8 +981,6 @@
 
     <!-- Experimental Features -->
     <string name="experimental_features_screen_title">Experimental Features</string>
-    <string name="disable_experimental_block_editor">Disable experimental block editor</string>
-    <string name="disable_experimental_block_editor_description">Opt out of additional block types and settings</string>
     <string name="experimental_block_editor_note">Experimental block editor will become the default in a future release and the ability to disable it will be removed.</string>
     <string name="experimental_block_editor">Experimental block editor</string>
     <string name="experimental_block_editor_description">Access additional block types and settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -706,6 +706,17 @@
     <string name="site_settings_use_third_party_blocks_summary">Load third-party blocks from plugins installed on your site.</string>
     <string name="site_settings_use_third_party_blocks_unsupported">Your site doesn\'t support loading third-party blocks in the editor.</string>
     <string name="site_connectivity_banner_text">Unable to connect to your site. Some functionality might be limited.</string>
+    <string name="site_settings_gutenberg_kit_enabled">Try the new editor</string>
+    <string name="site_settings_gutenberg_kit_enabled_summary">Opt in to the next-generation block editor for this site</string>
+    <string name="site_settings_gutenberg_kit_enabled_unsupported">Switch to the block editor first to try the new editor.</string>
+
+    <!-- GutenbergKit announcement -->
+    <string name="gutenberg_kit_announcement_title">A better block editor is coming</string>
+    <string name="gutenberg_kit_announcement_body">The next-generation block editor is ready, and it brings more new features.\n\nStarting in June 2026, it will become the default editor for everyone. %1$s</string>
+    <string name="gutenberg_kit_announcement_activate">Activate</string>
+    <string name="gutenberg_kit_announcement_maybe_later">Maybe later</string>
+    <string name="gutenberg_kit_announcement_learn_more">Learn more</string>
+    <string name="gutenberg_kit_learn_more_url" translatable="false">https://wordpress.com/support/editors/</string>
     <string name="site_settings_password_updated">Password updated</string>
     <string name="site_settings_update_password_message">To reconnect the app to your self-hosted site, enter the site\'s new password here.</string>
     <string name="site_settings_homepage_settings">Homepage Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -712,7 +712,8 @@
 
     <!-- GutenbergKit announcement -->
     <string name="gutenberg_kit_announcement_title">A better block editor is coming</string>
-    <string name="gutenberg_kit_announcement_body">The next-generation block editor is ready, and it brings more new features.\n\nBy the end of June 2026, it will become the default editor for everyone. %1$s</string>
+    <string name="gutenberg_kit_announcement_body_intro">The next-generation block editor is ready, and it brings more new features.</string>
+    <string name="gutenberg_kit_announcement_body_deadline">By the end of June 2026, it will become the default editor for everyone. %1$s</string>
     <string name="gutenberg_kit_announcement_activate">Activate</string>
     <string name="gutenberg_kit_announcement_maybe_later">Maybe later</string>
     <string name="gutenberg_kit_announcement_learn_more">Learn more</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -144,6 +144,12 @@
             android:summary="@string/site_settings_use_third_party_blocks_summary"
             android:title="@string/site_settings_use_third_party_blocks" />
 
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_gutenberg_kit_enabled"
+            android:key="@string/pref_key_gutenberg_kit_enabled"
+            android:summary="@string/site_settings_gutenberg_kit_enabled_summary"
+            android:title="@string/site_settings_gutenberg_kit_enabled" />
+
     </PreferenceCategory>
 
     <!-- Writing Settings -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -107,6 +107,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var siteConnectivityBannerViewModelSlice: SiteConnectivityBannerViewModelSlice
 
+    @Mock
+    lateinit var gutenbergKitAnnouncementController:
+            org.wordpress.android.ui.posts.GutenbergKitAnnouncementController
+
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<MySiteViewModel.State>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -164,6 +168,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             siteCapabilityChecker,
             gutenbergEditorPreloader,
             siteConnectivityBannerViewModelSlice,
+            gutenbergKitAnnouncementController,
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()
@@ -416,6 +421,36 @@ class MySiteViewModelTest : BaseUnitTest() {
             org.mockito.kotlin.eq(siteTest),
             org.mockito.kotlin.any()
         )
+    }
+
+    /* GUTENBERGKIT ANNOUNCEMENT */
+
+    @Test
+    fun `onResume posts gutenberg kit announcement event when controller says show`() = test {
+        initSelectedSite()
+        whenever(gutenbergKitAnnouncementController.shouldShowAnnouncement(siteTest)).thenReturn(true)
+        val observed = mutableListOf<SiteModel>()
+        viewModel.onShowGutenbergKitAnnouncement.observeForever { event ->
+            event?.getContentIfNotHandled()?.let { observed.add(it) }
+        }
+
+        viewModel.onResume()
+
+        assertThat(observed).containsExactly(siteTest)
+    }
+
+    @Test
+    fun `onResume does not post gutenberg kit announcement event when controller says skip`() = test {
+        initSelectedSite()
+        whenever(gutenbergKitAnnouncementController.shouldShowAnnouncement(siteTest)).thenReturn(false)
+        val observed = mutableListOf<SiteModel>()
+        viewModel.onShowGutenbergKitAnnouncement.observeForever { event ->
+            event?.getContentIfNotHandled()?.let { observed.add(it) }
+        }
+
+        viewModel.onResume()
+
+        assertThat(observed).isEmpty()
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorCapabilityResolverTest.kt
@@ -43,7 +43,7 @@ class EditorCapabilityResolverTest {
         )
         // Defaults that let resolution reach `Available` unless
         // a test overrides them.
-        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(true)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(any())).thenReturn(true)
         whenever(gutenbergKitPluginsFeature.isEnabled()).thenReturn(true)
         whenever(editorSettingsRepository.getSupportsEditorAssetsForSite(any())).thenReturn(true)
         whenever(editorSettingsRepository.getSupportsEditorSettingsForSite(any())).thenReturn(true)
@@ -54,11 +54,22 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `third-party blocks hidden when GutenbergKit disabled`() {
-        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(any())).thenReturn(false)
 
         val result = resolver.resolveThirdPartyBlocks(site)
 
         assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
+    }
+
+    @Test
+    fun `third-party blocks consult per-site GutenbergKit override`() {
+        val otherSite = SiteModel().apply { url = "https://other.example.com" }
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(site)).thenReturn(true)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(otherSite)).thenReturn(false)
+
+        assertThat(resolver.resolveThirdPartyBlocks(site))
+            .isInstanceOf(EditorCapabilityState.Available::class.java)
+        assertThat(resolver.resolveThirdPartyBlocks(otherSite)).isEqualTo(EditorCapabilityState.Hidden)
     }
 
     @Test
@@ -72,7 +83,7 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `third-party blocks hidden when both feature flags disabled`() {
-        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(any())).thenReturn(false)
         // lenient(): the resolver short-circuits on the GutenbergKit flag, so the plugins
         // stub is never read — strict mocking would treat that as a smell.
         lenient().`when`(gutenbergKitPluginsFeature.isEnabled()).thenReturn(false)
@@ -139,11 +150,22 @@ class EditorCapabilityResolverTest {
 
     @Test
     fun `theme styles hidden when GutenbergKit disabled`() {
-        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled()).thenReturn(false)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(any())).thenReturn(false)
 
         val result = resolver.resolveThemeStyles(site)
 
         assertThat(result).isEqualTo(EditorCapabilityState.Hidden)
+    }
+
+    @Test
+    fun `theme styles consult per-site GutenbergKit override`() {
+        val otherSite = SiteModel().apply { url = "https://other.example.com" }
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(site)).thenReturn(true)
+        whenever(gutenbergKitFeatureChecker.isGutenbergKitEnabled(otherSite)).thenReturn(false)
+
+        assertThat(resolver.resolveThemeStyles(site))
+            .isInstanceOf(EditorCapabilityState.Available::class.java)
+        assertThat(resolver.resolveThemeStyles(otherSite)).isEqualTo(EditorCapabilityState.Hidden)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementControllerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementControllerTest.kt
@@ -1,0 +1,132 @@
+package org.wordpress.android.ui.posts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.datasets.SiteSettingsProvider
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+@RunWith(MockitoJUnitRunner::class)
+class GutenbergKitAnnouncementControllerTest {
+    @Mock private lateinit var featureChecker: GutenbergKitFeatureChecker
+    @Mock private lateinit var siteSettingsProvider: SiteSettingsProvider
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    private val now = Instant.parse("2026-05-25T12:00:00Z")
+    private val clock = Clock.fixed(now, ZoneId.of("UTC"))
+    private val site = SiteModel().apply { url = SITE_URL }
+
+    private lateinit var controller: GutenbergKitAnnouncementController
+
+    @Before
+    fun setUp() {
+        controller = GutenbergKitAnnouncementController(
+            featureChecker, siteSettingsProvider, appPrefsWrapper, clock
+        )
+        // Defaults that let shouldShowAnnouncement reach `true` unless a test overrides them.
+        whenever(featureChecker.isGutenbergKitRemoteFeatureEnabled()).thenReturn(true)
+        whenever(siteSettingsProvider.isBlockEditorDefault(site)).thenReturn(true)
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride(SITE_URL)).thenReturn(null)
+        whenever(appPrefsWrapper.getGutenbergKitAnnouncementDeferredUntil(SITE_URL)).thenReturn(0L)
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is true when all gates pass`() {
+        assertThat(controller.shouldShowAnnouncement(site)).isTrue()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when site URL is empty`() {
+        val emptyUrlSite = SiteModel().apply { url = "" }
+        assertThat(controller.shouldShowAnnouncement(emptyUrlSite)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when site URL is null`() {
+        val nullUrlSite = SiteModel()
+        assertThat(controller.shouldShowAnnouncement(nullUrlSite)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when remote flag is off`() {
+        whenever(featureChecker.isGutenbergKitRemoteFeatureEnabled()).thenReturn(false)
+        assertThat(controller.shouldShowAnnouncement(site)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when site does not default to block editor`() {
+        whenever(siteSettingsProvider.isBlockEditorDefault(site)).thenReturn(false)
+        assertThat(controller.shouldShowAnnouncement(site)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when site has already opted in`() {
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride(SITE_URL)).thenReturn(true)
+        assertThat(controller.shouldShowAnnouncement(site)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false when site has already opted out`() {
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride(SITE_URL)).thenReturn(false)
+        assertThat(controller.shouldShowAnnouncement(site)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is false while deferral is still in the future`() {
+        whenever(appPrefsWrapper.getGutenbergKitAnnouncementDeferredUntil(SITE_URL))
+            .thenReturn(now.toEpochMilli() + 1)
+        assertThat(controller.shouldShowAnnouncement(site)).isFalse()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is true once deferral has expired`() {
+        whenever(appPrefsWrapper.getGutenbergKitAnnouncementDeferredUntil(SITE_URL))
+            .thenReturn(now.toEpochMilli() - 1)
+        assertThat(controller.shouldShowAnnouncement(site)).isTrue()
+    }
+
+    @Test
+    fun `shouldShowAnnouncement is true when deferral equals current clock`() {
+        whenever(appPrefsWrapper.getGutenbergKitAnnouncementDeferredUntil(SITE_URL))
+            .thenReturn(now.toEpochMilli())
+        assertThat(controller.shouldShowAnnouncement(site)).isTrue()
+    }
+
+    @Test
+    fun `onActivate writes a positive per-site override and clears any deferral`() {
+        controller.onActivate(site)
+        verify(appPrefsWrapper).setGutenbergKitSiteOverride(SITE_URL, true)
+        verify(appPrefsWrapper).setGutenbergKitAnnouncementDeferredUntil(SITE_URL, 0L)
+    }
+
+    @Test
+    fun `setOverride with false writes opt-out and clears any deferral`() {
+        controller.setOverride(site, false)
+        verify(appPrefsWrapper).setGutenbergKitSiteOverride(SITE_URL, false)
+        verify(appPrefsWrapper).setGutenbergKitAnnouncementDeferredUntil(SITE_URL, 0L)
+    }
+
+    @Test
+    fun `onMaybeLater defers for one week from now and does not write an override`() {
+        controller.onMaybeLater(site)
+        val expected = now.toEpochMilli() + GutenbergKitAnnouncementController.DEFER_DURATION_MILLIS
+        verify(appPrefsWrapper).setGutenbergKitAnnouncementDeferredUntil(SITE_URL, expected)
+        verify(appPrefsWrapper, never()).setGutenbergKitSiteOverride(eq(SITE_URL), any())
+    }
+
+    companion object {
+        private const val SITE_URL = "https://example.com"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.config.GutenbergKitFeature
@@ -19,11 +21,14 @@ class GutenbergKitFeatureCheckerTest {
     @Mock
     private lateinit var gutenbergKitFeature: GutenbergKitFeature
 
+    @Mock
+    private lateinit var appPrefsWrapper: AppPrefsWrapper
+
     private lateinit var featureChecker: GutenbergKitFeatureChecker
 
     @Before
     fun setUp() {
-        featureChecker = GutenbergKitFeatureChecker(experimentalFeatures, gutenbergKitFeature)
+        featureChecker = GutenbergKitFeatureChecker(experimentalFeatures, gutenbergKitFeature, appPrefsWrapper)
     }
 
     // Helper method to setup mock behavior
@@ -106,7 +111,9 @@ class GutenbergKitFeatureCheckerTest {
     }
 
     @Test
-    fun `isGutenbergKitEnabled returns true when GutenbergKit feature is enabled`() {
+    fun `remote feature flag alone does not enable GutenbergKit for editor routing`() {
+        // The remote `gutenberg_kit` flag only gates the announcement and Site Settings toggle
+        // visibility. Editor routing requires either the experimental flag or a per-site opt-in.
         setupFeatureFlags(
             experimentalBlockEditor = false,
             gutenbergKitEnabled = true,
@@ -115,11 +122,11 @@ class GutenbergKitFeatureCheckerTest {
 
         val result = featureChecker.isGutenbergKitEnabled()
 
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
     }
 
     @Test
-    fun `isGutenbergKitEnabled returns true when both experimental and GutenbergKit features are enabled`() {
+    fun `isGutenbergKitEnabled returns true when experimental flag is on regardless of remote flag`() {
         setupFeatureFlags(
             experimentalBlockEditor = true,
             gutenbergKitEnabled = true,
@@ -232,28 +239,118 @@ class GutenbergKitFeatureCheckerTest {
     }
 
     @Test
-    fun `feature is enabled when at least one enabling flag is true and disable flag is false`() {
-        val enabledTestCases = listOf(
-            Triple(true, false, false),   // Only experimental
-            Triple(false, true, false),   // Only GutenbergKit
-            Triple(true, true, false)     // Both enabled
+    fun `per-site opt-in enables GutenbergKit when no other flag is set`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isTrue()
+    }
+
+    @Test
+    fun `remote feature flag on with no override does not enable for a site`() {
+        // Editor routing only: announcement visibility is checked via
+        // `isGutenbergKitRemoteFeatureEnabled()` separately.
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = false
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(null)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isFalse()
+    }
+
+    @Test
+    fun `per-site opt-out wins over experimental flag`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = true,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(false)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isFalse()
+    }
+
+    @Test
+    fun `per-site opt-in wins when remote and experimental flags are off`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = false
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isTrue()
+    }
+
+    @Test
+    fun `per-site opt-in wins when remote flag is on`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = true,
+            disableExperimentalBlockEditor = false
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isTrue()
+    }
+
+    @Test
+    fun `disable flag overrides per-site opt-in`() {
+        setupFeatureFlags(
+            experimentalBlockEditor = false,
+            gutenbergKitEnabled = false,
+            disableExperimentalBlockEditor = true
+        )
+        val site = SiteModel().apply { url = "https://example.com" }
+        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
+
+        assertThat(featureChecker.isGutenbergKitEnabled(site)).isFalse()
+    }
+
+    @Test
+    fun `editor routing is enabled only by experimental flag or per-site opt-in`() {
+        // The remote `gutenberg_kit` flag is intentionally NOT an editor-routing input — it only
+        // gates announcement visibility. Editor routing requires experimental OR per-site opt-in.
+        data class Case(
+            val experimental: Boolean,
+            val gutenbergKitRemote: Boolean,
+            val siteOverride: Boolean?,
+            val expected: Boolean,
+        )
+        val cases = listOf(
+            Case(experimental = true, gutenbergKitRemote = false, siteOverride = null, expected = true),
+            Case(experimental = true, gutenbergKitRemote = true, siteOverride = null, expected = true),
+            Case(experimental = false, gutenbergKitRemote = true, siteOverride = null, expected = false),
+            Case(experimental = false, gutenbergKitRemote = false, siteOverride = true, expected = true),
+            Case(experimental = false, gutenbergKitRemote = true, siteOverride = true, expected = true),
+            Case(experimental = true, gutenbergKitRemote = true, siteOverride = false, expected = false),
+            Case(experimental = false, gutenbergKitRemote = false, siteOverride = null, expected = false),
         )
 
-        enabledTestCases.forEach { (experimental, gutenbergKit, disable) ->
+        cases.forEach { case ->
             setupFeatureFlags(
-                experimentalBlockEditor = experimental,
-                gutenbergKitEnabled = gutenbergKit,
-                disableExperimentalBlockEditor = disable
+                experimentalBlockEditor = case.experimental,
+                gutenbergKitEnabled = case.gutenbergKitRemote,
+                disableExperimentalBlockEditor = false
             )
+            val site = SiteModel().apply { url = "https://example.com" }
+            whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com"))
+                .thenReturn(case.siteOverride)
 
-            val result = featureChecker.isGutenbergKitEnabled()
-
-            assertThat(result)
-                .withFailMessage(
-                    "Should be true when at least one enabling flag is true " +
-                            "(experimental=$experimental, gutenbergKit=$gutenbergKit)"
-                )
-                .isTrue()
+            assertThat(featureChecker.isGutenbergKitEnabled(site))
+                .withFailMessage("Case $case")
+                .isEqualTo(case.expected)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitFeatureCheckerTest.kt
@@ -31,220 +31,76 @@ class GutenbergKitFeatureCheckerTest {
         featureChecker = GutenbergKitFeatureChecker(experimentalFeatures, gutenbergKitFeature, appPrefsWrapper)
     }
 
-    // Helper method to setup mock behavior
     private fun setupFeatureFlags(
         experimentalBlockEditor: Boolean = false,
         gutenbergKitEnabled: Boolean = false,
-        disableExperimentalBlockEditor: Boolean = false
     ) {
         whenever(experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR))
             .thenReturn(experimentalBlockEditor)
         whenever(gutenbergKitFeature.isEnabled()).thenReturn(gutenbergKitEnabled)
-        whenever(experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR))
-            .thenReturn(disableExperimentalBlockEditor)
     }
 
     // ===== Feature State Tests =====
 
     @Test
     fun `getFeatureState returns correct individual flag values when all flags are false`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = false)
 
         val featureState = featureChecker.getFeatureState()
 
         assertThat(featureState.isExperimentalBlockEditorEnabled).isFalse()
         assertThat(featureState.isGutenbergKitFeatureEnabled).isFalse()
-        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isFalse()
-        assertThat(featureState.isGutenbergKitEnabled).isFalse()
-    }
-
-    @Test
-    fun `getFeatureState returns correct individual flag values when all flags are true`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = true
-        )
-
-        val featureState = featureChecker.getFeatureState()
-
-        assertThat(featureState.isExperimentalBlockEditorEnabled).isTrue()
-        assertThat(featureState.isGutenbergKitFeatureEnabled).isTrue()
-        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isTrue()
-        // Should be false because disable flag overrides
         assertThat(featureState.isGutenbergKitEnabled).isFalse()
     }
 
     @Test
     fun `getFeatureState returns correct values for mixed flag states`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = true, gutenbergKitEnabled = false)
 
         val featureState = featureChecker.getFeatureState()
 
         assertThat(featureState.isExperimentalBlockEditorEnabled).isTrue()
         assertThat(featureState.isGutenbergKitFeatureEnabled).isFalse()
-        assertThat(featureState.isDisableExperimentalBlockEditorEnabled).isFalse()
         assertThat(featureState.isGutenbergKitEnabled).isTrue()
     }
 
-    // ===== GutenbergKit Enabled Logic Tests =====
+    // ===== Editor-routing Logic Tests =====
 
     @Test
     fun `isGutenbergKitEnabled returns true when experimental block editor is enabled`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = true, gutenbergKitEnabled = false)
 
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isTrue()
+        assertThat(featureChecker.isGutenbergKitEnabled()).isTrue()
     }
 
     @Test
     fun `remote feature flag alone does not enable GutenbergKit for editor routing`() {
         // The remote `gutenberg_kit` flag only gates the announcement and Site Settings toggle
         // visibility. Editor routing requires either the experimental flag or a per-site opt-in.
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = true)
 
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isFalse()
+        assertThat(featureChecker.isGutenbergKitEnabled()).isFalse()
     }
 
     @Test
     fun `isGutenbergKitEnabled returns true when experimental flag is on regardless of remote flag`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = true, gutenbergKitEnabled = true)
 
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isTrue()
+        assertThat(featureChecker.isGutenbergKitEnabled()).isTrue()
     }
 
     @Test
     fun `isGutenbergKitEnabled returns false when all flags are disabled`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = false)
 
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isFalse()
+        assertThat(featureChecker.isGutenbergKitEnabled()).isFalse()
     }
 
-    @Test
-    fun `isGutenbergKitEnabled returns false when disable flag is enabled regardless of other flags`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = true
-        )
-
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `isGutenbergKitEnabled returns false when only disable flag is enabled`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = true
-        )
-
-        val result = featureChecker.isGutenbergKitEnabled()
-
-        assertThat(result).isFalse()
-    }
-
-    // ===== Edge Cases and Consistency Tests =====
-
-    @Test
-    fun `isGutenbergKitEnabled matches getFeatureState isGutenbergKitEnabled for all combinations`() {
-        val testCases = listOf(
-            Triple(false, false, false),
-            Triple(false, false, true),
-            Triple(false, true, false),
-            Triple(false, true, true),
-            Triple(true, false, false),
-            Triple(true, false, true),
-            Triple(true, true, false),
-            Triple(true, true, true)
-        )
-
-        testCases.forEach { (experimental, gutenbergKit, disable) ->
-            setupFeatureFlags(
-                experimentalBlockEditor = experimental,
-                gutenbergKitEnabled = gutenbergKit,
-                disableExperimentalBlockEditor = disable
-            )
-
-            val directResult = featureChecker.isGutenbergKitEnabled()
-            val stateResult = featureChecker.getFeatureState().isGutenbergKitEnabled
-
-            assertThat(directResult)
-                .withFailMessage(
-                    "Results should match for flags: experimental=$experimental, " +
-                            "gutenbergKit=$gutenbergKit, disable=$disable"
-                )
-                .isEqualTo(stateResult)
-        }
-    }
-
-    @Test
-    fun `disable flag always overrides other settings`() {
-        val testCases = listOf(
-            Triple(false, false, true),  // Only disable flag
-            Triple(false, true, true),   // GutenbergKit + disable
-            Triple(true, false, true),   // Experimental + disable
-            Triple(true, true, true)     // All flags on
-        )
-
-        testCases.forEach { (experimental, gutenbergKit, disable) ->
-            setupFeatureFlags(
-                experimentalBlockEditor = experimental,
-                gutenbergKitEnabled = gutenbergKit,
-                disableExperimentalBlockEditor = disable
-            )
-
-            val result = featureChecker.isGutenbergKitEnabled()
-
-            assertThat(result)
-                .withFailMessage(
-                    "Should be false when disable flag is true " +
-                            "(experimental=$experimental, gutenbergKit=$gutenbergKit)"
-                )
-                .isFalse()
-        }
-    }
+    // ===== Per-site Override Tests =====
 
     @Test
     fun `per-site opt-in enables GutenbergKit when no other flag is set`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = false)
         val site = SiteModel().apply { url = "https://example.com" }
         whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
 
@@ -255,11 +111,7 @@ class GutenbergKitFeatureCheckerTest {
     fun `remote feature flag on with no override does not enable for a site`() {
         // Editor routing only: announcement visibility is checked via
         // `isGutenbergKitRemoteFeatureEnabled()` separately.
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = true)
         val site = SiteModel().apply { url = "https://example.com" }
         whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(null)
 
@@ -268,11 +120,7 @@ class GutenbergKitFeatureCheckerTest {
 
     @Test
     fun `per-site opt-out wins over experimental flag`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = true,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = true, gutenbergKitEnabled = false)
         val site = SiteModel().apply { url = "https://example.com" }
         whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(false)
 
@@ -281,11 +129,7 @@ class GutenbergKitFeatureCheckerTest {
 
     @Test
     fun `per-site opt-in wins when remote and experimental flags are off`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = false)
         val site = SiteModel().apply { url = "https://example.com" }
         whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
 
@@ -294,28 +138,11 @@ class GutenbergKitFeatureCheckerTest {
 
     @Test
     fun `per-site opt-in wins when remote flag is on`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = true,
-            disableExperimentalBlockEditor = false
-        )
+        setupFeatureFlags(experimentalBlockEditor = false, gutenbergKitEnabled = true)
         val site = SiteModel().apply { url = "https://example.com" }
         whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
 
         assertThat(featureChecker.isGutenbergKitEnabled(site)).isTrue()
-    }
-
-    @Test
-    fun `disable flag overrides per-site opt-in`() {
-        setupFeatureFlags(
-            experimentalBlockEditor = false,
-            gutenbergKitEnabled = false,
-            disableExperimentalBlockEditor = true
-        )
-        val site = SiteModel().apply { url = "https://example.com" }
-        whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com")).thenReturn(true)
-
-        assertThat(featureChecker.isGutenbergKitEnabled(site)).isFalse()
     }
 
     @Test
@@ -342,7 +169,6 @@ class GutenbergKitFeatureCheckerTest {
             setupFeatureFlags(
                 experimentalBlockEditor = case.experimental,
                 gutenbergKitEnabled = case.gutenbergKitRemote,
-                disableExperimentalBlockEditor = false
             )
             val site = SiteModel().apply { url = "https://example.com" }
             whenever(appPrefsWrapper.getGutenbergKitSiteOverride("https://example.com"))

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
@@ -14,15 +14,11 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.config.GutenbergKitFeature
 
 @ExperimentalCoroutinesApi
 class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     @Mock
     private lateinit var experimentalFeatures: ExperimentalFeatures
-
-    @Mock
-    private lateinit var gutenbergKitFeature: GutenbergKitFeature
 
     @Mock
     private lateinit var appLogWrapper: AppLogWrapper
@@ -38,31 +34,15 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() {
         whenever(experimentalFeatures.isEnabled(any())).thenReturn(false)
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
     }
 
     @Test
-    fun `init shows disable block editor when gutenberg kit is enabled`() = test {
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(true)
-
-        createViewModel()
-
-        val states = viewModel.switchStates.value
-
-        assertThat(states).containsKey(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        assertThat(states).doesNotContainKey(Feature.EXPERIMENTAL_BLOCK_EDITOR)
-    }
-
-    @Test
-    fun `init shows experimental block editor when gutenberg kit is disabled`() = test {
-        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
-
+    fun `init shows experimental block editor feature`() = test {
         createViewModel()
 
         val states = viewModel.switchStates.value
 
         assertThat(states).containsKey(Feature.EXPERIMENTAL_BLOCK_EDITOR)
-        assertThat(states).doesNotContainKey(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
     }
 
     @Test
@@ -133,7 +113,6 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     private fun createViewModel() {
         viewModel = ExperimentalFeaturesViewModel(
             experimentalFeatures = experimentalFeatures,
-            gutenbergKitFeature = gutenbergKitFeature,
             appLogWrapper = appLogWrapper,
             appPrefsWrapper = appPrefsWrapper,
             analyticsTrackerWrapper = analyticsTrackerWrapper


### PR DESCRIPTION
Adds a per-site GutenbergKit opt-in surfaced as a one-time bottom sheet on the My Site screen, with a matching toggle in Site Settings. The remote `gutenberg_kit` flag only gates the announcement / Settings toggle visibility — it is deliberately not part of editor routing.

| Light | Dark |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/56c2db66-ceb4-4178-9cde-cd2e9d45c3ea" alt="Announcement sheet, light mode" width="320" /> | <img src="https://github.com/user-attachments/assets/8d81697c-03f1-4d7f-a01d-624194e4537a" alt="Announcement sheet, dark mode" width="320" /> |


## Summary

- Show / defer / activate decisions live in **`GutenbergKitAnnouncementController`** — pure logic, unit-tested via an injected `java.time.Clock`.
- The per-site override is the single source of truth: presence (either direction) means the user has decided for that site; absence means we may prompt. No global opt-in flag, no separate "shown" flag.
- **Maybe later** writes a per-site `GUTENBERG_KIT_ANNOUNCEMENT_DEFERRED_UNTIL_<url>` 7 days out instead of locking in an opt-out. Swipe / back / tap-outside is treated as an implicit Maybe later so the sheet doesn't re-prompt on every My Site resume.
- Editor routing in **`GutenbergKitFeatureChecker`** is `siteOverride ?: isExperimentalBlockEditorEnabled`. The remote `gutenberg_kit` feature flag is **intentionally not** in this expression — it only gates announcement / Settings toggle visibility. This lets us roll the announcement to a percentage of users without simultaneously flipping the default editor. When we're ready to make GutenbergKit the default for everyone, the change is a one-line edit (hard-code the fallback to `true`).
- Site Settings **Try the new editor** toggle: visible while the remote flag is on; checked state mirrors `GutenbergKitFeatureChecker.isGutenbergKitEnabled(site)` so it always reflects what the editor will actually do; on Aztec-default sites the row is shown disabled with an explanatory summary so users can still discover the option without a silent bundle-flip of `mobileEditor`.
- The legacy **"Disable experimental block editor"** kill switch in Settings → Experimental Features is removed — it was confusingly named, easy to misclick, and now redundant since GBKit is no longer default-on. Users who want to opt out either flip the per-site toggle in Site Settings or turn off the experimental block editor toggle.

## Changes

- **`GutenbergKitAnnouncementController.kt`** (new): `shouldShowAnnouncement(site)`, `onActivate(site)`, `setOverride(site, enabled)`, `onMaybeLater(site)`. `setOverride` always clears any deferral, so "explicit decision supersedes a pending defer" lives in one place.
- **`GutenbergKitFeatureChecker.kt`**: editor-routing resolution simplified to `siteOverride ?: isExperimentalBlockEditorEnabled`. The remote flag is no longer part of the resolution. `isDisableExperimentalBlockEditorEnabled` is removed from `FeatureState` along with the `DISABLE_EXPERIMENTAL_BLOCK_EDITOR` experimental flag itself.
- **`ExperimentalFeatures.kt` / `ExperimentalFeaturesViewModel.kt`**: drops the `DISABLE_EXPERIMENTAL_BLOCK_EDITOR` enum entry, its show-gating, and the now-unused `GutenbergKitFeature` constructor injection. The two associated strings (`disable_experimental_block_editor`, `disable_experimental_block_editor_description`) are removed from `values/strings.xml` — translated copies will fall off via the translation pipeline.
- **`MySiteViewModel.kt` / `MySiteFragment.kt`**: announcement check moved to My Site `onResume()`. Posts `_onShowGutenbergKitAnnouncement: SingleLiveEvent<Event<SiteModel>>`. Fragment observer guards with `isStateSaved` and an already-attached-instance check before `.show()`.
- **`GutenbergKitAnnouncementBottomSheetFragment.kt`** + **`GutenbergKitAnnouncementScreen.kt`** (new): Compose-based bottom sheet. `@AndroidEntryPoint` fragment hosts a `ComposeView` and forwards Activate / Maybe later / dismiss-without-decision through the controller. The screen wraps content height (so it grows with accessibility text scaling) and uses the existing `WordPress.BottomSheetDialogTheme.NonTranslucent` theme + `BottomSheetBehavior.STATE_EXPANDED` so the sheet opens at content height without status-bar-inset padding. "Learn more" is a `LinkAnnotation.Clickable` inside an `AnnotatedString` built from a `%1$s` placeholder, so translators can position the link anywhere in the body.
- **`SiteSettingsFragment.java`**: new `mGutenbergKitPref` row. `refreshGutenbergKitToggleAvailability()` is called from both `initPreferences()` and `setPreferencesFromSiteSettings()`, so flipping "Use block editor as default for new posts" on the same screen re-enables the GBKit row without leaving Settings. Toggle writes go through `mGutenbergKitAnnouncementController.setOverride(...)`.
- **`AppPrefs.java`**: `GUTENBERG_KIT_OPT_IN_SITES` / `OPT_OUT_SITES` (deletable `StringSet`s) and per-site `GUTENBERG_KIT_ANNOUNCEMENT_DEFERRED_UNTIL_<url>` longs. The previous draft's `GUTENBERG_KIT_USER_OPT_IN` and `GUTENBERG_KIT_ANNOUNCEMENT_SHOWN` undeletable flags are removed — there's no longer any state that should survive logout.
- **`EditorLauncher.kt`**: `logFeatureDisabledReason` and `getFeatureFlagsString` updated for the simplified resolution.
- **`EditorCapabilityResolver.kt`**: passes `site` through the GBKit gate so Theme Styles and Third-Party Blocks resolve against the same per-site view the launcher uses.
- **`RELEASE-NOTES.txt`**: entry under 26.8.

## Notes

- The **"Learn more"** link currently points at `https://wordpress.com/support/editors/` — a generic support page. The real GutenbergKit-specific support URL will land in a follow-up PR once the article is published; the string key (`gutenberg_kit_learn_more_url`) is in place so the swap is a one-line resource change.

## Test plan

- [ ] Fresh install, remote flag on (or experimental feature enabled to simulate it), site uses block editor:
  - [ ] Open the app → My Site → announcement appears.
  - [ ] Tap **Activate** → sheet dismisses → creating a new post on that site opens GutenbergKit. Returning to My Site, the sheet does **not** reappear.
  - [ ] Tap **Maybe later** (on a different site) → sheet dismisses → does **not** reappear within the 7-day window. You could force reappearance after expiry by shortening `DEFER_DURATION_MILLIS` locally (or jumping the device clock), but not required.
  - [ ] Swipe down / tap outside / back-button dismiss behaves the same as **Maybe later** (no reappearance for 7 days).
- [ ] Remote flag on (or experimental feature enabled to simulate it), site opted out of the block editor:
  - [ ] Creating a new post opens **Aztec / legacy editor**, not GutenbergKit. (Verifies the remote flag no longer gates editor routing.)
- [ ] Site Settings **Try the new editor** toggle:
  - [ ] Toggle ON → that site opens GutenbergKit; other sites are unaffected.
  - [ ] Toggle OFF after opting in → that site opens Aztec.
  - [ ] After **Maybe later** on the sheet, toggling the Site Settings switch (either direction) clears the deferral.
- [ ] Remote flag off:
  - [ ] Announcement does not appear.
  - [ ] "Try the new editor" row is hidden in Site Settings.
- [ ] Settings → Experimental Features no longer contains a "Disable experimental block editor" row.
- [ ] Accessibility text scaling (Settings → Display & Touch → Font size → Largest): re-open the sheet → the layout grows to fit the larger text without clipping.
- [ ] Configuration change: rotate the device while the sheet is open → sheet recreates without writing a deferral.
- [x] Unit tests: `GutenbergKitAnnouncementControllerTest`, `GutenbergKitFeatureCheckerTest`, `EditorCapabilityResolverTest`, `MySiteViewModelTest`, `ExperimentalFeaturesViewModelTest` pass.


