### PR TITLE
Show RS Unified Comments experimental flag in release builds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -39,10 +39,9 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     private fun shouldShowFeature(feature: Feature): Boolean {
-        // These features are only shown in debug builds
+        // This feature is only shown in debug builds
         return when (feature) {
-            Feature.EXPERIMENTAL_POST_TYPES,
-            Feature.RS_UNIFIED_COMMENTS -> BuildConfig.DEBUG
+            Feature.EXPERIMENTAL_POST_TYPES -> BuildConfig.DEBUG
             else -> true
         }
     }


### PR DESCRIPTION
Currently the RS unified comments experimental feature flag is only visible in debug builds, but this project is far enough along that we can enable it in release builds. This PR does just that.

### Testing
1. Build a non-debug (release) variant.
2. Me → Experimental Features → confirm **RS Unified Comments** now appears and is **off** by default.
