### PR TITLE
Fix crashes new in 26.8 (relative redirects, keystore decrypt, null post)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
@@ -188,6 +188,7 @@ class EditorJetpackSocialViewModel @Inject constructor(
     }
 
     private fun shouldShowJetpackSocial() = ::editPostRepository.isInitialized
+            && editPostRepository.hasPost()
             && !editPostRepository.isPage
             && siteModel.supportsPublicize()
             && currentPost?.status != PostStatus.PRIVATE.toString()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
@@ -100,6 +100,7 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
         )
 
         whenever(postSocialSharingModelMapper.map(any(), any())).thenReturn(FAKE_SOCIAL_SHARING_MODEL)
+        whenever(editPostRepository.hasPost()).thenReturn(true)
 
         classToTest.jetpackSocialContainerVisibility.observeForever(showJetpackSocialContainerObserver)
         classToTest.jetpackSocialUiState.observeForever(jetpackSocialUiStateObserver)
@@ -109,6 +110,14 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
     @Test
     fun `Should NOT load jetpack social if post is page`() = test {
         whenever(editPostRepository.isPage).thenReturn(true)
+        classToTest.start(FAKE_SITE_MODEL, editPostRepository)
+        verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any(), any())
+    }
+
+    @Test
+    fun `Should NOT load jetpack social if repository has no post`() = test {
+        // Guards against an NPE when the repository's post is null (e.g. config change / process death).
+        whenever(editPostRepository.hasPost()).thenReturn(false)
         classToTest.start(FAKE_SITE_MODEL, editPostRepository)
         verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any(), any())
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network
 
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Request
@@ -25,20 +24,24 @@ class CustomRedirectInterceptor : Interceptor {
 
     fun getRedirectRequest(originalRequest: Request, redirectResponse: Response): Request? {
         val location = redirectResponse.header("Location")
-        if (!location.isNullOrEmpty()) {
-            val newBuilder: Request.Builder = originalRequest.newBuilder().url(location)
-
-            // Remove the authorization header if the hosts' TLD and SLD are not the same
-            val originalHost = originalRequest.url.host
-            val redirectHttpUrl = location.toHttpUrlOrNull()
-            val redirectHost = redirectHttpUrl?.host ?: ""
-            if (!tldAndSldAreEqual(originalHost, redirectHost)) {
-                newBuilder.removeHeader("Authorization")
-            }
-
-            return newBuilder.build()
+        if (location.isNullOrEmpty()) {
+            return null
         }
-        return null
+
+        // Resolve the Location header against the original request URL. This handles both absolute
+        // redirects and relative ones (e.g. "/wp-json/..."). Passing a relative location straight to
+        // Request.Builder.url() crashes with "Expected URL scheme 'http' or 'https'...". resolve()
+        // returns null if the location can't be turned into a valid URL, in which case we don't follow.
+        val redirectUrl = originalRequest.url.resolve(location) ?: return null
+
+        val newBuilder: Request.Builder = originalRequest.newBuilder().url(redirectUrl)
+
+        // Remove the authorization header if the hosts' TLD and SLD are not the same
+        if (!tldAndSldAreEqual(originalRequest.url.host, redirectUrl.host)) {
+            newBuilder.removeHeader("Authorization")
+        }
+
+        return newBuilder.build()
     }
 
     private fun tldAndSldAreEqual(domain1: String, domain2: String): Boolean {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
@@ -24,15 +24,15 @@ class CustomRedirectInterceptor : Interceptor {
 
     fun getRedirectRequest(originalRequest: Request, redirectResponse: Response): Request? {
         val location = redirectResponse.header("Location")
-        if (location.isNullOrEmpty()) {
-            return null
-        }
 
         // Resolve the Location header against the original request URL. This handles both absolute
         // redirects and relative ones (e.g. "/wp-json/..."). Passing a relative location straight to
         // Request.Builder.url() crashes with "Expected URL scheme 'http' or 'https'...". resolve()
         // returns null if the location can't be turned into a valid URL, in which case we don't follow.
-        val redirectUrl = originalRequest.url.resolve(location) ?: return null
+        val redirectUrl = if (location.isNullOrEmpty()) null else originalRequest.url.resolve(location)
+        if (redirectUrl == null) {
+            return null
+        }
 
         val newBuilder: Request.Builder = originalRequest.newBuilder().url(redirectUrl)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCatego
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.DB
 import org.wordpress.android.util.UrlUtils
+import java.security.GeneralSecurityException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -728,8 +729,18 @@ class SiteSqlUtils
             apiRestUsernameIV.isNullOrEmpty() || apiRestPasswordIV.isNullOrEmpty()) {
             return this
         }
-        apiRestUsernamePlain = encryptionUtils.decrypt(apiRestUsernameEncrypted, apiRestUsernameIV)
-        apiRestPasswordPlain = encryptionUtils.decrypt(apiRestPasswordEncrypted, apiRestPasswordIV)
+        // Decryption relies on the AndroidKeyStore, which can fail on some devices (e.g. an invalidated
+        // key or an unavailable secure element). Because this runs inside the hot getSites() path, a
+        // thrown KeyStoreException would crash the whole app, so we swallow it and leave the credentials
+        // unset — the site simply behaves as if it has no stored REST credentials and can re-fetch them.
+        try {
+            apiRestUsernamePlain = encryptionUtils.decrypt(apiRestUsernameEncrypted, apiRestUsernameIV)
+            apiRestPasswordPlain = encryptionUtils.decrypt(apiRestPasswordEncrypted, apiRestPasswordIV)
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(DB, "Failed to decrypt API REST credentials for site $id", e)
+            apiRestUsernamePlain = null
+            apiRestPasswordPlain = null
+        }
         return this
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
@@ -50,4 +50,40 @@ class CustomRedirectInterceptorTest {
 
         assertEquals(redirectRequest?.headers("Authorization")?.firstOrNull(), "Bearer token")
     }
+
+    @Test
+    fun `interceptor resolves a relative Location against the original request URL`() {
+        val originalRequest = Request.Builder()
+            .url("https://original.com/wp-json/wp/v2/posts")
+            .header("Authorization", "Bearer token")
+            .build()
+        val redirectResponse = Response.Builder()
+            .request(originalRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(302)
+            .message("Redirect")
+            .header("Location", "/media/123")
+            .build()
+
+        val redirectRequest = interceptor.getRedirectRequest(originalRequest, redirectResponse)
+
+        // Same host, so the Authorization header is kept and the relative path is resolved.
+        assertEquals("https://original.com/media/123", redirectRequest?.url.toString())
+        assertEquals("Bearer token", redirectRequest?.headers("Authorization")?.firstOrNull())
+    }
+
+    @Test
+    fun `interceptor returns null when there is no Location header`() {
+        val originalRequest = Request.Builder()
+            .url("https://original.com")
+            .build()
+        val redirectResponse = Response.Builder()
+            .request(originalRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(302)
+            .message("Redirect")
+            .build()
+
+        assertNull(interceptor.getRedirectRequest(originalRequest, redirectResponse))
+    }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/SiteSqlUtilsTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/SiteSqlUtilsTest.kt
@@ -5,12 +5,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.wordpress.android.fluxc.encryption.EncryptionUtils
 import org.wordpress.android.fluxc.model.SiteModel
+import java.security.GeneralSecurityException
 
 @RunWith(RobolectricTestRunner::class)
 class SiteSqlUtilsTest {
@@ -214,6 +216,28 @@ class SiteSqlUtilsTest {
         }).execute()
 
         val stored = siteSqlUtils.getSites().single()
+
+        assertThat(stored.apiRestUsernamePlain).isNullOrEmpty()
+        assertThat(stored.apiRestPasswordPlain).isNullOrEmpty()
+    }
+
+    @Test
+    fun `reading a site whose credentials fail to decrypt does not crash and yields no plaintext`() {
+        // A keystore failure during decryption (seen in production as InvalidKeyException/KeyStoreException)
+        // must not propagate out of the hot getSites() path — it would crash the app. The site is returned
+        // without plaintext credentials instead.
+        whenever(fakeEncryptionUtils.decrypt(any(), any())).thenAnswer {
+            throw GeneralSecurityException("keystore failure")
+        }
+        WellSql.insert(SiteModel().apply {
+            url = "https://example.test"
+            apiRestUsernameEncrypted = "enc_user"
+            apiRestUsernameIV = "iv_user"
+            apiRestPasswordEncrypted = "enc_pass"
+            apiRestPasswordIV = "iv_pass"
+        }).execute()
+
+        val stored = encryptingSiteSqlUtils.getSites().single()
 
         assertThat(stored.apiRestUsernamePlain).isNullOrEmpty()
         assertThat(stored.apiRestPasswordPlain).isNullOrEmpty()


### PR DESCRIPTION
## Description

Fixes three crashes that first appeared in the 26.8 release (build 1496), targeting 26.9. Each commit addresses one Sentry issue and references it so it auto-closes on merge.

- **Resolve relative `Location` redirects** ([JETPACK-ANDROID-1J9N](https://a8c.sentry.io/issues/JETPACK-ANDROID-1J9N), [WORDPRESS-ANDROID-3GMP](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3GMP)) — `CustomRedirectInterceptor` passed a relative `Location` header straight to `Request.Builder.url()`, crashing with `IllegalArgumentException`. It now resolves the header against the request URL.
- **Survive keystore decryption failures** ([JETPACK-ANDROID-1JCD](https://a8c.sentry.io/issues/JETPACK-ANDROID-1JCD)) — a failing AndroidKeyStore op during credential decryption propagated out of the hot `getSites()` path and crashed the app; it is now caught and the credentials left unset.
- **Guard null post in Jetpack Social** ([WORDPRESS-ANDROID-3GM8](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-3GM8)) — `shouldShowJetpackSocial()` dereferenced a null post; it now short-circuits on `hasPost()`.

## Testing

- `./gradlew :libs:fluxc:testDebugUnitTest --tests "*CustomRedirectInterceptorTest" --tests "*SiteSqlUtilsTest"`
- `./gradlew :WordPress:testJetpackDebugUnitTest --tests "*EditorJetpackSocialViewModelTest"`

Each fix has an added/updated unit test covering the crashing path.
