### PR TITLE
Add a beta-promotion picker to release builds to the Play Store beta track

### DIFF
--- a/.buildkite/commands/gather-beta-candidates.sh
+++ b/.buildkite/commands/gather-beta-candidates.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+# Lists the promotable builds, opens the "choose a build" block step, and posts the
+# candidate list to Slack. No build — just gems + secrets.
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :android: Gathering candidates and opening the block step"
+bundle exec fastlane gather_beta_candidates

--- a/.buildkite/commands/gather-beta-candidates.sh
+++ b/.buildkite/commands/gather-beta-candidates.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # Lists the promotable builds, opens the "choose a build" block step, and posts the
 # candidate list to Slack. No build — just gems + secrets.

--- a/.buildkite/commands/promote-to-beta.sh
+++ b/.buildkite/commands/promote-to-beta.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # Promotes the build chosen in the preceding block step to the beta track. No build — just gems + secrets.
 

--- a/.buildkite/commands/promote-to-beta.sh
+++ b/.buildkite/commands/promote-to-beta.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# Promotes the build chosen in the preceding block step to the beta track. No build — just gems + secrets.
+
+# `beta_build_to_promote` must stay in sync with PROMOTION_META_DATA_KEY in fastlane/lanes/promote.rb,
+# which is the key the gather lane writes the block-step select field under.
+VERSION_CODE="$(buildkite-agent meta-data get "beta_build_to_promote" --default "")"
+
+if [[ -z "${VERSION_CODE}" ]]; then
+  echo "+++ :x: No build was selected to promote."
+  exit 1
+fi
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :rocket: Promoting ${VERSION_CODE} to the beta track"
+bundle exec fastlane promote_to_beta version_code:"${VERSION_CODE}"

--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -16,5 +16,5 @@ steps:
 # under `set -e` aborts before fastlane runs and bypasses that rescue. A build-level failure
 # notification ensures a broken run still reaches the channel.
 notify:
-  - slack: "#build-and-ship"
+  - slack: "#test-wpmobile-slack-integration"
     if: build.state == "failed"

--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -12,7 +12,9 @@ steps:
     command: ".buildkite/commands/gather-beta-candidates.sh"
     plugins: [$CI_TOOLKIT]
 
-# Backstop for setup failures (gems/secrets) that abort before the lane's own Slack rescue runs.
+# Slack backstop for any failed build — its unique value is failures that abort before the lane runs
+# (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
+# message. Channel intentionally stays the test channel for now (see send_slack_message).
 notify:
   - slack: "#test-wpmobile-slack-integration"
     if: build.state == "failed"

--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Beta promotion picker — run by a Buildkite schedule, or manually via the `PIPELINE` env var.
+# Lists the promotable builds, opens a block step to choose one, and promotes it to the beta track.
+
+agents:
+  queue: "android"
+
+steps:
+  - label: ":android: Gather builds to promote to beta"
+    command: ".buildkite/commands/gather-beta-candidates.sh"
+    plugins: [$CI_TOOLKIT]
+
+# Backstop: the gather lane posts its own failures to Slack, but a setup failure (gems/secrets)
+# under `set -e` aborts before fastlane runs and bypasses that rescue. A build-level failure
+# notification ensures a broken run still reaches the channel.
+notify:
+  - slack: "#build-and-ship"
+    if: build.state == "failed"

--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -12,9 +12,7 @@ steps:
     command: ".buildkite/commands/gather-beta-candidates.sh"
     plugins: [$CI_TOOLKIT]
 
