### PR TITLE
[Buildkite] Test Android Staging on `ami-08ace45d52a5caade`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################


### PR DESCRIPTION
Related: [buildkite-ci#872](https://github.com/Automattic/buildkite-ci/pull/872)

AMI Name: `android-build-image-6.53.0v1.15.0`

---

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-08ace45d52a5caade` works as expected.

---

## Testing instructions
<!--
Provide specific testing steps for reviewers. Use the following format:

Test case title:

1. Step 1
2. Step 2
- [ ] Verify expected outcome
3. Step 3
- [ ] Verify another expected outcome

Use numbered lists for action steps and checkboxes for verifications.
Organise by test case title when there are multiple scenarios.
-->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->