### PR TITLE
Add slow-path tests for PageRsFluxCBridge (Phase 5)

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/pagesrs/PageRsFluxCBridgeTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/pagesrs/PageRsFluxCBridgeTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -16,6 +17,13 @@ import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.persistence.PostSqlUtils
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.postsrs.PostRsToFluxCMapper
+import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.AnyPostWithEditContext
+import uniffi.wp_api.PostsRequestRetrieveWithEditContextResponse
+import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.WpErrorCode
+import uniffi.wp_api.WpNetworkHeaderMap
 
 class PageRsFluxCBridgeTest {
     private val wpApiClientProvider: WpApiClientProvider = mock()
@@ -93,6 +101,93 @@ class PageRsFluxCBridgeTest {
 
         verify(wpApiClientProvider).getWpApiClient(eq(site), anyOrNull())
     }
+
+    @Test
+    fun `slow path fetches, inserts as a page, and returns the re-read model`() = runTest {
+        val site = SiteModel().apply { id = 1 }
+        val client: WpApiClient = mock()
+        val rsPage: AnyPostWithEditContext = mock()
+        val mapped = PostModel().apply { setRemotePostId(REMOTE_ID) }
+        val stored = PostModel().apply {
+            setRemotePostId(REMOTE_ID)
+            setIsPage(true)
+        }
+        // No cache on the first lookup; the re-read after insert returns the stored row.
+        whenever(postStore.getPostByRemotePostId(REMOTE_ID, site)).thenReturn(null, stored)
+        whenever(wpApiClientProvider.getWpApiClient(eq(site), anyOrNull())).thenReturn(client)
+        whenever(client.request<PostsRequestRetrieveWithEditContextResponse>(any()))
+            .thenReturn(fetchSuccess(rsPage))
+        whenever(postMapper.map(eq(rsPage), eq(site))).thenReturn(mapped)
+
+        val result = bridge.fetchAndBridge(REMOTE_ID, site)
+
+        // The bridge returns the re-read row, not the mapper output.
+        assertThat(result).isSameAs(stored)
+        verify(wpApiClientProvider).getWpApiClient(eq(site), anyOrNull())
+        // The bridge flips isPage on the mapper output before inserting.
+        verify(postSqlUtils).insertOrUpdatePost(argThat { isPage }, eq(false))
+    }
+
+    @Test
+    fun `stale cached page without local changes is re-fetched from the network`() = runTest {
+        val site = SiteModel().apply { id = 1 }
+        val cached = PostModel().apply {
+            setRemotePostId(REMOTE_ID)
+            setIsPage(true)
+            setRemoteLastModified("2026-06-01T00:00:00Z")
+            setIsLocallyChanged(false)
+        }
+        val client: WpApiClient = mock()
+        val rsPage: AnyPostWithEditContext = mock()
+        val mapped = PostModel().apply { setRemotePostId(REMOTE_ID) }
+        val stored = PostModel().apply {
+            setRemotePostId(REMOTE_ID)
+            setIsPage(true)
+        }
+        whenever(postStore.getPostByRemotePostId(REMOTE_ID, site)).thenReturn(cached, stored)
+        whenever(wpApiClientProvider.getWpApiClient(eq(site), anyOrNull())).thenReturn(client)
+        whenever(client.request<PostsRequestRetrieveWithEditContextResponse>(any()))
+            .thenReturn(fetchSuccess(rsPage))
+        whenever(postMapper.map(eq(rsPage), eq(site))).thenReturn(mapped)
+
+        val result = bridge.fetchAndBridge(REMOTE_ID, site, lastModified = "2026-06-05T00:00:00Z")
+
+        assertThat(result).isSameAs(stored)
+        verify(wpApiClientProvider).getWpApiClient(eq(site), anyOrNull())
+        verify(postSqlUtils).insertOrUpdatePost(any(), eq(false))
+    }
+
+    @Test
+    fun `slow path throws with the server error message and does not insert`() = runTest {
+        val site = SiteModel().apply { id = 1 }
+        val client: WpApiClient = mock()
+        whenever(postStore.getPostByRemotePostId(REMOTE_ID, site)).thenReturn(null)
+        whenever(wpApiClientProvider.getWpApiClient(eq(site), anyOrNull())).thenReturn(client)
+        whenever(client.request<PostsRequestRetrieveWithEditContextResponse>(any()))
+            .thenReturn(fetchError("boom"))
+
+        val error = runCatching { bridge.fetchAndBridge(REMOTE_ID, site) }.exceptionOrNull()
+
+        assertThat(error)
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("boom")
+        verify(postSqlUtils, never()).insertOrUpdatePost(any(), any())
+    }
+
+    private fun fetchSuccess(page: AnyPostWithEditContext) =
+        WpRequestResult.Success(
+            PostsRequestRetrieveWithEditContextResponse(page, mock<WpNetworkHeaderMap>())
+        )
+
+    private fun fetchError(message: String) =
+        WpRequestResult.WpError<PostsRequestRetrieveWithEditContextResponse>(
+            errorCode = WpErrorCode.InvalidParam(),
+            errorMessage = message,
+            statusCode = 400.toUInt(),
+            response = "",
+            requestUrl = "https://example.com",
+            requestMethod = RequestMethod.GET,
+        )
 
     companion object {
         private const val REMOTE_ID = 100L

--- a/WordPress/src/test/java/org/wordpress/android/ui/pagesrs/PageRsFluxCBridgeTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/pagesrs/PageRsFluxCBridgeTest.kt
@@ -106,7 +106,7 @@ class PageRsFluxCBridgeTest {
     fun `slow path fetches, inserts as a page, and returns the re-read model`() = runTest {
         val site = SiteModel().apply { id = 1 }
         val client: WpApiClient = mock()
-        val rsPage: AnyPostWithEditContext = mock()
+        val rsPage = mockRsPage()
         val mapped = PostModel().apply { setRemotePostId(REMOTE_ID) }
         val stored = PostModel().apply {
             setRemotePostId(REMOTE_ID)
@@ -138,7 +138,7 @@ class PageRsFluxCBridgeTest {
             setIsLocallyChanged(false)
         }
         val client: WpApiClient = mock()
-        val rsPage: AnyPostWithEditContext = mock()
+        val rsPage = mockRsPage()
         val mapped = PostModel().apply { setRemotePostId(REMOTE_ID) }
         val stored = PostModel().apply {
             setRemotePostId(REMOTE_ID)
@@ -173,6 +173,11 @@ class PageRsFluxCBridgeTest {
             .hasMessage("boom")
         verify(postSqlUtils, never()).insertOrUpdatePost(any(), any())
     }
+
+    // The fetched page is a pass-through to the mocked mapper, so its contents are never
+    // read; mocking it avoids building the ~29-field data class by hand.
+    @Suppress("DoNotMockDataClass")
+    private fun mockRsPage(): AnyPostWithEditContext = mock()
 
     private fun fetchSuccess(page: AnyPostWithEditContext) =
         WpRequestResult.Success(


### PR DESCRIPTION
## Description

This small PR adds tests for `PageRsFluxCBridge`, which lets the new wordpress-rs pages list open a page in the FluxC-based editor by resolving a remote page id into a local `PostModel`. Its **slow path** — the network fetch, DB insert, and error handling that run whenever a page isn't already cached locally — previously had no test coverage.

## Testing instructions

Unit-test-only change.

1. Run `./gradlew :WordPress:testJetpackDebugUnitTest --tests "org.wordpress.android.ui.pagesrs.PageRsFluxCBridgeTest"`
- [x] Verify all 7 tests pass (4 existing + 3 new)
