### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3A8H: guard RemoteConfigStore reads against DB errors

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/RemoteConfigDao.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/RemoteConfigDao.kt
@@ -64,8 +64,10 @@ abstract class RemoteConfigDao {
 
     class RemoteConfigValueConverter {
         @TypeConverter
-        fun toRemoteConfigValueSource(value: Int): RemoteConfigValueSource =
-                enumValues<RemoteConfigValueSource>()[value]
+        fun toRemoteConfigValueSource(value: Int): RemoteConfigValueSource {
+            val values = enumValues<RemoteConfigValueSource>()
+            return if (value in values.indices) values[value] else RemoteConfigValueSource.BUILD_CONFIG
+        }
 
         @TypeConverter
         fun fromRemoteConfigValueSource(value: RemoteConfigValueSource): Int = value.ordinal

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/RemoteConfigStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/RemoteConfigStore.kt
@@ -42,7 +42,12 @@ class RemoteConfigStore @Inject constructor(
     }
 
     fun getRemoteConfigs(): List<RemoteConfig> {
-        return remoteConfigDao.getRemoteConfigList()
+        return try {
+            remoteConfigDao.getRemoteConfigList()
+        } catch (e: Exception) {
+            AppLog.e(AppLog.T.DB, "Failed to read remote config list", e)
+            emptyList()
+        }
     }
 
     fun insertRemoteConfig(key: String, value: String) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/RemoteConfigStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/RemoteConfigStore.kt
@@ -41,6 +41,7 @@ class RemoteConfigStore @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun getRemoteConfigs(): List<RemoteConfig> {
         return try {
             remoteConfigDao.getRemoteConfigList()


### PR DESCRIPTION
Fixes WORDPRESS-ANDROID-3A8H

## Summary

Defensive fix for [Sentry WORDPRESS-ANDROID-3A8H](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3A8H) — NPE inside `RemoteConfigDao_Impl.getRemoteConfigList` (210 users, 23k+ events).

The NPE bubbles up from Room when it can't materialize a row — most likely DB corruption (correlates with the cluster of `SQLiteDiskIOException` events in the same tables) or an out-of-range `source` ordinal hitting `enumValues()[value]`.

- `RemoteConfigStore.getRemoteConfigs()` now catches and logs read failures, returning an empty list instead of letting the NPE propagate to app startup callers.
- `RemoteConfigValueConverter.toRemoteConfigValueSource` now bounds-checks the ordinal and falls back to `BUILD_CONFIG` for unknown values rather than indexing past the enum.

## Test plan

- [ ] App boots normally on a healthy install (existing remote-config behaviour unchanged).
- [ ] Force a corrupt DB read (e.g. via `adb shell` to wipe the table file mid-read) — app no longer crashes; logs show the swallowed error.
- [ ] Manually feed an out-of-range ordinal — converter returns `BUILD_CONFIG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)