### PR TITLE
Probe direct host for editor capability detection on Atomic sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Resolved an issue where the editor could become impossible to exit when it failed to load.
 * [*] Atomic sites can now create application passwords without leaving the app.
+* [**] Fixed a case where the editor failed to load on WP.com Atomic sites whose host doesn't expose `wp-block-editor/v1/settings`.
 
 26.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/repositories/EditorSettingsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/repositories/EditorSettingsRepository.kt
@@ -12,7 +12,11 @@ import org.wordpress.android.fluxc.persistence.EditorSettingsSqlUtils
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import rs.wordpress.api.kotlin.ApiDiscoveryResult
+import rs.wordpress.api.kotlin.WpLoginClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.ApiUrlResolver
+import uniffi.wp_api.WpApiDetails
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -20,6 +24,7 @@ import javax.inject.Singleton
 @Singleton
 class EditorSettingsRepository @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
+    private val wpLoginClient: WpLoginClient,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val themeRepository: ThemeRepository,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
@@ -92,36 +97,14 @@ class EditorSettingsRepository @Inject constructor(
     private suspend fun fetchRouteSupport(
         site: SiteModel
     ): Boolean = try {
-        val client =
-            wpApiClientProvider.getWpApiClient(site)
-        val resolver =
-            wpApiClientProvider.getApiUrlResolver(site)
-        val response =
-            client.request { it.apiRoot().get() }
-
-        if (response is WpRequestResult.Success) {
-            val data = response.response.data
-            appPrefsWrapper
-                .setSiteSupportsEditorSettings(
-                    site,
-                    data.hasRouteForEndpoint(
-                        resolver,
-                        "/wp-block-editor/v1",
-                        "settings"
-                    )
-                )
-            appPrefsWrapper
-                .setSiteSupportsEditorAssets(
-                    site,
-                    data.hasRouteForEndpoint(
-                        resolver,
-                        "/wpcom/v2",
-                        "editor-assets"
-                    )
-                )
-            true
+        // For Atomic sites the editor fetches `wp-block-editor/v1/settings`
+        // from the direct host — proxy and direct host can advertise
+        // different route lists, so detection has to probe the direct host
+        // too. See #22879.
+        if (site.isWPComAtomic) {
+            fetchRouteSupportViaDirectHostDiscovery(site)
         } else {
-            false
+            fetchRouteSupportViaConfiguredClient(site)
         }
     } catch (e: CancellationException) {
         throw e
@@ -133,6 +116,70 @@ class EditorSettingsRepository @Inject constructor(
             e
         )
         false
+    }
+
+    private suspend fun fetchRouteSupportViaConfiguredClient(
+        site: SiteModel
+    ): Boolean {
+        val client = wpApiClientProvider.getWpApiClient(site)
+        val resolver = wpApiClientProvider.getApiUrlResolver(site)
+        val response = client.request { it.apiRoot().get() }
+        return if (response is WpRequestResult.Success) {
+            persistRouteSupport(site, response.response.data, resolver)
+            true
+        } else {
+            false
+        }
+    }
+
+    /**
+     * On WP.com Atomic sites the editor fetches `wp-block-editor/v1/settings`
+     * from the direct host — not the WP.com proxy — so detection has to
+     * match. Run REST API autodiscovery on the site URL so we don't have to
+     * assume the API lives at `/wp-json` (custom permalink structures or
+     * REST API paths would break that assumption), then use the routes list
+     * returned by discovery directly — no second request needed.
+     */
+    private suspend fun fetchRouteSupportViaDirectHostDiscovery(
+        site: SiteModel
+    ): Boolean {
+        val discovery = wpLoginClient.apiDiscovery(site.url)
+        if (discovery !is ApiDiscoveryResult.Success) {
+            AppLog.w(
+                T.EDITOR,
+                "Direct-host API discovery failed for" +
+                    " site=${site.name}: ${discovery::class.simpleName}"
+            )
+            return false
+        }
+        val resolver = wpApiClientProvider.urlResolverFor(
+            discovery.success.apiRootUrl
+        )
+        persistRouteSupport(site, discovery.success.apiDetails, resolver)
+        return true
+    }
+
+    private fun persistRouteSupport(
+        site: SiteModel,
+        data: WpApiDetails,
+        resolver: ApiUrlResolver,
+    ) {
+        appPrefsWrapper.setSiteSupportsEditorSettings(
+            site,
+            data.hasRouteForEndpoint(
+                resolver,
+                "/wp-block-editor/v1",
+                "settings"
+            )
+        )
+        appPrefsWrapper.setSiteSupportsEditorAssets(
+            site,
+            data.hasRouteForEndpoint(
+                resolver,
+                "/wpcom/v2",
+                "editor-assets"
+            )
+        )
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/WordPress/src/test/java/org/wordpress/android/repositories/EditorSettingsRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/repositories/EditorSettingsRepositoryTest.kt
@@ -15,10 +15,15 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.api.kotlin.WpLoginClient
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.ApiRootRequestGetResponse
 import uniffi.wp_api.ApiUrlResolver
+import uniffi.wp_api.AutoDiscoveryAttemptSuccess
+import uniffi.wp_api.DiscoveredAuthenticationMechanism
+import uniffi.wp_api.ParseUrlException
 import uniffi.wp_api.ThemeAuthor
 import uniffi.wp_api.ThemeAuthorUri
 import uniffi.wp_api.ThemeDescription
@@ -37,6 +42,9 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
     lateinit var wpApiClientProvider: WpApiClientProvider
 
     @Mock
+    lateinit var wpLoginClient: WpLoginClient
+
+    @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
     @Mock
@@ -47,6 +55,9 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
 
     @Mock
     lateinit var apiUrlResolver: ApiUrlResolver
+
+    @Mock
+    lateinit var directHostResolver: ApiUrlResolver
 
     private lateinit var repository: EditorSettingsRepository
 
@@ -64,6 +75,7 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
 
         repository = EditorSettingsRepository(
             wpApiClientProvider = wpApiClientProvider,
+            wpLoginClient = wpLoginClient,
             appPrefsWrapper = appPrefsWrapper,
             themeRepository = themeRepository,
             ioDispatcher = testDispatcher()
@@ -186,22 +198,155 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
                 .setSiteThemeIsBlockTheme(any(), any())
         }
 
-    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `atomic site probes via api discovery`() =
+        runTest {
+            val atomicSite = SiteModel().apply {
+                id = 2
+                url = "https://atomic.example.com"
+                setIsWPCom(true)
+                setIsWPComAtomic(true)
+            }
+            mockDiscoverySuccess(
+                siteUrl = atomicSite.url,
+                hasEditorSettings = false,
+                hasEditorAssets = false
+            )
+            whenever(themeRepository.fetchCurrentTheme(atomicSite))
+                .thenReturn(buildTheme(isBlockTheme = false))
+
+            val result =
+                repository.fetchEditorCapabilitiesForSite(atomicSite)
+
+            assertThat(result).isTrue()
+            verify(appPrefsWrapper)
+                .setSiteSupportsEditorSettings(atomicSite, false)
+            verify(appPrefsWrapper)
+                .setSiteSupportsEditorAssets(atomicSite, false)
+            verify(wpApiClientProvider, never()).getWpApiClient(atomicSite)
+        }
+
+    @Test
+    fun `atomic site returns false when discovery fails`() =
+        runTest {
+            val atomicSite = SiteModel().apply {
+                id = 4
+                url = "https://atomic.example.com"
+                setIsWPCom(true)
+                setIsWPComAtomic(true)
+            }
+            whenever(wpLoginClient.apiDiscovery(atomicSite.url))
+                .thenReturn(
+                    ApiDiscoveryResult.FailureParseSiteUrl(
+                        ParseUrlException.Generic("")
+                    )
+                )
+            whenever(themeRepository.fetchCurrentTheme(atomicSite))
+                .thenReturn(buildTheme(isBlockTheme = false))
+
+            val result =
+                repository.fetchEditorCapabilitiesForSite(atomicSite)
+
+            assertThat(result).isFalse()
+            verify(appPrefsWrapper, never())
+                .setSiteSupportsEditorSettings(any(), any())
+            verify(appPrefsWrapper, never())
+                .setSiteSupportsEditorAssets(any(), any())
+            verify(wpApiClientProvider, never()).getWpApiClient(atomicSite)
+        }
+
+    @Test
+    fun `atomic site with app password also probes via api discovery`() =
+        runTest {
+            val atomicSite = SiteModel().apply {
+                id = 3
+                url = "https://atomic.example.com"
+                setIsWPCom(true)
+                setIsWPComAtomic(true)
+                apiRestUsernamePlain = "user"
+                apiRestPasswordPlain = "secret"
+            }
+            mockDiscoverySuccess(
+                siteUrl = atomicSite.url,
+                hasEditorSettings = true,
+                hasEditorAssets = true
+            )
+            whenever(themeRepository.fetchCurrentTheme(atomicSite))
+                .thenReturn(buildTheme(isBlockTheme = false))
+
+            val result =
+                repository.fetchEditorCapabilitiesForSite(atomicSite)
+
+            assertThat(result).isTrue()
+            verify(appPrefsWrapper)
+                .setSiteSupportsEditorSettings(atomicSite, true)
+            verify(appPrefsWrapper)
+                .setSiteSupportsEditorAssets(atomicSite, true)
+            verify(wpApiClientProvider, never()).getWpApiClient(atomicSite)
+        }
+
     private suspend fun mockApiRootResponse(
         hasEditorSettings: Boolean,
         hasEditorAssets: Boolean
+    ) = mockApiRootResponseFor(
+        client = wpApiClient,
+        resolver = apiUrlResolver,
+        hasEditorSettings = hasEditorSettings,
+        hasEditorAssets = hasEditorAssets,
+    )
+
+    private suspend fun mockDiscoverySuccess(
+        siteUrl: String,
+        hasEditorSettings: Boolean,
+        hasEditorAssets: Boolean,
     ) {
         val apiDetails = mock<WpApiDetails>()
         whenever(
             apiDetails.hasRouteForEndpoint(
-                apiUrlResolver,
+                directHostResolver,
                 "/wp-block-editor/v1",
                 "settings"
             )
         ).thenReturn(hasEditorSettings)
         whenever(
             apiDetails.hasRouteForEndpoint(
-                apiUrlResolver,
+                directHostResolver,
+                "/wpcom/v2",
+                "editor-assets"
+            )
+        ).thenReturn(hasEditorAssets)
+        val apiRootUrl = mock<uniffi.wp_api.ParsedUrl>()
+        whenever(wpApiClientProvider.urlResolverFor(apiRootUrl))
+            .thenReturn(directHostResolver)
+        val success = AutoDiscoveryAttemptSuccess(
+            parsedSiteUrl = mock(),
+            apiRootUrl = apiRootUrl,
+            apiDetails = apiDetails,
+            authentication = DiscoveredAuthenticationMechanism
+                .ApplicationPasswords(mock()),
+        )
+        whenever(wpLoginClient.apiDiscovery(siteUrl))
+            .thenReturn(ApiDiscoveryResult.Success(success))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun mockApiRootResponseFor(
+        client: WpApiClient,
+        resolver: ApiUrlResolver,
+        hasEditorSettings: Boolean,
+        hasEditorAssets: Boolean
+    ) {
+        val apiDetails = mock<WpApiDetails>()
+        whenever(
+            apiDetails.hasRouteForEndpoint(
+                resolver,
+                "/wp-block-editor/v1",
+                "settings"
+            )
+        ).thenReturn(hasEditorSettings)
+        whenever(
+            apiDetails.hasRouteForEndpoint(
+                resolver,
                 "/wpcom/v2",
                 "editor-assets"
             )
@@ -211,7 +356,7 @@ class EditorSettingsRepositoryTest : BaseUnitTest() {
             data = apiDetails,
             headerMap = mock<WpNetworkHeaderMap>()
         )
-        whenever(wpApiClient.request<Any>(any()))
+        whenever(client.request<Any>(any()))
             .thenReturn(
                 WpRequestResult.Success(response)
                     as WpRequestResult<Any>

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
@@ -193,6 +193,16 @@ class WpApiClientProvider @Inject constructor(
         )
     }
 
+    /**
+     * Builds a [WpOrgSiteApiUrlResolver] for an already-parsed REST API root
+     * URL (e.g. one returned by `WpLoginClient.apiDiscovery`). Exposed so
+     * callers don't have to construct the uniffi resolver directly — useful
+     * for testability.
+     */
+    fun urlResolverFor(
+        apiRootUrl: ParsedUrl
+    ): uniffi.wp_api.ApiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl)
+
     fun getApiRootUrlFrom(site: SiteModel): String = site.buildUrl()
 
     private fun SiteModel.buildUrl(): String =


### PR DESCRIPTION
## Description

Fixes #22879. The editor stalls partway through preloading on WP.com Atomic sites whose direct host doesn't expose `wp-block-editor/v1/settings`, because capability detection reports "theme styles supported" via the WP.com proxy and then the editor 404s fetching that route from the direct host.

### Root cause

`EditorSettingsRepository.fetchRouteSupport` and `GutenbergView` were not talking to the same host on Atomic sites:

- **Detection:** `WpApiClientProvider.getWpApiClient(site)` returns the WP.com client whenever `site.isWPCom || site.isUsingWpComRestApi`, so `apiRoot()` is queried via `public-api.wordpress.com`. Its route list drives `hasRouteForEndpoint("/wp-block-editor/v1", "settings", ...)`.
- **Consumption:** `GutenbergView` uses the configured `siteURL` (the direct host) for its block-editor settings fetch, not `siteApiRoot`.

For Atomic sites those two hosts can diverge — the proxy advertises routes the direct host doesn't expose — and we confidently tell the editor "theme styles is supported" right before the editor 404s on the direct host.

### Fix

Detect against the host the editor will actually use. For all WP.com Atomic sites, run REST API autodiscovery on `site.url` and read the routes list off the discovery result directly. Non-Atomic shapes keep the existing `getWpApiClient` / `getApiUrlResolver` path.

- **`WpApiClientProvider`**: New `urlResolverFor(apiRootUrl: ParsedUrl)` — a thin wrapper around `WpOrgSiteApiUrlResolver` so callers can reuse the `ParsedUrl` returned by discovery without coupling to uniffi internals.
- **`EditorSettingsRepository`**: Takes a new `WpLoginClient` dependency. `fetchRouteSupport` branches on `site.isWPComAtomic`: that branch calls `wpLoginClient.apiDiscovery(site.url)` and uses `apiRootUrl` + `apiDetails` from the success result — no second `apiRoot().get()` needed. Non-Atomic shapes route through `fetchRouteSupportViaConfiguredClient`, which is the original logic untouched.

Discovery is used rather than an unauthenticated `apiRoot().get()` against `${site.url}/wp-json` so we don't bake in an assumption about where the REST API lives (custom permalink structures or non-default REST API paths would break that).

### What we explored

1. **Detect against the host the editor will use** ✅ — chosen. Specifically, REST API autodiscovery on `site.url`, so we don't assume the API lives at `/wp-json`. Matches the project intent of talking directly to the site whenever possible.
2. **Probe both, intersect.** Would close the false-positive but could close false-negatives we'd want to honor.
3. **Have GBKit consume `siteApiRoot` for `wp-block-editor/v1/settings`.** Library-side change, and the project intent ("direct to the site as much as possible") cuts the other way.

### Scope

Covers all WP.com Atomic sites — with or without an application password — because the editor talks to the direct host in both shapes. Atomic + app password didn't reproduce #22879 (Basic auth on the direct host exposes the route anyway), but the symmetric fix avoids surprises later. Non-Atomic shapes (Simple, self-hosted, JPC) keep the existing detection path unchanged.

## Testing instructions

Atomic site:

1. Sign into a WP.com account associated with automatticwidgets.wpcomstaging.com.
2. Open My Site for that site and let the dashboard settle so the preloader runs and capability detection completes.
3. Open Site Settings, verify "Use Theme Styles" appears disabled / unsupported.
4. Create a new post., verify the editor opens correctly.
5. Validate that the AI Assistant block is present and insert one. Ask it something, note that it works. This validates that third-party plugins are working correctly.

Simple Site test (regression check):

1. Use a WP.com Simple site, run the same AI Assistant test.

Unit tests:
- [x] `./gradlew :WordPress:testJetpackDebugUnitTest --tests EditorSettingsRepositoryTest` — passes (existing tests + new tests covering Atomic direct-host discovery).
