### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3EVH: read app theme pref off main thread

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -349,7 +349,7 @@ class AppInitializer @Inject constructor(
         // memory usage and the use of Configuration). More information: http://bit.ly/2H1KTQo
         // Note: if removed, this will cause crashes on Android < 21
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
-        AppThemeUtils.setAppTheme(application)
+        AppThemeUtils.setAppThemeAsync(application, appScope)
 
         // verify media is sanitized
         sanitizeMediaUploadStateForSite()

--- a/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.text.TextUtils
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 
 class AppThemeUtils {
@@ -14,16 +18,33 @@ class AppThemeUtils {
         @JvmOverloads
         fun setAppTheme(context: Context, newTheme: String? = null) {
             val themeName = if (TextUtils.isEmpty(newTheme)) {
-                val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-                sharedPreferences
-                    .getString(
-                        context.getString(R.string.pref_key_app_theme),
-                        context.getString(R.string.app_theme_entry_value_default)
-                    )
+                readThemeFromPrefs(context)
             } else {
                 newTheme
             }
+            applyNightMode(context, themeName)
+        }
 
+        // Reads SharedPreferences off the main thread before applying the theme. The first read of
+        // default SharedPreferences blocks on disk I/O, which has caused ANRs during app startup.
+        fun setAppThemeAsync(context: Context, scope: CoroutineScope) {
+            scope.launch(Dispatchers.IO) {
+                val themeName = readThemeFromPrefs(context)
+                withContext(Dispatchers.Main) {
+                    applyNightMode(context, themeName)
+                }
+            }
+        }
+
+        private fun readThemeFromPrefs(context: Context): String? =
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(
+                    context.getString(R.string.pref_key_app_theme),
+                    context.getString(R.string.app_theme_entry_value_default)
+                )
+
+        @SuppressLint("WrongConstant") // lint suggests deprecated constant for some reason
+        private fun applyNightMode(context: Context, themeName: String?) {
             when (themeName) {
                 context.getString(R.string.app_theme_entry_value_light) -> {
                     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)


### PR DESCRIPTION
## Description

Fixes [WORDPRESS-ANDROID-3EVH](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3EVH) — `ApplicationNotResponding` whose top frame is `AppThemeUtils.setAppTheme` → `AppCompatDelegate.setDefaultNightMode`. 3 users affected over the last 90 days, all on app versions 26.6/26.7.

`AppInitializer.init()` calls `AppThemeUtils.setAppTheme(application)` synchronously during `Application.onCreate()`. The first read of the default `SharedPreferences` blocks on disk I/O, which on slow devices is enough to trip the 5-second ANR threshold.

This change adds `AppThemeUtils.setAppThemeAsync(context, scope)` that reads the theme name on `Dispatchers.IO` and then applies the night mode on `Dispatchers.Main`. The synchronous `setAppTheme` overload is unchanged so existing callers (`AppSettingsFragment`, `JetpackMigrationFragment`) keep their current behavior.

**Trade-off:** if a user has selected a non-default theme, the first activity may briefly render with `MODE_NIGHT_FOLLOW_SYSTEM` before the async read completes and triggers a recreation. For users on the default theme, no flash occurs. Avoiding a 5-second ANR is worth the rare flash.

## Testing instructions

Default theme path:

1. Install a clean build (or `Settings → Apps → WordPress → Clear data`).
2. Launch the app.
- [ ] Verify the app starts in the system theme without flashing.

Light theme path:

1. Open `Me → App Settings → App theme` and select **Light**.
2. Force-stop the app and relaunch.
- [ ] Verify the app ends up in light mode (a brief flash may occur on slow devices — acceptable).

Dark theme path:

1. Open `Me → App Settings → App theme` and select **Dark**.
2. Force-stop the app and relaunch.
- [ ] Verify the app ends up in dark mode.

Settings change path (synchronous overload still works):

1. Open `Me → App Settings → App theme` and toggle between values.
- [ ] Verify the theme changes immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)