### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3808: harden WPcomLoginClient error path

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/WPcomLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/WPcomLoginHelper.kt
@@ -8,6 +8,7 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.browser.customtabs.CustomTabsSession
 import androidx.core.net.toUri
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -17,6 +18,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.rest.wpapi.WPcomLoginClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 class WPcomLoginHelper @Inject constructor(
@@ -24,7 +26,10 @@ class WPcomLoginHelper @Inject constructor(
     private val accountStore: AccountStore,
     appSecrets: AppSecrets,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        AppLog.e(AppLog.T.MAIN, "Uncaught exception in WPcomLoginHelper", throwable)
+    }
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + exceptionHandler)
 
     val wpcomLoginUri = loginClient.loginUri(appSecrets.redirectUri)
     private val customTabsServiceConnection = ServiceConnection(wpcomLoginUri)
@@ -66,9 +71,7 @@ class WPcomLoginHelper @Inject constructor(
                 },
                 onFailure = { error ->
                     withContext(Dispatchers.Main) {
-                        onFailure.accept(
-                            Exception(error)
-                        )
+                        onFailure.accept(error as? Exception ?: Exception(error))
                     }
                 }
             )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClient.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi
 import android.net.Uri
 import android.util.Log
 import com.google.gson.Gson
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import okhttp3.FormBody
 import okhttp3.Interceptor
@@ -11,7 +12,6 @@ import okhttp3.Request
 import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WPcomAuthorizationCodeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -67,25 +67,29 @@ class WPcomLoginClient @Inject constructor(
 
                 if (!response.isSuccessful) {
                     response.body?.let { Log.e("WPCOM_LOGIN", it.string()) }
-                    Result.failure(WPcomLoginError.AccessDenied)
+                    Result.failure(WPcomLoginException(WPcomLoginError.AccessDenied))
                 } else {
                     val json = response.body?.string()
-                        ?: return@withContext Result.failure(WPcomLoginError.InvalidResponse)
+                        ?: return@withContext Result.failure(
+                            WPcomLoginException(WPcomLoginError.InvalidResponse)
+                        )
                     val gson = Gson().fromJson(json, WPcomAuthorizationCodeResponse::class.java)
                     Result.success(gson.accessToken)
                 }
-            } catch (e: IOException) {
-                Log.e("WPCOM_LOGIN", "Network error exchanging auth code for token", e)
-                Result.failure(WPcomLoginError.NetworkError(e))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e("WPCOM_LOGIN", "Error exchanging auth code for token", e)
+                Result.failure(WPcomLoginException(WPcomLoginError.NetworkError(e)))
             }
         }
     }
 }
 
-sealed class WPcomLoginError(val code: Int): Throwable() {
-    data object AccessDenied: WPcomLoginError(CODE_ACCESS_DENIED)
-    data object InvalidResponse: WPcomLoginError(CODE_INVALID_RESPONSE)
-    data class NetworkError(override val cause: Throwable): WPcomLoginError(CODE_NETWORK_ERROR)
+sealed class WPcomLoginError(val code: Int) {
+    data object AccessDenied : WPcomLoginError(CODE_ACCESS_DENIED)
+    data object InvalidResponse : WPcomLoginError(CODE_INVALID_RESPONSE)
+    data class NetworkError(val cause: Throwable) : WPcomLoginError(CODE_NETWORK_ERROR)
 
     companion object {
         private const val CODE_ACCESS_DENIED = 1
@@ -93,3 +97,8 @@ sealed class WPcomLoginError(val code: Int): Throwable() {
         private const val CODE_NETWORK_ERROR = 3
     }
 }
+
+class WPcomLoginException(val error: WPcomLoginError) : Exception(
+    "WPcom login failed: $error",
+    (error as? WPcomLoginError.NetworkError)?.cause
+)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/WPcomLoginClientTest.kt
@@ -32,7 +32,9 @@ class WPcomLoginClientTest {
         val result = subject.exchangeAuthCodeForToken("any_code")
 
         assertTrue(result.isFailure)
-        val error = result.exceptionOrNull()
+        val exception = result.exceptionOrNull()
+        assertIs<WPcomLoginException>(exception)
+        val error = exception.error
         assertIs<WPcomLoginError.NetworkError>(error)
         assertSame(ioException, error.cause)
     }


### PR DESCRIPTION
Fixes [WORDPRESS-ANDROID-3808](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3808).

## Summary

Top WPcom-login Sentry crash (211 users / 5079 events over the last 16 months, still firing on the latest production build 1488). Surfaces in Sentry as `RuntimeException → InvocationTargetException → WPcomLoginError$AccessDenied`, culprit `WPcomLoginClient$exchangeAuthCodeForToken$3.invokeSuspend`. Also visible on Google Play Console (77 WordPress + 32 Jetpack distinct users in the last 30 days).

## Root cause

`WPcomLoginError` extended `Throwable`, and its variants `AccessDenied` / `InvalidResponse` were `data object` singletons. That means **a single Throwable instance with a stack trace frozen at class init** was reused for every failure — so any rethrow (or anything that turns a `Result.failure(throwable)` into an actual throw) shows the same `invokeSuspend` frame regardless of the actual origin, producing one giant grouped crash that's impossible to pinpoint.

Additionally, the suspend block only caught `IOException`, so any other exception from OkHttp / interceptors / response-body reads escaped the suspend boundary and propagated out of the `scope.launch` coroutine in `WPcomLoginHelper`. That scope had no `CoroutineExceptionHandler`, so an uncaught throw became a fatal process crash. The Sentry events all show `in_foreground: false` shortly after deeplink resume into `LoginActivity`, consistent with the `withContext(Dispatchers.Main)` resumption happening after activity teardown.

## Changes

- **`WPcomLoginClient.kt`** — drop the `Throwable` supertype from `WPcomLoginError`; introduce a fresh `WPcomLoginException(error: WPcomLoginError)` wrapper for `Result.failure(...)` so each failure captures its own stack at the actual call site. No more shared singleton stack.
- **`WPcomLoginClient.kt`** — widen `catch (IOException)` to `catch (Exception)` (with `CancellationException` rethrow), mapping unknown failures to `WPcomLoginError.NetworkError` so nothing escapes the suspend boundary.
- **`WPcomLoginHelper.kt`** — add a `CoroutineExceptionHandler` to the helper's scope as a safety net: any future uncaught throw inside `scope.launch { ... }` is logged via `AppLog.e` instead of crashing the process. Also simplify the `onFailure` to pass the existing `WPcomLoginException` through instead of double-wrapping.
- **`WPcomLoginClientTest.kt`** — update the existing test to unwrap `WPcomLoginException → error → NetworkError.cause`.

## Test plan

- [ ] Happy path: cold-start WPcom login → returning to the app via OAuth callback completes login and lands in the main app.
- [ ] Backgrounding: start WPcom login, switch apps for a few minutes, then tap the callback link → app no longer crashes; error UI or successful login is shown.
- [ ] Airplane mode during callback exchange → `NetworkError` path triggers (existing unit test covers this) and the in-app error message is shown rather than crashing.