### PR TITLE
Route the application-passwords list screen through Basic auth

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordsViewModel.kt
@@ -186,7 +186,13 @@ class ApplicationPasswordsViewModel @Inject constructor(
     }
 
     private suspend fun getApplicationPasswordsList(site: SiteModel): List<ApplicationPasswordWithViewContext> {
-        val wpApiClient = wpApiClientProvider.getWpApiClient(site)
+        // Always use the direct-host Basic-auth client. `getWpApiClient` routes WPCom-flagged
+        // sites (including Atomic) through the WP.com REST proxy, which doesn't expose the
+        // `application-passwords` routes — every call 404s with `rest_no_route`. Talking to the
+        // site directly with the stored application password sidesteps that limitation.
+        // Requires the SiteModel to have credentials already (e.g. via the My Site auto-mint
+        // flow); otherwise the call will 401.
+        val wpApiClient = wpApiClientProvider.getApplicationPasswordClient(site)
 
         val currentUserId = getCurrentUserId(wpApiClient)
         return if (currentUserId == null) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
@@ -70,6 +70,20 @@ class WpApiClientProvider @Inject constructor(
         }
     }
 
+    /**
+     * Always returns a Basic-auth client against the direct host using the SiteModel's
+     * application-password credentials, regardless of WP.com routing. Use this when you need to
+     * talk to the site's own REST endpoints with the application password — `getWpApiClient`
+     * routes WPCom-flagged sites (including Atomic) through the bearer-token path and the WP.com
+     * REST proxy, which doesn't expose application-password-authenticated routes like
+     * `/wp/v2/users/{id}/application-passwords`.
+     */
+    @Synchronized
+    fun getApplicationPasswordClient(site: SiteModel): WpApiClient =
+        selfHostedClients.getOrPut(site.id) {
+            createSelfHostedClient(site, uploadListener = null)
+        }
+
     private fun createSelfHostedClient(
         site: SiteModel,
         uploadListener: WpRequestExecutor.UploadListener?,


### PR DESCRIPTION
Fixes a bug where the application-passwords list screen returned an empty list / auth error on Atomic sites. Targets `trunk` directly so it can land independently — the larger Atomic headless mint work (#22885) builds on top of this.

> Supersedes #22892, which was auto-closed during a branch reshuffle when its diff against its (then-)base became empty.

## Summary

- Add `WpApiClientProvider.getApplicationPasswordClient(site)` — always returns a direct-host Basic-auth client built from the SiteModel's application-password credentials, regardless of WP.com routing.
- Swap `getWpApiClient(site)` → `getApplicationPasswordClient(site)` in `ApplicationPasswordsViewModel.kt`.

## Root Cause

`getWpApiClient` routes WPCom-flagged sites (including Atomic) through the WP.com REST proxy at `https://public-api.wordpress.com/rest/v1.1/sites/{id}/wp/v2/...`. The proxy doesn't expose the `application-passwords` routes — every request 404s with `rest_no_route`. This is the same upstream wordpress-rs limitation (Automattic/wordpress-rs#1350) that drove dropping the headless wordpress-rs mint attempt in #22885.

## Fix

The new method `getApplicationPasswordClient` always reuses the `selfHostedClients` cache path — Basic auth against the direct host using the SiteModel's `apiRestUsernamePlain` / `apiRestPasswordPlain`. The direct host serves the `application-passwords` routes on every WordPress install.

For self-hosted sites the behaviour is unchanged: both `getWpApiClient` and `getApplicationPasswordClient` end up returning the same Basic-auth client via `selfHostedClients.getOrPut(site.id)`. For Atomic and Jetpack-WPCom-REST sites the change is what matters — we now bypass the proxy and talk to the underlying WordPress install directly.

## Limitations

The SiteModel must already have application-password credentials. On a Simple WPCom site there are no such credentials and the call will 401 — but that screen isn't really meant to work on Simple sites anyway. For Atomic sites, the credentials are populated by the My Site auto-mint flow once #22885 lands; in the meantime, users on Atomic still need to authorize the first time via the Custom Tab flow.

## Test plan
- [ ] Open an Atomic site → Me → Application Passwords. List displays correctly.
- [ ] Open a self-hosted site with stored creds → Me → Application Passwords. List displays correctly (regression check).
- [ ] Delete an app password server-side → re-open the screen. Error message surfaces correctly.

## Related

- #22885 — Atomic headless application-password mint flow. Builds on top of this PR.
- Automattic/wordpress-rs#1350 — the upstream limitation this works around.