### PR TITLE
Fix NPE when creating app password for site with no username

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -74,7 +74,20 @@ internal class ApplicationPasswordsManager @Inject constructor(
         return if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
             jetpackApplicationPasswordsRestClient.fetchWPAdminUsername(site)
         } else {
-            UsernameFetchPayload(site.username)
+            val username = site.username
+            if (username.isNullOrEmpty()) {
+                UsernameFetchPayload(
+                    WPAPINetworkError(
+                        BaseNetworkError(
+                            GenericErrorType.NOT_AUTHENTICATED,
+                            "Site username is missing. " +
+                                "The application password was probably authorized using the Web flow"
+                        )
+                    )
+                )
+            } else {
+                UsernameFetchPayload(username)
+            }
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -96,7 +96,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
         username: String
     ): ApplicationPasswordCreationResult {
         if (!site.supportsApplicationPasswordsGeneration) {
-            ApplicationPasswordCreationResult.Failure(
+            return ApplicationPasswordCreationResult.Failure(
                 WPAPINetworkError(
                     BaseNetworkError(
                         GenericErrorType.NOT_AUTHENTICATED,

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -181,6 +181,27 @@ class ApplicationPasswordManagerTests {
         }
 
     @Test
+    fun `given a non-jetpack site with no password, when we ask for a password, then return Failure`() =
+        runTest {
+            val site = SiteModel().apply {
+                origin = SiteModel.ORIGIN_XMLRPC
+                url = "http://test-site.com"
+                username = "username"
+                password = null
+            }
+            whenever(applicationPasswordsStore.getCredentials(site)).thenReturn(null)
+
+            val result = mApplicationPasswordsManager.getApplicationCredentials(site)
+
+            Assert.assertTrue(result is ApplicationPasswordCreationResult.Failure)
+            assertEquals(
+                GenericErrorType.NOT_AUTHENTICATED,
+                (result as ApplicationPasswordCreationResult.Failure).error.type
+            )
+            verifyNoInteractions(mWpApiApplicationPasswordsRestClient)
+        }
+
+    @Test
     fun `when a jetpack site returns 404, then return feature not available`() =
         runTest {
             val site = testSite.apply {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -9,6 +9,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -157,6 +158,26 @@ class ApplicationPasswordManagerTests {
             )
 
             assertEquals(ApplicationPasswordCreationResult.Created(testCredentials), result)
+        }
+
+    @Test
+    fun `given a non-jetpack site with no username, when we ask for a password, then return Failure`() =
+        runTest {
+            val site = SiteModel().apply {
+                origin = SiteModel.ORIGIN_XMLRPC
+                url = "http://test-site.com"
+                username = null
+            }
+            whenever(applicationPasswordsStore.getCredentials(site)).thenReturn(null)
+
+            val result = mApplicationPasswordsManager.getApplicationCredentials(site)
+
+            Assert.assertTrue(result is ApplicationPasswordCreationResult.Failure)
+            assertEquals(
+                GenericErrorType.NOT_AUTHENTICATED,
+                (result as ApplicationPasswordCreationResult.Failure).error.type
+            )
+            verifyNoInteractions(mWpApiApplicationPasswordsRestClient)
         }
 
     @Test


### PR DESCRIPTION
## Description
Fixes a `NullPointerException` thrown while creating an Application Password for a self-hosted site that has no stored username.

In `ApplicationPasswordsManager.getOrFetchUsername`, a non-WPCOM site passed `site.username` straight into `UsernameFetchPayload`'s non-null `String` constructor. Since `SiteModel.username` is a Java (nullable) field, a null value triggered the compiler-generated overload-disambiguation `getClass()` check, crashing with:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at ...ApplicationPasswordsManager.getOrFetchUsername(ApplicationPasswordsManager.kt:77)
```

The fix guards for a null/empty username and returns a `NOT_AUTHENTICATED` error payload instead of crashing. The existing caller already converts an error payload into an `ApplicationPasswordCreationResult.Failure`, consistent with the equivalent guard in `createApplicationPassword`.

## Testing instructions

I don't think there's a manual way to test this.