### PR TITLE
Make application password uuid/name nullable to avoid Gson NPE

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -2,15 +2,18 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
 import com.google.gson.annotations.SerializedName
 
+// Note: Gson populates these fields via reflection and can assign null to a non-null Kotlin
+// property if the server omits it. uuid and name are kept nullable and guarded at the usage
+// sites to avoid a latent NPE.
 internal data class ApplicationPasswordCreationResponse(
-    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
-    @SerializedName("name") val name: String,
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID?,
+    @SerializedName("name") val name: String?,
     @SerializedName("password") val password: String
 )
 
 internal data class ApplicationPasswordsFetchResponse(
-    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
-    @SerializedName("name") val name: String
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID?,
+    @SerializedName("name") val name: String?
 )
 
 internal data class ApplicationPasswordDeleteResponse(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -47,8 +47,9 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess<ApplicationPasswordCreationResponse> -> {
-                response.data?.let {
-                    ApplicationPasswordCreationPayload(it.password, it.uuid)
+                val data = response.data
+                data?.uuid?.let {
+                    ApplicationPasswordCreationPayload(data.password, it)
                 } ?: ApplicationPasswordCreationPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,
@@ -77,8 +78,8 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess -> {
-                response.data?.firstOrNull { it.name == applicationName }?.let {
-                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                response.data?.firstOrNull { it.name == applicationName }?.uuid?.let {
+                    ApplicationPasswordUUIDFetchPayload(it)
                 } ?: ApplicationPasswordUUIDFetchPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -53,8 +53,9 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is WPAPIResponse.Success<ApplicationPasswordCreationResponse> -> {
-                response.data?.let {
-                    ApplicationPasswordCreationPayload(it.password, it.uuid)
+                val data = response.data
+                data?.uuid?.let {
+                    ApplicationPasswordCreationPayload(data.password, it)
                 } ?: ApplicationPasswordCreationPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,
@@ -85,8 +86,8 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is WPAPIResponse.Success -> {
-                response.data?.firstOrNull { it.name == applicationName }?.let {
-                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                response.data?.firstOrNull { it.name == applicationName }?.uuid?.let {
+                    ApplicationPasswordUUIDFetchPayload(it)
                 } ?: ApplicationPasswordUUIDFetchPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,
@@ -152,8 +153,8 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         @Suppress("UNCHECKED_CAST")
         return when (response) {
-            is WPAPIResponse.Success -> response.data?.let {
-                WPAPIResponse.Success(it.uuid)
+            is WPAPIResponse.Success -> response.data?.uuid?.let {
+                WPAPIResponse.Success(it)
             } ?: WPAPIResponse.Error(
                 WPAPINetworkError(
                     BaseNetworkError(


### PR DESCRIPTION
## Description

`ApplicationPasswordCreationResponse` and `ApplicationPasswordsFetchResponse` are
deserialized by Gson, which populates fields via reflection. When the server omits a
field, Gson assigns `null` to it even though the Kotlin property is declared non-null —
the violated invariant then surfaces as a latent `NullPointerException` when the value
is later dereferenced (e.g. `it.uuid` when building the UUID/creation payloads).

This follows up on a review comment from #22953 (the Site Settings GBKit toggle RC crash
fix), where the same latent issue was flagged but deferred as out of scope for that
targeted RC fix.

Changes (scoped to `uuid` and `name` only):
- Make `uuid` and `name` nullable in `ApplicationPasswordCreationResponse` and
  `ApplicationPasswordsFetchResponse`.
- Guard the `uuid` dereferences in `WPApiApplicationPasswordsRestClient` (create, fetch,
  and introspect paths) and `JetpackApplicationPasswordsRestClient` (create and fetch
  paths) so a missing `uuid` returns the existing error payload instead of crashing.
- `name` is only used in null-safe `==` comparisons, so it needs no usage-site guards.

No behavior change for well-formed responses; only the malformed/missing-field path is
affected, which now degrades gracefully to an error payload.

## Testing instructions

This is a defensive fix for malformed server responses that can't easily be reproduced
against a real backend. Verify via code review and existing coverage:

1. Run the fluxc unit tests:
   `./gradlew :libs:fluxc:testDebugUnitTest --tests "*ApplicationPassword*"`
- [ ] Verify application password creation/fetch/delete tests still pass.
2. Sign in to a self-hosted site using application-password auth and confirm login still
   works end to end.
- [ ] Verify the application password is created and the site connects normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)