### PR TITLE
Fix NPE in Site Settings GBKit toggle refresh with null site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1191,7 +1191,7 @@ public class SiteSettingsFragment extends PreferenceFragment
      * posts" on this screen), not only at first inflation.
      */
     private void refreshGutenbergKitToggleAvailability() {
-        if (mGutenbergKitPref == null) return;
+        if (mGutenbergKitPref == null || mSite == null) return;
         if (mSiteSettingsProvider.isBlockEditorDefault(mSite)) {
             mGutenbergKitPref.setEnabled(true);
             mGutenbergKitPref.setSummary(R.string.site_settings_gutenberg_kit_enabled_summary);


### PR DESCRIPTION
## Description

Fixes a crash in Site Settings ([Sentry issue, `com.jetpack.android@26.8-rc-5+1493`](https://a8c.sentry.io/issues/7522149510/)).

`SiteSettingsProviderImpl.isBlockEditorDefault(site: SiteModel)` declares a **non-null** Kotlin `site` parameter. The refresh of the GutenbergKit toggle is reached from the async `onSettingsUpdated()` callback (`SiteSettingsInterface` → `Handler`), which only guards with `isAdded()`. When `mSite` is `null` at that point, Java passes `null` into the non-null param and the compiler-generated `Intrinsics.checkNotNullParameter` check throws an NPE ("Attempt to invoke … getClass() on a null object reference").

This adds an `mSite == null` early-return guard to `refreshGutenbergKitToggleAvailability()`, matching the `mSite` null-guard pattern already used elsewhere in the fragment.

```diff
-        if (mGutenbergKitPref == null) return;
+        if (mGutenbergKitPref == null || mSite == null) return;
```

## Testing instructions

Open Site Settings:

1. Open the app and navigate to **My Site → Settings** for a site.
2. Toggle **Use block editor as default for new posts** on/off.
- [x] Verify the GutenbergKit toggle availability/summary refreshes without crashing.
