### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3CHQ: guard handleNewPostAction against null selected site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1198,7 +1198,8 @@ public class WPMainActivity extends BaseAppCompatActivity implements
 
         SiteModel selectedSite = getSelectedSite();
         if (selectedSite == null) {
-            // Sites exist but none is selected - send the user to My Sites so they can pick one
+            // Sites exist but none is selected - tell the user and route them to My Sites to pick one
+            ToastUtils.showToast(this, R.string.site_cannot_be_loaded, ToastUtils.Duration.LONG);
             mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1196,7 +1196,13 @@ public class WPMainActivity extends BaseAppCompatActivity implements
             return;
         }
 
-        ActivityLauncher.addNewPostForResult(this, getSelectedSite(), false, source, promptId, entryPoint);
+        SiteModel selectedSite = getSelectedSite();
+        if (selectedSite == null) {
+            // Sites exist but none is selected - send the user to My Sites so they can pick one
+            mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+            return;
+        }
+        ActivityLauncher.addNewPostForResult(this, selectedSite, false, source, promptId, entryPoint);
     }
 
     private void launchVoiceToContent() {


### PR DESCRIPTION
Fixes WORDPRESS-ANDROID-3CHQ

## Summary

Fix for [Sentry WORDPRESS-ANDROID-3CHQ](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3CHQ) — `EditorLauncherParams.Builder.forSite` crashes WPMainActivity launch with a non-null parameter NPE (142 users, 800+ events).

`WPMainActivity.handleNewPostAction` calls `addNewPostForResult(this, getSelectedSite(), …)` after only checking `mSiteStore.hasSite()`. The store can have sites while the selected-site repository hasn't picked one (e.g. just after a site is removed), so `getSelectedSite()` returns null and the `@NonNull SiteModel` parameter on `EditorLauncherParams.Builder.forSite(...)` throws.

This mirrors the existing null-site guard already present in `handleNewPageAction` a few lines above: when there's no selected site, route the user to My Sites instead of crashing.

## Test plan

I'm not sure how to best test this since I'm can't reproduce the problem. However, if you manually change [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/2f0726949dfad629a5eb5a3b1fcca1b67dc93cbe/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java#L1199) so that `selectedSite` is `null`, the fix can be tested by tapping the FAB on my site and selecting "Blog post."