### PR TITLE
Replace ActiveSupport's String#parameterize with a pure-Ruby helper

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -402,7 +402,7 @@ platform :android do
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = parameterize(ENV['BUILDKITE_BRANCH'])
+      branch = parameterize(ENV.fetch('BUILDKITE_BRANCH', nil))
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -391,17 +391,24 @@ platform :android do
     )
   end
 
+  # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.
+  # release-toolkit dropped its `activesupport` runtime dependency in v14.3.1,
+  # so `String#parameterize` is no longer available here.
+  def parameterize(string)
+    string.downcase.gsub(/[^a-z0-9\-_]+/, '-').squeeze('-').gsub(/\A-|-\z/, '')
+  end
+
   # This function is Buildkite-specific
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      branch = parameterize(ENV['BUILDKITE_BRANCH'])
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
     else
       repo = Git.open(PROJECT_ROOT_FOLDER)
-      commit = repo.current_branch.parameterize
+      commit = parameterize(repo.current_branch)
       branch = repo.revparse('HEAD')[0, 7]
 
       "#{branch}-#{commit}"


### PR DESCRIPTION
### Description

`release-toolkit` [v14.3.1](https://github.com/wordpress-mobile/release-toolkit/pull/709) dropped its `activesupport` runtime dependency. `WordPress-Android` (now on `release-toolkit` 14.4.1 via `~> 14.0`) still relies on `String#parameterize` in `generate_prototype_build_number`, so Prototype Builds now fail with:

```
lanes/build.rb:398:in `generate_prototype_build_number': undefined method `parameterize' for "<branch>":String (NoMethodError)
```

(see [build 26278](https://buildkite.com/automattic/wordpress-android/builds/26278))

This adds a tiny pure-Ruby `parameterize` helper that reproduces the behavior we rely on (downcase, replace runs of non-`[a-z0-9_-]` with `-`, squeeze, strip leading/trailing `-`) and routes the two call sites through it. Output is identical to ActiveSupport's `String#parameterize` for the branch/commit names involved (e.g. `fix/anr-3ex3-zendesk-init-off-main` → `fix-anr-3ex3-zendesk-init-off-main`, `release/26.0` → `release-26-0`).

### Testing instructions

- CI: the Prototype Build steps should succeed again.
- Locally: `ruby -c fastlane/lanes/build.rb` passes; `parameterize('fix/Foo_Bar!')` → `fix-foo_bar`.

### Release notes

Not needed (CI/tooling only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)