### PR TITLE
Set up a8c-secrets (identities only)

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age1px4jgu0wjycxsg42ytjxlg30n849sr00hu4a8h8chzx5lee3av5q9nz9w2
+# ci
+age17y372lsj335gd4054z6dypg7d4p96gjmj04txjn3u4kew29pkessqswe3c

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+wordpress-android@github.com@wordpress-mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,4 @@ Dangerfile*            @wordpress-mobile/apps-infra-tooling
 
 # Secrets
 .configure-files/     @wordpress-mobile/apps-infra-tooling
+.a8c-secrets/         @wordpress-mobile/apps-infra-tooling


### PR DESCRIPTION
Currently unused, just getting ahead. See https://linear.app/a8c/issue/AINFRA-2683
