### PR TITLE
Override image size for non-Photon sites to avoid OOM

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -140,18 +140,10 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     }
 
     /*
-     * returns the most optimal url to use when retrieving a media image for display here
+     * returns the most optimal url to use when retrieving a media image for display here - used only
+     * for sites that aren't Photon capable
      */
     private String getBestImageUrl(@NonNull MediaModel media) {
-        // return photon-ized url if the site allows it since this gives us the image at the
-        // exact size we need here
-        if (SiteUtils.isPhotonCapable(mSite)) {
-            return PhotonUtils.getPhotonImageUrl(media.getUrl(), mThumbWidth, mThumbHeight,
-                    mSite.isPrivateWPComAtomic());
-        }
-
-        // can't use photon, so try the various image sizes - note we favor medium-large and
-        // medium because they're more bandwidth-friendly than large
         if (!TextUtils.isEmpty(media.getFileUrlMediumLargeSize())) {
             return media.getFileUrlMediumLargeSize();
         } else if (!TextUtils.isEmpty(media.getFileUrlMediumSize())) {
@@ -160,7 +152,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             return media.getFileUrlLargeSize();
         }
 
-        // next stop is to return the thumbnail, which will look pixelated in the grid but it's
+        // next stop is to return the thumbnail, which will look pixelated in the grid, but it's
         // better than eating bandwidth showing the full-sized image
         if (!TextUtils.isEmpty(media.getThumbnailUrl())) {
             return media.getThumbnailUrl();
@@ -193,8 +185,15 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.mFileContainer.setVisibility(View.GONE);
             if (isLocalFile) {
                 mImageManager.load(holder.mImageView, ImageType.PHOTO, media.getFilePath(), ScaleType.CENTER_CROP);
+            } else if (SiteUtils.isPhotonCapable(mSite)) {
+                String photonUrl = PhotonUtils.getPhotonImageUrl(media.getUrl(), mThumbWidth, mThumbHeight,
+                        mSite.isPrivateWPComAtomic());
+                mImageManager.load(holder.mImageView, ImageType.PHOTO, photonUrl, ScaleType.CENTER_CROP);
             } else {
-                mImageManager.load(holder.mImageView, ImageType.PHOTO, getBestImageUrl(media), ScaleType.CENTER_CROP);
+                // Photon isn't available, so cap the decoded bitmap size to avoid OOM when
+                // falling back to medium/large/full-size URLs.
+                mImageManager.load(holder.mImageView, ImageType.PHOTO, getBestImageUrl(media),
+                        ScaleType.CENTER_CROP, mThumbWidth, mThumbHeight);
             }
         } else if (media.isVideo()) {
             holder.mFileContainer.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -107,7 +107,14 @@ class ImageManager @Inject constructor(
      * If no URL is provided, it only loads the placeholder
      */
     @JvmOverloads
-    fun load(imageView: ImageView, imageType: ImageType, imgUrl: String = "", scaleType: ScaleType = CENTER) {
+    fun load(
+        imageView: ImageView,
+        imageType: ImageType,
+        imgUrl: String = "",
+        scaleType: ScaleType = CENTER,
+        width: Int? = null,
+        height: Int? = null
+    ) {
         val context = imageView.context
         if (!context.isAvailable()) return
         Glide.with(context)
@@ -115,6 +122,7 @@ class ImageManager @Inject constructor(
             .addFallback(imageType)
             .addPlaceholder(imageType)
             .applyScaleType(scaleType)
+            .applySize(width, height)
             .into(imageView)
             .clearOnDetach()
     }


### PR DESCRIPTION
## Description

**Closes CMM-1947**

This PR resolves a long-standing problem with our media grid. For sites that aren't Photon-capable, when the media didn't have a smaller version available we would load the full-sized image into the grid, which could cause an OOM exception.

Here we resolved the problem by passing the height and width of the image for non-Photon sites.


## Testing instructions

- Place a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/e28cb58de20de0e2ecb62c443c0c88c067424639/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt#L614)
- Switch to a site that isn't Photon-capable
- My Site > Media
- Verify the breakpoint is hit