-# Backstop: the gather lane posts its own failures to Slack, but a setup failure (gems/secrets)
-# under `set -e` aborts before fastlane runs and bypasses that rescue. A build-level failure
-# notification ensures a broken run still reaches the channel.
+# Backstop for setup failures (gems/secrets) that abort before the lane's own Slack rescue runs.
 notify:
   - slack: "#test-wpmobile-slack-integration"
     if: build.state == "failed"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,6 +35,10 @@ APP_SPECIFIC_VALUES = {
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
+# Legacy version code pinned in the Play Store — it must never drop from a track, so every path that
+# writes a track release (AAB upload or beta promotion) keeps it in the release's version codes.
+PLAY_STORE_VERSION_CODES_TO_RETAIN = [1440].freeze
+
 PROTOTYPE_BUILD_TYPE = 'Debug'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
@@ -162,6 +166,9 @@ end
 #####################################################################################
 
 # Sends a Slack message to the given channel via the incoming webhook.
+#
+# The default is intentionally the test channel while the continuous-release process is being built
+# out; it moves to #build-and-ship once the flow ships to real testers.
 def send_slack_message(message:, channel: '#test-wpmobile-slack-integration')
   slack(
     username: 'WordPress Release Bot',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -148,7 +148,17 @@ def next_build_code
 end
 
 #####################################################################################
-# Slack / Env helpers
+# Environment helpers
+#####################################################################################
+
+# Use this instead of getting values from ENV directly. It will throw an error if the requested value is missing.
+def get_required_env(key)
+  UI.user_error!("Environment variable '#{key}' is not set. Have you setup #{USER_ENV_FILE_PATH} correctly?") unless ENV.key?(key)
+  ENV.fetch(key, nil)
+end
+
+#####################################################################################
+# Slack helpers
 #####################################################################################
 
 # Sends a Slack message to the given channel via the incoming webhook.
@@ -168,12 +178,6 @@ def notify_slack(message)
   send_slack_message(message: message)
 rescue StandardError => e
   UI.important("Slack notification failed (#{e.message}); continuing without it.")
-end
-
-# Returns an env var's value, failing loudly if it's unset.
-def get_required_env(key)
-  UI.user_error!("Environment variable '#{key}' is not set.") unless ENV.key?(key)
-  ENV.fetch(key, nil)
 end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -152,6 +152,7 @@ end
 ########################################################################
 import 'lanes/build.rb'
 import 'lanes/localization.rb'
+import 'lanes/promote.rb'
 import 'lanes/release.rb'
 import 'lanes/screenshots.rb'
 import 'lanes/test.rb'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,6 +35,11 @@ APP_SPECIFIC_VALUES = {
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
+# Version codes pinned in the Play Store that must never be dropped from a track. Every release to a
+# track has to retain these (see `upload_build_to_play_store` in build.rb and the beta promotion in
+# promote.rb).
+RETAINED_VERSION_CODES = [1440].freeze
+
 PROTOTYPE_BUILD_TYPE = 'Debug'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,11 +35,6 @@ APP_SPECIFIC_VALUES = {
 
 UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-android', 'secrets', 'google-upload-credentials.json')
 
-# Version codes pinned in the Play Store that must never be dropped from a track. Every release to a
-# track has to retain these (see `upload_build_to_play_store` in build.rb and the beta promotion in
-# promote.rb).
-RETAINED_VERSION_CODES = [1440].freeze
-
 PROTOTYPE_BUILD_TYPE = 'Debug'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
@@ -150,6 +145,35 @@ def next_build_code
   next_build_code = BUILD_CODE_CALCULATOR.next_build_code(build_code: current_build_code)
   # Return the formatted build code
   BUILD_CODE_FORMATTER.build_code(build_code: next_build_code)
+end
+
+#####################################################################################
+# Slack / Env helpers
+#####################################################################################
+
+# Sends a Slack message to the given channel via the incoming webhook.
+def send_slack_message(message:, channel: '#test-wpmobile-slack-integration')
+  slack(
+    username: 'WordPress Release Bot',
+    icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
+    slack_url: get_required_env('SLACK_WEBHOOK'),
+    channel: channel,
+    message: message,
+    default_payloads: []
+  )
+end
+
+# Posts to Slack without letting a webhook hiccup abort the caller.
+def notify_slack(message)
+  send_slack_message(message: message)
+rescue StandardError => e
+  UI.important("Slack notification failed (#{e.message}); continuing without it.")
+end
+
+# Returns an env var's value, failing loudly if it's unset.
+def get_required_env(key)
+  UI.user_error!("Environment variable '#{key}' is not set.") unless ENV.key?(key)
+  ENV.fetch(key, nil)
 end
 
 ########################################################################

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -186,65 +186,43 @@ platform :android do
     package_name = APP_SPECIFIC_VALUES[app.to_sym][:package_name]
     metadata_dir = File.join(FASTLANE_FOLDER, APP_SPECIFIC_VALUES[app.to_sym][:metadata_dir], 'android')
 
-    track = options[:track]
-    version_code = options[:version_code]
+    version_name = options[:version_name]
 
-    # Params shared by both modes.
-    params = {
-      package_name: package_name,
-      track: track,
-      release_status: options[:release_status] || 'draft',
-      skip_upload_images: true,
-      skip_upload_screenshots: true,
-      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
-      version_codes_to_retain: [1440]
-    }
-
-    if version_code
-      # Promotion: put a build that's already in the store onto this track by its version code —
-      # no rebuild, no re-upload, no metadata.
-      params.merge!(
-        version_code: Integer(version_code),
-        skip_upload_aab: true,
-        skip_upload_apk: true,
-        skip_upload_metadata: true,
-        skip_upload_changelogs: true
-      )
-    else
-      # Upload a freshly built AAB for the given version.
-      version_name = options[:version_name]
-      if version_name.nil?
-        UI.message("No version available for #{track} track for #{app}")
-        next
-      end
-
-      aab_file_path = bundle_file_path(app, version_name)
-      unless File.exist?(aab_file_path)
-        UI.error("Unable to find a build artifact at #{aab_file_path}")
-        next
-      end
-
-      params.merge!(
-        aab: aab_file_path,
-        metadata_path: metadata_dir,
-        # Only update app title/description/etc. for Production; skip for beta tracks.
-        skip_upload_metadata: (track != 'production'),
-        skip_upload_changelogs: false
-      )
+    if version_name.nil?
+      UI.message("No version available for #{options[:track]} track for #{app}")
+      next
     end
 
-    retry_count = 2
-    begin
-      upload_to_play_store(**params)
-    rescue FastlaneCore::Interface::FastlaneError => e
-      # Sometimes the upload fails randomly with "Google Api Error: Invalid request - This Edit has
-      # been deleted." — likely a race when multiple edits run at once (WP beta, JP beta). Retry.
-      if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
-        UI.error 'Upload failed with Google API error. Retrying in 2mn...'
-        sleep(120)
-        retry
+    aab_file_path = bundle_file_path(app, version_name)
+
+    if File.exist? aab_file_path
+      retry_count = 2
+      begin
+        upload_to_play_store(
+          package_name: package_name,
+          aab: aab_file_path,
+          track: options[:track],
+          release_status: 'draft',
+          metadata_path: metadata_dir,
+          skip_upload_metadata: (options[:track] != 'production'), # Only update app title/description/etc. if uploading for Production, skip for beta tracks
+          skip_upload_changelogs: false,
+          skip_upload_images: true,
+          skip_upload_screenshots: true,
+          json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
+          version_codes_to_retain: [1440]
+        )
+      rescue FastlaneCore::Interface::FastlaneError => e
+        # Sometimes the upload fails randomly with a "Google Api Error: Invalid request - This Edit has been deleted.".
+        # It seems one reason might be a race condition when we do multiple edits at the exact same time (WP beta, JP beta). Retrying usually fixes it
+        if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
+          UI.error 'Upload failed with Google API error. Retrying in 2mn...'
+          sleep(120)
+          retry
+        end
+        raise
       end
-      raise
+    else
+      UI.error("Unable to find a build artifact at #{aab_file_path}")
     end
   end
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -197,7 +197,7 @@ platform :android do
       skip_upload_images: true,
       skip_upload_screenshots: true,
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
-      version_codes_to_retain: RETAINED_VERSION_CODES
+      version_codes_to_retain: [1440]
     }
 
     if version_code

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -209,7 +209,7 @@ platform :android do
           skip_upload_images: true,
           skip_upload_screenshots: true,
           json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
-          version_codes_to_retain: [1440]
+          version_codes_to_retain: PLAY_STORE_VERSION_CODES_TO_RETAIN
         )
       rescue FastlaneCore::Interface::FastlaneError => e
         # Sometimes the upload fails randomly with a "Google Api Error: Invalid request - This Edit has been deleted.".

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -161,7 +161,7 @@ platform :android do
 
     %i[wordpress jetpack].each do |app|
       build_bundle(app: app, version_name: version_name, build_code: build_code, buildType: 'Release')
-      upload_build_to_play_store(app: app, version_name: version_name, track: 'internal')
+      upload_build_to_play_store(app: app, version_name: version_name, track: 'internal', release_status: 'completed')
       # `upload_gutenberg_sourcemaps` builds a file path from the app name, so it needs a String
       # (a Symbol can't be passed to `File.join`).
       upload_gutenberg_sourcemaps(app: app.to_s, release_version: version_name)
@@ -202,7 +202,7 @@ platform :android do
           package_name: package_name,
           aab: aab_file_path,
           track: options[:track],
-          release_status: 'draft',
+          release_status: options[:release_status] || 'draft',
           metadata_path: metadata_dir,
           skip_upload_metadata: (options[:track] != 'production'), # Only update app title/description/etc. if uploading for Production, skip for beta tracks
           skip_upload_changelogs: false,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -186,43 +186,65 @@ platform :android do
     package_name = APP_SPECIFIC_VALUES[app.to_sym][:package_name]
     metadata_dir = File.join(FASTLANE_FOLDER, APP_SPECIFIC_VALUES[app.to_sym][:metadata_dir], 'android')
 
-    version_name = options[:version_name]
+    track = options[:track]
+    version_code = options[:version_code]
 
-    if version_name.nil?
-      UI.message("No version available for #{options[:track]} track for #{app}")
-      next
+    # Params shared by both modes.
+    params = {
+      package_name: package_name,
+      track: track,
+      release_status: options[:release_status] || 'draft',
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
+      version_codes_to_retain: RETAINED_VERSION_CODES
+    }
+
+    if version_code
+      # Promotion: put a build that's already in the store onto this track by its version code —
+      # no rebuild, no re-upload, no metadata.
+      params.merge!(
+        version_code: Integer(version_code),
+        skip_upload_aab: true,
+        skip_upload_apk: true,
+        skip_upload_metadata: true,
+        skip_upload_changelogs: true
+      )
+    else
+      # Upload a freshly built AAB for the given version.
+      version_name = options[:version_name]
+      if version_name.nil?
+        UI.message("No version available for #{track} track for #{app}")
+        next
+      end
+
+      aab_file_path = bundle_file_path(app, version_name)
+      unless File.exist?(aab_file_path)
+        UI.error("Unable to find a build artifact at #{aab_file_path}")
+        next
+      end
+
+      params.merge!(
+        aab: aab_file_path,
+        metadata_path: metadata_dir,
+        # Only update app title/description/etc. for Production; skip for beta tracks.
+        skip_upload_metadata: (track != 'production'),
+        skip_upload_changelogs: false
+      )
     end
 
-    aab_file_path = bundle_file_path(app, version_name)
-
-    if File.exist? aab_file_path
-      retry_count = 2
-      begin
-        upload_to_play_store(
-          package_name: package_name,
-          aab: aab_file_path,
-          track: options[:track],
-          release_status: 'draft',
-          metadata_path: metadata_dir,
-          skip_upload_metadata: (options[:track] != 'production'), # Only update app title/description/etc. if uploading for Production, skip for beta tracks
-          skip_upload_changelogs: false,
-          skip_upload_images: true,
-          skip_upload_screenshots: true,
-          json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
-          version_codes_to_retain: [1440]
-        )
-      rescue FastlaneCore::Interface::FastlaneError => e
-        # Sometimes the upload fails randomly with a "Google Api Error: Invalid request - This Edit has been deleted.".
-        # It seems one reason might be a race condition when we do multiple edits at the exact same time (WP beta, JP beta). Retrying usually fixes it
-        if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
-          UI.error 'Upload failed with Google API error. Retrying in 2mn...'
-          sleep(120)
-          retry
-        end
-        raise
+    retry_count = 2
+    begin
+      upload_to_play_store(**params)
+    rescue FastlaneCore::Interface::FastlaneError => e
+      # Sometimes the upload fails randomly with "Google Api Error: Invalid request - This Edit has
+      # been deleted." — likely a race when multiple edits run at once (WP beta, JP beta). Retry.
+      if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
+        UI.error 'Upload failed with Google API error. Retrying in 2mn...'
+        sleep(120)
+        retry
       end
-    else
-      UI.error("Unable to find a build artifact at #{aab_file_path}")
+      raise
     end
   end
 

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -136,6 +136,24 @@ platform :android do
     UI.user_error!("Unable to read the beta track version codes for #{package_name}: #{e.message}")
   end
 
+  # Play intermittently 400s a call with "Google Api Error: ... This Edit has been deleted." Neither
+  # the google-apis transport (400s aren't retried) nor supply's call_google_api recovers, and
+  # recovery needs a fresh edit — so retry the whole begin_edit…commit/read block, not the single
+  # call. Also guards against a concurrent Play edit from another job invalidating ours.
+  def with_play_edit_retries(description, attempts: 3, wait: 15)
+    tries = 0
+    begin
+      yield
+    rescue FastlaneCore::Interface::FastlaneError => e
+      tries += 1
+      raise unless e.message.start_with?('Google Api Error') && tries < attempts
+
+      UI.error("#{description} failed (#{e.message}); retrying with a fresh edit (#{tries}/#{attempts - 1}) in #{wait}s")
+      sleep(wait)
+      retry
+    end
+  end
+
   # Lists every AAB version code uploaded for the given package (the Play "app bundle explorer"),
   # as an array of integers. Opens a throwaway Play edit and aborts it, so this only reads.
   def available_aab_version_codes(package_name:)
@@ -147,15 +165,16 @@ platform :android do
       { json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY, package_name: package_name }
     )
 
-    client = Supply::Client.make_from_config
-    client.begin_edit(package_name: package_name)
-    codes =
+    codes = with_play_edit_retries("Listing AAB version codes for #{package_name}") do
+      client = Supply::Client.make_from_config
+      client.begin_edit(package_name: package_name)
       begin
         client.aab_version_codes
       ensure
         # Always discard the throwaway edit, even if the read raises.
         client.abort_current_edit
       end
+    end
     Array(codes).compact.map(&:to_i)
   rescue StandardError => e
     # Raise rather than return [], as in beta_track_version_codes.
@@ -199,26 +218,28 @@ platform :android do
       { json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY, package_name: package_name, track: BETA_TRACK }
     )
 
