### PR TITLE
Improve new stats error states: centering and unavailable sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/authors/AuthorsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/authors/AuthorsDetailActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
@@ -207,7 +208,8 @@ private fun AuthorsErrorContent(
         Text(
             text = message,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.error
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(16.dp))
         if (onOpenWpAdmin != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/clicks/ClicksViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/clicks/ClicksViewModel.kt
@@ -49,7 +49,8 @@ class ClicksViewModel @Inject constructor(
             is ClicksResult.Error -> {
                 StatsCardFetchResult.Error(
                     messageResId = result.messageResId,
-                    isAuthError = result.isAuthError
+                    isAuthError = result.isAuthError,
+                    isNotAvailable = result.isNotAvailable
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsApiError.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsApiError.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.ui.newstats.datasource
+
+/**
+ * Error code returned by the WordPress.com stats API when the requested stat is
+ * not available for the site (e.g. file download stats on a Jetpack site). The
+ * response body looks like:
+ * `{"error":"invalid_blog","message":"File download stats are not available for Jetpack sites"}`
+ */
+private const val ERROR_CODE_INVALID_BLOG = "invalid_blog"
+
+/**
+ * Matches the value of the top-level "error" field in a WordPress.com API error
+ * body. Kept as a lightweight regex so it works in plain JVM unit tests without
+ * pulling in the Android [org.json] stubs.
+ */
+private val STATS_ERROR_CODE_REGEX = "\"error\"\\s*:\\s*\"([^\"]+)\"".toRegex()
+
+/**
+ * Extracts the WordPress.com stats API error code from a raw response body, or
+ * returns null when the body is missing or does not contain an error code.
+ */
+internal fun parseStatsApiErrorCode(response: String?): String? {
+    if (response.isNullOrBlank()) return null
+    return STATS_ERROR_CODE_REGEX.find(response)?.groupValues?.get(1)
+}
+
+/**
+ * Returns true when the stats API reports that the requested stat is not
+ * available for the site (WordPress.com `invalid_blog` error).
+ */
+internal fun isStatsUnavailableForSite(response: String?): Boolean =
+    parseStatsApiErrorCode(response) == ERROR_CODE_INVALID_BLOG

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
@@ -971,13 +971,13 @@ class StatsDataSourceImpl @Inject constructor(
     ): Pair<String, StatsErrorType> = when (result) {
         is WpRequestResult.WpError -> {
             val statusCode = result.statusCode.toInt()
-            val errorType = if (
+            val errorType = when {
+                isStatsUnavailableForSite(result.response) ->
+                    StatsErrorType.NOT_AVAILABLE
                 statusCode == HTTP_FORBIDDEN ||
-                statusCode == HTTP_UNAUTHORIZED
-            ) {
-                StatsErrorType.AUTH_ERROR
-            } else {
-                StatsErrorType.API_ERROR
+                    statusCode == HTTP_UNAUTHORIZED ->
+                    StatsErrorType.AUTH_ERROR
+                else -> StatsErrorType.API_ERROR
             }
             "StatsDataSourceImpl: $methodName WpError " +
                 "(status=$statusCode) - ${result.errorMessage}" to
@@ -1007,6 +1007,18 @@ class StatsDataSourceImpl @Inject constructor(
             "StatsDataSourceImpl: $methodName " +
                 "InvalidHttpStatusCode - " +
                 "${result.statusCode}" to StatsErrorType.API_ERROR
+        }
+        is WpRequestResult.UnknownError<*> -> {
+            val errorType = if (
+                isStatsUnavailableForSite(result.response)
+            ) {
+                StatsErrorType.NOT_AVAILABLE
+            } else {
+                StatsErrorType.UNKNOWN
+            }
+            "StatsDataSourceImpl: $methodName UnknownError " +
+                "(status=${result.statusCode}) - " +
+                "${result.response}" to errorType
         }
         else -> {
             "StatsDataSourceImpl: $methodName " +

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsErrorType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsErrorType.kt
@@ -11,5 +11,6 @@ enum class StatsErrorType(@StringRes val messageResId: Int) {
     NETWORK_ERROR(R.string.stats_error_network),
     PARSING_ERROR(R.string.stats_error_parsing),
     API_ERROR(R.string.stats_error_api),
+    NOT_AVAILABLE(R.string.stats_error_not_available),
     UNKNOWN(R.string.stats_error_unknown)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/filedownloads/FileDownloadsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/filedownloads/FileDownloadsViewModel.kt
@@ -50,7 +50,8 @@ class FileDownloadsViewModel @Inject constructor(
             is FileDownloadsResult.Error -> {
                 StatsCardFetchResult.Error(
                     messageResId = result.messageResId,
-                    isAuthError = result.isAuthError
+                    isAuthError = result.isAuthError,
+                    isNotAvailable = result.isNotAvailable
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/BaseStatsCardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/BaseStatsCardViewModel.kt
@@ -170,7 +170,8 @@ abstract class BaseStatsCardViewModel(
                         message = resourceProvider.getString(
                             result.messageResId
                         ),
-                        isAuthError = result.isAuthError
+                        isAuthError = result.isAuthError,
+                        isNotAvailable = result.isNotAvailable
                     )
                 }
             }
@@ -207,6 +208,7 @@ sealed class StatsCardFetchResult {
 
     data class Error(
         @StringRes val messageResId: Int,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : StatsCardFetchResult()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
@@ -365,10 +366,11 @@ private fun ErrorContent(
             Text(
                 text = state.message,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.error
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center
             )
-            Spacer(modifier = Modifier.height(16.dp))
             if (onOpenWpAdmin != null) {
+                Spacer(modifier = Modifier.height(16.dp))
                 Button(onClick = onOpenWpAdmin) {
                     Text(
                         text = stringResource(
@@ -376,7 +378,8 @@ private fun ErrorContent(
                         )
                     )
                 }
-            } else {
+            } else if (!state.isNotAvailable) {
+                Spacer(modifier = Modifier.height(16.dp))
                 Button(onClick = onRetry) {
                     Text(text = stringResource(R.string.retry))
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedCardUiState.kt
@@ -26,7 +26,8 @@ sealed class MostViewedCardUiState {
 
     data class Error(
         val message: String,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : MostViewedCardUiState()
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
@@ -235,7 +235,6 @@ private fun MostViewedDetailScreen(
                 message = uiState.message,
                 onRetry = onRetry,
                 onOpenWpAdmin = if (uiState.isAuthError) onOpenWpAdmin else null,
-                showRetry = !uiState.isNotAvailable,
                 modifier = contentModifier
             )
             is MostViewedDetailUiState.Loaded -> DetailLoadedContent(
@@ -317,7 +316,6 @@ private fun DetailErrorContent(
     message: String,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
-    showRetry: Boolean = true,
     onOpenWpAdmin: (() -> Unit)? = null
 ) {
     Column(
@@ -331,13 +329,12 @@ private fun DetailErrorContent(
             color = MaterialTheme.colorScheme.error,
             textAlign = TextAlign.Center
         )
+        Spacer(modifier = Modifier.height(16.dp))
         if (onOpenWpAdmin != null) {
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onOpenWpAdmin) {
                 Text(text = stringResource(R.string.my_site_btn_wp_admin))
             }
-        } else if (showRetry) {
-            Spacer(modifier = Modifier.height(16.dp))
+        } else {
             Button(onClick = onRetry) {
                 Text(text = stringResource(R.string.retry))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
@@ -234,6 +235,7 @@ private fun MostViewedDetailScreen(
                 message = uiState.message,
                 onRetry = onRetry,
                 onOpenWpAdmin = if (uiState.isAuthError) onOpenWpAdmin else null,
+                showRetry = !uiState.isNotAvailable,
                 modifier = contentModifier
             )
             is MostViewedDetailUiState.Loaded -> DetailLoadedContent(
@@ -315,6 +317,7 @@ private fun DetailErrorContent(
     message: String,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
+    showRetry: Boolean = true,
     onOpenWpAdmin: (() -> Unit)? = null
 ) {
     Column(
@@ -325,14 +328,16 @@ private fun DetailErrorContent(
         Text(
             text = message,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.error
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
         )
-        Spacer(modifier = Modifier.height(16.dp))
         if (onOpenWpAdmin != null) {
+            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onOpenWpAdmin) {
                 Text(text = stringResource(R.string.my_site_btn_wp_admin))
             }
-        } else {
+        } else if (showRetry) {
+            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onRetry) {
                 Text(text = stringResource(R.string.retry))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailFetcher.kt
@@ -70,7 +70,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalClicksChange,
             totalValueChangePercent = totalClicksChangePercent
         )
-        is ClicksResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
+        is ClicksResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
     }
 
     private fun SearchTermsResult.toFetchResult() = when (this) {
@@ -80,7 +80,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalViewsChange,
             totalValueChangePercent = totalViewsChangePercent
         )
-        is SearchTermsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
+        is SearchTermsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
     }
 
     private fun VideoPlaysResult.toFetchResult() = when (this) {
@@ -90,7 +90,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalViewsChange,
             totalValueChangePercent = totalViewsChangePercent
         )
-        is VideoPlaysResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
+        is VideoPlaysResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
     }
 
     private fun FileDownloadsResult.toFetchResult() = when (this) {
@@ -100,7 +100,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalDownloadsChange,
             totalValueChangePercent = totalDownloadsChangePercent
         )
-        is FileDownloadsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
+        is FileDownloadsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
     }
 
     private fun ClickItemData.toDetailItem(id: Long) = MostViewedDetailItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailFetcher.kt
@@ -70,7 +70,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalClicksChange,
             totalValueChangePercent = totalClicksChangePercent
         )
-        is ClicksResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
+        is ClicksResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
     }
 
     private fun SearchTermsResult.toFetchResult() = when (this) {
@@ -80,7 +80,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalViewsChange,
             totalValueChangePercent = totalViewsChangePercent
         )
-        is SearchTermsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
+        is SearchTermsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
     }
 
     private fun VideoPlaysResult.toFetchResult() = when (this) {
@@ -90,7 +90,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalViewsChange,
             totalValueChangePercent = totalViewsChangePercent
         )
-        is VideoPlaysResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
+        is VideoPlaysResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
     }
 
     private fun FileDownloadsResult.toFetchResult() = when (this) {
@@ -100,7 +100,7 @@ class MostViewedDetailFetcher @Inject constructor(
             totalValueChange = totalDownloadsChange,
             totalValueChangePercent = totalDownloadsChangePercent
         )
-        is FileDownloadsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError, isNotAvailable)
+        is FileDownloadsResult.Error -> StatsCardFetchResult.Error(messageResId, isAuthError)
     }
 
     private fun ClickItemData.toDetailItem(id: Long) = MostViewedDetailItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailViewModel.kt
@@ -93,7 +93,8 @@ class MostViewedDetailViewModel @Inject constructor(
                 )
                 is StatsCardFetchResult.Error -> MostViewedDetailUiState.Error(
                     message = resourceProvider.getString(result.messageResId),
-                    isAuthError = result.isAuthError
+                    isAuthError = result.isAuthError,
+                    isNotAvailable = result.isNotAvailable
                 )
             }
         } catch (e: CancellationException) {
@@ -118,6 +119,7 @@ sealed interface MostViewedDetailUiState {
 
     data class Error(
         val message: String,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : MostViewedDetailUiState
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/mostviewed/MostViewedDetailViewModel.kt
@@ -93,8 +93,7 @@ class MostViewedDetailViewModel @Inject constructor(
                 )
                 is StatsCardFetchResult.Error -> MostViewedDetailUiState.Error(
                     message = resourceProvider.getString(result.messageResId),
-                    isAuthError = result.isAuthError,
-                    isNotAvailable = result.isNotAvailable
+                    isAuthError = result.isAuthError
                 )
             }
         } catch (e: CancellationException) {
@@ -119,7 +118,6 @@ sealed interface MostViewedDetailUiState {
 
     data class Error(
         val message: String,
-        val isAuthError: Boolean = false,
-        val isNotAvailable: Boolean = false
+        val isAuthError: Boolean = false
     ) : MostViewedDetailUiState
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -1140,8 +1140,8 @@ class StatsRepository @Inject constructor(
                 items, total, change, pct
             )
         },
-        buildError = { resId, isAuth ->
-            ClicksResult.Error(resId, isAuth)
+        buildError = { resId, isAuth, isNotAvailable ->
+            ClicksResult.Error(resId, isAuth, isNotAvailable)
         },
         logLabel = "clicks"
     )
@@ -1171,8 +1171,8 @@ class StatsRepository @Inject constructor(
                 items, total, change, pct
             )
         },
-        buildError = { resId, isAuth ->
-            SearchTermsResult.Error(resId, isAuth)
+        buildError = { resId, isAuth, isNotAvailable ->
+            SearchTermsResult.Error(resId, isAuth, isNotAvailable)
         },
         logLabel = "search terms"
     )
@@ -1202,8 +1202,8 @@ class StatsRepository @Inject constructor(
                 items, total, change, pct
             )
         },
-        buildError = { resId, isAuth ->
-            VideoPlaysResult.Error(resId, isAuth)
+        buildError = { resId, isAuth, isNotAvailable ->
+            VideoPlaysResult.Error(resId, isAuth, isNotAvailable)
         },
         logLabel = "video plays"
     )
@@ -1235,8 +1235,8 @@ class StatsRepository @Inject constructor(
                 items, total, change, pct
             )
         },
-        buildError = { resId, isAuth ->
-            FileDownloadsResult.Error(resId, isAuth)
+        buildError = { resId, isAuth, isNotAvailable ->
+            FileDownloadsResult.Error(resId, isAuth, isNotAvailable)
         },
         logLabel = "file downloads"
     )
@@ -1411,7 +1411,7 @@ class StatsRepository @Inject constructor(
         metricOf: (Raw) -> Long,
         mapItem: (Raw, Long) -> Output,
         buildSuccess: (List<Output>, Long, Long, Double) -> R,
-        buildError: (Int, Boolean) -> R,
+        buildError: (Int, Boolean, Boolean) -> R,
         logLabel: String
     ): R = withContext(ioDispatcher) {
         val (curRange, prevRange) =
@@ -1455,7 +1455,9 @@ class StatsRepository @Inject constructor(
                 buildError(
                     curResult.errorType.messageResId,
                     curResult.errorType ==
-                        StatsErrorType.AUTH_ERROR
+                        StatsErrorType.AUTH_ERROR,
+                    curResult.errorType ==
+                        StatsErrorType.NOT_AVAILABLE
                 )
             }
         }
@@ -2053,7 +2055,8 @@ sealed class ClicksResult {
     ) : ClicksResult()
     data class Error(
         @StringRes val messageResId: Int,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : ClicksResult()
 }
 
@@ -2076,7 +2079,8 @@ sealed class SearchTermsResult {
     ) : SearchTermsResult()
     data class Error(
         @StringRes val messageResId: Int,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : SearchTermsResult()
 }
 
@@ -2099,7 +2103,8 @@ sealed class VideoPlaysResult {
     ) : VideoPlaysResult()
     data class Error(
         @StringRes val messageResId: Int,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : VideoPlaysResult()
 }
 
@@ -2122,7 +2127,8 @@ sealed class FileDownloadsResult {
     ) : FileDownloadsResult()
     data class Error(
         @StringRes val messageResId: Int,
-        val isAuthError: Boolean = false
+        val isAuthError: Boolean = false,
+        val isNotAvailable: Boolean = false
     ) : FileDownloadsResult()
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/searchterms/SearchTermsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/searchterms/SearchTermsViewModel.kt
@@ -49,7 +49,8 @@ class SearchTermsViewModel @Inject constructor(
             is SearchTermsResult.Error -> {
                 StatsCardFetchResult.Error(
                     messageResId = result.messageResId,
-                    isAuthError = result.isAuthError
+                    isAuthError = result.isAuthError,
+                    isNotAvailable = result.isNotAvailable
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsDetailActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -173,7 +174,8 @@ private fun ErrorContent(
                 style = MaterialTheme
                     .typography.bodyMedium,
                 color = MaterialTheme
-                    .colorScheme.onSurfaceVariant
+                    .colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onRetry) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/subscriberslist/SubscribersListDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/subscriberslist/SubscribersListDetailActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -259,7 +260,8 @@ private fun ErrorContent(
                 style = MaterialTheme
                     .typography.bodyMedium,
                 color = MaterialTheme
-                    .colorScheme.onSurfaceVariant
+                    .colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onRetry) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/utm/UtmDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/utm/UtmDetailActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
@@ -309,7 +310,8 @@ private fun DetailErrorContent(
             text = stringResource(messageResId),
             style = MaterialTheme.typography
                 .bodyMedium,
-            color = MaterialTheme.colorScheme.error
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(16.dp))
         if (onOpenWpAdmin != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/videoplays/VideoPlaysViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/videoplays/VideoPlaysViewModel.kt
@@ -49,7 +49,8 @@ class VideoPlaysViewModel @Inject constructor(
             is VideoPlaysResult.Error -> {
                 StatsCardFetchResult.Error(
                     messageResId = result.messageResId,
-                    isAuthError = result.isAuthError
+                    isAuthError = result.isAuthError,
+                    isNotAvailable = result.isNotAvailable
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/yearinreview/YearInReviewDetailActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
@@ -242,7 +243,8 @@ private fun DetailErrorContent(
             text = message,
             style = MaterialTheme.typography
                 .bodyMedium,
-            color = MaterialTheme.colorScheme.error
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = onRetry) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1675,6 +1675,7 @@
     <string name="stats_error_not_authenticated">Not authenticated</string>
     <string name="stats_error_network">Network error. Please check your connection and try again</string>
     <string name="stats_error_parsing">There was a problem loading the data. Please try again</string>
+    <string name="stats_error_not_available">These stats aren\'t available for this site</string>
     <string name="stats_error_admin_url_unavailable">Unable to open WP Admin for this site</string>
 
     <!-- stats ring chart accessibility -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/datasource/StatsApiErrorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/datasource/StatsApiErrorTest.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.ui.newstats.datasource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class StatsApiErrorTest {
+    @Test
+    fun `given invalid_blog body, when parseStatsApiErrorCode, then error code is returned`() {
+        val response =
+            """{"error":"invalid_blog","message":"File download stats are not available for Jetpack sites"}"""
+
+        assertThat(parseStatsApiErrorCode(response)).isEqualTo("invalid_blog")
+    }
+
+    @Test
+    fun `given spaced json, when parseStatsApiErrorCode, then error code is returned`() {
+        val response = """{ "error" : "invalid_blog" , "message": "nope" }"""
+
+        assertThat(parseStatsApiErrorCode(response)).isEqualTo("invalid_blog")
+    }
+
+    @Test
+    fun `given body without error field, when parseStatsApiErrorCode, then null is returned`() {
+        val response = """{"message":"Something went wrong"}"""
+
+        assertThat(parseStatsApiErrorCode(response)).isNull()
+    }
+
+    @Test
+    fun `given null or blank body, when parseStatsApiErrorCode, then null is returned`() {
+        assertThat(parseStatsApiErrorCode(null)).isNull()
+        assertThat(parseStatsApiErrorCode("")).isNull()
+        assertThat(parseStatsApiErrorCode("   ")).isNull()
+    }
+
+    @Test
+    fun `given invalid_blog body, when isStatsUnavailableForSite, then true is returned`() {
+        val response =
+            """{"error":"invalid_blog","message":"File download stats are not available for Jetpack sites"}"""
+
+        assertThat(isStatsUnavailableForSite(response)).isTrue()
+    }
+
+    @Test
+    fun `given a different error code, when isStatsUnavailableForSite, then false is returned`() {
+        val response = """{"error":"unauthorized","message":"nope"}"""
+
+        assertThat(isStatsUnavailableForSite(response)).isFalse()
+    }
+
+    @Test
+    fun `given null body, when isStatsUnavailableForSite, then false is returned`() {
+        assertThat(isStatsUnavailableForSite(null)).isFalse()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryFileDownloadsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryFileDownloadsTest.kt
@@ -370,6 +370,32 @@ class StatsRepositoryFileDownloadsTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given not available error, when fetchFileDownloads, then correct message is returned`() =
+        test {
+            whenever(
+                statsDataSource.fetchFileDownloads(
+                    any(), any(), any()
+                )
+            ).thenReturn(
+                FileDownloadsDataResult.Error(
+                    StatsErrorType.NOT_AVAILABLE
+                )
+            )
+
+            val result = repository.fetchFileDownloads(
+                TEST_SITE_ID, StatsPeriod.Last7Days
+            )
+
+            assertThat(result).isInstanceOf(
+                FileDownloadsResult.Error::class.java
+            )
+            val error = result as FileDownloadsResult.Error
+            assertThat(error.messageResId)
+                .isEqualTo(R.string.stats_error_not_available)
+            assertThat(error.isAuthError).isFalse()
+        }
+
+    @Test
     fun `given unknown error, when fetchFileDownloads, then correct message is returned`() =
         test {
             whenever(


### PR DESCRIPTION
## Description

> Follow-up from #23077.

Improves error handling and presentation across the new stats screens. Three related changes:

1. **Center error messages in detail screens** — the error `Text` in the Authors, Emails, Subscribers list, UTM, Year in review, and Most viewed detail screens (and the stats card) had no `textAlign`, so a message that wraps to multiple lines left-aligned instead of centering. Added `textAlign = TextAlign.Center`, matching the existing `NoConnectionContent`/`TagsAndCategories` convention.

2. **Surface a clear message when stats are unavailable for the site** — the WordPress.com stats API returns an `invalid_blog` error (e.g. file download stats on a Jetpack site) as a `WpRequestResult.UnknownError` with a 404. This was unhandled and fell through to the generic "An unexpected error occurred", discarding the API's reason. Added a lightweight, dependency-free parser for the API error code, a new `StatsErrorType.NOT_AVAILABLE` mapped to a meaningful string ("These stats aren't available for this site"), and classification of the `invalid_blog` code in both the `UnknownError` and `WpError` branches.

3. **Hide the Retry button for unavailable stats** — retrying a `NOT_AVAILABLE` error never succeeds, so an `isNotAvailable` flag is threaded through the card error chain (repository results, card ViewModels, `StatsCardFetchResult`, and the card/detail UI states). When set, only the message is shown — no Retry or WP Admin button — on both the stats card and the detail screen.

Unit tests added for the error-code parser and the `NOT_AVAILABLE` mapping.

## Testing instructions

<img width="400" alt="stats_detail_screenshot" src="https://github.com/user-attachments/assets/ec5bee14-4f2a-481f-aeb2-136bf344b8b5" />

<img width="438" height="151" alt="Screenshot 2026-07-09 at 12 49 08" src="https://github.com/user-attachments/assets/9ab45323-e39f-4efd-9cf6-730b43d6c358" />


Error message centering:

1. Open Stats on any site and open a detail screen (e.g. Authors) while offline so the error state shows.
- [x] Verify the (wrapping) error message is horizontally centered, not left-aligned.

Unavailable stats message + no Retry (requires a Jetpack/self-hosted site):

1. Log in to a Jetpack site where file download stats are unavailable.
2. Open Stats → Traffic and scroll to the **File downloads** card.
- [x] Verify it shows "These stats aren't available for this site" (centered).
- [x] Verify there is **no** Retry button on the card.

- [x] Verify other stats work as expected