### PR TITLE
Fix TransactionTooLargeException from GutenbergKit editor arguments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -167,13 +167,20 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         val gutenbergViewContainer =
             rootView!!.findViewById<ViewGroup>(R.id.gutenberg_view_container)
 
+        // The arguments hold the configuration with title and content stripped
+        // (see newInstance); re-populate them from the host's persisted post
+        // data, the same source the configuration was originally built from,
+        // kept fresh by the editor's autosave.
         val configuration = requireNotNull(
             BundleCompat.getParcelable(
                 requireArguments(),
                 ARG_GUTENBERG_KIT_SETTINGS,
                 EditorConfiguration::class.java
             )
-        )
+        ).toBuilder()
+            .setTitle(mEditorFragmentListener.persistedTitle)
+            .setContent(mEditorFragmentListener.persistedContent)
+            .build()
 
         val siteLocalId = requireArguments().getInt(ARG_SITE_LOCAL_ID)
         val gutenbergView = GutenbergView(
@@ -577,7 +584,17 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         ): GutenbergKitEditorFragment {
             val fragment = GutenbergKitEditorFragment()
             val args = Bundle()
-            args.putParcelable(ARG_GUTENBERG_KIT_SETTINGS, configuration)
+            // Strip title and content before storing the configuration in the
+            // arguments: Android parcels fragment arguments into the activity's
+            // saved instance state on every stop, and large post content can
+            // push the parcel past the ~1 MB binder limit, crashing with
+            // TransactionTooLargeException (WORDPRESS-ANDROID-2XAX).
+            // onCreateView restores both fields from the host's persisted post.
+            val strippedConfiguration = configuration.toBuilder()
+                .setTitle("")
+                .setContent("")
+                .build()
+            args.putParcelable(ARG_GUTENBERG_KIT_SETTINGS, strippedConfiguration)
             args.putInt(ARG_SITE_LOCAL_ID, site.id)
             fragment.arguments = args
             return fragment


### PR DESCRIPTION
## Description

Fixes the Sentry issue [WORDPRESS-ANDROID-2XAX](https://sentry.io/organizations/a8c/issues/?query=WORDPRESS-ANDROID-2XAX), a fatal `TransactionTooLargeException` seen on the current release.

`GutenbergKitEditorFragment.newInstance` stores the `EditorConfiguration` parcelable — including the entire post HTML via `setContent()` — in the fragment's arguments. Android parcels fragment arguments into the activity's saved instance state on every stop, so a post with large content (e.g. embedded base64 images) pushes the parcel past the ~1 MB binder limit and crashes the app (the crash bundle showed the `gutenberg_kit_settings` arguments at 1.15 MB).

The fix keeps the post body out of the arguments:

- `newInstance` strips title and content from the configuration (`configuration.toBuilder().setTitle("").setContent("").build()`) before storing it. All small fields (auth, API roots, cookies, flags) remain.
- `onCreateView` re-populates title and content from the host's `persistedTitle`/`persistedContent`, which are backed by `editPostRepository` — the same source the configuration was originally built from, kept fresh by the editor's autosave (`savePostWithDelay`).

Side benefit: after process-death restoration, the editor now shows the latest autosaved content rather than a stale copy frozen in the arguments at fragment-creation time.

No unit tests added: the change is saved-state plumbing not meaningfully testable in JVM unit tests.

Fixes WORDPRESS-ANDROID-2XAX

## Testing instructions

Editor still loads existing content:

1. Open an existing post with a title and content in the editor
- [x] Verify the title and content appear as expected
2. Edit the content and go back to save, then reopen the post
- [x] Verify the edits were preserved

Saved-state restoration:

1. Open a post in the editor, then background the app
2. Kill the process and return to the app
- [x] Verify the editor restores with the latest autosaved title and content