-    client = Supply::Client.make_from_config
-    client.begin_edit(package_name: package_name)
+    with_play_edit_retries("Promoting #{version_code} to beta for #{package_name}") do
+      client = Supply::Client.make_from_config
+      client.begin_edit(package_name: package_name)
 
-    committed = false
-    begin
-      release = AndroidPublisher::TrackRelease.new(
-        # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
-        status: 'draft',
-        # Keep the pinned legacy code(s) on the track, same as the AAB-upload path.
-        version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN]
-      )
-      track = client.tracks(BETA_TRACK).first || AndroidPublisher::Track.new(track: BETA_TRACK)
-      track.releases = [release]
+      committed = false
+      begin
+        release = AndroidPublisher::TrackRelease.new(
+          # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
+          status: 'draft',
+          # Keep the pinned legacy code(s) on the track, same as the AAB-upload path.
+          version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN]
+        )
+        track = client.tracks(BETA_TRACK).first || AndroidPublisher::Track.new(track: BETA_TRACK)
+        track.releases = [release]
 
-      client.update_track(BETA_TRACK, track)
-      client.commit_current_edit!
-      committed = true
-    ensure
-      # Discard the edit if we bailed before committing (a committed edit can't be aborted).
-      client.abort_current_edit unless committed
+        client.update_track(BETA_TRACK, track)
+        client.commit_current_edit!
+        committed = true
+      ensure
+        # Discard the edit if we bailed before committing (a committed edit can't be aborted).
+        client.abort_current_edit unless committed
+      end
     end
   end
 

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -96,8 +96,8 @@ platform :android do
   # Candidate discovery
   #################################################
 
-  # The promotable builds: version codes present in both apps' Play libraries and above the
-  # current beta release, newest first, capped to PROMOTION_CANDIDATE_LIMIT.
+  # The promotable version codes: present in both apps' Play libraries and above the current beta
+  # release, newest first, capped to PROMOTION_CANDIDATE_LIMIT.
   def beta_promotion_candidates
     apps = %i[wordpress jetpack]
 
@@ -115,20 +115,7 @@ platform :android do
     end
 
     common = available_per_app.reduce(:&) || []
-    codes = common.select { |code| combined_floor.nil? || code > combined_floor }.max(PROMOTION_CANDIDATE_LIMIT)
-
-    codes.map { |code| candidate_for(code) }
-  end
-
-  # Builds a candidate hash from a version code, decoding the version name and build number the
-  # continuous formatter encoded: `versionCode = (major * 10 + minor) * 1_000_000 + build_number`.
-  def candidate_for(version_code)
-    prefix = version_code / 1_000_000
-    {
-      version_code: version_code,
-      version_name: "#{prefix / 10}.#{prefix % 10}",
-      build_number: version_code % 1_000_000
-    }
+    common.select { |code| combined_floor.nil? || code > combined_floor }.max(PROMOTION_CANDIDATE_LIMIT)
   end
 
   # Reads the version codes currently on the given package's `beta` track, as an array of integers.
@@ -202,7 +189,7 @@ platform :android do
   #################################################
 
   def write_promotion_steps_file(candidates:)
-    options = candidates.map { |candidate| { 'label' => candidate_label(candidate), 'value' => candidate[:version_code].to_s } }
+    options = candidates.map { |code| { 'label' => code.to_s, 'value' => code.to_s } }
 
     steps = {
       'steps' => [
@@ -242,10 +229,6 @@ platform :android do
     sh('bash', '-c', "cd '#{PROJECT_ROOT_FOLDER}' && source .buildkite/shared-pipeline-vars && buildkite-agent pipeline upload '#{PROMOTION_STEPS_RELATIVE_PATH}'")
   end
 
-  def candidate_label(candidate)
-    "#{candidate[:version_name]} (#{candidate[:version_code]}) · build ##{candidate[:build_number]}"
-  end
-
   #################################################
   # Slack
   #################################################
@@ -255,7 +238,7 @@ platform :android do
   def post_candidates_to_slack(candidates:, pick_url: nil)
     build_url = ENV.fetch('BUILDKITE_BUILD_URL', nil)
 
-    candidate_lines = candidates.map { |candidate| slack_candidate_line(candidate) }
+    candidate_lines = candidates.map { |code| "• `#{code}`" }
 
     choose_line =
       if pick_url
@@ -276,10 +259,6 @@ platform :android do
     )
   end
 
-  def slack_candidate_line(candidate)
-    "• `#{candidate[:version_code]}` — #{candidate[:version_name]} · build ##{candidate[:build_number]}"
-  end
-
   # Posts the per-app outcome of a promotion.
   def post_promotion_result_to_slack(version_code:, results:)
     status_lines = results.map do |app, result|
@@ -297,25 +276,6 @@ platform :android do
 
         #{status_lines.join("\n")}
       MSG
-    )
-  end
-
-  # Posts to Slack without letting a webhook hiccup abort the caller.
-  def notify_slack(message)
-    send_slack_message(message: message)
-  rescue StandardError => e
-    UI.important("Slack notification failed (#{e.message}); continuing without it.")
-  end
-
-  # Sends a Slack message to the given channel via the incoming webhook.
-  def send_slack_message(message:, channel: '#test-wpmobile-slack-integration')
-    slack(
-      username: 'WordPress Release Bot',
-      icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
-      slack_url: get_required_env('SLACK_WEBHOOK'),
-      channel: channel,
-      message: message,
-      default_payloads: []
     )
   end
 
@@ -369,7 +329,7 @@ platform :android do
     request = Net::HTTP::Get.new(uri)
     request['Authorization'] = "Bearer #{buildkite_api_token}"
     # Bound the request so a hung response can't stall the gather lane across all 5 poll attempts.
-    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 10) do |http|
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 30, read_timeout: 30) do |http|
       http.request(request)
     end
   end
@@ -393,11 +353,5 @@ platform :android do
     return if branch == DEFAULT_BRANCH
 
     UI.user_error!("Promotion only runs on `#{DEFAULT_BRANCH}` (current branch: #{branch.empty? ? 'none' : "`#{branch}`"}). Refusing to proceed.")
-  end
-
-  # Returns an env var's value, failing loudly if it's unset.
-  def get_required_env(key)
-    UI.user_error!("Environment variable '#{key}' is not set.") unless ENV.key?(key)
-    ENV.fetch(key, nil)
   end
 end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -1,41 +1,133 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'net/http'
