### PR TITLE
Fix Czech `confirm_remove_site` translation breaking release/26.8 lint

### DIFF
--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -210,7 +210,7 @@ Language: cs_CZ
     <string name="site_settings_tags_empty_subtitle">Proč jej nevytvořit, aby bylo snazší označovat příspěvky štítky?</string>
     <string name="posts_published_empty_subtitle">Proč jej nevytvořit?</string>
     <string name="media_empty_list_subtitle">Proč něco nenahrát?</string>
-    <string name="confirm_remove_site">Odebrat \\"%s\\" z aplikace?</string>
+    <string name="confirm_remove_site">Odebrat \"%s\" z aplikace?</string>
     <string name="he_support_forbidden_error">Omlouváme se, tuto akci nemáte povoleno provést.</string>
     <string name="he_support_generic_error">Došlo k chybě. Zkuste to prosím později.</string>
     <string name="he_support_send_ticket_button">Odeslat</string>


### PR DESCRIPTION
Fixes a broken Czech translation that fails release lint on `release/26.8` and blocks the beta build.

## Summary

- The Czech `confirm_remove_site` string was synced from GlotPress with a doubled backslash (`\\"`) instead of the single-backslash escape (`\"`) used by the English source.
- This breaks `lintWordpressRelease` / `lintJetpackRelease` with `StringFormatMatches`, taking CI red from build [#26605](https://buildkite.com/automattic/wordpress-android/builds/26605) onward (last green: [#26604](https://buildkite.com/automattic/wordpress-android/builds/26604)).

## Root Cause

Android string escaping reads `\\` as an escaped literal backslash. So `Odebrat \\"%s\\" z aplikace?` is parsed as a backslash followed by an unescaped `"`, which hides the `%s` placeholder from lint's format-string analysis. Lint then concludes the string takes **0** arguments while the call site supplies **1**:

```
ChooseSiteActivity.kt:296: Error: Wrong argument count, format string confirm_remove_site
requires 0 but format call supplies 1 [StringFormatMatches]
    values-cs/strings.xml:213: This definition requires 0 arguments
```

`getString(R.string.confirm_remove_site, siteName)` passes one argument, matching the English source `Remove \"%s\" from the app?`. Czech was the **only** locale with the doubled-backslash form — every other locale uses `\"%s\"` or its own quote characters (`„%s"`, `«%s»`, `「%s」`).

## Fix

**WordPress/src/main/res/values-cs/strings.xml**: `\\"%s\\"` → `\"%s\"`, restoring the `%s` placeholder and matching the English source.

```diff
-    <string name="confirm_remove_site">Odebrat \\"%s\\" z aplikace?</string>
+    <string name="confirm_remove_site">Odebrat \"%s\" z aplikace?</string>
```

The underlying GlotPress translation should also be corrected so the next sync doesn't reintroduce it — that's a separate effort.

## Test plan

- [ ] `lintWordpressRelease` and `lintJetpackRelease` pass on CI (the `StringFormatMatches` error is gone).
- [ ] Czech "Remove site" dialog renders the site name in place of `%s` (no stray backslashes).