### PR TITLE
Track analytics on the RS comment detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -290,8 +290,13 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         val result = withContext(bgDispatcher) { moderate(APPROVED) }
         if (result is RsResult.Error) {
             _uiState.value = _uiState.value?.copy(status = UNAPPROVED)
-        } else if (noteId != null) {
-            _commentModerated.value = Event(APPROVED)
+        } else {
+            // Match the legacy screen, which tracks the implicit approve when replying to an
+            // unapproved comment (this path is only reached from an unapproved comment).
+            trackCommentAction(Stat.COMMENT_APPROVED)
+            if (noteId != null) {
+                _commentModerated.value = Event(APPROVED)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
+import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
 import org.wordpress.android.fluxc.model.CommentStatus.DELETED
@@ -33,6 +35,8 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -64,7 +68,8 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val notificationsActionsWrapper: NotificationsActionsWrapper,
-    private val notificationsTableWrapper: NotificationsTableWrapper
+    private val notificationsTableWrapper: NotificationsTableWrapper,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _uiState = MutableLiveData<CommentDetailsUiState>()
     private val _uiActionEvent = MutableLiveData<Event<CommentDetailsActionEvent>>()
@@ -215,6 +220,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
                 _uiState.value = _uiState.value?.copy(isLiked = !isLike)
                 showSnackbar(R.string.error_generic)
             } else {
+                trackCommentAction(if (isLike) Stat.COMMENT_LIKED else Stat.COMMENT_UNLIKED)
                 withContext(bgDispatcher) {
                     localCommentCacheUpdateHandler.requestCommentsUpdate()
                     refreshNote()
@@ -226,6 +232,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
 
     fun onEditClicked() {
         if (loadedComment == null) return
+        trackCommentAction(Stat.COMMENT_EDITOR_OPENED)
         // In note mode edit through the note identifier so the edit screen refreshes the note DB
         // after saving, keeping the notifications list consistent with the edited comment.
         val identifier = noteId?.let { NotificationCommentIdentifier(it, remoteCommentId) }
@@ -266,6 +273,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
             if (result is RsResult.Error) {
                 showError(result.message, R.string.error_generic)
             } else {
+                trackCommentReply(comment)
                 _commentChanged.value = Event(Unit)
                 // Replying to an unapproved comment implicitly approves it, matching legacy behaviour
                 if (currentStatus() == UNAPPROVED) {
@@ -301,6 +309,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
                 _uiState.value = _uiState.value?.copy(status = previousStatus)
                 showError(result.message, R.string.error_moderate_comment)
             } else {
+                moderationStat(previousStatus, newStatus)?.let { trackCommentAction(it) }
                 _commentChanged.value = Event(Unit)
                 if (noteId != null) {
                     _commentModerated.value = Event(newStatus)
@@ -346,6 +355,42 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
     }
 
     private fun currentStatus(): CommentStatus = _uiState.value?.status ?: CommentStatus.ALL
+
+    /** The analytics source the legacy screen used: notifications when opened from a note, else site comments. */
+    private fun commentActionSource(): AnalyticsCommentActionSource =
+        if (noteId != null) AnalyticsCommentActionSource.NOTIFICATIONS else AnalyticsCommentActionSource.SITE_COMMENTS
+
+    private fun trackCommentAction(stat: Stat) =
+        analyticsUtilsWrapper.trackCommentActionWithSiteDetails(stat, commentActionSource(), site)
+
+    /** Mirrors the legacy reply tracking, which carries the post and comment ids as event properties. */
+    private fun trackCommentReply(comment: RsComment) {
+        val model = CommentModel()
+        model.remotePostId = comment.postId
+        model.remoteCommentId = remoteCommentId
+        analyticsUtilsWrapper.trackCommentReplyWithDetails(
+            isQuickReply = false,
+            site = site,
+            comment = model,
+            actionSource = commentActionSource()
+        )
+    }
+
+    /**
+     * Maps a moderation to the matching analytics event, mirroring the legacy detail screen:
+     * restoring from spam/trash to approved tracks the specific un-spam/un-trash action rather than
+     * a generic approve.
+     */
+    private fun moderationStat(previousStatus: CommentStatus, newStatus: CommentStatus): Stat? = when {
+        previousStatus == SPAM && newStatus == APPROVED -> Stat.COMMENT_UNSPAMMED
+        previousStatus == TRASH && newStatus == APPROVED -> Stat.COMMENT_UNTRASHED
+        newStatus == APPROVED -> Stat.COMMENT_APPROVED
+        newStatus == UNAPPROVED -> Stat.COMMENT_UNAPPROVED
+        newStatus == SPAM -> Stat.COMMENT_SPAMMED
+        newStatus == TRASH -> Stat.COMMENT_TRASHED
+        newStatus == DELETED -> Stat.COMMENT_DELETED
+        else -> null
+    }
 
     private fun isOffline(): Boolean {
         if (networkUtilsWrapper.isNetworkAvailable()) return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsDetailsActivity.kt
@@ -5,11 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.UnifiedCommentsDetailsActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 class UnifiedCommentsDetailsActivity : BaseAppCompatActivity() {
@@ -32,6 +35,14 @@ class UnifiedCommentsDetailsActivity : BaseAppCompatActivity() {
 
         val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
         val remoteCommentId = intent.getLongExtra(KEY_REMOTE_COMMENT_ID, 0)
+
+        if (savedInstanceState == null) {
+            // Match the legacy site-comments host: track the initial comment view. The
+            // notifications host tracks its own COMMENT_VIEWED, so only the site path fires here.
+            AnalyticsUtils.trackCommentActionWithSiteDetails(
+                Stat.COMMENT_VIEWED, AnalyticsCommentActionSource.SITE_COMMENTS, site
+            )
+        }
 
         val fm = supportFragmentManager
         if (fm.findFragmentByTag(TAG_UNIFIED_COMMENT_DETAILS_FRAGMENT) == null) {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
@@ -114,4 +115,11 @@ class AnalyticsUtilsWrapper @Inject constructor(
         actionSource: AnalyticsCommentActionSource,
         site: SiteModel
     ) = AnalyticsUtils.trackCommentActionWithSiteDetails(stat, actionSource, site)
+
+    fun trackCommentReplyWithDetails(
+        isQuickReply: Boolean,
+        site: SiteModel,
+        comment: CommentModel,
+        actionSource: AnalyticsCommentActionSource
+    ) = AnalyticsUtils.trackCommentReplyWithDetails(isQuickReply, site, comment, actionSource)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
@@ -104,18 +104,7 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn("2 hours ago")
         whenever(notificationsActionsWrapper.downloadNoteAndUpdateDB(any())).thenReturn(true)
 
-        viewModel = UnifiedCommentDetailsViewModel(
-            mainDispatcher = testDispatcher(),
-            bgDispatcher = testDispatcher(),
-            commentsRsDataSource = commentsRsDataSource,
-            commentsStore = commentsStore,
-            localCommentCacheUpdateHandler = localCommentCacheUpdateHandler,
-            networkUtilsWrapper = networkUtilsWrapper,
-            dateTimeUtilsWrapper = dateTimeUtilsWrapper,
-            notificationsActionsWrapper = notificationsActionsWrapper,
-            notificationsTableWrapper = notificationsTableWrapper,
-            analyticsUtilsWrapper = analyticsUtilsWrapper
-        )
+        viewModel = createViewModel()
 
         setupObservers()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.check
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -16,6 +17,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
 import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
@@ -46,6 +48,8 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -70,6 +74,9 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var notificationsTableWrapper: NotificationsTableWrapper
+
+    @Mock
+    lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
 
     private lateinit var viewModel: UnifiedCommentDetailsViewModel
 
@@ -106,7 +113,8 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
             networkUtilsWrapper = networkUtilsWrapper,
             dateTimeUtilsWrapper = dateTimeUtilsWrapper,
             notificationsActionsWrapper = notificationsActionsWrapper,
-            notificationsTableWrapper = notificationsTableWrapper
+            notificationsTableWrapper = notificationsTableWrapper,
+            analyticsUtilsWrapper = analyticsUtilsWrapper
         )
 
         setupObservers()
@@ -449,6 +457,147 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
 
         assertThat(uiStates.last().isLiked).isTrue
     }
+
+    @Test
+    fun `approving an unapproved comment tracks COMMENT_APPROVED for site comments`() = test {
+        whenever(commentsRsDataSource.getComment(site, REMOTE_COMMENT_ID)).thenReturn(UNAPPROVED_RS_COMMENT)
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onApproveClicked()
+
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_APPROVED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+    }
+
+    @Test
+    fun `unapproving an approved comment tracks COMMENT_UNAPPROVED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onApproveClicked()
+
+        verify(analyticsUtilsWrapper).trackCommentActionWithSiteDetails(
+            Stat.COMMENT_UNAPPROVED, AnalyticsCommentActionSource.SITE_COMMENTS, site
+        )
+    }
+
+    @Test
+    fun `spamming tracks COMMENT_SPAMMED and un-spamming tracks COMMENT_UNSPAMMED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+        viewModel.onSpamClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_SPAMMED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+
+        whenever(commentsRsDataSource.getComment(site, REMOTE_COMMENT_ID)).thenReturn(RS_COMMENT.copy(status = SPAM))
+        val spammedViewModel = createViewModel()
+        spammedViewModel.start(site, REMOTE_COMMENT_ID)
+        spammedViewModel.onSpamClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_UNSPAMMED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+    }
+
+    @Test
+    fun `trashing tracks COMMENT_TRASHED and un-trashing tracks COMMENT_UNTRASHED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+        viewModel.onTrashClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_TRASHED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+
+        whenever(commentsRsDataSource.getComment(site, REMOTE_COMMENT_ID)).thenReturn(RS_COMMENT.copy(status = TRASH))
+        val trashedViewModel = createViewModel()
+        trashedViewModel.start(site, REMOTE_COMMENT_ID)
+        trashedViewModel.onTrashClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_UNTRASHED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+    }
+
+    @Test
+    fun `deleting permanently tracks COMMENT_DELETED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onDeletePermanentlyClicked()
+
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_DELETED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+    }
+
+    @Test
+    fun `liking tracks COMMENT_LIKED and unliking tracks COMMENT_UNLIKED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+        viewModel.onLikeClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_LIKED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+
+        whenever(commentsStore.getCommentByLocalSiteAndRemoteId(LOCAL_SITE_ID, REMOTE_COMMENT_ID))
+            .thenReturn(listOf(CACHED_COMMENT.copy(iLike = true)))
+        val likedViewModel = createViewModel()
+        likedViewModel.start(site, REMOTE_COMMENT_ID)
+        likedViewModel.onLikeClicked()
+        verify(analyticsUtilsWrapper)
+            .trackCommentActionWithSiteDetails(Stat.COMMENT_UNLIKED, AnalyticsCommentActionSource.SITE_COMMENTS, site)
+    }
+
+    @Test
+    fun `opening the editor tracks COMMENT_EDITOR_OPENED`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onEditClicked()
+
+        verify(analyticsUtilsWrapper).trackCommentActionWithSiteDetails(
+            Stat.COMMENT_EDITOR_OPENED, AnalyticsCommentActionSource.SITE_COMMENTS, site
+        )
+    }
+
+    @Test
+    fun `a successful reply tracks the reply with the post and comment ids`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onReplyClicked("nice post")
+
+        verify(analyticsUtilsWrapper).trackCommentReplyWithDetails(
+            eq(false),
+            eq(site),
+            check {
+                assertThat(it.remotePostId).isEqualTo(REMOTE_POST_ID)
+                assertThat(it.remoteCommentId).isEqualTo(REMOTE_COMMENT_ID)
+            },
+            eq(AnalyticsCommentActionSource.SITE_COMMENTS)
+        )
+    }
+
+    @Test
+    fun `note-mode actions track with the notifications source`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID, NOTE_ID)
+
+        viewModel.onApproveClicked()
+
+        verify(analyticsUtilsWrapper).trackCommentActionWithSiteDetails(
+            Stat.COMMENT_UNAPPROVED, AnalyticsCommentActionSource.NOTIFICATIONS, site
+        )
+    }
+
+    @Test
+    fun `a failed moderation does not track an analytics event`() = test {
+        whenever(commentsRsDataSource.updateStatus(eq(site), eq(REMOTE_COMMENT_ID), any()))
+            .thenReturn(RsResult.Error("nope"))
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onApproveClicked()
+
+        verifyNoInteractions(analyticsUtilsWrapper)
+    }
+
+    private fun createViewModel() = UnifiedCommentDetailsViewModel(
+        mainDispatcher = testDispatcher(),
+        bgDispatcher = testDispatcher(),
+        commentsRsDataSource = commentsRsDataSource,
+        commentsStore = commentsStore,
+        localCommentCacheUpdateHandler = localCommentCacheUpdateHandler,
+        networkUtilsWrapper = networkUtilsWrapper,
+        dateTimeUtilsWrapper = dateTimeUtilsWrapper,
+        notificationsActionsWrapper = notificationsActionsWrapper,
+        notificationsTableWrapper = notificationsTableWrapper,
+        analyticsUtilsWrapper = analyticsUtilsWrapper
+    )
 
     private fun setupObservers() {
         uiStates.clear()

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
@@ -554,6 +554,29 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `replying to an unapproved comment tracks the implicit approve`() = test {
+        whenever(commentsRsDataSource.getComment(site, REMOTE_COMMENT_ID)).thenReturn(UNAPPROVED_RS_COMMENT)
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        viewModel.onReplyClicked("nice post")
+
+        verify(analyticsUtilsWrapper).trackCommentActionWithSiteDetails(
+            Stat.COMMENT_APPROVED, AnalyticsCommentActionSource.SITE_COMMENTS, site
+        )
+    }
+
+    @Test
+    fun `a note-mode reply tracks with the notifications source`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID, NOTE_ID)
+
+        viewModel.onReplyClicked("nice post")
+
+        verify(analyticsUtilsWrapper).trackCommentReplyWithDetails(
+            eq(false), eq(site), any(), eq(AnalyticsCommentActionSource.NOTIFICATIONS)
+        )
+    }
+
+    @Test
     fun `note-mode actions track with the notifications source`() = test {
         viewModel.start(site, REMOTE_COMMENT_ID, NOTE_ID)
 


### PR DESCRIPTION
The wordpress-rs comment detail screen (`UnifiedCommentDetailsViewModel`) fired no analytics, dropping the per-action events the legacy `CommentDetailFragment` reported. This restores parity so the screen can be enabled without losing tracking.

Events emitted, matching the legacy screen:

- Moderation: `COMMENT_APPROVED` / `UNAPPROVED` / `SPAMMED` / `UNSPAMMED` / `TRASHED` / `UNTRASHED` / `DELETED` — including the un-spam/un-trash special case, and the implicit `COMMENT_APPROVED` when replying to an unapproved comment.
- `COMMENT_LIKED` / `COMMENT_UNLIKED`, `COMMENT_REPLIED_TO`, `COMMENT_EDITOR_OPENED`.
- `COMMENT_VIEWED` fires from the site host (`UnifiedCommentsDetailsActivity`); the notifications host already tracks its own, so the site path is the only new emitter.

### Testing
Run `./gradlew :WordPress:testWordPressDebugUnitTest --tests '*UnifiedCommentDetailsViewModelTest'` and ensure all tests pass.
