### PR TITLE
CMM-2127: Fix date picker placeholder overflow in long locales

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
@@ -106,6 +106,10 @@ private fun DateRangePickerContent(
                     modifier = Modifier.padding(start = 24.dp, end = 12.dp, top = 16.dp)
                 )
             },
+            // Omit the default headline: in long locales (e.g. Spanish) its start/end
+            // placeholder texts overflow and wrap one character per line. The title above
+            // already labels the dialog, so the headline is redundant. See CMM-2127.
+            headline = null,
             showModeToggle = true,
             colors = DatePickerDefaults.colors(
                 containerColor = MaterialTheme.colorScheme.surface


### PR DESCRIPTION
## Description

In the new mobile-app Stats date-range picker, with long locales such as Spanish, the end placeholder was squeezed to near-zero width and wrapped **one character per line vertically**, making it unreadable and impossible to interact with.

<img width="280" alt="screenshot_2026-06-24-08-31-35-98_2c541ed6e62ef762723ac4c81ea52bd1" src="https://github.com/user-attachments/assets/5a4c59d3-a471-4bb8-b1b9-ca9404c23c2d" />

This PR removes the redundant headline. The dialog already shows a clear, overflow-safe title ("Select date range"), so dropping the headline fixes the broken layout in every locale without losing context.

<img width="280" alt="after1" src="https://github.com/user-attachments/assets/d6ab0ae3-38d6-4606-9161-80ccbbe06527" />

Fixes [CMM-2127](https://linear.app/a8c/issue/CMM-2127).

## Testing instructions

Date picker placeholder readability:

1. Switch the device language to Spanish.
2. Enable the new Stats feature and open **Stats**.
3. Tap the date picker and choose **"pick dates"**.
- [x] Verify the placeholder text no longer wraps vertically / one character per line.
- [x] Verify the picker is fully readable and interactable in both calendar and input modes.
4. Select a start and end date and tap **OK**.
- [x] Verify the chosen range is applied.
5. Repeat in English (and ideally another long locale) and in dark mode.
- [x] Verify the dialog renders cleanly with no overflow.