### PR TITLE
Fix Sentry JETPACK-ANDROID-1G48: rewrap UniFFI LinkageError in WpServiceProvider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
@@ -37,7 +37,16 @@ class WpServiceProvider @Inject constructor(
 
     @Synchronized
     fun getService(site: SiteModel): WpService {
-        return services.getOrPut(site.id) { createService(site) }
+        return try {
+            services.getOrPut(site.id) { createService(site) }
+        } catch (e: LinkageError) {
+            // ExceptionInInitializerError / NoClassDefFoundError / UnsatisfiedLinkError:
+            // the wordpress-rs native library is out of sync with its Kotlin bindings
+            // on this device (most commonly armeabi-v7a split-APK builds). Rewrap as a
+            // RuntimeException so the caller's existing catch(Exception) can surface a
+            // friendly error state instead of crashing.
+            throw WpServiceUnavailableException(e)
+        }
     }
 
     /** Removes all cached services. */
@@ -98,3 +107,12 @@ class WpServiceProvider @Inject constructor(
         }
     }
 }
+
+/**
+ * Thrown when the wordpress-rs native library cannot be initialized on this device
+ * (e.g. UniFFI checksum mismatch between the native .so and the Kotlin bindings).
+ * Wraps the original [LinkageError] so callers can recover gracefully via the
+ * existing `catch (Exception)` paths in the RS post-list flow.
+ */
+class WpServiceUnavailableException(cause: LinkageError) :
+    RuntimeException("wordpress-rs native library unavailable: ${cause.message}", cause)


### PR DESCRIPTION
Fixes JETPACK-ANDROID-1G48
Fixes WORDPRESS-ANDROID-3EZ1

## Summary

Fix for [Sentry JETPACK-ANDROID-1G48](https://a8c.sentry.io/issues/JETPACK-ANDROID-1G48) (49 users) + [WORDPRESS-ANDROID-3EZ1](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3EZ1) (66 users) — combined **115 users** hit `ExceptionInInitializerError` when opening the new RS post list. The underlying cause is `RuntimeException: UniFFI API checksum mismatch`, almost always on **armeabi-v7a** split APKs where the native `.so` is out of sync with the Kotlin bindings.

Once `IntegrityCheckingUniffiLib.<clinit>` fails the JVM caches the failure, so every subsequent call to anything in `uniffi.wp_api` throws `NoClassDefFoundError` — which explains the very high per-user event counts.

`PostRsListViewModel.initTab` already wraps `serviceProvider.getService(site)` in `try { ... } catch (e: Exception)`, but `ExceptionInInitializerError` is an `Error`, not an `Exception`, so it escapes the catch and crashes the app.

## Fix

Catch `LinkageError` (the supertype of `ExceptionInInitializerError`, `NoClassDefFoundError`, and `UnsatisfiedLinkError`) at the entry point in `WpServiceProvider.getService()` and rewrap as a new `WpServiceUnavailableException` (a `RuntimeException`). The existing UI error path in `initTab` now handles it via `friendlyErrorMessage`, and the user sees an error state instead of a crash.

The `getOrPut` cache is not poisoned on failure (the lambda's throw prevents insertion), so as soon as the underlying issue is resolved the service can be created normally.

The **root cause** still needs an upstream fix in `wordpress-rs` — likely a stale cached AAR or missing regenerate-bindings step before assembling the armeabi-v7a split. This PR is the defensive shield while that lands.

## Test plan

- [ ] On a healthy device (arm64), open the RS post list — works as before, no error state.
- [ ] To simulate the failure on a dev build: temporarily mutate the UniFFI checksum constant (or run an old binding against new native) — confirm the post list shows the generic error state instead of crashing.
- [ ] Verify Sentry no longer reports `ExceptionInInitializerError` from `WpServiceProvider.createService` after the next release (would be replaced by `WpServiceUnavailableException` with the same root cause preserved).