+require 'yaml'
+
+# Promotes an already-uploaded build to the Play Store `beta` track without rebuilding.
+# `gather_beta_candidates` lists the promotable builds and opens a Buildkite block step for a
+# developer to pick one; `promote_to_beta` promotes the chosen version code for both apps.
+#
+# WordPress and Jetpack share a version code from the same build, so one pick promotes both.
+
+BETA_TRACK = 'beta'
+
+# The most candidates to offer in the picker.
+PROMOTION_CANDIDATE_LIMIT = 12
+
+# The block step writes the chosen version code here; the promote step reads it back.
+# NOTE: `.buildkite/commands/promote-to-beta.sh` reads this same key as a bare string literal
+# (`meta-data get "beta_build_to_promote"`) — keep the two in sync.
+PROMOTION_META_DATA_KEY = 'beta_build_to_promote'
+# Matched via the Buildkite API to find the block step's job and build its unblock URL.
+PROMOTION_BLOCK_LABEL = ':android: Promote to beta'
+PROMOTION_BLOCK_STEP_KEY = 'promote_to_beta_block'
+
+# Written verbatim into the generated steps so `buildkite-agent pipeline upload` interpolates it.
+CI_TOOLKIT_PLUGIN_REF = '$CI_TOOLKIT'
+
+# Where the gather lane writes the generated block + promote steps (gitignored `build/`).
+PROMOTION_STEPS_FILE = File.join(PROJECT_ROOT_FOLDER, 'build', 'promote-steps.yml')
+
+# Buildkite coordinates, used to build the block step's unblock-dialog deep link.
+BUILDKITE_ORGANIZATION = 'automattic'
+BUILDKITE_PIPELINE = 'wordpress-android'
+
 platform :android do
-  # Gathers the internal builds that can be promoted to the `beta` track.
+  # Lists the promotable builds and opens a Buildkite block step for a developer to pick one.
+  # A build is promotable when its version code is present in both apps' Play libraries and higher
+  # than the current `beta` release. Uploads the block + promote steps here (not from the CI
+  # script) so it can read back the block step's job id for the Slack unblock-dialog link.
   #
-  # Builds three things and logs each so we can confirm the Play API access and the data shape
-  # before wiring up the picker:
-  #   1. the beta floor — the highest version code already on each app's `beta` track,
-  #   2. the pool — every AAB version code uploaded for each app (the Play "app bundle explorer"),
-  #   3. the candidates — codes present for both apps and above the floor, newest first.
-  #
-  # Read-only for now: it doesn't open the picker or promote anything.
-  #
-  # Usage:
-  #   bundle exec fastlane gather_beta_candidates
-  desc 'Gather and log promotable beta candidates (beta floor + available AABs)'
+  # @called_by CI (`.buildkite/commands/gather-beta-candidates.sh`)
+  desc 'Gather promotable beta candidates and open the promotion block step'
   lane :gather_beta_candidates do
+    ensure_promotion_on_trunk!
+
+    candidates = beta_promotion_candidates
+
+    if candidates.empty?
+      notify_slack(':android: *Beta promotion* — no builds above the current beta version code. Nothing to promote.')
+      UI.important('No promotion candidates found; skipping block step generation.')
+      next
+    end
+
+    write_promotion_steps_file(candidates: candidates)
+    upload_promotion_steps
+    post_candidates_to_slack(candidates: candidates, pick_url: promotion_unblock_dialog_url)
+
+    UI.success("Prepared #{candidates.count} promotion candidate(s) and opened the block step.")
+  rescue StandardError => e
+    notify_slack(":x: *Beta promotion* failed before the picker could open — #{e.message}")
+    raise
+  end
+
+  # Promotes the chosen build to the `beta` track for both WordPress and Jetpack.
+  #
+  # @param [String] version_code The version code to promote, e.g. `269027172`.
+  # @called_by CI (`.buildkite/commands/promote-to-beta.sh`)
+  desc 'Promote an existing build to the beta track (WordPress + Jetpack)'
+  lane :promote_to_beta do |version_code: nil|
+    # Set once the per-app result has been posted, so the rescue doesn't double-report it.
+    result_posted = false
+    ensure_promotion_on_trunk!
+
+    version_code = version_code.to_s.strip
+    UI.user_error!('`version_code` is required, e.g. `version_code:269027172`') if version_code.empty?
+
+    UI.important("Promoting version code #{version_code} to the beta track for WordPress and Jetpack")
+
+    results = distribute_to_beta(version_code: version_code)
+
+    post_promotion_result_to_slack(version_code: version_code, results: results)
+    result_posted = true
+
+    failed = results.reject { |_, result| result[:ok] }.keys
+    UI.user_error!("Beta promotion failed for: #{failed.join(', ')}") unless failed.empty?
+
+    UI.success("Promoted #{version_code} to beta for: #{results.keys.join(', ')}")
+  rescue StandardError => e
+    notify_slack(":x: *Beta promotion* failed — #{e.message}") unless result_posted
+    raise
+  end
+
+  #################################################
+  # Candidate discovery
+  #################################################
+
+  # The promotable builds: version codes present in both apps' Play libraries and above the
+  # current beta release, newest first, capped to PROMOTION_CANDIDATE_LIMIT.
+  def beta_promotion_candidates
     apps = %i[wordpress jetpack]
 
-    # 1. The floor: the highest version code already on each app's beta track.
     combined_floor = apps.filter_map do |app|
       codes = beta_track_version_codes(package_name: APP_SPECIFIC_VALUES[app][:package_name])
       UI.message("#{app}: beta track version codes = #{codes.sort.inspect}")
       codes.max
     end.max
-    UI.message("Combined beta floor (max across both apps) = #{combined_floor.inspect}")
+    UI.message("Combined beta floor = #{combined_floor.inspect}")
 
-    # 2. The pool: every AAB version code uploaded for each app.
     available_per_app = apps.map do |app|
       codes = available_aab_version_codes(package_name: APP_SPECIFIC_VALUES[app][:package_name])
       UI.message("#{app}: available AAB version codes = #{codes.sort.inspect}")
       codes
     end
 
-    # 3. Promotable candidates: present for both apps and above the beta floor, newest first.
     common = available_per_app.reduce(:&) || []
-    candidates = common.select { |code| combined_floor.nil? || code > combined_floor }.sort.reverse
-    UI.success("Promotable candidates (in both apps, > #{combined_floor.inspect}) = #{candidates.inspect}")
+    codes = common.select { |code| combined_floor.nil? || code > combined_floor }.sort.reverse.first(PROMOTION_CANDIDATE_LIMIT)
+
+    codes.map { |code| candidate_for(code) }
+  end
+
+  # Builds a candidate hash from a version code, decoding the version name and build number the
+  # continuous formatter encoded: `versionCode = (major * 10 + minor) * 1_000_000 + build_number`.
+  def candidate_for(version_code)
+    prefix = version_code / 1_000_000
+    {
+      version_code: version_code,
+      version_name: "#{prefix / 10}.#{prefix % 10}",
+      build_number: version_code % 1_000_000
+    }
   end
 
   # Reads the version codes currently on the given package's `beta` track, as an array of integers.
