### PR TITLE
CMM-1947: Use thumbnail URL in media picker to prevent OOM

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.mediapicker.loader.MediaSource.MediaLoadingResul
 import org.wordpress.android.ui.mediapicker.loader.MediaSource.MediaLoadingResult.Failure
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
@@ -126,13 +127,25 @@ class MediaLibraryDataSource(
         return this.filter { it.url.isNotBlank() }.map { mediaModel ->
             MediaItem(
                 RemoteId(mediaModel.mediaId),
-                mediaModel.url,
+                mediaModel.thumbnailOrFullUrl(),
                 mediaModel.title,
                 mediaType,
                 mediaModel.mimeType,
                 mediaModel.uploadDate?.let { dateTimeUtilsWrapper.dateFromIso8601(it)?.time } ?: 0L
             )
         }
+    }
+
+    private fun MediaModel.thumbnailOrFullUrl(): String {
+        val thumbnail = thumbnailUrl
+        if (!thumbnail.isNullOrBlank()) {
+            return thumbnail
+        }
+        AppLog.w(
+            AppLog.T.MEDIA,
+            "MediaLibraryDataSource > no thumbnail for mediaId=$mediaId, falling back to full-size URL"
+        )
+        return url
     }
 
     private fun getFromDatabase(mediaType: MediaType): List<MediaItem> {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSourceTest.kt
@@ -318,6 +318,19 @@ class MediaLibraryDataSourceTest : BaseUnitTest() {
         assertThat(result.data[0].url).isEqualTo("http://media.jpg")
     }
 
+    @Test
+    fun `uses thumbnail URL for picker item when available`() = test {
+        val mediaModel = buildMediaModel(10)
+        mediaModel.thumbnailUrl = "http://media-thumb.jpg"
+        whenever(mediaStore.getSiteImages(siteModel)).thenReturn(listOf(mediaModel))
+
+        val dataSource = setupDataSource(false, setOf(IMAGE))
+        val result = dataSource.load(forced = false, loadMore = false, filter = null) as Success
+
+        assertThat(result.data).hasSize(1)
+        assertThat(result.data[0].url).isEqualTo("http://media-thumb.jpg")
+    }
+
     private fun setupDataSource(
         hasMore: Boolean,
         allowedTypes: Set<MediaType>,


### PR DESCRIPTION
## Description

**Fixes CMM-1947**

The media picker grid was loading `mediaModel.url` (the full-size original) instead of thumbnails when the site didn't support Photon.

This PR makes `MediaLibraryDataSource` prefer `mediaModel.thumbnailUrl` when it's available, falling back to the full URL with an `AppLog.w` warning so we can spot the rare no-thumbnail case in logs. This handles the common path (Photon-capable sites and most self-hosted sites where a thumbnail is generated server-side). The remaining edge case — non-Photon sites with no thumbnail at all — is uncommon and will still hit the original URL; the new log line gives us visibility if it recurs.

## Testing instructions

Verify thumbnail loading on a real Media Library:

1. Open WordPress / Jetpack on a device or emulator and select a site with several media items in its library.
2. Open Post Settings → tap Featured Image → choose "WordPress Media Library".
- [ ] Verify the grid populates with thumbnails and does not crash.
3. Pick an image from the grid.
- [ ] Verify the correct full-size media is selected and applied as the featured image (i.e. swapping the grid URL did not break selection — the picker still returns the correct media ID).
4. Repeat against a self-hosted (Jetpack) site if you have one available.
- [ ] Verify thumbnails load correctly there too.

Filter `logcat` for `MediaLibraryDataSource > no thumbnail` to spot any media items falling back to the full URL.