### PR TITLE
Fix Sentry JETPACK-ANDROID-1G35: guard Tracks event emission against Locale NPE

### DIFF
--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -367,13 +367,21 @@ public class AnalyticsTrackerNosara extends Tracker {
             propertiesToJSON = new JSONObject(predefinedEventProperties);
         }
 
-        if (propertiesToJSON.length() > 0) {
-            mNosaraClient.track(mEventsPrefix + eventName, propertiesToJSON, user, userType);
-            String jsonString = propertiesToJSON.toString();
-            AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName + ", Properties: " + jsonString);
-        } else {
-            mNosaraClient.track(mEventsPrefix + eventName, user, userType);
-            AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName);
+        // Tracks' MessageBuilder.createRequestCommonPropsJSONObject can throw — most
+        // commonly NPE on Locale.getDefault().toString() returning null after a config
+        // restore race (Sentry: JETPACK-ANDROID-1G35). Analytics failures should never
+        // crash the app, so swallow the throw and log it.
+        try {
+            if (propertiesToJSON.length() > 0) {
+                mNosaraClient.track(mEventsPrefix + eventName, propertiesToJSON, user, userType);
+                String jsonString = propertiesToJSON.toString();
+                AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName + ", Properties: " + jsonString);
+            } else {
+                mNosaraClient.track(mEventsPrefix + eventName, user, userType);
+                AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName);
+            }
+        } catch (Exception e) {
+            AppLog.e(AppLog.T.STATS, "Failed to track event " + eventName, e);
         }
     }
 
@@ -420,7 +428,14 @@ public class AnalyticsTrackerNosara extends Tracker {
             setWordPressComUserName(metadata.getUsername());
             // Re-unify the user
             if (getAnonID() != null) {
-                mNosaraClient.trackAliasUser(getWordPressComUserName(), getAnonID(), TracksClient.NosaraUserType.WPCOM);
+                try {
+                    mNosaraClient.trackAliasUser(
+                            getWordPressComUserName(), getAnonID(), TracksClient.NosaraUserType.WPCOM);
+                } catch (Exception e) {
+                    // Same family as the track() NPE above (Sentry JETPACK-ANDROID-1G35) —
+                    // don't let an alias-emit failure crash login.
+                    AppLog.e(AppLog.T.STATS, "Failed to track alias user", e);
+                }
                 clearAnonID();
             }
         } else {


### PR DESCRIPTION
Fixes [JETPACK-ANDROID-1G35](https://a8c.sentry.io/issues/JETPACK-ANDROID-1G35).

## Summary

The Automattic Tracks Android library's `MessageBuilder.createRequestCommonPropsJSONObject` dereferences `Locale.getDefault().toString()`. On a rare config-restore race inside `ConfigurationController.updateLocaleListFromAppContext`, `Locale.getDefault()` returns `null` and the NPE propagates out of `TracksClient.track()`, crashing the app.

Sentry user count: **60 Jetpack** in the last 30 days. Play Console reports **31 Jetpack users**.

## Changes

`AnalyticsTrackerNosara.java`:

- Wrap the two `mNosaraClient.track(...)` calls inside the `track(...)` method's emission step in a `try / catch (Exception)`. On failure, log via `AppLog.e(T.STATS, …)` (so it still reaches Sentry via the AppLog crash bridge) and return normally.
- Wrap the `mNosaraClient.trackAliasUser(...)` call inside `refreshMetadata()` similarly, so an alias-emit failure during login doesn't crash the activity.

No behavior change on the happy path.

## Test plan

- [ ] Normal event tracking still works — confirm analytics events appear in Tracks via the usual debug path.
- [ ] Login → log out → log in flow exercises `trackAliasUser` — verify normal completion.
