### PR TITLE
Map rs media upload failures to specific error types (cherry-pick #23023)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3094,7 +3094,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                     getString(R.string.error_media_insufficient_fs_permissions)
 
                 MediaErrorType.NOT_FOUND -> errorMessage = getString(R.string.error_media_not_found)
-                MediaErrorType.AUTHORIZATION_REQUIRED -> errorMessage = getString(R.string.error_media_unauthorized)
+                MediaErrorType.AUTHORIZATION_REQUIRED, MediaErrorType.NOT_AUTHENTICATED ->
+                    errorMessage = getString(R.string.error_media_unauthorized)
                 MediaErrorType.PARSE_ERROR -> errorMessage = getString(R.string.error_media_parse_error)
                 MediaErrorType.MALFORMED_MEDIA_ARG, MediaErrorType.NULL_MEDIA_ARG, MediaErrorType.GENERIC_ERROR ->
                     errorMessage = getString(R.string.error_refresh_media)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2745,7 +2745,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                     getString(R.string.error_media_insufficient_fs_permissions)
 
                 MediaErrorType.NOT_FOUND -> errorMessage = getString(R.string.error_media_not_found)
-                MediaErrorType.AUTHORIZATION_REQUIRED -> errorMessage = getString(R.string.error_media_unauthorized)
+                MediaErrorType.AUTHORIZATION_REQUIRED, MediaErrorType.NOT_AUTHENTICATED ->
+                    errorMessage = getString(R.string.error_media_unauthorized)
                 MediaErrorType.PARSE_ERROR -> errorMessage = getString(R.string.error_media_parse_error)
                 MediaErrorType.MALFORMED_MEDIA_ARG, MediaErrorType.NULL_MEDIA_ARG, MediaErrorType.GENERIC_ERROR ->
                     errorMessage = getString(R.string.error_refresh_media)

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -132,6 +132,7 @@ public class WPMediaUtils {
             case NOT_FOUND:
                 return context.getString(R.string.error_media_not_found);
             case AUTHORIZATION_REQUIRED:
+            case NOT_AUTHENTICATED:
                 return context.getString(R.string.media_error_no_permission_upload);
             case REQUEST_TOO_LARGE:
                 if (media == null) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRSApiRestClient.kt
@@ -27,6 +27,7 @@ import uniffi.wp_api.MediaDetailsPayload
 import uniffi.wp_api.MediaListParams
 import uniffi.wp_api.MediaUpdateParams
 import uniffi.wp_api.MediaWithEditContext
+import uniffi.wp_api.RequestExecutionErrorReason
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Named
@@ -165,17 +166,112 @@ class MediaRSApiRestClient @Inject constructor(
                 }
             }
 
-            is WpRequestResult.InvalidHttpStatusCode<*>,
-            is WpRequestResult.WpError<*>,
-            is WpRequestResult.RequestExecutionFailed<*>,
-            is WpRequestResult.UnknownError<*> -> {
-                appLogWrapper.e(AppLog.T.MEDIA, "Unknown error: $mediaResponse")
-                MediaError(MediaErrorType.GENERIC_ERROR).apply {
-                    message = "Unknown error occurred"
-                }
-            }
+            is WpRequestResult.InvalidHttpStatusCode<*> -> parseInvalidHttpStatusCode(mediaResponse)
+            is WpRequestResult.WpError<*> -> parseWpError(mediaResponse)
+            is WpRequestResult.RequestExecutionFailed<*> -> parseRequestExecutionFailed(mediaResponse)
+            is WpRequestResult.UnknownError<*> -> parseUnknownError(mediaResponse)
         }
     }
