### PR TITLE
Fix Reader TransactionTooLargeException by skipping WebView saved state

### DIFF
--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -15,11 +15,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <!--
+            saveEnabled is off because the WebView's saved state (its serialized back/forward
+            list) can reach megabytes and overflow the saved-state Binder transaction, crashing
+            with TransactionTooLargeException. The post is always re-rendered from local data
+            by ReaderPostRenderer, so this state is never used on restore.
+        -->
         <org.wordpress.android.ui.reader.views.ReaderWebView
             android:id="@+id/reader_webview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"
+            android:saveEnabled="false"
             android:scrollbars="none" />
 
         <ProgressBar


### PR DESCRIPTION
## Description

This PR fixes a long-standing `TransactionTooLargeException` when `ReaderPostPagerActivity` is stopped, resolving  [JETPACK-ANDROID-PCC](https://a8c.sentry.io/issues/JETPACK-ANDROID-PCC) (71 users / 9,500+ events since April 2024).

The crash event's bundle stats show a single view carrying **1.8 MB of the 1.9 MB** saved-state parcel — the `ReaderWebView` in the post detail fragment. Android caps the Binder transaction that delivers saved instance state at ~1 MB, so the oversized parcel kills the app.

That saved state is never actually used:

- `ReaderPostDetailFragment` always re-renders the post from local data via `ReaderPostRenderer` (`showPostInWebView`), including after recreation.
- The WebView never navigates internally — link clicks are routed externally through `ReaderWebViewUrlClickListener`.

The fix simply sets `android:saveEnabled="false"` on `reader_webview`, removing ~94% of the parcel with no behavior change.

## Testing instructions

Reader post detail still renders and restores correctly:

1. Open the Reader and tap a post to open the post detail screen
2. Swipe between a few posts in the pager
- [x] Verify each post renders its content normally
3. Rotate the device (or toggle dark mode) to force an activity recreation
- [x] Verify the post content re-renders correctly after recreation
4. Background the app, then return to it
- [x] Verify the post detail screen is restored without a crash