@@ -43,7 +135,7 @@ platform :android do
   def beta_track_version_codes(package_name:)
     google_play_track_version_codes(
       package_name: package_name,
-      track: 'beta',
+      track: BETA_TRACK,
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
   rescue StandardError => e
@@ -71,5 +163,258 @@ platform :android do
   rescue StandardError => e
     UI.error("Failed to list available AAB version codes for #{package_name}: #{e.message}")
     []
+  end
+
+  #################################################
+  # Promotion
+  #################################################
+
+  # Promotes a version code to beta for each app, returning a per-app `{ ok:, error: }` result.
+  # A failure for one app doesn't stop the other.
+  def distribute_to_beta(version_code:)
+    %i[wordpress jetpack].to_h do |app|
+      package_name = APP_SPECIFIC_VALUES[app][:package_name]
+      result =
+        begin
+          promote_version_code_to_beta(package_name: package_name, version_code: version_code)
+          { ok: true }
+        rescue StandardError => e
+          UI.error("Failed to promote #{app} (#{version_code}): #{e.message}")
+          { ok: false, error: e.message }
+        end
+      [app, result]
+    end
+  end
+
+  # Creates a `beta` release referencing an existing bundle (no rebuild, no re-upload). Retries
+  # once on the intermittent Google API edit error, mirroring `upload_build_to_play_store`.
+  def promote_version_code_to_beta(package_name:, version_code:)
+    retry_count = 2
+    begin
+      upload_to_play_store(
+        package_name: package_name,
+        version_code: Integer(version_code),
+        track: BETA_TRACK,
+        skip_upload_aab: true,
+        skip_upload_apk: true,
+        skip_upload_metadata: true,
+        skip_upload_images: true,
+        skip_upload_screenshots: true,
+        skip_upload_changelogs: true,
+        # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
+        release_status: 'draft',
+        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      )
+    rescue FastlaneCore::Interface::FastlaneError => e
+      if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
+        UI.error('Promotion failed with Google API error. Retrying in 2mn...')
+        sleep(120)
+        retry
+      end
+      raise
+    end
+  end
+
+  #################################################
+  # Buildkite block step
+  #################################################
+
+  def write_promotion_steps_file(candidates:)
+    options = candidates.map { |candidate| { 'label' => candidate_label(candidate), 'value' => candidate[:version_code].to_s } }
+
+    steps = {
+      'steps' => [
+        {
+          'block' => PROMOTION_BLOCK_LABEL,
+          'key' => PROMOTION_BLOCK_STEP_KEY,
+          'prompt' => 'Choose the build to release to beta testers. This promotes the matching WordPress and Jetpack builds.',
+          # Keep the build "running" (not green) while it waits for a human.
+          'blocked_state' => 'running',
+          'fields' => [
+            {
+              'select' => 'Build to promote',
+              'key' => PROMOTION_META_DATA_KEY,
+              # No default, and required: an un-actioned unblock must not silently promote
+              # whatever sorted newest — force an explicit human choice.
+              'required' => true,
+              'options' => options
+            }
+          ]
+        },
+        {
+          'label' => ':rocket: Promote selected build to beta',
+          'command' => '.buildkite/commands/promote-to-beta.sh',
+          'plugins' => [CI_TOOLKIT_PLUGIN_REF],
+          'agents' => { 'queue' => 'android' }
+        }
+      ]
+    }
+
+    FileUtils.mkdir_p(File.dirname(PROMOTION_STEPS_FILE))
+    # `line_width: -1` keeps each label on one line (no YAML folding).
+    File.write(PROMOTION_STEPS_FILE, steps.to_yaml(line_width: -1))
+    UI.message("Wrote promotion steps for #{candidates.count} build(s) to #{PROMOTION_STEPS_FILE}")
+  end
+
+  # Source `shared-pipeline-vars` first so `$CI_TOOLKIT` is interpolated.
+  def upload_promotion_steps
+    sh('bash', '-c', "cd '#{PROJECT_ROOT_FOLDER}' && source .buildkite/shared-pipeline-vars && buildkite-agent pipeline upload build/promote-steps.yml")
+  end
+
+  def candidate_label(candidate)
+    "#{candidate[:version_name]} (#{candidate[:version_code]}) · build ##{candidate[:build_number]}"
+  end
+
+  #################################################
+  # Slack
+  #################################################
+
+  # Posts the candidate list. Links straight to the unblock dialog when we resolved the block
+  # step's job id; otherwise points at the build so a degraded link isn't mistaken for the picker.
+  def post_candidates_to_slack(candidates:, pick_url: nil)
+    build_url = ENV.fetch('BUILDKITE_BUILD_URL', nil)
+
+    candidate_lines = candidates.map { |candidate| slack_candidate_line(candidate) }
+
+    choose_line =
+      if pick_url
+        "\n\n:point_right: <#{pick_url}|Choose a build to promote>"
+      elsif build_url
+        "\n\n:warning: Couldn't deep-link to the picker — open <#{build_url}|the build> and unblock the promotion step to choose a build."
+      else
+        ''
+      end
+
+    notify_slack(
+      <<~MSG
+        :android: *Beta promotion* — choose a build to release to beta testers (WordPress + Jetpack).#{choose_line}
+
+        *Candidates:*
+        #{candidate_lines.join("\n")}
+      MSG
+    )
+  end
+
+  def slack_candidate_line(candidate)
+    "• `#{candidate[:version_code]}` — #{candidate[:version_name]} · build ##{candidate[:build_number]}"
+  end
+
+  # Posts the per-app outcome of a promotion.
+  def post_promotion_result_to_slack(version_code:, results:)
+    status_lines = results.map do |app, result|
+      next "• #{app}: :x: #{result[:error]}" unless result[:ok]
+
+      "• #{app}: :white_check_mark: submitted to beta"
+    end
+
+    all_ok = results.values.all? { |result| result[:ok] }
+    header = all_ok ? ':rocket: *Promoted to beta*' : ':warning: *Beta promotion finished with errors*'
+
+    notify_slack(
+      <<~MSG
+        #{header} — `#{version_code}`
+
+        #{status_lines.join("\n")}
+      MSG
+    )
+  end
+
+  # Posts to Slack without letting a webhook hiccup abort the caller.
+  def notify_slack(message)
+    send_slack_message(message: message)
+  rescue StandardError => e
+    UI.important("Slack notification failed (#{e.message}); continuing without it.")
+  end
+
+  # Sends a Slack message to the given channel via the incoming webhook.
+  def send_slack_message(message:, channel: '#build-and-ship')
+    slack(
+      username: 'WordPress Release Bot',
+      icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
+      slack_url: get_required_env('SLACK_WEBHOOK'),
+      channel: channel,
+      message: message,
+      default_payloads: []
+    )
+  end
+
+  #################################################
+  # Buildkite deep link
+  #################################################
+
+  # The block step's unblock-dialog URL, or nil (callers fall back to the build URL).
+  def promotion_unblock_dialog_url
+    org = ENV.fetch('BUILDKITE_ORGANIZATION_SLUG', BUILDKITE_ORGANIZATION)
+    pipeline = ENV.fetch('BUILDKITE_PIPELINE_SLUG', BUILDKITE_PIPELINE)
+    build_number = ENV.fetch('BUILDKITE_BUILD_NUMBER', nil)
+    return nil if build_number.nil?
+
+    job_id = block_step_job_id(org: org, pipeline: pipeline, build_number: build_number)
+    return nil if job_id.nil?
+
+    "https://buildkite.com/organizations/#{org}/pipelines/#{pipeline}/builds/#{build_number}/jobs/#{job_id}/unblock_dialog"
+  end
+
+  # Polls the build for the just-uploaded block step's job id (it takes a moment to register).
+  def block_step_job_id(org:, pipeline:, build_number:)
+    uri = URI("https://api.buildkite.com/v2/organizations/#{org}/pipelines/#{pipeline}/builds/#{build_number}")
+
+    5.times do |attempt|
+      job = find_promotion_block_job(uri)
+      return job['id'] if job
+
+      sleep(2) unless attempt == 4
+    end
+
+    UI.important('Could not resolve the promotion block step job id; Slack will link to the build instead.')
+    nil
+  rescue StandardError => e
+    UI.important("Error resolving the block step job id (#{e.message}); Slack will link to the build instead.")
+    nil
+  end
+
+  def find_promotion_block_job(uri)
+    response = buildkite_api_get(uri)
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    manual_jobs = JSON.parse(response.body).fetch('jobs', []).select { |job| job['type'] == 'manual' }
+
+    # Match on the stable step key the block was generated with; fall back to the label only if the
+    # API didn't surface a step key, so a second manual step whose label contains ours can't shadow it.
+    manual_jobs.find { |job| job['step_key'] == PROMOTION_BLOCK_STEP_KEY } ||
+      manual_jobs.find { |job| job['label'].to_s.include?(PROMOTION_BLOCK_LABEL) }
+  end
+
+  def buildkite_api_get(uri)
+    request = Net::HTTP::Get.new(uri)
+    request['Authorization'] = "Bearer #{buildkite_api_token}"
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+  end
+
+  # A Buildkite API token with `read_builds` scope — `BUILDKITE_API_TOKEN` on CI, `BUILDKITE_TOKEN`
+  # locally. Only needed for the Slack deep link; the flow still works without it (links to the build).
+  def buildkite_api_token
+    token = ENV.fetch('BUILDKITE_API_TOKEN', nil) || ENV.fetch('BUILDKITE_TOKEN', nil)
+    UI.user_error!('No Buildkite API token found. Set `BUILDKITE_API_TOKEN` (or `BUILDKITE_TOKEN`).') if token.to_s.empty?
+    token
+  end
+
+  #################################################
+  # Utils
+  #################################################
+
+  # The promote lanes distribute to real testers and can be run by hand, so they must only ever run
+  # from the scheduled `trunk` jobs. Any other branch — or a local run — is a mistake: fail loudly.
+  def ensure_promotion_on_trunk!
+    branch = ENV.fetch('BUILDKITE_BRANCH', '')
+    return if branch == DEFAULT_BRANCH
+
+    UI.user_error!("Promotion only runs on `#{DEFAULT_BRANCH}` (current branch: #{branch.empty? ? 'none' : "`#{branch}`"}). Refusing to proceed.")
+  end
+
+  # Returns an env var's value, failing loudly if it's unset.
+  def get_required_env(key)
+    UI.user_error!("Environment variable '#{key}' is not set.") unless ENV.key?(key)
+    ENV.fetch(key, nil)
   end
 end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -313,7 +313,7 @@ platform :android do
   end
 
   # Sends a Slack message to the given channel via the incoming webhook.
-  def send_slack_message(message:, channel: '#build-and-ship')
+  def send_slack_message(message:, channel: '#test-wpmobile-slack-integration')
     slack(
       username: 'WordPress Release Bot',
       icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -162,18 +162,14 @@ platform :android do
   #################################################
 
   # Promotes a version code to beta for each app, returning a per-app `{ ok:, error: }` result.
-  # A failure for one app doesn't stop the other. Reuses upload_build_to_play_store (build.rb),
-  # which owns the actual Play upload — the retry, the pinned retained codes, and the skip flags.
+  # A failure for one app doesn't stop the other.
   def distribute_to_beta(version_code:)
     %i[wordpress jetpack].to_h do |app|
       result =
         begin
-          upload_build_to_play_store(
-            app: app.to_s,
-            track: BETA_TRACK,
-            version_code: version_code,
-            # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
-            release_status: 'draft'
+          promote_version_code_to_beta(
+            package_name: APP_SPECIFIC_VALUES[app][:package_name],
+            version_code: version_code
           )
           { ok: true }
         rescue StandardError => e
@@ -181,6 +177,43 @@ platform :android do
           { ok: false, error: e.message }
         end
       [app, result]
+    end
+  end
+
+  # Creates a draft `beta` release referencing an already-uploaded version code, via the Play API.
+  #
+  # `upload_to_play_store` can't do this: it only builds a track release from binaries uploaded in
+  # the same run, so a bare `version_code:` with `skip_upload_aab` commits an empty edit. We create
+  # the release directly instead, mirroring supply's own `update_track`.
+  def promote_version_code_to_beta(package_name:, version_code:)
+    require 'supply'
+    require 'supply/options'
+
+    Supply.config = FastlaneCore::Configuration.create(
+      Supply::Options.available_options,
+      { json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY, package_name: package_name, track: BETA_TRACK }
+    )
+
+    client = Supply::Client.make_from_config
+    client.begin_edit(package_name: package_name)
+
+    committed = false
+    begin
+      release = AndroidPublisher::TrackRelease.new(
+        # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
+        status: 'draft',
+        # Keep the pinned legacy code on the track, matching the AAB-upload path's version_codes_to_retain.
+        version_codes: [Integer(version_code), 1440]
+      )
+      track = client.tracks(BETA_TRACK).first || AndroidPublisher::Track.new(track: BETA_TRACK)
+      track.releases = [release]
+
+      client.update_track(BETA_TRACK, track)
+      client.commit_current_edit!
+      committed = true
+    ensure
+      # Discard the edit if we bailed before committing (a committed edit can't be aborted).
+      client.abort_current_edit unless committed
     end
   end
 

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -178,48 +178,25 @@ platform :android do
   #################################################
 
   # Promotes a version code to beta for each app, returning a per-app `{ ok:, error: }` result.
-  # A failure for one app doesn't stop the other.
+  # A failure for one app doesn't stop the other. Reuses upload_build_to_play_store (build.rb),
+  # which owns the actual Play upload — the retry, the pinned retained codes, and the skip flags.
   def distribute_to_beta(version_code:)
     %i[wordpress jetpack].to_h do |app|
-      package_name = APP_SPECIFIC_VALUES[app][:package_name]
       result =
         begin
-          promote_version_code_to_beta(package_name: package_name, version_code: version_code)
+          upload_build_to_play_store(
+            app: app.to_s,
+            track: BETA_TRACK,
+            version_code: version_code,
+            # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
+            release_status: 'draft'
+          )
           { ok: true }
         rescue StandardError => e
           UI.error("Failed to promote #{app} (#{version_code}): #{e.message}")
           { ok: false, error: e.message }
         end
       [app, result]
-    end
-  end
-
-  # Creates a `beta` release referencing an existing bundle (no rebuild, no re-upload). Retries
-  # once on the intermittent Google API edit error, mirroring `upload_build_to_play_store`.
-  def promote_version_code_to_beta(package_name:, version_code:)
-    retry_count = 2
-    begin
-      upload_to_play_store(
-        package_name: package_name,
-        version_code: Integer(version_code),
-        track: BETA_TRACK,
-        skip_upload_aab: true,
-        skip_upload_apk: true,
-        skip_upload_metadata: true,
-        skip_upload_images: true,
-        skip_upload_screenshots: true,
-        skip_upload_changelogs: true,
-        # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
-        release_status: 'draft',
-        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-      )
-    rescue FastlaneCore::Interface::FastlaneError => e
-      if e.message.start_with?('Google Api Error') && (retry_count -= 1).positive?
-        UI.error('Promotion failed with Google API error. Retrying in 2mn...')
-        sleep(120)
-        retry
-      end
-      raise
     end
   end
 

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -396,7 +396,10 @@ platform :android do
   def buildkite_api_get(uri)
     request = Net::HTTP::Get.new(uri)
     request['Authorization'] = "Bearer #{buildkite_api_token}"
-    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+    # Bound the request so a hung response can't stall the gather lane across all 5 poll attempts.
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 10) do |http|
+      http.request(request)
+    end
   end
 
   # A Buildkite API token with `read_builds` scope — `BUILDKITE_API_TOKEN` on CI, `BUILDKITE_TOKEN`

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -327,19 +327,13 @@ platform :android do
 
   def buildkite_api_get(uri)
     request = Net::HTTP::Get.new(uri)
-    request['Authorization'] = "Bearer #{buildkite_api_token}"
+    # `BUILDKITE_TOKEN` needs the `read_builds` scope. It's only used for the Slack deep link, so a
+    # missing token just degrades to linking the build (see `block_step_job_id`'s rescue).
+    request['Authorization'] = "Bearer #{get_required_env('BUILDKITE_TOKEN')}"
     # Bound the request so a hung response can't stall the gather lane across all 5 poll attempts.
     Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 30, read_timeout: 30) do |http|
       http.request(request)
     end
-  end
-
-  # A Buildkite API token with `read_builds` scope — `BUILDKITE_API_TOKEN` on CI, `BUILDKITE_TOKEN`
-  # locally. Only needed for the Slack deep link; the flow still works without it (links to the build).
-  def buildkite_api_token
-    token = ENV.fetch('BUILDKITE_API_TOKEN', nil) || ENV.fetch('BUILDKITE_TOKEN', nil)
-    UI.user_error!('No Buildkite API token found. Set `BUILDKITE_API_TOKEN` (or `BUILDKITE_TOKEN`).') if token.to_s.empty?
-    token
   end
 
   #################################################

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -1,28 +1,41 @@
 # frozen_string_literal: true
 
 platform :android do
-  # Fetches the current `beta` track version codes for WordPress and Jetpack and logs them.
+  # Gathers the internal builds that can be promoted to the `beta` track.
   #
-  # This is the first step of the beta promotion picker: the highest code already on `beta` is the
-  # floor that a promotable `internal` build has to exceed. For now the lane only reads and logs, so
-  # we can confirm Play API access and see the shape of the data before building the rest of the flow.
+  # Builds three things and logs each so we can confirm the Play API access and the data shape
+  # before wiring up the picker:
+  #   1. the beta floor — the highest version code already on each app's `beta` track,
+  #   2. the pool — every AAB version code uploaded for each app (the Play "app bundle explorer"),
+  #   3. the candidates — codes present for both apps and above the floor, newest first.
+  #
+  # Read-only for now: it doesn't open the picker or promote anything.
   #
   # Usage:
   #   bundle exec fastlane gather_beta_candidates
-  desc 'Fetch and log the current beta track version codes for WordPress and Jetpack'
+  desc 'Gather and log promotable beta candidates (beta floor + available AABs)'
   lane :gather_beta_candidates do
-    floors = %i[wordpress jetpack].map do |app|
-      package_name = APP_SPECIFIC_VALUES[app][:package_name]
-      codes = beta_track_version_codes(package_name: package_name)
+    apps = %i[wordpress jetpack]
 
-      UI.message("#{app} (#{package_name}): beta track version codes = #{codes.inspect}")
-      floor = codes.max
-      UI.message("#{app}: beta floor = #{floor.inspect}")
-      floor
+    # 1. The floor: the highest version code already on each app's beta track.
+    combined_floor = apps.filter_map do |app|
+      codes = beta_track_version_codes(package_name: APP_SPECIFIC_VALUES[app][:package_name])
+      UI.message("#{app}: beta track version codes = #{codes.sort.inspect}")
+      codes.max
+    end.max
+    UI.message("Combined beta floor (max across both apps) = #{combined_floor.inspect}")
+
+    # 2. The pool: every AAB version code uploaded for each app.
+    available_per_app = apps.map do |app|
+      codes = available_aab_version_codes(package_name: APP_SPECIFIC_VALUES[app][:package_name])
+      UI.message("#{app}: available AAB version codes = #{codes.sort.inspect}")
+      codes
     end
 
-    combined_floor = floors.compact.max
-    UI.success("Combined beta floor (max across both apps) = #{combined_floor.inspect}")
+    # 3. Promotable candidates: present for both apps and above the beta floor, newest first.
+    common = available_per_app.reduce(:&) || []
+    candidates = common.select { |code| combined_floor.nil? || code > combined_floor }.sort.reverse
+    UI.success("Promotable candidates (in both apps, > #{combined_floor.inspect}) = #{candidates.inspect}")
   end
 
   # Reads the version codes currently on the given package's `beta` track, as an array of integers.
@@ -35,6 +48,28 @@ platform :android do
     )
   rescue StandardError => e
     UI.error("Failed to fetch beta track version codes for #{package_name}: #{e.message}")
