### PR TITLE
Add regression test for null-username application password creation

### DIFF
--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -90,6 +90,22 @@ class ApplicationPasswordManagerTests {
     }
 
     @Test
+    fun `given a non-jetpack site with a null username, when we ask for a password, then return Failure`() =
+        runTest {
+            val site = SiteModel().apply {
+                url = "http://no-username.example.com"
+                origin = SiteModel.ORIGIN_XMLRPC
+                username = null
+            }
+
+            whenever(applicationPasswordsStore.getCredentials(site)).thenReturn(null)
+
+            val result = mApplicationPasswordsManager.getApplicationCredentials(site)
+
+            Assert.assertTrue(result is ApplicationPasswordCreationResult.Failure)
+        }
+
+    @Test
     fun `given a local password exists, when we ask for a password, then return it`() = runTest {
         whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
         val result = mApplicationPasswordsManager.getApplicationCredentials(


### PR DESCRIPTION
## Description

Adds the missing regression unit test for the application-password creation NPE.

**Sentry:** [7520323693](https://a8c.sentry.io/issues/7520323693/)

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at ApplicationPasswordsManager.getOrFetchUsername(ApplicationPasswordsManager.kt:77)
    at ApplicationPasswordsManager.getApplicationCredentials(ApplicationPasswordsManager.kt:58)
```

## Background

PR #22885 relaxed the early guard in `getApplicationCredentials` from `site.isWPCom` to
`site.isWPComSimpleSite`, so sites that previously returned `NotSupported` now flow into
`getOrFetchUsername`. When such a site takes the non-`ORIGIN_WPCOM_REST` branch with a null
`username`, `UsernameFetchPayload(site.username)` passed `null` into a non-null `String`
constructor param, triggering Kotlin's null-parameter intrinsic NPE.

## The production fix is already on `trunk` ✅

The null/empty guard (returning an error `UsernameFetchPayload` so the call degrades to a
`Failure` result instead of crashing) already landed in `trunk` via the **Merge release/26.8
into trunk** PR #22987, commit `5853043dd887c8ce8eeedc428f4a86be8a00ce4e`.

Verified against the remote default branch (`origin/trunk` @ `a99ac705f48`):

- `git show origin/trunk:.../ApplicationPasswordsManager.kt` shows the guard at lines 77–90:
  ```kotlin
  val username = site.username
  if (username.isNullOrEmpty()) {
      UsernameFetchPayload(
          WPAPINetworkError(
              BaseNetworkError(
                  GenericErrorType.NOT_AUTHENTICATED,
                  "Site username is missing. " +
                      "The application password was probably authorized using the Web flow"
              )
          )
      )
  } else {
      UsernameFetchPayload(username)
  }
  ```
- GitHub Contents API for `ApplicationPasswordsManager.kt?ref=trunk` confirms the same guard
  (`if (username.isNullOrEmpty())` at line 78, `"Site username is missing."` at line 83).
- `git log -S "username.isNullOrEmpty()"` on `origin/trunk` attributes the line to
  `5853043dd88` (#22987).

Because the fix is already in `trunk`, this PR contains **only** the regression test — the
production code is unchanged.

## Change

Adds `ApplicationPasswordManagerTests`:
`given a non-jetpack site with a null username, when we ask for a password, then return Failure`.

The test fails against the pre-fix code and passes with the fix already in trunk. Diff is a
single file, +16 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)