### PR TITLE
Hardening for the Atomic application-password validator and cleanup flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.mysite.cards.applicationpassword
 
+import kotlinx.coroutines.CancellationException
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.WpErrorCode
 import javax.inject.Inject
 
 /**
@@ -13,11 +15,18 @@ import javax.inject.Inject
  * direct host. Uses [WpApiClientProvider.getApplicationPasswordClient] so the call exercises the
  * application password specifically — `getWpApiClient` would route WPCom-flagged sites through the
  * bearer-token path and would not catch a revoked password.
+ *
+ * Classification is intentionally asymmetric: a return of [Outcome.Invalid] cascades into a
+ * credential wipe + re-mint in the caller, so we only classify as Invalid when we have positive
+ * evidence the server rejected the credential (auth-specific [WpErrorCode] or
+ * [RequestExecutionErrorReason]). Everything ambiguous — 5xx, parse errors, offline, DNS — falls
+ * to [Outcome.NetworkUnavailable], which hides the card and lets the next foreground retry.
  */
 class ApplicationPasswordValidator @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
     private val appLogWrapper: AppLogWrapper,
 ) {
+    @Suppress("ReturnCount")
     suspend fun validate(site: SiteModel): Outcome {
         appLogWrapper.d(
             AppLog.T.MAIN,
@@ -27,25 +36,9 @@ class ApplicationPasswordValidator @Inject constructor(
             val client = wpApiClientProvider.getApplicationPasswordClient(site)
             val response = client.request { it.users().retrieveMeWithViewContext() }
             appLogWrapper.d(AppLog.T.MAIN, "A_P: Validation response: ${response::class.simpleName}")
-            when (response) {
-                is WpRequestResult.Success -> {
-                    val user = response.response.data
-                    appLogWrapper.d(
-                        AppLog.T.MAIN,
-                        "A_P: Validation Success returned user id=${user.id}, slug='${user.slug}', name='${user.name}'"
-                    )
-                    Outcome.Valid
-                }
-                is WpRequestResult.WpError -> Outcome.Invalid
-                is WpRequestResult.UnknownError -> Outcome.Invalid
-                is WpRequestResult.RequestExecutionFailed ->
-                    if (response.reason is RequestExecutionErrorReason.HttpTimeoutError) {
-                        Outcome.NetworkUnavailable
-                    } else {
-                        Outcome.Invalid
-                    }
-                else -> Outcome.Invalid
-            }
+            classify(response)
+        } catch (e: CancellationException) {
+            throw e
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             appLogWrapper.e(
                 AppLog.T.MAIN,
@@ -54,6 +47,41 @@ class ApplicationPasswordValidator @Inject constructor(
             Outcome.NetworkUnavailable
         }
     }
+
+    private fun <T> classify(response: WpRequestResult<T>): Outcome = when (response) {
+        is WpRequestResult.Success -> Outcome.Valid
+
+        is WpRequestResult.WpError -> if (isAuthErrorCode(response.errorCode)) {
+            Outcome.Invalid
+        } else {
+            // Parseable WP error envelope that isn't an auth rejection (e.g. 5xx returned as a
+            // structured WpError, or a server-side plugin returning a custom code). Ambiguous —
+            // don't wipe creds.
+            Outcome.NetworkUnavailable
+        }
+
+        is WpRequestResult.RequestExecutionFailed -> if (isAuthErrorReason(response.reason)) {
+            Outcome.Invalid
+        } else {
+            // Timeouts, offline, DNS, SSL, generic transport errors — all non-destructive.
+            Outcome.NetworkUnavailable
+        }
+
+        // UnknownError (4xx/5xx without parseable WP error JSON), parse errors, and any other
+        // variants are all ambiguous. Default to non-destructive.
+        else -> Outcome.NetworkUnavailable
+    }
+
+    private fun isAuthErrorCode(code: WpErrorCode): Boolean =
+        code is WpErrorCode.Unauthorized ||
+            code is WpErrorCode.Forbidden ||
+            code is WpErrorCode.ApplicationPasswordNotFound ||
+            code is WpErrorCode.NoAuthenticatedAppPassword
+
+    private fun isAuthErrorReason(reason: RequestExecutionErrorReason): Boolean =
+        reason is RequestExecutionErrorReason.HttpAuthenticationRejectedError ||
+            reason is RequestExecutionErrorReason.HttpAuthenticationRequiredError ||
+            reason is RequestExecutionErrorReason.HttpForbiddenError
 
     enum class Outcome { Valid, Invalid, NetworkUnavailable }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
@@ -26,7 +26,6 @@ class ApplicationPasswordValidator @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
     private val appLogWrapper: AppLogWrapper,
 ) {
-    @Suppress("ReturnCount")
     suspend fun validate(site: SiteModel): Outcome {
         appLogWrapper.d(
             AppLog.T.MAIN,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
@@ -51,12 +51,20 @@ class ApplicationPasswordValidator @Inject constructor(
     private fun <T> classify(response: WpRequestResult<T>): Outcome = when (response) {
         is WpRequestResult.Success -> Outcome.Valid
 
-        is WpRequestResult.WpError -> if (isAuthErrorCode(response.errorCode)) {
+        // A WpError is the server returning a parseable error envelope. Treat any 401/403 as an
+        // auth rejection regardless of the WpErrorCode value — WordPress emits a wide variety of
+        // codes for credential failures (`incorrect_password`, `invalid_username`,
+        // `application_passwords_disabled_for_user`, plugin-defined codes, etc.) and many of them
+        // get parsed as `WpErrorCode.CustomError` via the library's untagged fallback. Status
+        // code is the reliable signal. Also include a few non-auth-status codes that we know
+        // mean the credential is unusable.
+        is WpRequestResult.WpError -> if (
+            isAuthErrorCode(response.errorCode) || isAuthStatusCode(response.statusCode)
+        ) {
             Outcome.Invalid
         } else {
-            // Parseable WP error envelope that isn't an auth rejection (e.g. 5xx returned as a
-            // structured WpError, or a server-side plugin returning a custom code). Ambiguous —
-            // don't wipe creds.
+            // Parseable error envelope without an auth-rejection signal (e.g. a 5xx returned as
+            // a structured WpError). Ambiguous — don't wipe creds.
             Outcome.NetworkUnavailable
         }
 
@@ -78,10 +86,18 @@ class ApplicationPasswordValidator @Inject constructor(
             code is WpErrorCode.ApplicationPasswordNotFound ||
             code is WpErrorCode.NoAuthenticatedAppPassword
 
+    private fun isAuthStatusCode(statusCode: UShort): Boolean =
+        statusCode.toInt() == HTTP_UNAUTHORIZED || statusCode.toInt() == HTTP_FORBIDDEN
+
     private fun isAuthErrorReason(reason: RequestExecutionErrorReason): Boolean =
         reason is RequestExecutionErrorReason.HttpAuthenticationRejectedError ||
             reason is RequestExecutionErrorReason.HttpAuthenticationRequiredError ||
             reason is RequestExecutionErrorReason.HttpForbiddenError
+
+    companion object {
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+    }
 
     enum class Outcome { Valid, Invalid, NetworkUnavailable }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.WpErrorCode
+import java.net.HttpURLConnection
 import javax.inject.Inject
 
 /**
@@ -18,9 +19,10 @@ import javax.inject.Inject
  *
  * Classification is intentionally asymmetric: a return of [Outcome.Invalid] cascades into a
  * credential wipe + re-mint in the caller, so we only classify as Invalid when we have positive
- * evidence the server rejected the credential (auth-specific [WpErrorCode] or
- * [RequestExecutionErrorReason]). Everything ambiguous — 5xx, parse errors, offline, DNS — falls
- * to [Outcome.NetworkUnavailable], which hides the card and lets the next foreground retry.
+ * evidence the server rejected the credential — an auth-specific [WpErrorCode], an auth-specific
+ * [RequestExecutionErrorReason], or a [WpRequestResult.WpError] with a 401/403 status. Everything
+ * ambiguous — 5xx, parse errors, offline, DNS — falls to [Outcome.NetworkUnavailable], which
+ * hides the card and lets the next foreground retry.
  */
 class ApplicationPasswordValidator @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
@@ -55,8 +57,9 @@ class ApplicationPasswordValidator @Inject constructor(
         // codes for credential failures (`incorrect_password`, `invalid_username`,
         // `application_passwords_disabled_for_user`, plugin-defined codes, etc.) and many of them
         // get parsed as `WpErrorCode.CustomError` via the library's untagged fallback. Status
-        // code is the reliable signal. Also include a few non-auth-status codes that we know
-        // mean the credential is unusable.
+        // code is the reliable signal. Additionally, accept a small allowlist of WpErrorCode
+        // names (e.g. `ApplicationPasswordNotFound`, which comes back with 404) that signal an
+        // unusable credential outside the 401/403 status range.
         is WpRequestResult.WpError -> if (
             isAuthErrorCode(response.errorCode) || isAuthStatusCode(response.statusCode)
         ) {
@@ -86,17 +89,13 @@ class ApplicationPasswordValidator @Inject constructor(
             code is WpErrorCode.NoAuthenticatedAppPassword
 
     private fun isAuthStatusCode(statusCode: UInt): Boolean =
-        statusCode.toInt() == HTTP_UNAUTHORIZED || statusCode.toInt() == HTTP_FORBIDDEN
+        statusCode.toInt() == HttpURLConnection.HTTP_UNAUTHORIZED ||
+            statusCode.toInt() == HttpURLConnection.HTTP_FORBIDDEN
 
     private fun isAuthErrorReason(reason: RequestExecutionErrorReason): Boolean =
         reason is RequestExecutionErrorReason.HttpAuthenticationRejectedError ||
             reason is RequestExecutionErrorReason.HttpAuthenticationRequiredError ||
             reason is RequestExecutionErrorReason.HttpForbiddenError
-
-    companion object {
-        private const val HTTP_UNAUTHORIZED = 401
-        private const val HTTP_FORBIDDEN = 403
-    }
 
     enum class Outcome { Valid, Invalid, NetworkUnavailable }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidator.kt
@@ -86,7 +86,7 @@ class ApplicationPasswordValidator @Inject constructor(
             code is WpErrorCode.ApplicationPasswordNotFound ||
             code is WpErrorCode.NoAuthenticatedAppPassword
 
-    private fun isAuthStatusCode(statusCode: UShort): Boolean =
+    private fun isAuthStatusCode(statusCode: UInt): Boolean =
         statusCode.toInt() == HTTP_UNAUTHORIZED || statusCode.toInt() == HTTP_FORBIDDEN
 
     private fun isAuthErrorReason(reason: RequestExecutionErrorReason): Boolean =

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
@@ -1,0 +1,248 @@
+package org.wordpress.android.ui.mysite.cards.applicationpassword
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.WpErrorCode
+
+@ExperimentalCoroutinesApi
+class ApplicationPasswordValidatorTest : BaseUnitTest() {
+    @Mock
+    lateinit var wpApiClientProvider: WpApiClientProvider
+
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+
+    @Mock
+    lateinit var wpApiClient: WpApiClient
+
+    private lateinit var validator: ApplicationPasswordValidator
+    private lateinit var site: SiteModel
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        validator = ApplicationPasswordValidator(wpApiClientProvider, appLogWrapper)
+        site = SiteModel().apply {
+            id = 1
+            url = "https://example.com"
+            apiRestUsernamePlain = "user"
+            apiRestPasswordPlain = "pass"
+        }
+        whenever(wpApiClientProvider.getApplicationPasswordClient(site)).thenReturn(wpApiClient)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun stubResponse(response: WpRequestResult<*>) {
+        whenever(wpApiClient.request<Any>(any())).thenReturn(response as WpRequestResult<Any>)
+    }
+
+    private fun wpError(code: WpErrorCode) = WpRequestResult.WpError<Any>(
+        errorCode = code,
+        errorMessage = "msg",
+        statusCode = 401.toUShort(),
+        response = "",
+        requestUrl = "https://example.com",
+        requestMethod = RequestMethod.GET,
+    )
+
+    private fun requestFailed(reason: RequestExecutionErrorReason) =
+        WpRequestResult.RequestExecutionFailed<Any>(
+            statusCode = null,
+            redirects = null,
+            reason = reason,
+            requestUrl = "https://example.com",
+            requestMethod = RequestMethod.GET,
+        )
+
+    // --- Success ---
+
+    @Test
+    fun `Success maps to Valid`() = runTest {
+        stubResponse(WpRequestResult.Success<Any>(response = Any()))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Valid)
+    }
+
+    // --- WpError: auth-related codes map to Invalid ---
+
+    @Test
+    fun `WpError Unauthorized maps to Invalid`() = runTest {
+        stubResponse(wpError(WpErrorCode.Unauthorized()))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `WpError Forbidden maps to Invalid`() = runTest {
+        stubResponse(wpError(WpErrorCode.Forbidden()))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `WpError ApplicationPasswordNotFound maps to Invalid`() = runTest {
+        stubResponse(wpError(WpErrorCode.ApplicationPasswordNotFound()))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `WpError NoAuthenticatedAppPassword maps to Invalid`() = runTest {
+        stubResponse(wpError(WpErrorCode.NoAuthenticatedAppPassword()))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    // --- WpError: non-auth codes must NOT wipe creds ---
+
+    @Test
+    fun `WpError InvalidParam maps to NetworkUnavailable (do not wipe creds)`() = runTest {
+        stubResponse(wpError(WpErrorCode.InvalidParam()))
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    // --- RequestExecutionFailed: auth-related reasons map to Invalid ---
+
+    @Test
+    fun `RequestExecutionFailed HttpAuthenticationRejectedError maps to Invalid`() = runTest {
+        stubResponse(
+            requestFailed(
+                RequestExecutionErrorReason.HttpAuthenticationRejectedError(
+                    hostname = "example.com",
+                    method = null,
+                )
+            )
+        )
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `RequestExecutionFailed HttpAuthenticationRequiredError maps to Invalid`() = runTest {
+        stubResponse(
+            requestFailed(
+                RequestExecutionErrorReason.HttpAuthenticationRequiredError(
+                    hostname = "example.com",
+                    method = null,
+                )
+            )
+        )
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `RequestExecutionFailed HttpForbiddenError maps to Invalid`() = runTest {
+        stubResponse(
+            requestFailed(RequestExecutionErrorReason.HttpForbiddenError(hostname = "example.com"))
+        )
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    // --- RequestExecutionFailed: non-auth reasons must NOT wipe creds ---
+
+    @Test
+    fun `RequestExecutionFailed HttpTimeoutError maps to NetworkUnavailable`() = runTest {
+        stubResponse(requestFailed(RequestExecutionErrorReason.HttpTimeoutError))
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `RequestExecutionFailed DeviceIsOfflineError maps to NetworkUnavailable`() = runTest {
+        stubResponse(
+            requestFailed(RequestExecutionErrorReason.DeviceIsOfflineError(errorMessage = "off"))
+        )
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `RequestExecutionFailed NonExistentSiteError maps to NetworkUnavailable`() = runTest {
+        stubResponse(
+            requestFailed(
+                RequestExecutionErrorReason.NonExistentSiteError(
+                    errorMessage = null,
+                    suggestedAction = null,
+                )
+            )
+        )
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `RequestExecutionFailed HttpError maps to NetworkUnavailable`() = runTest {
+        stubResponse(requestFailed(RequestExecutionErrorReason.HttpError(reason = "boom")))
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    // --- Other variants: all default to NetworkUnavailable ---
+
+    @Test
+    fun `UnknownError (5xx without parseable JSON) maps to NetworkUnavailable`() = runTest {
+        stubResponse(
+            WpRequestResult.UnknownError<Any>(
+                statusCode = 503.toUShort(),
+                response = "<html>Service Unavailable</html>",
+                requestUrl = "https://example.com",
+                requestMethod = RequestMethod.GET,
+            )
+        )
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `InvalidHttpStatusCode maps to NetworkUnavailable`() = runTest {
+        stubResponse(
+            WpRequestResult.InvalidHttpStatusCode<Any>(
+                statusCode = 999.toUShort(),
+                requestUrl = "https://example.com",
+                requestMethod = RequestMethod.GET,
+            )
+        )
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `ResponseParsingError maps to NetworkUnavailable`() = runTest {
+        stubResponse(
+            WpRequestResult.ResponseParsingError<Any>(
+                reason = "bad json",
+                response = "not json",
+                requestUrl = "https://example.com",
+                requestMethod = RequestMethod.GET,
+            )
+        )
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    // --- Exception handling ---
+
+    @Test
+    fun `generic Exception maps to NetworkUnavailable`() = runTest {
+        whenever(wpApiClient.request<Any>(any())).thenThrow(RuntimeException("boom"))
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `CancellationException is rethrown, not swallowed`() = runTest {
+        whenever(wpApiClient.request<Any>(any())).thenThrow(CancellationException("cancelled"))
+        validator.validate(site)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
@@ -55,7 +55,7 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
     private fun wpError(code: WpErrorCode, statusCode: Int = 401) = WpRequestResult.WpError<Any>(
         errorCode = code,
         errorMessage = "msg",
-        statusCode = statusCode.toUShort(),
+        statusCode = statusCode.toUInt(),
         response = "",
         requestUrl = "https://example.com",
         requestMethod = RequestMethod.GET,
@@ -221,7 +221,7 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
     fun `UnknownError (5xx without parseable JSON) maps to NetworkUnavailable`() = runTest {
         stubResponse(
             WpRequestResult.UnknownError<Any>(
-                statusCode = 503.toUShort(),
+                statusCode = 503.toUInt(),
                 response = "<html>Service Unavailable</html>",
                 requestUrl = "https://example.com",
                 requestMethod = RequestMethod.GET,
@@ -235,7 +235,7 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
     fun `InvalidHttpStatusCode maps to NetworkUnavailable`() = runTest {
         stubResponse(
             WpRequestResult.InvalidHttpStatusCode<Any>(
-                statusCode = 999.toUShort(),
+                statusCode = 999.toUInt(),
                 requestUrl = "https://example.com",
                 requestMethod = RequestMethod.GET,
             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
@@ -52,10 +52,10 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
         whenever(wpApiClient.request<Any>(any())).thenReturn(response as WpRequestResult<Any>)
     }
 
-    private fun wpError(code: WpErrorCode) = WpRequestResult.WpError<Any>(
+    private fun wpError(code: WpErrorCode, statusCode: Int = 401) = WpRequestResult.WpError<Any>(
         errorCode = code,
         errorMessage = "msg",
-        statusCode = 401.toUShort(),
+        statusCode = statusCode.toUShort(),
         response = "",
         requestUrl = "https://example.com",
         requestMethod = RequestMethod.GET,
@@ -107,8 +107,35 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
     // --- WpError: non-auth codes must NOT wipe creds ---
 
     @Test
-    fun `WpError InvalidParam maps to NetworkUnavailable (do not wipe creds)`() = runTest {
-        stubResponse(wpError(WpErrorCode.InvalidParam()))
+    fun `WpError non-auth code with non-auth status maps to NetworkUnavailable`() = runTest {
+        // Non-401/403 status with an unrelated WpErrorCode: ambiguous, don't wipe creds.
+        stubResponse(wpError(WpErrorCode.InvalidParam(), statusCode = 400))
+        assertThat(validator.validate(site))
+            .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
+    }
+
+    @Test
+    fun `WpError with 401 status maps to Invalid regardless of code`() = runTest {
+        // WordPress emits a wide range of WpErrorCodes for credential rejections (e.g.
+        // `incorrect_password`, `invalid_username`, plugin-defined codes). Many fall through
+        // to wordpress-rs's untagged-string fallback and aren't recognized as auth codes by
+        // name. The status code is the reliable signal — a parseable WpError with 401/403 is
+        // always an auth rejection regardless of which WpErrorCode it carries.
+        stubResponse(wpError(WpErrorCode.InvalidParam(), statusCode = 401))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `WpError with 403 status maps to Invalid regardless of code`() = runTest {
+        stubResponse(wpError(WpErrorCode.InvalidParam(), statusCode = 403))
+        assertThat(validator.validate(site)).isEqualTo(ApplicationPasswordValidator.Outcome.Invalid)
+    }
+
+    @Test
+    fun `WpError with 500 status maps to NetworkUnavailable`() = runTest {
+        // A server returning a structured WpError on 5xx is unusual but possible. Without an
+        // auth-status signal and without an auth code, treat it as transient.
+        stubResponse(wpError(WpErrorCode.InvalidParam(), statusCode = 500))
         assertThat(validator.validate(site))
             .isEqualTo(ApplicationPasswordValidator.Outcome.NetworkUnavailable)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordValidatorTest.kt
@@ -52,7 +52,9 @@ class ApplicationPasswordValidatorTest : BaseUnitTest() {
         whenever(wpApiClient.request<Any>(any())).thenReturn(response as WpRequestResult<Any>)
     }
 
-    private fun wpError(code: WpErrorCode, statusCode: Int = 401) = WpRequestResult.WpError<Any>(
+    // Default to a non-auth status so WpErrorCode-only tests isolate the code path from the
+    // status path. Tests of the status path (401/403) pass an explicit value.
+    private fun wpError(code: WpErrorCode, statusCode: Int = 500) = WpRequestResult.WpError<Any>(
         errorCode = code,
         errorMessage = "msg",
         statusCode = statusCode.toUInt(),

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -2434,12 +2434,47 @@ open class SiteStore @Inject constructor(
         }
 
     /**
-     * Clears stored application-password credentials (encrypted prefs) so the next call to
+     * Clears stored application-password credentials so the next call to
      * [createApplicationPassword] mints a fresh one. Use this when a validation call against the
      * stored credentials has failed (e.g. 401, password revoked server-side).
+     *
+     * Both storage locations are cleared:
+     * - The encrypted SharedPreferences cache (`ApplicationPasswordsStore`), so
+     *   [ApplicationPasswordsManager] doesn't short-circuit the next mint by returning
+     *   `Existing` with the revoked password.
+     * - The SiteModel's credential columns (`apiRest*`), so subsequent reads — validation
+     *   loops, XML-RPC rediscovery, etc. — don't see the stale credentials.
+     *
+     * `wpApiRestUrl` is intentionally preserved. Unlike [removeApplicationPassword] (full sign-out),
+     * the discovered REST URL is reusable across credential rotations; clearing it would force a
+     * re-discovery on every refresh after a revoke.
      */
     fun deleteStoredApplicationPasswordCredentials(site: SiteModel) {
         applicationPasswordsManagerProvider.get().deleteLocalApplicationPassword(site)
+        emitChange(clearApplicationPasswordColumns(site))
+    }
+
+    @Suppress("SwallowedException")
+    private fun clearApplicationPasswordColumns(siteModel: SiteModel): OnSiteChanged {
+        return try {
+            val siteFromDB = getSiteByLocalId(siteModel.id)
+                ?: return OnSiteChanged(SiteError(SiteErrorType.INVALID_SITE))
+            // Clear both Plain and Encrypted columns. `SiteSqlUtils.encryptAPIRestCredentials`
+            // short-circuits when the encrypted columns are non-empty, so clearing only the plain
+            // values would leave the stale ciphertext in place and `decryptAPIRestCredentials`
+            // would resurrect them on the next read.
+            siteFromDB.apply {
+                apiRestUsernamePlain = ""
+                apiRestPasswordPlain = ""
+                apiRestUsernameEncrypted = ""
+                apiRestPasswordEncrypted = ""
+                apiRestUsernameIV = ""
+                apiRestPasswordIV = ""
+            }
+            OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteFromDB))
+        } catch (e: DuplicateSiteException) {
+            OnSiteChanged(SiteError(DUPLICATE_SITE))
+        }
     }
 
     private fun persistApplicationPasswordCredentials(


### PR DESCRIPTION
Four corrections to the validator + cleanup flow introduced in #22885. Found during on-device testing of that PR.

## Summary

1. Tighten validator error classification — only return `Invalid` when there's positive evidence the credential was rejected.
2. Treat 401/403 `WpError` responses as auth failures regardless of error-code name.
3. Clear the SiteModel's credential columns in `deleteStoredApplicationPasswordCredentials`, not just the encrypted-prefs cache.
4. Adapt to the wordpress-rs UInt status-code API (post-rebase mechanical change).

## Root Cause

#22885 introduced an asymmetric pipeline: any `Outcome.Invalid` from `ApplicationPasswordValidator` triggers `siteStore.deleteStoredApplicationPasswordCredentials(...)` + a re-mint. The original implementation had three bugs that combined to either destroy working credentials or strand the user with an unrecoverable revoked password:

### 1. Validator misclassified recoverable errors as `Invalid`

The original `when` mapped `WpRequestResult.WpError`, `UnknownError`, and the `else` branch all to `Outcome.Invalid`. That meant a transient 5xx, a `DeviceIsOfflineError`, a parse error, or any unrecognized variant would all wipe working credentials. The generic `catch (Exception)` also swallowed `CancellationException`.

### 2. WpError auth detection used WpErrorCode names instead of status codes

The first fix tightened the classification to recognize a fixed allowlist of `WpErrorCode` variants (`Unauthorized`, `Forbidden`, `ApplicationPasswordNotFound`, `NoAuthenticatedAppPassword`). That missed the most common case in practice: WordPress returns `{"code": "incorrect_password", ...}` for a revoked application password (Basic auth rejection), and wordpress-rs parses that into `WpErrorCode.CustomError("incorrect_password")` via its untagged-string fallback. None of the name-based matchers caught `CustomError`, so the validator silently returned `Outcome.NetworkUnavailable` and the My Site card stayed hidden when it should have triggered a re-mint. Reproduced on-device:

```
A_P: Validating application password for ... as user='jkmassel'
A_P: Validation response: WpError
A_P: Validation network error for ...
```

Status code is the reliable signal — any parseable `WpError` with a 401/403 status is, by definition, an auth rejection regardless of which `WpErrorCode` it carries.

### 3. `deleteStoredApplicationPasswordCredentials` only cleared the encrypted-prefs cache

The method cleared only `ApplicationPasswordsStore` (encrypted SharedPreferences) and left the SiteModel's `apiRest*` DB columns untouched. Combined with the validate→wipe→re-mint loop, if validation returned `Invalid` and the subsequent mint failed (network down, server unreachable, etc.), the next `buildCard` reloaded the site from DB, `decryptAPIRestCredentials` resurrected the stale plain fields, `siteHasBadCredentials` reported false, and validation ran again with the same revoked password. The `attemptXmlRpcRediscovery` path also reads the plain fields directly and 401s when they're stale.

## Fix

### Validator
- Invert the default: anything unrecognized → `Outcome.NetworkUnavailable` (non-destructive). Only return `Outcome.Invalid` when there's positive evidence of an auth rejection — auth-specific `WpErrorCode`, auth-specific `RequestExecutionErrorReason`, **or** a `WpError` with 401/403 status. The auth-code and auth-reason lists are a superset of `PostRsErrorUtils.isAuthError`, adding `Forbidden` and `HttpForbiddenError`.
- Re-throw `CancellationException` before the generic `Exception` catch.

### Credential cleanup
- `deleteStoredApplicationPasswordCredentials` now clears the SiteModel's plain and encrypted credential columns in addition to the encrypted-prefs cache, using the same fetch-fresh-from-DB / mutate / save pattern as `removeApplicationPassword`. Emits `OnSiteChanged` so observers see the credential state change. `wpApiRestUrl` is intentionally preserved — unlike full sign-out, the discovered REST URL is reusable across credential rotations. (Note: some sites are observed with a NULL `wpApiRestUrl` for unrelated reasons; tracked in #22899.)

### Wordpress-rs UInt migration
- The wordpress-rs bump on trunk (`fc05d3bb3d9`) changed `statusCode` from `UShort` to `UInt`. One-line signature change in `isAuthStatusCode` + four `toUShort()` → `toUInt()` test fixture updates. No behavior change.

## Tests

`ApplicationPasswordValidatorTest` (new, 21 tests):
- `Success` → `Valid`.
- `WpError` for each auth-related `WpErrorCode` → `Invalid`.
- `WpError` with any code + status 401/403 → `Invalid` (covers the `incorrect_password` case).
- `WpError` with non-auth code + non-auth status → `NetworkUnavailable`.
- `WpError` with non-auth code + 500 → `NetworkUnavailable`.
- `RequestExecutionFailed` for each auth-related reason → `Invalid`.
- `RequestExecutionFailed` for each non-auth reason (timeout, offline, DNS, generic transport) → `NetworkUnavailable`.
- `UnknownError`, `InvalidHttpStatusCode`, `ResponseParsingError` → `NetworkUnavailable`.
- Generic `Exception` → `NetworkUnavailable`.
- `CancellationException` is rethrown.

## Test plan
- [x] Atomic site with valid creds — pull-to-refresh. Validate succeeds → no card.
- [x] Atomic site with revoked creds — pull-to-refresh. Validator returns `Invalid` → wipe → re-mint succeeds → no card.
- [x] Atomic site with revoked creds + airplane mode — pull-to-refresh. Validator returns `NetworkUnavailable` → no card, no destructive action; creds preserved in DB.
- [x] Self-hosted regression: still works.
- [x] `:WordPress:testJetpackDebugUnitTest --tests "org.wordpress.android.ui.mysite.cards.applicationpassword.*"` all pass.

## Related

- Stacked on #22885.