+    []
+  end
+
+  # Lists every AAB version code uploaded for the given package (the Play "app bundle explorer"),
+  # as an array of integers. Opens a throwaway Play edit and aborts it, so this only reads.
+  # Returns an empty array if the lookup fails.
+  def available_aab_version_codes(package_name:)
+    require 'supply'
+    require 'supply/options'
+
+    Supply.config = FastlaneCore::Configuration.create(
+      Supply::Options.available_options,
+      { json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY, package_name: package_name }
+    )
+
+    client = Supply::Client.make_from_config
+    client.begin_edit(package_name: package_name)
+    codes = client.aab_version_codes
+    client.abort_current_edit
+    Array(codes).compact.map(&:to_i)
+  rescue StandardError => e
+    UI.error("Failed to list available AAB version codes for #{package_name}: #{e.message}")
     []
   end
 end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+platform :android do
+  # Fetches the current `beta` track version codes for WordPress and Jetpack and logs them.
+  #
+  # This is the first step of the beta promotion picker: the highest code already on `beta` is the
+  # floor that a promotable `internal` build has to exceed. For now the lane only reads and logs, so
+  # we can confirm Play API access and see the shape of the data before building the rest of the flow.
+  #
+  # Usage:
+  #   bundle exec fastlane gather_beta_candidates
+  desc 'Fetch and log the current beta track version codes for WordPress and Jetpack'
+  lane :gather_beta_candidates do
+    floors = %i[wordpress jetpack].map do |app|
+      package_name = APP_SPECIFIC_VALUES[app][:package_name]
+      codes = beta_track_version_codes(package_name: package_name)
+
+      UI.message("#{app} (#{package_name}): beta track version codes = #{codes.inspect}")
+      floor = codes.max
+      UI.message("#{app}: beta floor = #{floor.inspect}")
+      floor
+    end
+
+    combined_floor = floors.compact.max
+    UI.success("Combined beta floor (max across both apps) = #{combined_floor.inspect}")
+  end
+
+  # Reads the version codes currently on the given package's `beta` track, as an array of integers.
+  # Returns an empty array if the track has no releases or the lookup fails.
+  def beta_track_version_codes(package_name:)
+    google_play_track_version_codes(
+      package_name: package_name,
+      track: 'beta',
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+    )
+  rescue StandardError => e
+    UI.error("Failed to fetch beta track version codes for #{package_name}: #{e.message}")
+    []
+  end
+end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -26,8 +26,10 @@ PROMOTION_BLOCK_STEP_KEY = 'promote_to_beta_block'
 # Written verbatim into the generated steps so `buildkite-agent pipeline upload` interpolates it.
 CI_TOOLKIT_PLUGIN_REF = '$CI_TOOLKIT'
 
