### PR TITLE
Fetch all taxonomy terms so the list/hierarchy is complete (CMM-2122 follow-up)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -55,6 +55,13 @@ open class DataViewViewModel @Inject constructor(
 
     open val emptyView = DataViewEmptyView()
 
+    /**
+     * When false, the list is fetched in full by a single [performNetworkRequest] call and
+     * incremental (scroll) pagination is disabled. Subclasses that need the complete data set
+     * up front - e.g. to build a hierarchy - override this.
+     */
+    protected open val supportsLoadMore: Boolean = true
+
     private fun updateState(update: (DataViewUiState) -> DataViewUiState) {
         _uiState.update { update(it) }
     }
@@ -67,7 +74,7 @@ open class DataViewViewModel @Inject constructor(
                     if (currentState.searchQuery.isNotEmpty()) LoadingState.EMPTY_SEARCH
                     else LoadingState.EMPTY
                 } else LoadingState.LOADED,
-                canLoadMore = items.size == PAGE_SIZE
+                canLoadMore = supportsLoadMore && items.size == PAGE_SIZE
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -107,6 +107,10 @@ class TermsViewModel @Inject constructor(
     private var currentTerms = listOf<AnyTermWithEditContext>()
     private var navController: NavHostController? = null
 
+    // All terms are fetched in a single pass so the full list/hierarchy can be built, so the
+    // DataView incremental scroll pagination is not used here.
+    override val supportsLoadMore: Boolean = false
+
     private val _termDetailState = MutableStateFlow<TermDetailUiState?>(null)
     val termDetailState: StateFlow<TermDetailUiState?> = _termDetailState.asStateFlow()
 
@@ -251,7 +255,7 @@ class TermsViewModel @Inject constructor(
             return@withContext emptyList()
         }
 
-        val allTerms = getTermsList(selectedSite, page, searchQuery, sortOrder, sortBy)
+        val allTerms = getTermsList(selectedSite, searchQuery, sortOrder, sortBy)
         currentTerms = allTerms
 
         // Sort the results hierarchically if necessary
@@ -528,49 +532,51 @@ class TermsViewModel @Inject constructor(
 
     private suspend fun getTermsList(
         site: SiteModel,
-        page: Int,
         searchQuery: String,
         sortOrder: WpApiParamOrder,
         sortBy: DataViewDropdownItem?
     ): List<AnyTermWithEditContext> {
         val wpApiClient = wpApiClientProvider.getWpApiClient(site)
+        val orderBy = when {
+            sortBy == null -> null
+            sortBy.id == SORT_BY_COUNT_ID -> WpApiParamTermsOrderBy.COUNT
+            else -> WpApiParamTermsOrderBy.NAME
+        }
 
-        val termsResponse = wpApiClient.request { requestBuilder ->
-            requestBuilder.terms().listWithEditContext(
-                termEndpointType = getTermEndpointType(),
-                params = TermListParams(
-                    page = page.toUInt(),
-                    search = searchQuery,
-                    order = when (sortOrder) {
-                        WpApiParamOrder.ASC -> WpApiParamOrder.ASC
-                        WpApiParamOrder.DESC -> WpApiParamOrder.DESC
-                    },
-                    orderby = if (sortBy == null) {
-                        null
-                    } else {
-                        if (sortBy.id == SORT_BY_COUNT_ID) {
-                            WpApiParamTermsOrderBy.COUNT
-                        } else {
-                            WpApiParamTermsOrderBy.NAME // default
-                        }
-                    }
+        // Fetch every page so the complete list is available before it is sorted/built into a
+        // hierarchy. The REST API defaults to 10 terms per page, so we request a larger page size
+        // and follow the pagination params until all terms have been fetched (see CMM-2122).
+        val allTerms = mutableListOf<AnyTermWithEditContext>()
+        var params: TermListParams? = TermListParams(
+            perPage = TERMS_PER_PAGE,
+            search = searchQuery,
+            order = sortOrder,
+            orderby = orderBy
+        )
+        while (params != null) {
+            val currentParams = params
+            val termsResponse = wpApiClient.request { requestBuilder ->
+                requestBuilder.terms().listWithEditContext(
+                    termEndpointType = getTermEndpointType(),
+                    params = currentParams
                 )
-            )
-        }
-
-        return when (termsResponse) {
-            is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.API, "Fetched ${termsResponse.response.data.size} terms")
-                termsResponse.response.data
             }
+            when (termsResponse) {
+                is WpRequestResult.Success -> {
+                    allTerms.addAll(termsResponse.response.data)
+                    params = termsResponse.response.nextPageParams
+                }
 
-            else -> {
-                val error = "Error getting Terms list for taxonomy: $taxonomySlug"
-                appLogWrapper.e(AppLog.T.API, error)
-                onError(error)
-                emptyList()
+                else -> {
+                    val error = "Error getting Terms list for taxonomy: $taxonomySlug"
+                    appLogWrapper.e(AppLog.T.API, error)
+                    onError(error)
+                    return emptyList()
+                }
             }
         }
+        appLogWrapper.d(AppLog.T.API, "Fetched ${allTerms.size} terms")
+        return allTerms
     }
 
     private fun getTermEndpointType(): TermEndpointType = when (taxonomySlug) {
@@ -586,5 +592,6 @@ class TermsViewModel @Inject constructor(
     companion object {
         private const val SORT_BY_NAME_ID = 1L
         private const val SORT_BY_COUNT_ID = 2L
+        private const val TERMS_PER_PAGE = 100u
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -72,6 +72,11 @@ data class ParentOption(
     val name: String
 )
 
+private data class TermsFetchResult(
+    val terms: List<AnyTermWithEditContext>,
+    val isComplete: Boolean
+)
+
 sealed class UiEvent {
     data class ShowError(val messageRes: Int) : UiEvent()
 }
@@ -240,6 +245,8 @@ class TermsViewModel @Inject constructor(
     }
 
     override suspend fun performNetworkRequest(
+        // page is unused: the full list is fetched in one pass (see getTermsList) and
+        // incremental pagination is disabled via supportsLoadMore.
         page: Int,
         searchQuery: String,
         filter: DataViewDropdownItem?,
@@ -255,7 +262,7 @@ class TermsViewModel @Inject constructor(
             return@withContext emptyList()
         }
 
-        val allTerms = getTermsList(selectedSite, searchQuery, sortOrder, sortBy)
+        val (allTerms, isComplete) = getTermsList(selectedSite, searchQuery, sortOrder, sortBy)
         currentTerms = allTerms
 
         // Sort the results hierarchically if necessary
@@ -265,8 +272,10 @@ class TermsViewModel @Inject constructor(
             allTerms
         }
 
-        // Store terms when they are not filtered
-        if (sortedTerms.isNotEmpty() && filter == null) {
+        // Store terms only when the complete list was fetched and it isn't filtered. Persisting a
+        // partial list (e.g. after a mid-pagination failure) would poison the local cache with an
+        // incomplete set whose hierarchy is broken.
+        if (sortedTerms.isNotEmpty() && filter == null && isComplete) {
             storeTerms(selectedSite, sortedTerms)
         }
 
@@ -530,12 +539,17 @@ class TermsViewModel @Inject constructor(
         return indentation
     }
 
+    /**
+     * Fetches every page of terms and returns them together with whether the whole list was
+     * fetched successfully. [TermsFetchResult.isComplete] is false when a page failed mid
+     * pagination, so callers can avoid persisting a partial (and potentially broken) list.
+     */
     private suspend fun getTermsList(
         site: SiteModel,
         searchQuery: String,
         sortOrder: WpApiParamOrder,
         sortBy: DataViewDropdownItem?
-    ): List<AnyTermWithEditContext> {
+    ): TermsFetchResult {
         val wpApiClient = wpApiClientProvider.getWpApiClient(site)
         val orderBy = when {
             sortBy == null -> null
@@ -553,6 +567,7 @@ class TermsViewModel @Inject constructor(
             order = sortOrder,
             orderby = orderBy
         )
+        var isComplete = true
         while (params != null) {
             val currentParams = params
             val termsResponse = wpApiClient.request { requestBuilder ->
@@ -576,12 +591,13 @@ class TermsViewModel @Inject constructor(
                     if (allTerms.isEmpty()) {
                         onError(error)
                     }
+                    isComplete = false
                     break
                 }
             }
         }
-        appLogWrapper.d(AppLog.T.API, "Fetched ${allTerms.size} terms")
-        return allTerms
+        appLogWrapper.d(AppLog.T.API, "Fetched ${allTerms.size} terms (complete=$isComplete)")
+        return TermsFetchResult(allTerms, isComplete)
     }
 
     private fun getTermEndpointType(): TermEndpointType = when (taxonomySlug) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/taxonomies/TermsViewModel.kt
@@ -570,8 +570,13 @@ class TermsViewModel @Inject constructor(
                 else -> {
                     val error = "Error getting Terms list for taxonomy: $taxonomySlug"
                     appLogWrapper.e(AppLog.T.API, error)
-                    onError(error)
-                    return emptyList()
+                    // Keep any terms already fetched from earlier pages so a transient failure
+                    // mid-pagination degrades gracefully instead of dropping the whole list. Only
+                    // surface the error when nothing could be fetched at all.
+                    if (allTerms.isEmpty()) {
+                        onError(error)
+                    }
+                    break
                 }
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.taxonomies
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.Resources
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -10,7 +11,9 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -25,8 +28,17 @@ import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.dataview.LoadingState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.NetworkUtilsWrapper
+import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.AnyTermWithEditContext
+import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.TaxonomyType
+import uniffi.wp_api.TermListParams
+import uniffi.wp_api.TermsRequestListWithEditContextResponse
+import uniffi.wp_api.WpNetworkHeaderMap
 
 @ExperimentalCoroutinesApi
 class TermsViewModelTest : BaseUnitTest() {
@@ -62,6 +74,14 @@ class TermsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var networkAvailabilityProvider: WpNetworkAvailabilityProvider
+
+    @Mock
+    private lateinit var wpApiClient: WpApiClient
+
+    @Mock
+    private lateinit var resources: Resources
+
+    private val testSite = SiteModel()
 
     @Before
     fun setUp() {
@@ -286,4 +306,129 @@ class TermsViewModelTest : BaseUnitTest() {
         assertThat(event).isInstanceOf(UiEvent.ShowError::class.java)
         assertThat((event as UiEvent.ShowError).messageRes).isEqualTo(R.string.error_deleting_term)
     }
+
+    @Test
+    fun `performNetworkRequest follows pagination and combines all pages`() = test {
+        stubSuccessfulFetch()
+        val firstPage = createListResponse(
+            terms = List(2) { createTestTerm(id = it.toLong()) },
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val secondPage = createListResponse(
+            terms = List(3) { createTestTerm(id = (it + 2).toLong()) },
+            nextPageParams = null
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(firstPage, secondPage)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        // Two pages requested, all 5 terms combined into the list
+        verify(wpApiClient, times(2)).request<TermsRequestListWithEditContextResponse>(any())
+        assertThat(viewModel.uiState.value.items).hasSize(5)
+        assertThat(viewModel.uiState.value.loadingState).isEqualTo(LoadingState.LOADED)
+    }
+
+    @Test
+    fun `canLoadMore stays false even when a full page is returned`() = test {
+        stubSuccessfulFetch()
+        // A single page that is exactly PAGE_SIZE (25) long with no further pages. Without the
+        // supportsLoadMore override the base canLoadMore check would flip to true here.
+        val fullPage = createListResponse(
+            terms = List(25) { createTestTerm(id = it.toLong()) },
+            nextPageParams = null
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(fullPage)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.items).hasSize(25)
+        assertThat(viewModel.uiState.value.canLoadMore).isFalse
+    }
+
+    @Test
+    fun `partial failure on a later page keeps already fetched terms`() = test {
+        stubSuccessfulFetch()
+        val firstPage = createListResponse(
+            terms = List(2) { createTestTerm(id = it.toLong()) },
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val errorResponse = WpRequestResult.UnknownError<TermsRequestListWithEditContextResponse>(
+            statusCode = 500u,
+            response = "Internal Server Error",
+            requestUrl = "",
+            requestMethod = RequestMethod.GET
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(firstPage, errorResponse)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        // The first page is preserved and the error state is not surfaced
+        assertThat(viewModel.uiState.value.items).hasSize(2)
+        assertThat(viewModel.uiState.value.loadingState).isEqualTo(LoadingState.LOADED)
+    }
+
+    @Test
+    fun `failure on the first page surfaces the error state`() = test {
+        stubSuccessfulFetch()
+        val errorResponse = WpRequestResult.UnknownError<TermsRequestListWithEditContextResponse>(
+            statusCode = 500u,
+            response = "Internal Server Error",
+            requestUrl = "",
+            requestMethod = RequestMethod.GET
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(errorResponse)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.loadingState).isEqualTo(LoadingState.ERROR)
+        assertThat(viewModel.uiState.value.items).isEmpty()
+    }
+
+    private fun stubSuccessfulFetch() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(testSite)
+        // Raw site instance (not a matcher): getWpApiClient is a concrete method with a default
+        // parameter, which trips up Mockito matchers.
+        whenever(wpApiClientProvider.getWpApiClient(testSite)).thenReturn(wpApiClient)
+        whenever(context.resources).thenReturn(resources)
+        // Raw values (not matchers) so the vararg getString overload stubs cleanly; every test
+        // term uses count = 0L.
+        whenever(resources.getString(R.string.term_count, 0L)).thenReturn("count")
+    }
+
+    private fun createListResponse(
+        terms: List<AnyTermWithEditContext>,
+        nextPageParams: TermListParams?
+    ): WpRequestResult<TermsRequestListWithEditContextResponse> = WpRequestResult.Success(
+        response = TermsRequestListWithEditContextResponse(
+            terms,
+            mock<WpNetworkHeaderMap>(),
+            nextPageParams,
+            null
+        )
+    )
+
+    private fun createTestTerm(id: Long, parent: Long = 0L): AnyTermWithEditContext =
+        AnyTermWithEditContext(
+            id = id,
+            count = 0L,
+            description = "",
+            link = "https://example.com/tag/$id",
+            name = "Term $id",
+            slug = "term-$id",
+            taxonomy = TaxonomyType.PostTag,
+            parent = parent
+        )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/taxonomies/TermsViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.taxonomies
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -13,6 +14,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -394,6 +396,107 @@ class TermsViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.uiState.value.loadingState).isEqualTo(LoadingState.ERROR)
         assertThat(viewModel.uiState.value.items).isEmpty()
+    }
+
+    @Test
+    fun `hierarchy is built across pages so a child paged after its parent nests under it`() = test {
+        stubSuccessfulFetch()
+        // The child is returned on the first page and its parent only on the second. Building the
+        // tree per-page would leave the child an orphan root; building from the full set must nest
+        // it. This is the headline bug this change fixes.
+        val firstPage = createListResponse(
+            terms = listOf(createTestTerm(id = 2L, parent = 1L)),
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val secondPage = createListResponse(
+            terms = listOf(createTestTerm(id = 1L, parent = 0L)),
+            nextPageParams = null
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(firstPage, secondPage)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        advanceUntilIdle()
+
+        val items = viewModel.uiState.value.items
+        assertThat(items).hasSize(2)
+        // Parent first at the root level, then the child indented one level (INDENTATION_IN_DP=10)
+        assertThat(items[0].id).isEqualTo(1L)
+        assertThat(items[0].indentation).isEqualTo(0.dp)
+        assertThat(items[1].id).isEqualTo(2L)
+        assertThat(items[1].indentation).isEqualTo(10.dp)
+    }
+
+    @Test
+    fun `hierarchy indents grandchildren split across pages by their depth`() = test {
+        stubSuccessfulFetch()
+        // root (id 1) -> child (id 2) -> grandchild (id 3), each delivered on a different page so
+        // the full chain only exists once every page has been combined.
+        val firstPage = createListResponse(
+            terms = listOf(createTestTerm(id = 3L, parent = 2L)),
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val secondPage = createListResponse(
+            terms = listOf(createTestTerm(id = 2L, parent = 1L)),
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val thirdPage = createListResponse(
+            terms = listOf(createTestTerm(id = 1L, parent = 0L)),
+            nextPageParams = null
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(firstPage, secondPage, thirdPage)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_CATEGORY, isHierarchical = true)
+        advanceUntilIdle()
+
+        val items = viewModel.uiState.value.items
+        assertThat(items.map { it.id }).containsExactly(1L, 2L, 3L)
+        assertThat(items.map { it.indentation }).containsExactly(0.dp, 10.dp, 20.dp)
+    }
+
+    @Test
+    fun `complete fetch stores the terms locally`() = test {
+        stubSuccessfulFetch()
+        val page = createListResponse(
+            terms = List(2) { createTestTerm(id = it.toLong()) },
+            nextPageParams = null
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(page)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        verify(fluxCDispatcher).dispatch(any())
+    }
+
+    @Test
+    fun `partial failure does not store the incomplete terms locally`() = test {
+        stubSuccessfulFetch()
+        val firstPage = createListResponse(
+            terms = List(2) { createTestTerm(id = it.toLong()) },
+            nextPageParams = TermListParams(perPage = 100u)
+        )
+        val errorResponse = WpRequestResult.UnknownError<TermsRequestListWithEditContextResponse>(
+            statusCode = 500u,
+            response = "Internal Server Error",
+            requestUrl = "",
+            requestMethod = RequestMethod.GET
+        )
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(firstPage, errorResponse)
+
+        val viewModel = createViewModel()
+        viewModel.initialize(DEFAULT_TAXONOMY_TAG, isHierarchical = false)
+        advanceUntilIdle()
+
+        // The fetched terms are still shown, but an incomplete list must not poison the cache
+        assertThat(viewModel.uiState.value.items).hasSize(2)
+        verify(fluxCDispatcher, never()).dispatch(any())
     }
 
     private fun stubSuccessfulFetch() {


### PR DESCRIPTION
## Description

The DataView-based taxonomy management screen in Site Settings (`TermsViewModel`) only ever showed a single page of terms, and for hierarchical taxonomies (categories) the tree was wrong once there was more than one page.

**Two root causes:**

1. **Page size.** `getTermsList` built `TermListParams` without `perPage`, so the WordPress REST API fell back to its default of **10** terms per page. `DataViewViewModel` decides whether to keep loading with `canLoadMore = items.size == PAGE_SIZE` (25), so a 10-item first page made `canLoadMore` false and paging stopped after one call.

2. **Hierarchy built from partial pages.** Even with a larger page size, the screen built the category tree from one page at a time. `sortByHierarchy`/`getHierarchicalIndentation` treat any term whose parent isn't *in the current page* as a root, so a child whose parent landed on another page rendered as a **top-level orphan**. Server-side paging + client-side per-page tree building can't produce a correct hierarchy.

This is the same class of bug fixed for the application-password wp-rs taxonomy client in **CMM-2122** (#23017), surfaced here through a different (DataView) code path.

## Fix

Fetch **all** term pages up front — request 100 per page and follow `nextPageParams` until exhausted (mirroring the wp-rs taxonomy client) — and build the hierarchy from the complete set.

Because the whole list is loaded in one pass, incremental scroll pagination is opted out of via a new `supportsLoadMore` hook on `DataViewViewModel`:

- Default is `true`, so all other DataView screens are unaffected.
- `TermsViewModel` overrides it to `false`.
- Without it, the base `canLoadMore = items.size == PAGE_SIZE` check could re-request a second page (duplicating terms) or flip the screen to an empty state when the total happened to be an exact multiple of the page size.

## Testing instructions

On a site with **more than one page** of categories/tags

1. Site Settings → manage Categories.
- [x] Verify all categories load (not capped at 10/25), with a single fetch sequence (multiple background page requests, no scroll needed).
- [x] Verify nested categories are correctly indented under their parents, including parent/child pairs that previously fell on different pages.
2. Site Settings → manage Tags (flat).
- [x] Verify all tags load.
3. Search and sort (by name / by count).
- [x] Verify results are complete and correctly ordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)