### PR TITLE
Fix Sentry WORDPRESS-ANDROID-3F8W: skip Sentry for empty_fetch_params

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -188,7 +188,8 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
                 emitError(
                     siteUrl = siteUrl,
-                    errorMessage = "empty_fetch_params"
+                    errorMessage = "empty_fetch_params",
+                    reportToSentry = false,
                 )
             } else {
                 discoverAndDispatchFetchSite(


### PR DESCRIPTION
## Summary

Fixes [WORDPRESS-ANDROID-3F8W](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3F8W) — `Application password login failed: empty_fetch_params` (~463 users / ~720 events).

Sibling of the issues silenced in #22846. When the deep-link callback arrives with one of `username` / `password` / `siteUrl` / `apiRootUrl` missing — most commonly `apiRootUrl` not present in the URI — `fetchSites` emits an `empty_fetch_params` error to the UI and tracks the failure via `trackStoringFailed(..., "empty_fetch_params")`. It was also firing a crash report because `emitError` defaulted to `reportToSentry = true`. #22846 added the `reportToSentry` flag and silenced the `empty_credentials` / `site_not_found` / `no_rows_affected` validation outcomes, but missed this earlier check.

## What changed

`fetchSites` now passes `reportToSentry = false` for the `empty_fetch_params` branch. The UI surfacing and analytics tracking are unchanged — only the Sentry noise stops.

## Test plan

- [ ] Walk through application password login on a self-hosted site (happy path) to confirm no behavior regression.
- [ ] Sanity-check Sentry dashboards 1 week after the next release ships to confirm event-rate drop on 3F8W.

🤖 Generated with [Claude Code](https://claude.com/claude-code)