-# Where the gather lane writes the generated block + promote steps (gitignored `build/`).
-PROMOTION_STEPS_FILE = File.join(PROJECT_ROOT_FOLDER, 'build', 'promote-steps.yml')
+# Where the gather lane writes the generated block + promote steps (gitignored `build/`). The
+# relative form is what `buildkite-agent pipeline upload` receives (it runs from PROJECT_ROOT_FOLDER).
+PROMOTION_STEPS_RELATIVE_PATH = File.join('build', 'promote-steps.yml')
+PROMOTION_STEPS_FILE = File.join(PROJECT_ROOT_FOLDER, PROMOTION_STEPS_RELATIVE_PATH)
 
 # Buildkite coordinates, used to build the block step's unblock-dialog deep link.
 BUILDKITE_ORGANIZATION = 'automattic'
@@ -264,7 +266,7 @@ platform :android do
 
   # Source `shared-pipeline-vars` first so `$CI_TOOLKIT` is interpolated.
   def upload_promotion_steps
-    sh('bash', '-c', "cd '#{PROJECT_ROOT_FOLDER}' && source .buildkite/shared-pipeline-vars && buildkite-agent pipeline upload build/promote-steps.yml")
+    sh('bash', '-c', "cd '#{PROJECT_ROOT_FOLDER}' && source .buildkite/shared-pipeline-vars && buildkite-agent pipeline upload '#{PROMOTION_STEPS_RELATIVE_PATH}'")
   end
 
   def candidate_label(candidate)

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -76,6 +76,7 @@ platform :android do
 
     version_code = version_code.to_s.strip
     UI.user_error!('`version_code` is required, e.g. `version_code:269027172`') if version_code.empty?
+    UI.user_error!("`version_code` must be an integer, got #{version_code.inspect}") unless version_code.match?(/\A\d+\z/)
 
     UI.important("Promoting version code #{version_code} to the beta track for WordPress and Jetpack")
 
@@ -116,7 +117,7 @@ platform :android do
     end
 
     common = available_per_app.reduce(:&) || []
-    codes = common.select { |code| combined_floor.nil? || code > combined_floor }.sort.reverse.first(PROMOTION_CANDIDATE_LIMIT)
+    codes = common.select { |code| combined_floor.nil? || code > combined_floor }.max(PROMOTION_CANDIDATE_LIMIT)
 
     codes.map { |code| candidate_for(code) }
   end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -36,10 +36,8 @@ BUILDKITE_ORGANIZATION = 'automattic'
 BUILDKITE_PIPELINE = 'wordpress-android'
 
 platform :android do
-  # Lists the promotable builds and opens a Buildkite block step for a developer to pick one.
-  # A build is promotable when its version code is present in both apps' Play libraries and higher
-  # than the current `beta` release. Uploads the block + promote steps here (not from the CI
-  # script) so it can read back the block step's job id for the Slack unblock-dialog link.
+  # Lists the promotable builds — version codes in both apps' Play libraries above the current
+  # `beta` release — and opens a Buildkite block step for a developer to pick one.
   #
   # @called_by CI (`.buildkite/commands/gather-beta-candidates.sh`)
   desc 'Gather promotable beta candidates and open the promotion block step'
@@ -142,14 +140,12 @@ platform :android do
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
   rescue StandardError => e
-    # Fail loudly: swallowing this into [] would let a transient failure read as "nothing to
-    # promote" (the intersection collapses) or "promote everything" (the floor becomes nil).
+    # Raise rather than return []: an errored lookup must not read as an empty beta track.
     UI.user_error!("Unable to read the beta track version codes for #{package_name}: #{e.message}")
   end
 
   # Lists every AAB version code uploaded for the given package (the Play "app bundle explorer"),
   # as an array of integers. Opens a throwaway Play edit and aborts it, so this only reads.
-  # Returns an empty array if the lookup fails.
   def available_aab_version_codes(package_name:)
     require 'supply'
     require 'supply/options'
@@ -170,7 +166,7 @@ platform :android do
       end
     Array(codes).compact.map(&:to_i)
   rescue StandardError => e
