### PR TITLE
Fix Sentry 328G: 'too many SQL variables' in UploadSqlUtils

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UploadSqlUtils.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UploadSqlUtils.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.wordpress.android.fluxc.persistence.WellSqlConfig.SQLITE_MAX_VARIABLE_NUMBER;
+import static org.wordpress.android.fluxc.persistence.WellSqlConfig.SQLITE_VARIABLE_BATCH_SIZE;
 
 public class UploadSqlUtils {
     public static int insertOrUpdateMedia(MediaUploadModel media) {
@@ -172,7 +172,7 @@ public class UploadSqlUtils {
 
     public static @NonNull List<PostModel> getPostModelsForPostUploadModels(List<PostUploadModel> postUploadModels) {
         if (postUploadModels.size() > 0) {
-            List<List<PostUploadModel>> batches = getBatches(postUploadModels, SQLITE_MAX_VARIABLE_NUMBER);
+            List<List<PostUploadModel>> batches = getBatches(postUploadModels, SQLITE_VARIABLE_BATCH_SIZE);
             List<PostModel> postModelList = new ArrayList<>();
 
             for (List<PostUploadModel> batch : batches) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -28,6 +28,11 @@ open class WellSqlConfig : DefaultWellConfig {
         // SQLite versions prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
         // @see https://www.sqlite.org/limits.html
         const val SQLITE_MAX_VARIABLE_NUMBER = 999
+
+        // Batch size for IN-clause queries. Kept below SQLITE_MAX_VARIABLE_NUMBER to leave headroom for
+        // any additional bound parameters and for devices whose SQLite enforces a lower effective limit;
+        // batching at exactly the max can still throw "too many SQL variables" on some devices.
+        const val SQLITE_VARIABLE_BATCH_SIZE = 900
     }
 
     constructor(context: Context) : super(context)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/upload/UploadSqlUtilsTest.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.persistence.UploadSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.post.PostTestUtils;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -248,6 +249,33 @@ public class UploadSqlUtilsTest {
         pendingPostModels = UploadSqlUtils.getPostModelsForPostUploadModels(pendingPostUploadModels);
         assertEquals(1, pendingPostModels.size());
         assertEquals(postUploadModel2.getId(), pendingPostModels.get(0).getId());
+    }
+
+    // Regression test for Sentry 328G ("too many SQL variables"): when more PostUploadModels than the
+    // SQLite variable batch size are registered, getPostModelsForPostUploadModels must split the IN query
+    // into batches and still return every matching PostModel, without exceeding the host-parameter limit.
+    @Test
+    public void testGetPostModelsForPostUploadModelsBatchesLargeInput() {
+        final int count = WellSqlConfig.SQLITE_VARIABLE_BATCH_SIZE + 5;
+        for (int i = 0; i < count; i++) {
+            PostModel testPost = UploadTestUtils.getTestPost();
+            testPost.setIsLocalDraft(true);
+            assertEquals(1, mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(testPost));
+        }
+        List<PostModel> postList = PostTestUtils.getPosts();
+        assertEquals(count, postList.size());
+
+        // Register a PostUploadModel for every inserted PostModel
+        List<PostUploadModel> postUploadModels = new ArrayList<>();
+        for (PostModel post : postList) {
+            PostUploadModel postUploadModel = new PostUploadModel(post.getId());
+            UploadSqlUtils.insertOrUpdatePost(postUploadModel);
+            postUploadModels.add(postUploadModel);
+        }
+
+        // The batched IN query must return all of them without throwing "too many SQL variables"
+        List<PostModel> result = UploadSqlUtils.getPostModelsForPostUploadModels(postUploadModels);
+        assertEquals(count, result.size());
     }
 
     @Test


### PR DESCRIPTION
Fixes Sentry **328G** (also covers its duplicates **325B / 325C**).

### Impact (Sentry)
~**7,759 events** from **1 affected user**, first seen 2024-08-22, still ongoing:
- **328G / 325B** (`getPostModelsForPostUploadModels`, same Sentry group): 5,879 events
- **325C** (the same crash re-wrapped as "Unable to stop service …UploadService"): 1,880 events

The crash is concentrated in a single user whose device has accumulated >999 pending post uploads, which is exactly the condition that trips the batch limit.

### Problem
`UploadSqlUtils.getPostModelsForPostUploadModels` batches the `PostModel … WHERE _id IN (…)` query at exactly `SQLITE_MAX_VARIABLE_NUMBER` (999). On devices whose SQLite enforces a lower effective host-parameter limit, 999 still throws `SQLiteException: too many SQL variables`, crashing the `UploadService` during post-upload processing.

### Fix
Batch at a new `SQLITE_VARIABLE_BATCH_SIZE` (900) to leave headroom below the limit.

Scope is kept to the crashing PostModel query. The other `SQLITE_MAX_VARIABLE_NUMBER` users (`ListItemSqlUtils`, `PluginSqlUtils`) share the latent pattern but are out of scope for this issue.

### Testing
- New `UploadSqlUtilsTest.testGetPostModelsForPostUploadModelsBatchesLargeInput` inserts more than the batch size of registered uploads and asserts every `PostModel` is returned across batches.
- `./gradlew :libs:fluxc:testDebugUnitTest --tests "org.wordpress.android.fluxc.upload.UploadSqlUtilsTest"` → 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
