### PR TITLE
Apply shared OkHttp timeouts to the wordpress-rs `CustomOkHttpClient` clients

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/restapi/WpComApiClientProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/networking/restapi/WpComApiClientProvider.kt
@@ -2,25 +2,20 @@ package org.wordpress.android.networking.restapi
 
 import okhttp3.OkHttpClient
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpNetworkAvailabilityProvider
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.applyWpRsTimeouts
 import rs.wordpress.api.kotlin.WpComApiClient
 import rs.wordpress.api.kotlin.WpHttpClient
 import rs.wordpress.api.kotlin.WpRequestExecutor
 import uniffi.wp_api.WpAuthentication
 import uniffi.wp_api.WpAuthenticationProvider
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-
-private const val READ_WRITE_TIMEOUT = 60L
-private const val CONNECT_TIMEOUT = 30L
 
 class WpComApiClientProvider @Inject constructor(
     private val networkAvailabilityProvider: WpNetworkAvailabilityProvider,
 ) {
     fun getWpComApiClient(accessToken: String): WpComApiClient {
         val okHttpClient = OkHttpClient.Builder()
-            .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
-            .readTimeout(READ_WRITE_TIMEOUT, TimeUnit.SECONDS)
-            .writeTimeout(READ_WRITE_TIMEOUT, TimeUnit.SECONDS)
+            .applyWpRsTimeouts()
             .build()
 
         return WpComApiClient(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpApiClientProvider.kt
@@ -135,6 +135,7 @@ class WpApiClientProvider @Inject constructor(
                 }
             })
             .apply { interceptors.forEach { addInterceptor(it) } }
+            .applyWpRsTimeouts()
             .build()
 
         val httpClient = WpHttpClient.CustomOkHttpClient(okHttpClient)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpRsOkHttpTimeouts.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/rs/WpRsOkHttpTimeouts.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.rs
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+private const val CONNECT_TIMEOUT_SECONDS = 30L
+private const val READ_TIMEOUT_SECONDS = 60L
+private const val WRITE_TIMEOUT_SECONDS = 60L
+
+/**
+ * Applies the shared OkHttp timeouts used by wordpress-rs clients that supply their own
+ * [OkHttpClient] via `WpHttpClient.CustomOkHttpClient`. Those clients bypass the library's
+ * `DefaultHttpClient`, so without this they fall back to OkHttp's short 10s per-operation
+ * defaults, which time out prematurely on slow sites or large responses.
+ */
+fun OkHttpClient.Builder.applyWpRsTimeouts(): OkHttpClient.Builder =
+    connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)


### PR DESCRIPTION
## Description
The wordpress-rs `CustomOkHttpClient` paths supply their own `OkHttpClient` and so don't receive the library's `DefaultHttpClient` timeouts. `getWpApiClientCookiesNonceAuthentication` set none at all, leaving it on OkHttp's short 10s per-operation defaults, which time out prematurely on slow sites or large responses. Add a shared `applyWpRsTimeouts()` extension (connect 30s / read 60s / write 60s, matching the fluxc `BaseRequest` convention) and route both the cookies/nonce client and `WpComApiClientProvider` through it as a single source of truth.
