### PR TITLE
Keep WP.com/Jetpack sites on their proxy media client over wp-rs

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -901,10 +901,10 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.pushMedia(payload.site, payload.media);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.pushMedia(payload.site, payload.media);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.pushMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.pushMedia(payload.site, payload.media);
         }
@@ -954,12 +954,12 @@ public class MediaStore extends Store {
             MediaUtils.stripLocation(payload.media.getFilePath());
         }
 
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.uploadMedia(payload.site, payload.media);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.uploadMedia(payload.site, payload.media);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.uploadMedia(payload.site, payload.media);
         } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
                    && mApplicationPasswordsConfiguration.isEnabled()) {
             mApplicationPasswordsMediaRestClient.uploadMedia(payload.site, payload.media);
@@ -980,14 +980,14 @@ public class MediaStore extends Store {
                 offset = MediaSqlUtils.getMediaWithStates(payload.site, list).size();
             }
         }
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.fetchMediaList(
-                    payload.site, payload.number, offset, payload.mimeType, payload.searchTerm);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMediaList(
                     payload.site, payload.number, offset, payload.mimeType, payload.searchTerm);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.fetchMediaList(
+                    payload.site, payload.number, offset, payload.mimeType, payload.searchTerm);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.fetchMediaList(
                     payload.site, payload.number, offset, payload.mimeType, payload.searchTerm);
         } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
                    && mApplicationPasswordsConfiguration.isEnabled()) {
@@ -1005,12 +1005,12 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.fetchMedia(payload.site, payload.media);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMedia(payload.site, payload.media);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.fetchMedia(payload.site, payload.media);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.fetchMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.fetchMedia(payload.site, payload.media);
         }
@@ -1022,10 +1022,10 @@ public class MediaStore extends Store {
             return;
         }
 
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.deleteMedia(payload.site, payload.media);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.deleteMedia(payload.site, payload.media);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.deleteMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.deleteMedia(payload.site, payload.media);
         }
@@ -1040,12 +1040,12 @@ public class MediaStore extends Store {
             MediaSqlUtils.insertOrUpdateMedia(media);
         }
 
-        if (payload.site.isUsingSelfHostedRestApi()) {
-            mMediaRSApiRestClient.cancelUpload(payload.media);
-        } else if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.cancelUpload(media);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.cancelUpload(media);
+        } else if (payload.site.isUsingSelfHostedRestApi()) {
+            mMediaRSApiRestClient.cancelUpload(payload.media);
         } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
                    && mApplicationPasswordsConfiguration.isEnabled()) {
             mApplicationPasswordsMediaRestClient.cancelUpload(media);


### PR DESCRIPTION
## Description

Media routing in `MediaStore` evaluated `isUsingSelfHostedRestApi()` first in
each of the six routing blocks (push, upload, fetch list, fetch, delete,
cancel). That predicate is `!isWPCom() && hasAppPassword`, so as soon as a
Jetpack-connected self-hosted site gained application-password credentials
(now minted automatically/headlessly), every media call flipped off the mature
WP.com-proxy clients (`MediaRestClient` / `WPComV2MediaRestClient`) and onto the
newer WordPress-rs client (`MediaRSApiRestClient`).

Symptoms reported on 26.8: uploads failing with a generic "Upload Failed",
duplicate attachments on retry, and an empty media library (the list fetch
returns no items on error). All of these clear when reverting to 26.7.

This PR reorders the six routing blocks so `isUsingWpComRestApi()` and
`isJetpackCPConnected()` are evaluated **before** `isUsingSelfHostedRestApi()`:

- Genuinely self-hosted sites (no WP.com / Jetpack routing) still use the wp-rs
  client.
- Jetpack-connected sites stay on the proxy path that worked before the
  application-password migration.
- Keeping all six blocks in sync also prevents `uploadMedia` and `cancelUpload`
  from targeting different clients for the same site.

## Testing instructions

Media on a Jetpack-connected self-hosted site:

1. Log in with a Jetpack-connected self-hosted site that has application-password
   credentials.
2. Open the site's Media library.
- [ ] Verify existing media loads (library is not empty).
3. Upload a new image.
- [ ] Verify the upload succeeds (no "Upload Failed").
- [ ] Verify no duplicate attachment is created.
4. Delete a media item.
- [ ] Verify it is removed without error.

Regression check — genuinely self-hosted site (no Jetpack/WP.com):

1. Log in with a self-hosted site that uses application passwords but is not
   Jetpack-connected.
- [ ] Verify media list, upload, and delete still work

1. Log in with a WP-COM site
- [ ] Verify media list, upload, and delete still work