### PR TITLE
Enable Dangermattic strings guardrail

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -17,6 +17,8 @@ if github.pr_labels.include?('Releases')
   return
 end
 
+android_strings_checker.check_existing_strings_not_modified unless github.pr_labels.include?('Allow String Modifications')
+
 common_release_checker.check_internal_release_notes_changed(report_type: :message)
 
 view_changes_checker.check


### PR DESCRIPTION
Updates `danger-dangermattic` to 1.3.0 and enables its Android strings guardrail.
