### PR TITLE
Fix Sentry 3GCQ/3GDH: keep Gson-deserialized models from R8 full mode

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -65,6 +65,13 @@
 -keep class org.wordpress.android.fluxc** { *; }
 ###### FluxC - end
 
+###### Gson model classes - begin
+# Kotlin data classes deserialized by Gson via reflection (Unsafe.allocateInstance).
+# AGP 9's R8 full mode can class-merge or transform these into abstract types,
+# causing InstantiationException / ClassCastException at runtime.
+-keep class org.wordpress.android.models.recommend.** { *; }
+###### Gson model classes - end
+
 ###### Dagger - begin
 -dontwarn com.google.errorprone.annotations.*
 ###### Dagger - end

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -69,7 +69,27 @@
 # Kotlin data classes deserialized by Gson via reflection (Unsafe.allocateInstance).
 # AGP 9's R8 full mode can class-merge or transform these into abstract types,
 # causing InstantiationException / ClassCastException at runtime.
+
+# RecommendApiCallsProvider.RecommendTemplateData (Sentry 3GCQ, 3GDH)
 -keep class org.wordpress.android.models.recommend.** { *; }
+
+# InviteLinksApiCallsProvider.InviteLinksItem
+-keep class org.wordpress.android.ui.people.InviteLinksApiCallsProvider$InviteLinksItem { *; }
+
+# ReaderReadingPreferences and its nested Theme/FontFamily/FontSize enums
+-keep class org.wordpress.android.ui.reader.models.ReaderReadingPreferences { *; }
+-keep class org.wordpress.android.ui.reader.models.ReaderReadingPreferences$* { *; }
+
+# SubfilterListItemMapper.MappedSubfilterListItem (top-level private)
+-keep class org.wordpress.android.ui.reader.subfilter.MappedSubfilterListItem { *; }
+
+# New stats card configurations and the *CardType enums referenced by their fields
+-keep class org.wordpress.android.ui.newstats.StatsCardsConfiguration { *; }
+-keep class org.wordpress.android.ui.newstats.StatsCardType { *; }
+-keep class org.wordpress.android.ui.newstats.InsightsCardType { *; }
+-keep class org.wordpress.android.ui.newstats.repository.InsightsCardsConfigurationRepository$PersistedConfig { *; }
+-keep class org.wordpress.android.ui.newstats.subscribers.SubscribersCardsConfiguration { *; }
+-keep class org.wordpress.android.ui.newstats.subscribers.SubscribersCardType { *; }
 ###### Gson model classes - end
 
 ###### Dagger - begin


### PR DESCRIPTION
## Summary

This PR targets `release/26.8` to fix two crashes (`WORDPRESS-ANDROID-3GCQ`, `WORDPRESS-ANDROID-3GDH`) that appeared **only** in 26.8-rc-5 — both at the same line of `RecommendApiCallsProvider.getTemplateFromJson` where Gson deserializes a Kotlin `data class`. 

Root cause: 26.8 upgraded to AGP 9, which defaults R8 to [full mode](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization?utm_source=android-studio-app&utm_medium=app#r8-full-mode). Full mode class-merges/strips classes constructed only reflectively (via `Unsafe.allocateInstance`), so `RecommendTemplateData` ended up effectively abstract at runtime → `InstantiationException` (3GCQ) and `ClassCastException` (3GDH). Existing `-dontoptimize` does **not** prevent class merging — the header comment in `proguard.cfg` already flags this risk.

Sentry: [3GCQ](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3GCQ) · [3GDH](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3GDH)



## Changes

Commit 1 — fix for the two Sentry crashes:
- `-keep class org.wordpress.android.models.recommend.** { *; }`

Commit 2 — preemptive audit of other `fromJson<T>` call sites on Kotlin data classes that have no keep rule and would hit the same bug under R8 full mode:
- `InviteLinksApiCallsProvider.InviteLinksItem`
- `ReaderReadingPreferences` (+ nested `Theme`, `FontFamily`, `FontSize` enums)
- `SubfilterListItemMapper.MappedSubfilterListItem`
- `StatsCardsConfiguration` + `StatsCardType`
- `SubscribersCardsConfiguration` + `SubscribersCardType`
- `InsightsCardsConfigurationRepository.PersistedConfig` + `InsightsCardType`

Skipped: `DebugCookie` (debug-only menu), `QueryResult<T>` (generic — needs per-call-site type audit).

The two crashes use `Fixes WORDPRESS-ANDROID-...` in commit 1 so Sentry auto-resolves them on merge.

## Test plan

- [x] Local minified release build still launches and reaches the home screen
- [x] Me → About → Share loads without the bad-format error message
- [x] Reader detail opens with saved reading preferences (theme/font) restored
- [x] New Stats screen opens with previously-configured card visibility
- [x] Subscribers card on New Stats opens with previous visibility
- [x] Users → Invite People → Get invite link returns a working link (requires `site.hasCapabilityListUsers`)
