### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3808: catch network errors in WPcomLoginClient

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
@@ -11,6 +11,7 @@ import okhttp3.Request
 import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WPcomAuthorizationCodeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -61,15 +62,21 @@ class WPcomLoginClient @Inject constructor(
             .build()
 
         return withContext(context) {
-            val response = client.newCall(request).execute()
+            try {
+                val response = client.newCall(request).execute()
 
-            if (!response.isSuccessful) {
-                response.body?.let { Log.e("WPCOM_LOGIN", it.string()) }
-                Result.failure(WPcomLoginError.AccessDenied)
-            } else {
-                val json = response.body?.string() ?: return@withContext Result.failure(WPcomLoginError.InvalidResponse)
-                val gson = Gson().fromJson(json, WPcomAuthorizationCodeResponse::class.java)
-                Result.success(gson.accessToken)
+                if (!response.isSuccessful) {
+                    response.body?.let { Log.e("WPCOM_LOGIN", it.string()) }
+                    Result.failure(WPcomLoginError.AccessDenied)
+                } else {
+                    val json = response.body?.string()
+                        ?: return@withContext Result.failure(WPcomLoginError.InvalidResponse)
+                    val gson = Gson().fromJson(json, WPcomAuthorizationCodeResponse::class.java)
+                    Result.success(gson.accessToken)
+                }
+            } catch (e: IOException) {
+                Log.e("WPCOM_LOGIN", "Network error exchanging auth code for token", e)
+                Result.failure(WPcomLoginError.NetworkError(e))
             }
         }
     }
@@ -78,4 +85,5 @@ class WPcomLoginClient @Inject constructor(
 sealed class WPcomLoginError(val code: Int): Throwable() {
     data object AccessDenied: WPcomLoginError(1)
     data object InvalidResponse: WPcomLoginError(2)
+    data class NetworkError(override val cause: Throwable): WPcomLoginError(3)
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
@@ -83,7 +83,13 @@ class WPcomLoginClient @Inject constructor(
 }
 
 sealed class WPcomLoginError(val code: Int): Throwable() {
-    data object AccessDenied: WPcomLoginError(1)
-    data object InvalidResponse: WPcomLoginError(2)
-    data class NetworkError(override val cause: Throwable): WPcomLoginError(3)
+    data object AccessDenied: WPcomLoginError(CODE_ACCESS_DENIED)
+    data object InvalidResponse: WPcomLoginError(CODE_INVALID_RESPONSE)
+    data class NetworkError(override val cause: Throwable): WPcomLoginError(CODE_NETWORK_ERROR)
+
+    companion object {
+        private const val CODE_ACCESS_DENIED = 1
+        private const val CODE_INVALID_RESPONSE = 2
+        private const val CODE_NETWORK_ERROR = 3
+    }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClientTest.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import kotlinx.coroutines.Dispatchers
+import okhttp3.Interceptor
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import org.wordpress.android.fluxc.test
+import java.io.IOException
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class WPcomLoginClientTest {
+    private val appSecrets = AppSecrets("appId", "appSecret", "https://redirect.example/cb")
+
+    @Test
+    fun `IOException during token exchange returns NetworkError with cause`() = test {
+        val ioException = IOException("simulated network failure")
+        val throwingInterceptor = Interceptor { _ -> throw ioException }
+
+        val subject = WPcomLoginClient(
+            context = Dispatchers.Unconfined,
+            appSecrets = appSecrets,
+            interceptors = setOf(throwingInterceptor)
+        )
+
+        val result = subject.exchangeAuthCodeForToken("any_code")
+
+        assertTrue(result.isFailure)
+        val error = result.exceptionOrNull()
+        assertIs<WPcomLoginError.NetworkError>(error)
+        assertSame(ioException, error.cause)
+    }
+}


### PR DESCRIPTION
Fixes WORDPRESS-ANDROID-3808

## Summary

Fix for [Sentry WORDPRESS-ANDROID-3808](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3808) — `RuntimeException`/`InvocationTargetException` crashing the auth-code exchange (160 users, ~5k events).

`WPcomLoginClient.exchangeAuthCodeForToken` runs a synchronous `OkHttp` call inside `withContext`. Any `IOException` (timeout, no network, DNS) escapes uncaught and is wrapped at the suspend boundary, surfacing as a crash.

This PR wraps the call in try/catch and adds a new `WPcomLoginError.NetworkError(cause)` variant so the UI layer can route the failure through the existing `Result.failure` path as a retryable error.

## Test plan

- [x] Successful login still works (happy path unchanged).
- [x] Toggle airplane mode mid-login (may require a slow network to do this) → app no longer crashes; failure path triggered. 