-    # Fail loudly, like beta_track_version_codes: a swallowed [] collapses the candidate set.
+    # Raise rather than return [], as in beta_track_version_codes.
     UI.user_error!("Unable to list the available AAB version codes for #{package_name}: #{e.message}")
   end
 
@@ -220,8 +216,7 @@ platform :android do
             {
               'select' => 'Build to promote',
               'key' => PROMOTION_META_DATA_KEY,
-              # No default, and required: an un-actioned unblock must not silently promote
-              # whatever sorted newest — force an explicit human choice.
+              # Required, no default: an un-actioned unblock can't silently promote a build.
               'required' => true,
               'options' => options
             }
@@ -255,8 +250,8 @@ platform :android do
   # Slack
   #################################################
 
-  # Posts the candidate list. Links straight to the unblock dialog when we resolved the block
-  # step's job id; otherwise points at the build so a degraded link isn't mistaken for the picker.
+  # Posts the candidate list, linking to the unblock dialog when the job id resolved, otherwise to
+  # the build so a degraded link isn't mistaken for the picker.
   def post_candidates_to_slack(candidates:, pick_url: nil)
     build_url = ENV.fetch('BUILDKITE_BUILD_URL', nil)
 
@@ -365,8 +360,7 @@ platform :android do
 
     manual_jobs = JSON.parse(response.body).fetch('jobs', []).select { |job| job['type'] == 'manual' }
 
-    # Match on the stable step key the block was generated with; fall back to the label only if the
-    # API didn't surface a step key, so a second manual step whose label contains ours can't shadow it.
+    # Prefer the stable step key; fall back to the label only if the API doesn't surface it.
     manual_jobs.find { |job| job['step_key'] == PROMOTION_BLOCK_STEP_KEY } ||
       manual_jobs.find { |job| job['label'].to_s.include?(PROMOTION_BLOCK_LABEL) }
   end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -131,7 +131,7 @@ platform :android do
   end
 
   # Reads the version codes currently on the given package's `beta` track, as an array of integers.
-  # Returns an empty array if the track has no releases or the lookup fails.
+  # Returns an empty array only when the track legitimately has no releases; a lookup error raises.
   def beta_track_version_codes(package_name:)
     google_play_track_version_codes(
       package_name: package_name,
@@ -139,8 +139,9 @@ platform :android do
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
   rescue StandardError => e
-    UI.error("Failed to fetch beta track version codes for #{package_name}: #{e.message}")
-    []
+    # Fail loudly: swallowing this into [] would let a transient failure read as "nothing to
+    # promote" (the intersection collapses) or "promote everything" (the floor becomes nil).
+    UI.user_error!("Unable to read the beta track version codes for #{package_name}: #{e.message}")
   end
 
   # Lists every AAB version code uploaded for the given package (the Play "app bundle explorer"),
@@ -157,12 +158,17 @@ platform :android do
 
     client = Supply::Client.make_from_config
     client.begin_edit(package_name: package_name)
-    codes = client.aab_version_codes
-    client.abort_current_edit
+    codes =
+      begin
+        client.aab_version_codes
+      ensure
+        # Always discard the throwaway edit, even if the read raises.
+        client.abort_current_edit
+      end
     Array(codes).compact.map(&:to_i)
   rescue StandardError => e
-    UI.error("Failed to list available AAB version codes for #{package_name}: #{e.message}")
-    []
+    # Fail loudly, like beta_track_version_codes: a swallowed [] collapses the candidate set.
+    UI.user_error!("Unable to list the available AAB version codes for #{package_name}: #{e.message}")
   end
 
   #################################################

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -202,8 +202,8 @@ platform :android do
       release = AndroidPublisher::TrackRelease.new(
         # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
         status: 'draft',
-        # Keep the pinned legacy code on the track, matching the AAB-upload path's version_codes_to_retain.
-        version_codes: [Integer(version_code), 1440]
+        # Keep the pinned legacy code(s) on the track, same as the AAB-upload path.
+        version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN]
       )
       track = client.tracks(BETA_TRACK).first || AndroidPublisher::Track.new(track: BETA_TRACK)
       track.releases = [release]

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -43,6 +43,9 @@ platform :android do
   desc 'Gather promotable beta candidates and open the promotion block step'
   lane :gather_beta_candidates do
     ensure_promotion_on_trunk!
+    # Fail loudly up front if Slack isn't configured: every step here reports to Slack, and
+    # notify_slack otherwise swallows a missing SLACK_WEBHOOK as if it were a transient hiccup.
+    get_required_env('SLACK_WEBHOOK')
 
     candidates = beta_promotion_candidates
 
@@ -71,6 +74,8 @@ platform :android do
     # Set once the per-app result has been posted, so the rescue doesn't double-report it.
     result_posted = false
     ensure_promotion_on_trunk!
+    # Fail loudly up front if Slack isn't configured (see gather_beta_candidates).
+    get_required_env('SLACK_WEBHOOK')
 
     version_code = version_code.to_s.strip
     UI.user_error!('`version_code` is required, e.g. `version_code:269027172`') if version_code.empty?


### PR DESCRIPTION
### Description

Adds a way to promote an already-uploaded build to the Play Store `beta` track without rebuilding. A developer picks a build from a Buildkite block step, and WordPress and Jetpack are promoted together (they share a version code, so one pick covers both).

**On the term "promote":** this isn't entirely Play Console's "Promote release" (which advances a track's current release). Here we pick any uploaded build and create a `beta` release for it, but it's still promotion up the track ladder. It's the terminology this PR proposes, but happy to take it to another direction if reviewers have a strong preference to use another term.

What's included:

- **`fastlane/lanes/promote.rb`** — two lanes:
  - `gather_beta_candidates` lists the promotable builds (version codes present in both apps' Play libraries and above the current `beta` release, newest first), writes and uploads a Buildkite block step to choose one, and posts the candidate list to Slack.
  - `promote_to_beta version_code:<code>` creates a draft `beta` release for that version code in each app directly via the Play API (`Supply::Client`): open an edit, set the release on the `beta` track, commit.
- **`.buildkite/`** — `promote-beta.yml` plus `commands/gather-beta-candidates.sh` and `commands/promote-to-beta.sh`, wiring the gather → block → promote flow. Candidate discovery reads the beta track (`google_play_track_version_codes`) and the uploaded-bundle list (`Supply::Client#aab_version_codes` over a throwaway, aborted edit).
- **`fastlane/Fastfile`** — adds the `send_slack_message`, `notify_slack`, and `get_required_env` helpers and the `PLAY_STORE_VERSION_CODES_TO_RETAIN` constant, and imports the new lane file.
- **`fastlane/lanes/build.rb`** — `version_codes_to_retain` now references the shared `PLAY_STORE_VERSION_CODES_TO_RETAIN` constant.

**Notes:**

- The beta release is created as `release_status: 'draft'`, so nothing reaches beta testers yet. Flip to `'completed'` in `promote.rb` when ready to distribute.
- The promote lanes only run on `trunk` (`ensure_promotion_on_trunk!`); a local or off-branch run fails by design.

### Testing instructions

Promotion is a Play Store track operation, so there is no app build to install. The flow runs entirely on Buildkite and ends in a draft release in the Play Console (which does not reach testers and can be discarded).

Because the promote lanes refuse to run off `trunk`, e2e-test from a throwaway branch with the guard removed:

Set up a test branch:

1. Branch off `task/promote-to-beta` (e.g. `task/promote-to-beta-e2e`).
2. Remove the `ensure_promotion_on_trunk!` calls in `fastlane/lanes/promote.rb` and commit.
- [ ] Verify the gather and promote lanes no longer refuse to run off `trunk`.

Run the picker:

3. Start a Buildkite build on the test branch with the env var `PIPELINE=promote-beta.yml`.
- [ ] Verify the "Gather builds to promote to beta" step lists candidate version codes and posts them to Slack with a link to the block step.
- [ ] Verify a "Promote to beta" block step is waiting for input.
4. Open the Slack link (or the build) and unblock the step, choosing a build.
- [ ] Verify the "Promote selected build to beta" step runs `promote_to_beta`.
- [ ] Verify Slack posts a per-app result (WordPress and Jetpack submitted to beta).

Confirm in the Play Console:

5. Open the Play Console for WordPress, then Jetpack.
- [ ] Verify a draft release for the chosen version code appears on the beta track for both apps.
- [ ] Discard the draft release(s) after verifying — draft releases do not reach testers.
