### PR TITLE
Fix NPE when application password response is missing password or UUID

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 import com.google.gson.annotations.SerializedName
 
 internal data class ApplicationPasswordCreationResponse(
-    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
-    @SerializedName("name") val name: String,
-    @SerializedName("password") val password: String
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID?,
+    @SerializedName("name") val name: String?,
+    @SerializedName("password") val password: String?
 )
 
 internal data class ApplicationPasswordsFetchResponse(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -47,14 +47,18 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess<ApplicationPasswordCreationResponse> -> {
-                response.data?.let {
-                    ApplicationPasswordCreationPayload(it.password, it.uuid)
-                } ?: ApplicationPasswordCreationPayload(
-                    BaseNetworkError(
-                        GenericErrorType.UNKNOWN,
-                        "Password missing from response"
+                val password = response.data?.password
+                val uuid = response.data?.uuid
+                if (password != null && uuid != null) {
+                    ApplicationPasswordCreationPayload(password, uuid)
+                } else {
+                    ApplicationPasswordCreationPayload(
+                        BaseNetworkError(
+                            GenericErrorType.UNKNOWN,
+                            "Password or UUID missing from response"
+                        )
                     )
-                )
+                }
             }
             is JetpackError<ApplicationPasswordCreationResponse> ->
                 ApplicationPasswordCreationPayload(response.error)
@@ -77,8 +81,8 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess -> {
-                response.data?.firstOrNull { it.name == applicationName }?.let {
-                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                response.data?.firstOrNull { it.name == applicationName }?.uuid?.let {
+                    ApplicationPasswordUUIDFetchPayload(it)
                 } ?: ApplicationPasswordUUIDFetchPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -53,14 +53,18 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is WPAPIResponse.Success<ApplicationPasswordCreationResponse> -> {
-                response.data?.let {
-                    ApplicationPasswordCreationPayload(it.password, it.uuid)
-                } ?: ApplicationPasswordCreationPayload(
-                    BaseNetworkError(
-                        GenericErrorType.UNKNOWN,
-                        "Password missing from response"
+                val password = response.data?.password
+                val uuid = response.data?.uuid
+                if (password != null && uuid != null) {
+                    ApplicationPasswordCreationPayload(password, uuid)
+                } else {
+                    ApplicationPasswordCreationPayload(
+                        BaseNetworkError(
+                            GenericErrorType.UNKNOWN,
+                            "Password or UUID missing from response"
+                        )
                     )
-                )
+                }
             }
 
             is WPAPIResponse.Error<ApplicationPasswordCreationResponse> ->

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClientTest.kt
@@ -1,0 +1,118 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class JetpackApplicationPasswordsRestClientTest {
+    private val applicationName = "name"
+    private val testSite = SiteModel().apply {
+        url = "http://test-site.com"
+    }
+
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder = mock()
+
+    private lateinit var restClient: JetpackApplicationPasswordsRestClient
+
+    @Before
+    fun setup() {
+        restClient = JetpackApplicationPasswordsRestClient(
+            jetpackTunnelGsonRequestBuilder = jetpackTunnelGsonRequestBuilder,
+            appContext = mock(),
+            dispatcher = mock(),
+            requestQueue = mock(),
+            accessToken = mock(),
+            userAgent = mock()
+        )
+    }
+
+    @Test
+    fun `given a valid response, when creating a password, then return the credentials`() = runTest {
+        givenPostResponse(
+            JetpackSuccess(ApplicationPasswordCreationResponse(uuid = "uuid", name = applicationName, password = "pwd"))
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertFalse(payload.isError)
+        assertEquals("pwd", payload.password)
+        assertEquals("uuid", payload.uuid)
+    }
+
+    @Test
+    fun `given a response with a null password, when creating a password, then return an error`() = runTest {
+        givenPostResponse(
+            JetpackSuccess(ApplicationPasswordCreationResponse(uuid = "uuid", name = applicationName, password = null))
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a response with a null uuid, when creating a password, then return an error`() = runTest {
+        givenPostResponse(
+            JetpackSuccess(ApplicationPasswordCreationResponse(uuid = null, name = applicationName, password = "pwd"))
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a null response body, when creating a password, then return an error`() = runTest {
+        givenPostResponse(JetpackSuccess(null))
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a network error, when creating a password, then propagate the error`() = runTest {
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.SERVER_ERROR))
+        givenPostResponse(JetpackError(error))
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals(error, payload.error)
+    }
+
+    private suspend fun givenPostResponse(response: JetpackResponse<ApplicationPasswordCreationResponse>) {
+        whenever(
+            jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                any(),
+                any(),
+                any(),
+                any(),
+                eq(ApplicationPasswordCreationResponse::class.java)
+            )
+        ).thenReturn(response)
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClientTest.kt
@@ -1,0 +1,121 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class WPApiApplicationPasswordsRestClientTest {
+    private val applicationName = "name"
+    private val testSite = SiteModel().apply {
+        url = "http://test-site.com"
+        username = "username"
+        password = "password"
+    }
+
+    private val cookieNonceAuthenticator: CookieNonceAuthenticator = mock()
+
+    private lateinit var restClient: WPApiApplicationPasswordsRestClient
+
+    @Before
+    fun setup() {
+        restClient = WPApiApplicationPasswordsRestClient(
+            wpApiGsonRequestBuilder = mock(),
+            cookieNonceAuthenticator = cookieNonceAuthenticator,
+            noCookieRequestQueue = mock(),
+            requestQueue = mock(),
+            dispatcher = mock(),
+            userAgent = mock()
+        )
+    }
+
+    @Test
+    fun `given a valid response, when creating a password, then return the credentials`() = runTest {
+        givenCreationResponse(
+            WPAPIResponse.Success(
+                ApplicationPasswordCreationResponse(uuid = "uuid", name = applicationName, password = "pwd")
+            )
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertFalse(payload.isError)
+        assertEquals("pwd", payload.password)
+        assertEquals("uuid", payload.uuid)
+    }
+
+    @Test
+    fun `given a response with a null password, when creating a password, then return an error`() = runTest {
+        givenCreationResponse(
+            WPAPIResponse.Success(
+                ApplicationPasswordCreationResponse(uuid = "uuid", name = applicationName, password = null)
+            )
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a response with a null uuid, when creating a password, then return an error`() = runTest {
+        givenCreationResponse(
+            WPAPIResponse.Success(
+                ApplicationPasswordCreationResponse(uuid = null, name = applicationName, password = "pwd")
+            )
+        )
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a null response body, when creating a password, then return an error`() = runTest {
+        givenCreationResponse(WPAPIResponse.Success(null))
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals("Password or UUID missing from response", payload.error.message)
+    }
+
+    @Test
+    fun `given a network error, when creating a password, then propagate the error`() = runTest {
+        val error = WPAPINetworkError(BaseNetworkError(GenericErrorType.SERVER_ERROR))
+        givenCreationResponse(WPAPIResponse.Error(error))
+
+        val payload = restClient.createApplicationPassword(testSite, applicationName)
+
+        assertTrue(payload.isError)
+        assertEquals(error, payload.error)
+    }
+
+    private suspend fun givenCreationResponse(response: WPAPIResponse<ApplicationPasswordCreationResponse>) {
+        whenever(
+            cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest<WPAPIResponse<ApplicationPasswordCreationResponse>>(
+                eq(testSite),
+                any()
+            )
+        ).thenReturn(response)
+    }
+}


### PR DESCRIPTION
## Description

Fixes a crash when the WordPress.com / WP-API application password endpoint returns a `200` response that is missing the `password` or `uuid` field.

`ApplicationPasswordCreationResponse` declared its fields as **non-null**, but Gson populates objects via reflection and bypasses Kotlin's null-safety. When the field is absent/null in the JSON, the value flowed into the non-null `ApplicationPasswordCreationPayload` constructor and threw an NPE. In the minified release build the parameter null-check compiles to a bare `getClass()` call, which is exactly the reported crash signature.

### Fix
- Made `uuid`, `name`, and `password` on `ApplicationPasswordCreationResponse` nullable to match what Gson can actually produce.
- Validate the fields on the success path; when either `password` or `uuid` is missing, return the existing error payload (`"Password or UUID missing from response"`) instead of crashing. The result propagates as a normal `ApplicationPasswordCreationResult.Failure` — the same path used for other creation errors.
- Applied to both `JetpackApplicationPasswordsRestClient` (where the crash was reported) and `WPApiApplicationPasswordsRestClient`, which share the response type.

### Tests
Added unit tests for both clients covering: valid response, null password, null uuid, null body, and network error.

## Crash report
https://a8c.sentry.io/issues/7522022287/?environment=prod&environment=release&project=5731682&query=release%3A%22com.jetpack.android%4026.8-rc-5%2B1493%22&referrer=release-issue-stream

Reported on `com.jetpack.android@26.8-rc-5+1493`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
