### PR TITLE
Add CI-only Reposilite Maven Central mirror as first repository

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,14 @@ static def loadPropertiesFromFile(File inputFile) {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        if (gradle.ext.isCi) {
+            // CI-only Reposilite mirror (Maven Central). Listed first so CI resolves
+            // through our internal proxy before reaching out to public repositories.
+            maven {
+                url 'http://10.0.2.215:8080/maven-central'
+                allowInsecureProtocol = true
+            }
+        }
         google()
         mavenCentral()
         maven {


### PR DESCRIPTION
## Description

Mirrors [DayOne-Android #8001](https://github.com/bloom/DayOne-Android/pull/8001).

Prepends an internal Reposilite proxy (`http://10.0.2.215:8080/maven-central`) as the **first** repository in `dependencyResolutionManagement`, guarded by `gradle.ext.isCi`. On CI, dependency resolution hits the internal proxy before falling back to public repositories; local builds are unaffected since the block is skipped when `isCi` is false.

`allowInsecureProtocol = true` is set because the mirror is served over plain HTTP.

## Testing instructions

CI configuration change:

1. Verify a local build resolves dependencies normally (the mirror block is skipped when not on CI).
- [ ] `./gradlew :WordPress:dependencies` (or any build) succeeds locally without contacting the proxy.
2. Verify CI builds resolve through the mirror.
- [ ] Confirm CI dependency resolution succeeds with the Reposilite proxy listed first.