### PR TITLE
Fix "No matches" flash in wp-rs Pages search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
@@ -1118,7 +1118,17 @@ internal class PagesRsListViewModel @Inject constructor(
                 pageForPosts = currentSite?.pageForPosts ?: 0L
             ).map { row -> row.withMenuActions(currentSite) }
             updateTabUiState(tab) {
-                copy(pages = rows, isLoading = false, error = null, isAuthError = false)
+                // Only clear the loading flag once we actually have rows. While the first page
+                // is still being fetched (e.g. a fresh search collection with no cache), rows is
+                // empty; keeping isLoading lets the shimmer show instead of flashing the
+                // "No matches" empty state. updateListInfoForTab() flips isLoading off once the
+                // fetch genuinely completes, at which point an empty result is real.
+                copy(
+                    pages = rows,
+                    isLoading = if (rows.isEmpty()) isLoading else false,
+                    error = null,
+                    isAuthError = false
+                )
             }
             resolveAuthorNames(tab, uiModels)
             resolveFeaturedImages(tab, uiModels)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
@@ -1125,7 +1125,7 @@ internal class PagesRsListViewModel @Inject constructor(
                 // fetch genuinely completes, at which point an empty result is real.
                 copy(
                     pages = rows,
-                    isLoading = if (rows.isEmpty()) isLoading else false,
+                    isLoading = isLoading && rows.isEmpty(),
                     error = null,
                     isAuthError = false
                 )


### PR DESCRIPTION
## Description

When typing in the search bar of the new wp-rs Pages list, the "No pages matching your search" empty-state message flashed for the duration of the network fetch before the real results appeared. This PR resolves that problem.

The fix conditionally holds the `isLoading` flag while a freshly created search collection has no cached rows yet, so the shimmer shows during the fetch instead of the empty state; `updateListInfoForTab()` clears the flag once the fetch genuinely completes, at which point an empty result is real.

## Testing

To verify manually:

1. Open the new Pages list and tap search.
2. Type a multi-character query.
3. Confirm a shimmer (not "No pages matching your search") shows during the fetch, and the empty message only appears when there genuinely are no matches.
