### PR TITLE
Validate string-key guardrail end-to-end (dangermattic#126)

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -17,6 +17,11 @@ if github.pr_labels.include?('Releases')
   return
 end
 
+# Enforce string-key immutability: the value of an existing translatable string must not change in
+# place — add a new key for new copy instead, so in-progress translations stay valid. Bypass with
+# the `Allow String Modifications` label for intentional changes.
+android_strings_checker.check_existing_strings_not_modified unless github.pr_labels.include?('Allow String Modifications')
+
 common_release_checker.check_internal_release_notes_changed(report_type: :message)
 
 view_changes_checker.check

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,10 @@
 
 source 'https://rubygems.org'
 
-gem 'danger-dangermattic', '~> 1.2'
+# TEMPORARY: point at the dangermattic branch to validate the new string-key guardrail
+# (https://github.com/Automattic/dangermattic/pull/126).
+# Revert to the released `~> 1.2` constraint once that PR ships in a tagged release.
+gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic.git', branch: 'add/strings-immutability-check'
 gem 'fastlane', '~> 2'
 
 ### Fastlane Plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/Automattic/dangermattic.git
+  revision: 15f27d50d3c6b71487865d06ed920051a1e73cc6
+  branch: add/strings-immutability-check
+  specs:
+    danger-dangermattic (1.2.4)
+      danger (~> 9.5, >= 9.5.3)
+      danger-plugin-api (~> 1.0)
+      danger-rubocop (~> 0.13)
+      rubocop (~> 1.63)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,11 +71,6 @@ GEM
       octokit (>= 4.0)
       pstore (~> 0.1)
       terminal-table (>= 1, < 5)
-    danger-dangermattic (1.2.4)
-      danger (~> 9.4)
-      danger-plugin-api (~> 1.0)
-      danger-rubocop (~> 0.13)
-      rubocop (~> 1.63)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     danger-rubocop (0.13.0)
@@ -373,7 +379,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger-dangermattic (~> 1.2)
+  danger-dangermattic!
   faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2)
   fastlane-plugin-firebase_app_distribution (~> 1.0)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="about_the_app">About the app</string>
     <string name="username">Username</string>
     <string name="cancel">Cancel</string>
-    <string name="save">Save</string>
+    <string name="save">Save changes</string>
     <string name="add">Add</string>
     <string name="remove">Remove</string>
     <string name="removed">Removed</string>


### PR DESCRIPTION
Temporary draft to verify the new string-key guardrail from Automattic/dangermattic#126 end to end. **Not for merge.**

- Points `danger-dangermattic` at the PR branch
- Wires `check_existing_strings_not_modified` into the `Dangerfile`
- Changes an existing string value (`save`: "Save" → "Save changes")

**Expected:** the Danger check fails on the `save` change, proving the guardrail works. Revert once the guardrail ships in a tagged dangermattic release.