### PR TITLE
Match iOS date formatting in the new posts and pages lists

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
@@ -172,7 +172,7 @@ private fun FullEntityAnyPostWithEditContext.toPageUiModel(
                 ?: page.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = PostRsDateFormatter.format(page.dateGmt, page.status),
+        date = PostRsDateFormatter.format(page.dateGmt, page.status, useTimeForScheduled = true),
         lastModified = DateTimeUtils.iso8601UTCFromDate(page.modifiedGmt),
         link = page.link,
         hasPassword = !page.password.isNullOrEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
@@ -172,7 +172,7 @@ private fun FullEntityAnyPostWithEditContext.toPageUiModel(
                 ?: page.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = PostRsDateFormatter.format(page.dateGmt, page.status, useTimeForScheduled = true),
+        date = PostRsDateFormatter.format(page.dateGmt, page.status),
         lastModified = DateTimeUtils.iso8601UTCFromDate(page.modifiedGmt),
         link = page.link,
         hasPassword = !page.password.isNullOrEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsDateFormatter.kt
@@ -4,48 +4,57 @@ import android.text.format.DateUtils
 import uniffi.wp_api.PostStatus
 import java.text.DateFormat
 import java.util.Date
+import kotlin.math.abs
 
 /**
  * Formats post dates from the wordpress-rs API for display in the
- * post list. Matches the date formatting behavior of the old
- * FluxC-based post list.
+ * posts and pages lists. Mirrors the iOS app's date formatting
+ * (see AbstractPostHelper / NSDate+Helpers): relative time only for
+ * the last week, an absolute medium date beyond that.
  */
 object PostRsDateFormatter {
     private const val MILLIS_PER_SECOND = 1000L
     private const val SECONDS_PER_HOUR = 3600L
     private const val HOURS_PER_DAY = 24L
-    private const val DAYS_PER_YEAR = 365L
-    private const val SECONDS_PER_YEAR =
-        SECONDS_PER_HOUR * HOURS_PER_DAY * DAYS_PER_YEAR
+    private const val DAYS_PER_WEEK = 7L
+    private const val SECONDS_PER_WEEK =
+        SECONDS_PER_HOUR * HOURS_PER_DAY * DAYS_PER_WEEK
 
     /**
-     * Formats a GMT [Date] for display:
-     * - Scheduled posts show an abbreviated absolute date
-     * - Posts < 1 year ago show relative time ("2 hr. ago")
-     * - Older posts show an abbreviated absolute date
+     * Formats a GMT [Date] for display, matching the iOS posts/pages list:
+     * - Scheduled posts show an abbreviated absolute date; when [useTimeForScheduled] is true the
+     *   time of day is included too (e.g. "Dec 15, 2025, 9:00 AM") so the user can see when a
+     *   scheduled page will publish.
+     * - Other posts within the last week show relative time ("2 days ago", "Yesterday").
+     * - Older posts show an abbreviated absolute date ("Dec 15, 2025").
      */
-    fun format(dateGmt: Date, status: PostStatus?): String {
+    fun format(dateGmt: Date, status: PostStatus?, useTimeForScheduled: Boolean = false): String {
         val millis = dateGmt.time
         val now = System.currentTimeMillis()
+        val isScheduled = status is PostStatus.Future
         val secondsSince = (now - millis) / MILLIS_PER_SECOND
-        val useRelative = status !is PostStatus.Future &&
-            secondsSince < SECONDS_PER_YEAR
+        val useRelative = !isScheduled && abs(secondsSince) < SECONDS_PER_WEEK
 
-        return if (useRelative) {
-            DateUtils.getRelativeTimeSpanString(
+        return when {
+            useRelative -> DateUtils.getRelativeTimeSpanString(
                 millis,
                 now,
-                DateUtils.MINUTE_IN_MILLIS,
-                DateUtils.FORMAT_ABBREV_ALL
+                DateUtils.MINUTE_IN_MILLIS
             ).toString()
-        } else {
-            formatAbbrDate(millis)
+            isScheduled && useTimeForScheduled -> formatAbbrDateTime(millis)
+            else -> formatAbbrDate(millis)
         }
     }
 
     private fun formatAbbrDate(millis: Long): String {
         val dateFormat =
             DateFormat.getDateInstance(DateFormat.MEDIUM)
+        return dateFormat.format(Date(millis))
+    }
+
+    private fun formatAbbrDateTime(millis: Long): String {
+        val dateFormat =
+            DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
         return dateFormat.format(Date(millis))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsDateFormatter.kt
@@ -22,13 +22,12 @@ object PostRsDateFormatter {
 
     /**
      * Formats a GMT [Date] for display, matching the iOS posts/pages list:
-     * - Scheduled posts show an abbreviated absolute date; when [useTimeForScheduled] is true the
-     *   time of day is included too (e.g. "Dec 15, 2025, 9:00 AM") so the user can see when a
-     *   scheduled page will publish.
+     * - Scheduled posts show an absolute date with the time of day (e.g. "Dec 15, 2025, 9:00 AM")
+     *   so the user can see when the post or page will publish.
      * - Other posts within the last week show relative time ("2 days ago", "Yesterday").
      * - Older posts show an abbreviated absolute date ("Dec 15, 2025").
      */
-    fun format(dateGmt: Date, status: PostStatus?, useTimeForScheduled: Boolean = false): String {
+    fun format(dateGmt: Date, status: PostStatus?): String {
         val millis = dateGmt.time
         val now = System.currentTimeMillis()
         val isScheduled = status is PostStatus.Future
@@ -41,7 +40,7 @@ object PostRsDateFormatter {
                 now,
                 DateUtils.MINUTE_IN_MILLIS
             ).toString()
-            isScheduled && useTimeForScheduled -> formatAbbrDateTime(millis)
+            isScheduled -> formatAbbrDateTime(millis)
             else -> formatAbbrDate(millis)
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsDateFormatterTest.kt
@@ -10,28 +10,16 @@ import java.util.TimeZone
 
 class PostRsDateFormatterTest {
     @Test
-    fun `scheduled date includes the time of day when requested`() {
+    fun `scheduled date includes the time of day`() {
         withFixedLocaleAndZone {
             val date = Date(FIXED_MILLIS)
 
-            val dateOnly = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = false)
-            val withTime = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = true)
+            val formatted = PostRsDateFormatter.format(date, PostStatus.Future)
+            val dateOnly = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
 
-            // The time-of-day form appends the time to the same medium date (iOS parity).
-            assertThat(withTime).startsWith(dateOnly)
-            assertThat(withTime).isNotEqualTo(dateOnly)
-        }
-    }
-
-    @Test
-    fun `scheduled date omits the time of day by default`() {
-        withFixedLocaleAndZone {
-            val date = Date(FIXED_MILLIS)
-
-            val default = PostRsDateFormatter.format(date, PostStatus.Future)
-            val dateOnly = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = false)
-
-            assertThat(default).isEqualTo(dateOnly)
+            // Scheduled dates show the medium date plus the time of day (iOS parity).
+            assertThat(formatted).startsWith(dateOnly)
+            assertThat(formatted).isNotEqualTo(dateOnly)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/PostRsDateFormatterTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.ui.postsrs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import uniffi.wp_api.PostStatus
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class PostRsDateFormatterTest {
+    @Test
+    fun `scheduled date includes the time of day when requested`() {
+        withFixedLocaleAndZone {
+            val date = Date(FIXED_MILLIS)
+
+            val dateOnly = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = false)
+            val withTime = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = true)
+
+            // The time-of-day form appends the time to the same medium date (iOS parity).
+            assertThat(withTime).startsWith(dateOnly)
+            assertThat(withTime).isNotEqualTo(dateOnly)
+        }
+    }
+
+    @Test
+    fun `scheduled date omits the time of day by default`() {
+        withFixedLocaleAndZone {
+            val date = Date(FIXED_MILLIS)
+
+            val default = PostRsDateFormatter.format(date, PostStatus.Future)
+            val dateOnly = PostRsDateFormatter.format(date, PostStatus.Future, useTimeForScheduled = false)
+
+            assertThat(default).isEqualTo(dateOnly)
+        }
+    }
+
+    @Test
+    fun `published date older than a week shows an absolute medium date`() {
+        withFixedLocaleAndZone {
+            // Older than the one-week relative window (and well under a year) — iOS shows an
+            // absolute medium date here, where legacy Android still showed relative time.
+            val date = Date(System.currentTimeMillis() - THIRTY_DAYS_MILLIS)
+
+            val formatted = PostRsDateFormatter.format(date, PostStatus.Publish)
+            val expected = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
+
+            assertThat(formatted).isEqualTo(expected)
+        }
+    }
+
+    private fun withFixedLocaleAndZone(block: () -> Unit) {
+        val previousLocale = Locale.getDefault()
+        val previousZone = TimeZone.getDefault()
+        try {
+            Locale.setDefault(Locale.US)
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+            block()
+        } finally {
+            Locale.setDefault(previousLocale)
+            TimeZone.setDefault(previousZone)
+        }
+    }
+
+    companion object {
+        // A fixed instant so the formatted output is deterministic under the pinned locale/zone.
+        private const val FIXED_MILLIS = 1_765_792_800_000L
+        private const val THIRTY_DAYS_MILLIS = 30L * 24 * 60 * 60 * 1000
+    }
+}


### PR DESCRIPTION
## Description

Aligns the date formatting in the new wp-rs posts and pages lists with the iOS app, which differed from this implementation in two ways:

* Scheduled items now show the publish **time of day** alongside the date, which was a big missing piece. 
* For non-scheduled items, relative time ("2 days ago") is now used only within the last week — beyond that, an absolute medium date is shown, instead of the previous behavior of showing relative time for up to a year.

This touches the shared `PostRsDateFormatter`, so it applies to both the new posts and pages lists. Note this intentionally diverges from the legacy Android lists; those are separate code paths and are unaffected.

## Testing instructions

Scheduled date + time:

1. Open Pages on a site that has scheduled pages.
2. Go to the **Scheduled** tab.
- [x] Verify each scheduled page shows its date **and** time of day.

Published relative vs. absolute:

1. Open the **Published** tab (pages or posts).
- [x] Verify a page edited within the last week shows relative time ("2 days ago", "Yesterday").
- [x] Verify a page older than a week shows an absolute date ("Dec 15, 2025"), not "X months ago".