### PR TITLE
Fix DoNotMockDataClass lint error: replace ThemeWithEditContext mock with real instance

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/repositories/EditorSettingsRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/repositories/EditorSettingsRepositoryTest.kt
@@ -19,6 +19,15 @@ import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.ApiRootRequestGetResponse
 import uniffi.wp_api.ApiUrlResolver
+import uniffi.wp_api.ThemeAuthor
+import uniffi.wp_api.ThemeAuthorUri
+import uniffi.wp_api.ThemeDescription
+import uniffi.wp_api.ThemeName
+import uniffi.wp_api.ThemeStatus
+import uniffi.wp_api.ThemeStylesheet
+import uniffi.wp_api.ThemeTags
+import uniffi.wp_api.ThemeUri
+import uniffi.wp_api.ThemeWithEditContext
 import uniffi.wp_api.WpApiDetails
 import uniffi.wp_api.WpNetworkHeaderMap
 
@@ -224,10 +233,33 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
     private suspend fun mockThemeResponse(
         isBlockTheme: Boolean
     ) {
-        val theme = mock<uniffi.wp_api.ThemeWithEditContext>()
-        whenever(theme.isBlockTheme).thenReturn(isBlockTheme)
         whenever(
             themeRepository.fetchCurrentTheme(testSite)
-        ).thenReturn(theme)
+        ).thenReturn(buildTheme(isBlockTheme = isBlockTheme))
     }
+
+    private fun buildTheme(
+        stylesheet: String = "test-theme",
+        isBlockTheme: Boolean = false
+    ) = ThemeWithEditContext(
+        stylesheet = ThemeStylesheet(stylesheet),
+        template = stylesheet,
+        requiresPhp = "",
+        requiresWp = "",
+        textdomain = stylesheet,
+        version = "1.0",
+        screenshot = "",
+        author = ThemeAuthor(raw = "", rendered = ""),
+        authorUri = ThemeAuthorUri(raw = "", rendered = ""),
+        description = ThemeDescription(raw = "", rendered = ""),
+        name = ThemeName(raw = stylesheet, rendered = stylesheet),
+        tags = ThemeTags(raw = emptyList(), rendered = ""),
+        themeUri = ThemeUri(raw = "", rendered = ""),
+        status = ThemeStatus.Active,
+        isBlockTheme = isBlockTheme,
+        stylesheetUri = "",
+        templateUri = "",
+        themeSupports = null,
+        defaultTemplateTypes = emptyList()
+    )
 }


### PR DESCRIPTION
Fixes a lint failure on `trunk` introduced by #22785: `EditorSettingsRepositoryTest.mockThemeResponse()` mocks `uniffi.wp_api.ThemeWithEditContext` (a uniffi-generated data class), tripping the `DoNotMockDataClass` lint rule.

The test only reads `theme.isBlockTheme`, so a real instance is straightforward.

## Summary

- Replace `mock<ThemeWithEditContext>()` with a real instance constructed via a `buildTheme(stylesheet, isBlockTheme)` factory.
- Factory mirrors the one already in `ThemeRepositoryTest.buildTheme`.

## Why CI didn't catch this on #22785 — root cause

Stale base branch. The chain:

1. #22637 (merged 2026-04-22) parallelized the lint jobs **and switched the PR-time lint variant from Release to Debug** in `.buildkite/commands/lint.sh`.
2. #22785's branch was based on a `trunk` commit predating #22637 (`git merge-base` of the PR head and #22637's merge commit is `61bd1edd6242` — before #22637 landed). The branch was never rebased.
3. So #22785's PR builds ran the **old** `lint.sh`, which executed `./gradlew lintWordpressRelease`. Confirmed via build 26166 logs: the only WordPress lint tasks that ran were `:WordPress:lintAnalyzeWordpressRelease` and `:WordPress:lintReportWordpressRelease`. **No `lintAnalyzeWordpressReleaseUnitTest` task ran**, because AGP's release-variant lint skips the unit test source set by default.
4. The `DoNotMockDataClass` violation lives in a unit test file → never analyzed → CI passed.
5. After squash-merge to trunk, every subsequent PR runs the **new** `lint.sh` → `lintWordpressDebug` → analyzes unit test sources → catches the inherited violation. PR #22833 was the first PR branched from post-merge trunk (created 18 minutes after #22785 merged).

(My initial guess was a Gradle build cache reuse issue. Logs ruled that out — the actual run was on Release variant from the stale script.)

## Preventing the class of bug — separate ask

The right structural fix is to enable GitHub branch protection's **"Require branches to be up to date before merging"** on `trunk`. After enabling, any PR with a stale base must rebase (or merge trunk in) before merging, which forces CI to re-run with the current `lint.sh` — closing the entire stale-CI-script failure mode.

Cost is real (rebase churn on busy days) but bounded; if a merge queue is in use it's effectively implicit.

I considered also flipping `lint { checkTestSources = true }` in `build.gradle` so that trunk-side Release-variant lint covers test sources too. Verified locally: it surfaces 27 pre-existing test-source violations (mostly deliberate test patterns: passing `null` to non-nullable `LiveData`, hardcoded resource ints in fixtures, etc.) that would need baseline reconciliation across all four lint variants. That's a separate, larger PR — branch protection alone covers the actual reported bug pattern.

## Drive-by note (not in this PR)

Lint output reports 13 unmatched baseline entries (`DoNotMockDataClass` ×8, `DoNotMockSealedClass` ×5) — a baseline cleanup is overdue but out of scope here.

## Test plan

- [x] `./gradlew :WordPress:lintWordpressDebug` — passes
- [x] `./gradlew :WordPress:testWordpressDebugUnitTest --tests "org.wordpress.android.repositories.EditorSettingsRepositoryTest"` — passes
- [x] CI `lint-wordpress` and `lint-jetpack` green
- [ ] After this lands, rebase #22833 and confirm its lint passes
- [ ] Follow-up: enable "Require branches to be up to date" on `trunk`