### PR TITLE
Fix Sentry JETPACK-ANDROID-1A0P: allow null imageUrl in showReaderPhotoViewer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.kt
@@ -470,7 +470,7 @@ object ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_IMAGE_URL, imageUrl)
         intent.putExtra(ReaderConstants.ARG_IS_PRIVATE, isPrivate)
         intent.putExtra(ReaderConstants.ARG_IS_GALLERY, isGallery)
-        if (!TextUtils.isEmpty(content)) {
+        if (!content.isNullOrEmpty()) {
             intent.putExtra(ReaderConstants.ARG_CONTENT, content)
         }
         if (!galleryImageUrls.isNullOrEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.kt
@@ -448,7 +448,7 @@ object ReaderActivityLauncher {
     @Suppress("LongParameterList")
     fun showReaderPhotoViewer(
         context: Context,
-        imageUrl: String,
+        imageUrl: String?,
         content: String?,
         sourceView: View?,
         imageOptions: EnumSet<PhotoViewerOption>,
@@ -456,7 +456,10 @@ object ReaderActivityLauncher {
         startY: Int,
         galleryImageUrls: ArrayList<String>? = null
     ) {
-        if (TextUtils.isEmpty(imageUrl)) {
+        if (imageUrl.isNullOrEmpty()) {
+            val message = "showReaderPhotoViewer called with null or empty imageUrl"
+            AppLog.w(T.READER, message)
+            reportNullOrEmptyUrlToSentry(context, message)
             return
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderActivityLauncherTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderActivityLauncherTest.kt
@@ -9,7 +9,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType
+import org.wordpress.android.ui.reader.ReaderActivityLauncher.PhotoViewerOption
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import java.util.EnumSet
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = android.app.Application::class)
@@ -113,6 +115,36 @@ class ReaderActivityLauncherTest {
     fun `openUrl with null url and external type does not throw`() {
         assertThatCode {
             ReaderActivityLauncher.openUrl(context, null, OpenUrlType.EXTERNAL)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `showReaderPhotoViewer with null imageUrl does not throw`() {
+        assertThatCode {
+            ReaderActivityLauncher.showReaderPhotoViewer(
+                context,
+                null,
+                null,
+                null,
+                EnumSet.noneOf(PhotoViewerOption::class.java),
+                0,
+                0
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `showReaderPhotoViewer with empty imageUrl does not throw`() {
+        assertThatCode {
+            ReaderActivityLauncher.showReaderPhotoViewer(
+                context,
+                "",
+                null,
+                null,
+                EnumSet.noneOf(PhotoViewerOption::class.java),
+                0,
+                0
+            )
         }.doesNotThrowAnyException()
     }
 }


### PR DESCRIPTION
Fixes JETPACK-ANDROID-1A0P

## Summary

Fix for [Sentry JETPACK-ANDROID-1A0P](https://a8c.sentry.io/issues/JETPACK-ANDROID-1A0P) — 93 users hit `Parameter specified as non-null is null: method ReaderActivityLauncher.showReaderPhotoViewer`.

The method has a `TextUtils.isEmpty(imageUrl)` guard at the top of its body, but the Kotlin parameter null-check fires before the body runs, so a null parameter crashes instead of being silently dropped.

This PR mirrors the pattern from #22830:

- Relax `imageUrl` to `String?` and use `isNullOrEmpty()` so the existing early-return handles the null case. Smart-cast keeps the rest of the body operating on a non-null `imageUrl`; Java callers and the `@JvmStatic`/`@JvmOverloads` exports stay compatible.
- When the early-return fires, an `AppLog.w` records the event and a Sentry breadcrumb is emitted via the existing `reportNullOrEmptyUrlToSentry` helper, so the upstream caller passing null can be tracked down separately.

## Test plan

- [ ] Tap an image in a Reader post — opens the photo viewer as before.
- [ ] Programmatically force a null/empty `imageUrl` — now silently no-ops and logs a warning + Sentry breadcrumb.

New unit tests in `ReaderActivityLauncherTest` cover the no-op behavior for null `imageUrl` and empty `imageUrl`.
