### PR TITLE
Fix editor exit hang when GutenbergView never finishes loading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 26.8
 -----
-
+* [**] Resolved an issue where the editor could become impossible to exit when it failed to load.
 
 26.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -1878,15 +1878,24 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         updateAndSavePostAsync(listener, isFinishing)
     }
 
+    @Suppress("ReturnCount")
     private fun updateFromEditor(oldContent: String, isFinishing: Boolean = false): UpdateFromEditor {
         editorFragment?.let {
+            // Don't read title/content from a stalled editor — doing so would
+            // overwrite the in-memory PostModel with empty strings, and the
+            // postChanged observer would then persist that empty state to
+            // SQLite. See issue #22878.
+            if (!it.isEditorReady()) {
+                AppLog.w(AppLog.T.EDITOR, "Skipping content update: Gutenberg editor not ready")
+                return UpdateFromEditor.Failed(java.lang.Exception("Gutenberg editor not ready"))
+            }
             return try {
                 // To reduce redundant bridge events emitted to the Gutenberg editor, we get title and content at once
                 val titleAndContent = it.getTitleAndContent(oldContent, isFinishing)
                 val title = titleAndContent.first as String
                 val content = titleAndContent.second as String
                 PostFields(title, content)
-            } catch (e: EditorFragmentAbstract.EditorFragmentNotAddedException) {
+            } catch (e: GutenbergKitEditorFragmentBase.EditorFragmentNotAddedException) {
                 AppLog.e(AppLog.T.EDITOR, "Impossible to save the post, we weren't able to update it.")
                 UpdateFromEditor.Failed(e)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -42,6 +42,7 @@ import org.wordpress.gutenberg.GutenbergView.TitleAndContentCallback
 import org.wordpress.gutenberg.Media
 import org.wordpress.gutenberg.model.EditorConfiguration
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
@@ -50,6 +51,9 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
 
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
+
+    @Volatile
+    private var editorReady = false
 
     private val textWatcher = LiveTextWatcher()
     private var historyChangeListener: HistoryChangeListener? = null
@@ -257,7 +261,10 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
             }
         )
 
+        editorReady = false
+
         gutenbergView.setEditorDidBecomeAvailable {
+            editorReady = true
             mEditorFragmentListener.onEditorFragmentContentReady(
                 ArrayList<Any?>(), false
             )
@@ -434,8 +441,19 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         )
 
         val finalResult = try {
-            latch.await()
-            result[0]
+            val completed = latch.await(
+                GET_TITLE_AND_CONTENT_TIMEOUT_SECONDS, TimeUnit.SECONDS
+            )
+            if (!completed) {
+                AppLog.w(
+                    AppLog.T.EDITOR,
+                    "Timed out waiting for title and content from " +
+                        "Gutenberg editor"
+                )
+                null
+            } else {
+                result[0]
+            }
         } catch (e: InterruptedException) {
             AppLog.w(
                 AppLog.T.EDITOR,
@@ -446,7 +464,10 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
             null
         }
 
-        return finalResult ?: Pair("", "")
+        // Surface failure to the caller as a checked exception so it can
+        // skip mutating the PostModel rather than persisting empty content
+        // over the user's existing draft. See issue #22878.
+        return finalResult ?: throw EditorFragmentNotAddedException()
     }
 
     override fun getEditorName(): String {
@@ -517,6 +538,8 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         super.onDestroy()
     }
 
+    fun isEditorReady(): Boolean = editorReady
+
     fun setXPostsEnabled(enabled: Boolean) {
         isXPostsEnabled = enabled
     }
@@ -550,6 +573,8 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
 
         private const val CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101
         private const val CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102
+
+        private const val GET_TITLE_AND_CONTENT_TIMEOUT_SECONDS = 5L
 
         fun newInstance(
             configuration: EditorConfiguration,


### PR DESCRIPTION
## Summary

If `GutenbergView` never finishes loading (e.g. an upstream 404 on `wp-block-editor/v1/settings`, network failure mid-init, or any other case where the JS bridge never becomes available), the editor activity gets stuck — back press doesn't dismiss it, the "saving" progress dialog stays open, and the only way out is to force-stop the app.

Fixes #22878.

## Root cause

`GutenbergKitEditorFragment.getTitleAndContent` blocks on `CountDownLatch.await()` with no timeout. The save-on-exit flow (`savePostAndOptionallyFinish` → `updateAndSavePostAsyncOnEditorExit` → `updateAndSavePostAsync` → `updateFromEditor` → `getTitleAndContent`) sits on this latch waiting for `TitleAndContentCallback.onResult` to fire from JS. When `GutenbergView` hasn't finished loading, the bridge call is dropped silently — GBKit internally guards on its private `isEditorLoaded` field and logs `"You can't change the editor content until it has loaded"`. `latch.countDown()` never fires; the activity never finishes.

Introduced incidentally by #22764 ("Upgrade GutenbergKit from v0.11.1 to v0.15.2"), which switched the bridge call from sync to async-with-latch.

## Fix

GBKit doesn't currently expose a public ready-state property — only the `setEditorDidBecomeAvailable {}` callback. Three layers, all host-side.

### 1. Track ready state in the fragment

`@Volatile var editorReady` flipped inside the `setEditorDidBecomeAvailable {}` listener we already register; reset to `false` in `onCreateView` so a stale `true` doesn't leak across config changes. `@Volatile` is required because the field is written from the JS bridge thread and read from `bgDispatcher` (via `EditPostRepository.updateAsync`). Exposed publicly via `isEditorReady()`.

### 2. Bound the latch

Replace `latch.await()` with `latch.await(5, TimeUnit.SECONDS)`. On timeout (or `InterruptedException`), `getTitleAndContent` throws `EditorFragmentNotAddedException` rather than returning a sentinel empty `Pair`.

### 3. Short-circuit the save flow before it mutates the `PostModel`

`GutenbergKitActivity.updateFromEditor` checks `isEditorReady()` before calling `getTitleAndContent`. When false (or when the timeout path throws), it returns `UpdateFromEditor.Failed(...)`. `StorePostViewModel.updatePostObjectWithUI` treats `Failed` as a no-op — `updatePostContentNewEditor` is never called, the in-memory `PostModel` is not mutated, `_postChanged` does not fire, and the auto-save observer at `GutenbergKitActivity.kt:1158-1162` does not run.

This last step is load-bearing. An earlier draft of this PR returned `Pair("", "")` from `getTitleAndContent` on stall, on the assumption that "empty post → no save attempted." That assumption was **wrong**. `_postChanged` fires whenever the in-memory `PostModel` changes, and `editPostRepository.postChanged.observe` calls `storePostViewModel.savePostToDb` regardless of `shouldSavePost()`. For an existing draft, the in-memory overwrite to empty would have been persisted to SQLite, silently wiping the user's content.

### Incidental: exception-class mismatch in `updateFromEditor`'s catch

The pre-existing catch was `catch (e: EditorFragmentAbstract.EditorFragmentNotAddedException)`, but `GutenbergKitEditorFragment` throws `GutenbergKitEditorFragmentBase.EditorFragmentNotAddedException` — two unrelated inner classes sharing the same simple name, descending separately from `Exception`. The catch was dead code. Changed to match the actually-thrown class so the new timeout-throw is caught.

### Net behaviour

Editor stall → `Failed` returned → no `PostModel` mutation → no DB write → activity finishes via `ActivityFinishState.CANCELLED` within ~5s. Existing draft on disk is preserved.

The underlying 404 / route-detection asymmetry on Atomic sites is a separate concern, owned by #22812 / capability-detection territory. This PR is specifically about the host's failure mode when the editor doesn't load, regardless of *why* it didn't load.

## Test plan

- [ ] On WP.com simple site, open a post in the editor, type, and exit — content saves and the activity finishes as before.
- [ ] On an Atomic site (I suggest using `automatticwidgets.wpcomstaging.com`), the editor stalls with Theme Styles and Third-Party Blocks enabled (you'll need to turn these on in Site Settings to see it), open a post in the editor, wait for the stall, press the back button or X — the activity finishes within ~5 seconds instead of hanging indefinitely.
- [ ] **Open an existing draft with non-empty content** on a stalling site, wait for the stall, exit, then reopen the post in a working session — the original content is still there (not overwritten with empty).
- [ ] No `savePostToDb` call is made when exiting from a stalled session (verify in logs).

## Related

- Surfaced during testing of #22579 (Integrate Gutenberg Preloading).