### PR TITLE
Revert "Guard SiteModel.setUrl against null to prevent NPE on site fetch" (#23007)

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
 import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.yarolegovich.wellsql.core.Identifiable;
@@ -322,13 +323,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         return mUrl;
     }
 
-    public void setUrl(@Nullable String url) {
-        if (url == null) {
-            // Don't set the URL. The value can come from a deserialized network response, so it may be null
-            // despite the annotation; guard against it to avoid an NPE in the URI constructor.
-            AppLog.e(T.API, "Trying to set a null url");
-            return;
-        }
+    public void setUrl(@NonNull String url) {
         try {
             // Normalize the URL, because it can be used as an identifier.
             mUrl = (new URI(url)).normalize().toString();

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/model/site/SiteModelTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/model/site/SiteModelTest.kt
@@ -253,16 +253,6 @@ class SiteModelTest {
         )
     }
 
-    /* setUrl */
-    @Test
-    fun `given valid url, when url is set, it is normalized and stored`() {
-        val site = SiteUtils.generateWPComSite()
-
-        site.url = "https://example.com/a/./b"
-
-        assertEquals("https://example.com/a/b", site.url)
-    }
-
     private fun SiteModel.setPublicizeSupport(enablePublicizeSupport: Boolean) {
         this.hasCapabilityPublishPosts = enablePublicizeSupport
         if (isJetpackConnected) {


### PR DESCRIPTION
## Description

Reverts #23007 (merge commit `2c13628d757446e07adfb3cb8cccdbad8266d373`).

That PR added a defensive guard to `SiteModel.setUrl`, changing its parameter from
`@NonNull String` to `@Nullable String` and skipping the URL assignment when the value
was `null`, to avoid an NPE during site fetch when a WPCOM REST response carried a null URL.

**Why revert:**

- The NPE's **root cause was server-side** and has since been **resolved** — the client no
  longer receives null URLs on this path.
- The original `@NonNull` contract on `setUrl` had stood for a long time without issue. The
  guard was defensive client-side code masking a server contract, so we restore the original
  behavior rather than keep it.

This restores `setUrl(@NonNull String)`, re-adds the `androidx.annotation.NonNull` import, and
removes the URL-normalization test that the original PR introduced.

Context: https://a8c.slack.com/archives/C0180B5PRJ4/p1781793377817889?thread_ts=1781728523.752459&cid=C0180B5PRJ4

## Testing instructions

1. Run `./gradlew :libs:fluxc:testDebugUnitTest --tests "*.SiteModelTest"`
- [ ] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)