### PR TITLE
Keep JNA/UniFFI classes so wordpress-rs survives R8 in release builds

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -3,6 +3,21 @@
 # optimizations. Disable until reflection-safe keep rules are fully verified.
 -dontoptimize
 
+###### wordpress-rs (JNA + UniFFI) - begin
+# wordpress-rs exposes its Rust API through UniFFI-generated JNA Structures
+# (e.g. uniffi.wp_api.RustBuffer). JNA reads the @Structure.FieldOrder annotation
+# reflectively at runtime to compute each native struct's field layout. AGP 9's R8
+# treats that annotation as unused and strips it during shrinking, so getFieldOrder()
+# returns empty and the app crashes on launch in minified release builds. Keep the
+# JNA classes, the UniFFI bindings, and the annotation so the layout still resolves.
+-keep class com.sun.jna.** { *; }
+-keep class * extends com.sun.jna.Structure { *; }
+-keepclassmembers class * extends com.sun.jna.Structure { *; }
+-keep,allowobfuscation @interface com.sun.jna.Structure$FieldOrder
+-keep @com.sun.jna.Structure$FieldOrder class * { *; }
+-keep class uniffi.** { *; }
+###### wordpress-rs (JNA + UniFFI) - end
+
 ###### OkHttp - begin
 -dontwarn okio.**
 -dontwarn okhttp3.**


### PR DESCRIPTION
AGP 9's R8 strips the @com.sun.jna.Structure.FieldOrder annotation that wordpress-rs JNA bindings read reflectively at runtime, causing a launch crash in minified release builds. Keep the JNA classes, UniFFI bindings, and the annotation so native struct layouts still resolve.