+
+    private fun parseInvalidHttpStatusCode(mediaResponse: WpRequestResult.InvalidHttpStatusCode<*>): MediaError {
+        val status = mediaResponse.statusCode.toInt()
+        appLogWrapper.e(
+            AppLog.T.MEDIA,
+            "Media request failed with HTTP $status " +
+                    "(${mediaResponse.requestMethod} ${mediaResponse.requestUrl})"
+        )
+        return buildMediaError(
+            type = MediaErrorType.fromHttpStatusCode(status),
+            statusCode = status,
+            message = "Media request failed with HTTP status $status",
+            logMessage = "InvalidHttpStatusCode: status=$status, " +
+                    "method=${mediaResponse.requestMethod}, url=${mediaResponse.requestUrl}"
+        )
+    }
+
+    private fun parseWpError(mediaResponse: WpRequestResult.WpError<*>): MediaError {
+        val status = mediaResponse.statusCode.toInt()
+        appLogWrapper.e(
+            AppLog.T.MEDIA,
+            "Media request returned WpError ${mediaResponse.errorCode} " +
+                    "(HTTP $status): ${mediaResponse.errorMessage}"
+        )
+        return buildMediaError(
+            type = MediaErrorType.fromHttpStatusCode(status),
+            statusCode = status,
+            message = mediaResponse.errorMessage,
+            logMessage = "WpError: code=${mediaResponse.errorCode}, status=$status, " +
+                    "method=${mediaResponse.requestMethod}, url=${mediaResponse.requestUrl}, " +
+                    "message=${mediaResponse.errorMessage}"
+        )
+    }
+
+    private fun parseRequestExecutionFailed(mediaResponse: WpRequestResult.RequestExecutionFailed<*>): MediaError {
+        val status = mediaResponse.statusCode?.toInt()
+        appLogWrapper.e(
+            AppLog.T.MEDIA,
+            "Media request execution failed: ${mediaResponse.reason} (HTTP $status)"
+        )
+        return buildMediaError(
+            type = mediaErrorTypeFromExecutionReason(mediaResponse.reason),
+            statusCode = status,
+            message = "Media request could not be completed",
+            logMessage = "RequestExecutionFailed: reason=${mediaResponse.reason}, status=$status, " +
+                    "method=${mediaResponse.requestMethod}, url=${mediaResponse.requestUrl}"
+        )
+    }
+
+    private fun parseUnknownError(mediaResponse: WpRequestResult.UnknownError<*>): MediaError {
+        val status = mediaResponse.statusCode.toInt()
+        appLogWrapper.e(
+            AppLog.T.MEDIA,
+            "Media request returned unknown error (HTTP $status): ${mediaResponse.response}"
+        )
+        return buildMediaError(
+            type = MediaErrorType.fromHttpStatusCode(status),
+            statusCode = status,
+            message = "Media request failed with HTTP status $status",
+            logMessage = "UnknownError: status=$status, method=${mediaResponse.requestMethod}, " +
+                    "url=${mediaResponse.requestUrl}, response=${mediaResponse.response}"
+        )
+    }
+
+    private fun buildMediaError(
+        type: MediaErrorType,
+        statusCode: Int?,
+        message: String?,
+        logMessage: String
+    ): MediaError = MediaError(type).apply {
+        statusCode?.let { this.statusCode = it }
+        this.message = message
+        this.logMessage = logMessage
+    }
+
+    /**
+     * Maps a transport-level failure reason (no HTTP response, or a connection/auth problem) to a
+     * more specific [MediaErrorType]. Intentionally exhaustive (no `else`) so that any new
+     * [RequestExecutionErrorReason] added upstream is surfaced as a compile error here rather than
+     * silently degrading to [MediaErrorType.GENERIC_ERROR].
+     */
+    private fun mediaErrorTypeFromExecutionReason(reason: RequestExecutionErrorReason): MediaErrorType =
+        when (reason) {
+            is RequestExecutionErrorReason.HttpTimeoutError -> MediaErrorType.TIMEOUT
+            is RequestExecutionErrorReason.DeviceIsOfflineError,
+            is RequestExecutionErrorReason.InvalidSslError -> MediaErrorType.CONNECTION_ERROR
+            is RequestExecutionErrorReason.NonExistentSiteError -> MediaErrorType.NOT_FOUND
+            // Keep this aligned with MediaErrorType.fromHttpStatusCode: a 403 (forbidden) maps to
+            // NOT_AUTHENTICATED, while a 401 (auth required/rejected/misconfigured) maps to
+            // AUTHORIZATION_REQUIRED.
+            is RequestExecutionErrorReason.HttpForbiddenError -> MediaErrorType.NOT_AUTHENTICATED
+            is RequestExecutionErrorReason.HttpAuthenticationRequiredError,
+            is RequestExecutionErrorReason.HttpAuthenticationRejectedError,
+            is RequestExecutionErrorReason.MisconfiguredHttpAuthenticationError ->
+                MediaErrorType.AUTHORIZATION_REQUIRED
+            is RequestExecutionErrorReason.MisconfiguredRateLimitError,
+            is RequestExecutionErrorReason.CancellationError,
+            is RequestExecutionErrorReason.HttpError,
+            is RequestExecutionErrorReason.GenericError -> MediaErrorType.GENERIC_ERROR
+        }
 
     private fun notifyMediaFetched(
         site: SiteModel,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -527,15 +527,19 @@ public class MediaStore extends Store {
             switch (code) {
                 case 400:
                     return MediaErrorType.BAD_REQUEST;
+                case 401:
+                    return MediaErrorType.AUTHORIZATION_REQUIRED;
                 case 404:
                     return MediaErrorType.NOT_FOUND;
                 case 403:
                     return MediaErrorType.NOT_AUTHENTICATED;
                 case 413:
                     return MediaErrorType.REQUEST_TOO_LARGE;
-                case 500:
-                    return MediaErrorType.SERVER_ERROR;
                 default:
+                    // any 5xx is a server-side failure (502/503 included, not just 500)
+                    if (code >= 500 && code <= 599) {
+                        return MediaErrorType.SERVER_ERROR;
+                    }
                     return MediaErrorType.GENERIC_ERROR;
             }
         }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -777,6 +777,31 @@ public class MediaStoreTest {
         assertEquals(0, mMediaStore.getSiteMediaCount(testSite2));
     }
 
+    @Test
+    public void testMediaErrorTypeFromHttpStatusCode() {
+        assertEquals(MediaStore.MediaErrorType.BAD_REQUEST, MediaStore.MediaErrorType.fromHttpStatusCode(400));
+        assertEquals(MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED,
+                MediaStore.MediaErrorType.fromHttpStatusCode(401));
+        assertEquals(MediaStore.MediaErrorType.NOT_AUTHENTICATED, MediaStore.MediaErrorType.fromHttpStatusCode(403));
+        assertEquals(MediaStore.MediaErrorType.NOT_FOUND, MediaStore.MediaErrorType.fromHttpStatusCode(404));
+        assertEquals(MediaStore.MediaErrorType.REQUEST_TOO_LARGE, MediaStore.MediaErrorType.fromHttpStatusCode(413));
+    }
+
+    @Test
+    public void testMediaErrorTypeFromHttpStatusCodeServerErrorRange() {
+        // any 5xx should be treated as a server error, not just 500
+        assertEquals(MediaStore.MediaErrorType.SERVER_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(500));
+        assertEquals(MediaStore.MediaErrorType.SERVER_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(502));
+        assertEquals(MediaStore.MediaErrorType.SERVER_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(503));
+        assertEquals(MediaStore.MediaErrorType.SERVER_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(599));
+    }
+
+    @Test
+    public void testMediaErrorTypeFromHttpStatusCodeUnmappedIsGeneric() {
+        assertEquals(MediaStore.MediaErrorType.GENERIC_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(418));
+        assertEquals(MediaStore.MediaErrorType.GENERIC_ERROR, MediaStore.MediaErrorType.fromHttpStatusCode(600));
+    }
+
     private MediaModel getBasicMedia() {
         return generateMedia("Test Title", "Test Description", "Test Caption", "Test Alt");
     }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaRsApiRestClientTest.kt
@@ -41,7 +41,9 @@ import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.MediaCaptionWithEditContext
+import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.WpErrorCode
 import uniffi.wp_api.MediaDeleteResponse
 import uniffi.wp_api.MediaDescriptionWithEditContext
 import uniffi.wp_api.MediaDetails
@@ -66,6 +68,7 @@ private const val SUFFIX_SEPARATOR = "?"
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
+@Suppress("LargeClass")
 class MediaRsApiRestClientTest {
     @Mock
     private lateinit var dispatcher: Dispatcher
@@ -178,8 +181,8 @@ class MediaRsApiRestClientTest {
         assertEquals(testSite, payload.site)
         assertEquals(testMedia, payload.media) // Error case returns original media
         assertNotNull(payload.error)
-        assertEquals(MediaErrorType.GENERIC_ERROR, payload.error?.type)
-        assertEquals("Unknown error occurred", payload.error?.message)
+        assertEquals(MediaErrorType.SERVER_ERROR, payload.error?.type)
+        assertEquals(500, payload.error?.statusCode)
     }
 
     @Test
@@ -318,7 +321,8 @@ class MediaRsApiRestClientTest {
         assertEquals(testSite, payload.site)
         assertEquals(testMedia, payload.media) // Error case returns original media
         assertNotNull(payload.error)
-        assertEquals(MediaErrorType.GENERIC_ERROR, payload.error?.type)
+        assertEquals(MediaErrorType.NOT_FOUND, payload.error?.type)
+        assertEquals(404, payload.error?.statusCode)
     }
 
     @Test
@@ -501,9 +505,97 @@ class MediaRsApiRestClientTest {
         assertEquals(testMedia, payload.media)
         assertEquals(MediaUploadState.FAILED.toString(), payload.media?.uploadState)
         assertNotNull(payload.error)
-        assertEquals(MediaErrorType.GENERIC_ERROR, payload.error?.type)
+        assertEquals(MediaErrorType.REQUEST_TOO_LARGE, payload.error?.type)
+        assertEquals(413, payload.error?.statusCode)
         assertEquals(1f, payload.progress, 0.01f)
         assertEquals(false, payload.completed)
+    }
+
+    @Test
+    fun `uploadMedia with WpError 401 dispatches authorization required error`() = runTest {
+        val testSite = createTestSite()
+        val testMedia = createTestMedia().apply {
+            filePath = "/valid/path/file.jpg"
+        }
+
+        whenever(fileCheckWrapper.canReadFile(any())).thenReturn(true)
+        whenever(wpApiClient.request<Any>(any())).thenReturn(
+            WpRequestResult.WpError(
+                errorCode = WpErrorCode.CannotEdit(),
+                errorMessage = "Sorry, you are not allowed to upload media.",
+                statusCode = 401u,
+                response = "",
+                requestUrl = "",
+                requestMethod = RequestMethod.POST
+            )
+        )
+
+        restClient.uploadMedia(testSite, testMedia)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val payload = actionCaptor.value.payload as ProgressPayload
+        assertNotNull(payload.error)
+        assertEquals(MediaErrorType.AUTHORIZATION_REQUIRED, payload.error?.type)
+        assertEquals(401, payload.error?.statusCode)
+        assertEquals("Sorry, you are not allowed to upload media.", payload.error?.message)
+    }
+
+    @Test
+    fun `uploadMedia with request execution timeout dispatches timeout error`() = runTest {
+        val testSite = createTestSite()
+        val testMedia = createTestMedia().apply {
+            filePath = "/valid/path/file.jpg"
+        }
+
+        whenever(fileCheckWrapper.canReadFile(any())).thenReturn(true)
+        whenever(wpApiClient.request<Any>(any())).thenReturn(
+            WpRequestResult.RequestExecutionFailed(
+                statusCode = null,
+                redirects = null,
+                reason = RequestExecutionErrorReason.HttpTimeoutError,
+                requestUrl = "",
+                requestMethod = RequestMethod.POST
+            )
+        )
+
+        restClient.uploadMedia(testSite, testMedia)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val payload = actionCaptor.value.payload as ProgressPayload
+        assertNotNull(payload.error)
+        assertEquals(MediaErrorType.TIMEOUT, payload.error?.type)
+    }
+
+    @Test
+    fun `uploadMedia with request execution forbidden dispatches not authenticated error`() = runTest {
+        val testSite = createTestSite()
+        val testMedia = createTestMedia().apply {
+            filePath = "/valid/path/file.jpg"
+        }
+
+        whenever(fileCheckWrapper.canReadFile(any())).thenReturn(true)
+        whenever(wpApiClient.request<Any>(any())).thenReturn(
+            WpRequestResult.RequestExecutionFailed(
+                statusCode = null,
+                redirects = null,
+                reason = RequestExecutionErrorReason.HttpForbiddenError(hostname = ""),
+                requestUrl = "",
+                requestMethod = RequestMethod.POST
+            )
+        )
+
+        restClient.uploadMedia(testSite, testMedia)
+
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val payload = actionCaptor.value.payload as ProgressPayload
+        assertNotNull(payload.error)
+        assertEquals(MediaErrorType.NOT_AUTHENTICATED, payload.error?.type)
     }
 
     @Test
@@ -582,8 +674,8 @@ class MediaRsApiRestClientTest {
         assertEquals(testSite, payload.site)
         assertEquals(testMedia, payload.media) // Error case returns original media
         assertNotNull(payload.error)
-        assertEquals(MediaErrorType.GENERIC_ERROR, payload.error?.type)
-        assertEquals("Unknown error occurred", payload.error?.message)
+        assertEquals(MediaErrorType.SERVER_ERROR, payload.error?.type)
+        assertEquals(500, payload.error?.statusCode)
     }
 
     @Test


### PR DESCRIPTION
## Description

Cherry-pick of #23023 (`8a595bb4f38`) onto `release/26.9`. The cherry-pick applied cleanly with no conflicts.

---

Self-hosted sites authenticated with an Application Password upload media through the new `wordpress-rs` REST path (`MediaRSApiRestClient`). When an upload failed, four genuinely different `WpRequestResult` outcomes — `InvalidHttpStatusCode`, `WpError`, `RequestExecutionFailed`, and `UnknownError` — were all collapsed into a single `GENERIC_ERROR` with the message "Unknown error occurred". The real cause (HTTP status, error code, transport reason) only existed in a `$mediaResponse` log line, so user reports surfaced as an undiagnosable generic snackbar ("Couldn't complete this action").

This PR splits that catch-all into specific handling:

- **HTTP-status mapping** (`InvalidHttpStatusCode` / `WpError` / `UnknownError`) reuses the existing `MediaErrorType.fromHttpStatusCode()` rather than duplicating the logic: `400 → BAD_REQUEST`, `401 → AUTHORIZATION_REQUIRED`, `403 → NOT_AUTHENTICATED`, `404 → NOT_FOUND`, `413 → REQUEST_TOO_LARGE`, `5xx → SERVER_ERROR`, else `GENERIC_ERROR`. `fromHttpStatusCode` was also generalized so the whole `5xx` range (not just `500`) maps to `SERVER_ERROR`.
- **Transport-reason mapping** (`RequestExecutionFailed`) via `mediaErrorTypeFromExecutionReason()`: timeout → `TIMEOUT`, offline/SSL → `CONNECTION_ERROR`, forbidden → `NOT_AUTHENTICATED`, auth required/rejected/misconfigured → `AUTHORIZATION_REQUIRED`, non-existent site → `NOT_FOUND`. The `when` is intentionally exhaustive (no `else`) so a new upstream `RequestExecutionErrorReason` variant becomes a compile error here instead of silently degrading to `GENERIC_ERROR`.
- Each branch now populates `MediaError.statusCode` and a structured `logMessage` (status, error code, reason, request URL and method) so future reports are self-diagnosing.
- The new `NOT_AUTHENTICATED` mapping for 403 is wired through the UI layers (`EditPostActivity`, `GutenbergKitActivity`, `WPMediaUtils`) so those failures still show the existing no-permission message.

Because the upload snackbar text is driven by `MediaError.type`, this also improves the user-facing message: many failures now show an actionable message (e.g. "media too large", "you don't have permission to upload") instead of the generic one.

⚠️ This improves diagnosis and labelling of the error class; it does not by itself change whether a given upload succeeds.

## Testing instructions

Covered by unit tests in `MediaRsApiRestClientTest` and `MediaStoreTest`. To verify locally:

1. Run `./gradlew :libs:fluxc:testDebugUnitTest --tests "*.MediaRsApiRestClientTest" --tests "*.MediaStoreTest"`
- [ ] Verify all tests pass

On-device sanity check (self-hosted site logged in with an Application Password):

- [ ] Verify uploads work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
