### PR TITLE
Skip repeat editor capability fetches in MySiteViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -78,6 +78,12 @@ class MySiteViewModel @Inject constructor(
        as they're already built on site select. */
     private var isSiteSelected = false
 
+    /* Editor capabilities rarely change, so once we've successfully fetched them for a site we
+       skip subsequent non-user-initiated fetches in this ViewModel session. Failed fetches do
+       not populate this set, so a transient network failure recovers on the next onResume.
+       User-initiated refreshes (e.g. pull-to-refresh) always bypass this gate. */
+    private val fetchedCapabilitiesForSite = mutableSetOf<Int>()
+
     val onScrollTo: MutableLiveData<Event<Int>> = MutableLiveData()
 
     val onSnackbarMessage = merge(
@@ -202,8 +208,14 @@ class MySiteViewModel @Inject constructor(
         site: SiteModel,
         isUserInitiated: Boolean
     ) {
+        if (site.id in fetchedCapabilitiesForSite && !isUserInitiated) {
+            return
+        }
         val ok = editorSettingsRepository
             .fetchEditorCapabilitiesForSite(site)
+        if (ok) {
+            fetchedCapabilitiesForSite.add(site.id)
+        }
         val hasCache = editorSettingsRepository
             .hasCachedCapabilities(site)
         if (!ok && (isUserInitiated || !hasCache)) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -362,6 +362,89 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(dashboardCardsViewModelSlice).clearValue()
     }
 
+    @Test
+    fun `given selected site, when onResume invoked twice, then editor capabilities are fetched once`() = test {
+        initSelectedSite()
+
+        viewModel.onResume()
+        advanceUntilIdle()
+        viewModel.onResume()
+        advanceUntilIdle()
+
+        verify(editorSettingsRepository, times(1)).fetchEditorCapabilitiesForSite(siteTest)
+    }
+
+    @Test
+    fun `given selected site, when onResume then non-PTR refresh, then editor capabilities are fetched once`() =
+        test {
+            initSelectedSite()
+
+            viewModel.onResume()
+            advanceUntilIdle()
+            viewModel.refresh(isPullToRefresh = false)
+            advanceUntilIdle()
+
+            verify(editorSettingsRepository, times(1)).fetchEditorCapabilitiesForSite(siteTest)
+        }
+
+    @Test
+    fun `given selected site, when onResume then PTR refresh, then editor capabilities are fetched twice`() = test {
+        initSelectedSite()
+
+        viewModel.onResume()
+        advanceUntilIdle()
+        viewModel.refresh(isPullToRefresh = true)
+        advanceUntilIdle()
+
+        verify(editorSettingsRepository, times(2)).fetchEditorCapabilitiesForSite(siteTest)
+    }
+
+    @Test
+    fun `given PTR refresh, when onResume invoked after, then editor capabilities are not re-fetched`() = test {
+        initSelectedSite()
+
+        viewModel.refresh(isPullToRefresh = true)
+        advanceUntilIdle()
+        viewModel.onResume()
+        advanceUntilIdle()
+
+        verify(editorSettingsRepository, times(1)).fetchEditorCapabilitiesForSite(siteTest)
+    }
+
+    @Test
+    fun `given fetch failed, when onResume invoked again, then editor capabilities are re-fetched`() = test {
+        initSelectedSite()
+        whenever(editorSettingsRepository.fetchEditorCapabilitiesForSite(siteTest)).thenReturn(false, true)
+
+        viewModel.onResume()
+        advanceUntilIdle()
+        viewModel.onResume()
+        advanceUntilIdle()
+
+        verify(editorSettingsRepository, times(2)).fetchEditorCapabilitiesForSite(siteTest)
+    }
+
+    @Test
+    fun `given site switched, when onResume invoked, then editor capabilities are fetched for the new site`() =
+        test {
+            initSelectedSite()
+            val otherSite = SiteModel().apply {
+                id = TEST_SITE_ID + 1
+                url = TEST_URL
+                name = TEST_SITE_NAME
+                siteId = (TEST_SITE_ID + 1).toLong()
+            }
+
+            viewModel.onResume()
+            advanceUntilIdle()
+            whenever(selectedSiteRepository.getSelectedSite()).thenReturn(otherSite)
+            viewModel.onResume()
+            advanceUntilIdle()
+
+            verify(editorSettingsRepository, times(1)).fetchEditorCapabilitiesForSite(siteTest)
+            verify(editorSettingsRepository, times(1)).fetchEditorCapabilitiesForSite(otherSite)
+        }
+
 
 
     /* LAND ON THE EDITOR A/B EXPERIMENT */


### PR DESCRIPTION
## Description

Follow-up to #22785 (review feedback from @nbradbury). The capability fetch in `MySiteViewModel.onResume()` (`apiRoot` + `themes?status=active`) was firing on every return to the My Site tab — combined with the `launch` in `refresh()`, the same two requests could fire twice in close succession (e.g. resume after pull-to-refresh).

Editor capabilities rarely change, so we now dedup with an in-memory set keyed by `site.id`, populated when `fetchEditorCapabilitiesWithSnackbar` is first attempted for a site this ViewModel session. Subsequent non-user-initiated calls return early. User-initiated paths (pull-to-refresh, `refresh(isPullToRefresh = true)`) bypass the gate so the user can always force a fresh fetch.

Per-session caching is sufficient — no TTL or persistent storage needed. The next ViewModel session will refetch.

## Testing instructions

Covered by four new unit tests in `MySiteViewModelTest`:
- [x] Two `onResume()` calls → 1 fetch
- [x] `onResume()` + non-PTR `refresh()` → 1 fetch
- [x] `onResume()` + PTR `refresh(true)` → 2 fetches
- [x] PTR `refresh(true)` + `onResume()` → 1 fetch

Manual verification:

1. Open the app and navigate to the My Site tab on a site with cached capabilities.
2. Navigate away to another tab and back to My Site.
- [ ] Verify no `apiRoot` or `themes?status=active` requests fire in logcat on the return.
3. Pull-to-refresh the My Site tab.
- [ ] Verify both requests fire on the PTR.
4. Switch the selected site, then return to My Site.
- [ ] Verify capabilities are fetched for the newly-selected site (different `site.id`).

## Related issues

Follow-up to #22785 — addresses one of the two follow-ups agreed in review.