### PR TITLE
Fix foreground service timeout for dataSync upload service

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -3,10 +3,12 @@ package org.wordpress.android.ui.uploads;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -176,6 +178,24 @@ public class UploadService extends Service {
         super.onTimeout(startId);
         stopSelf(startId);
         AppLog.i(T.MAIN, "UploadService > timed out");
+    }
+
+    // Android 15+ enforces a 6-hour-per-24h cap on dataSync foreground services. The system calls
+    // this two-arg overload before throwing ForegroundServiceDidNotStopInTimeException; we have a
+    // few seconds to stop. Cancel in-flight uploads eagerly so onDestroy() finishes within budget.
+    @Override
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    public void onTimeout(int startId, int fgsType) {
+        super.onTimeout(startId, fgsType);
+        AppLog.w(T.MAIN, "UploadService > foreground service timeout reached (type=" + fgsType
+                         + "); stopping service");
+        if (mMediaUploadHandler != null) {
+            mMediaUploadHandler.cancelInProgressUploads();
+        }
+        if (mPostUploadHandler != null) {
+            mPostUploadHandler.cancelInProgressUploads();
+        }
+        stopSelf(startId);
     }
 
     private void unpackMediaIntent(@NonNull Intent intent) {


### PR DESCRIPTION
## Description

Closes #21730.

This is one of our most prevalent issues in Sentry. We attempted to resolve this in #21732 but our fix didn't work because our solution was to override `onTimeout(int)` instead of `onTimeout(int, int)` (API 35+).

`UploadService` is declared with `android:foregroundServiceType="dataSync"`. Android 15 (API 35) imposes a cumulative 6-hour-per-24h cap on `dataSync` foreground services. When the cap is reached, the system invokes `Service.onTimeout(int startId, int fgsType)` and gives the service a few seconds to call `stopSelf()`. If it doesn't, the system throws `RemoteServiceException$ForegroundServiceDidNotStopInTimeException` — which is exactly what we're seeing in Sentry.

This PR adds an override of the two-arg `onTimeout(int, int)` (API 35+) that:
- Cancels in-flight media and post uploads up front (so `onDestroy()` cleanup completes within the OS-granted window).
- Calls `stopSelf(startId)`.

Cancelled uploads flow through the existing `OnMediaUploaded(canceled = true)` path, so the user sees the standard "upload didn't finish" notification with a Retry action — no new notification surface needed.

## Testing instructions

This crash only reproduces after ~6h of cumulative `dataSync` FGS time within a 24h window on an Android 15+ device, so a manual end-to-end repro is impractical. Recommended verification:

- [ ] On any device, start a media upload from the editor and verify the upload completes successfully and the foreground notification clears.