### PR TITLE
Enable WAL on the Reader database to prevent onStart ANRs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -188,6 +188,17 @@ public class ReaderDatabase extends SQLiteOpenHelper {
     }
 
     @Override
+    public void onConfigure(SQLiteDatabase db) {
+        super.onConfigure(db);
+        // Enable Write-Ahead Logging so reads and a single writer can run concurrently. Without WAL,
+        // Android caps the connection pool at a single connection for the whole reader DB, which
+        // serializes every read/write across all threads. That serialization causes ANRs when a
+        // main-thread read (e.g. reloading Reader tags in onStart) blocks behind a background write
+        // such as purge()/reset()/addOrUpdatePosts(). See ReaderTagTable.getTagFromEndpoint ANR.
+        db.enableWriteAheadLogging();
+    }
+
+    @Override
     public void onCreate(SQLiteDatabase db) {
         createAllTables(db);
     }


### PR DESCRIPTION
See: https://a8c.sentry.io/issues/6617010704/?environment=prod&environment=release&project=5731682&query=is%3Aunresolved&referrer=issue-stream&sort=freq

## Description

Fixes an ANR where the main thread blocks in `SQLiteConnectionPool.waitForConnection`
during `ReaderPostListFragment.onStart` → `reloadTags()` → `ReaderUtils.getDefaultTag()`
→ `ReaderTagTable.getTagFromEndpoint()`.

The query itself is trivial (`SELECT * FROM tbl_tags WHERE endpoint LIKE ? LIMIT 1`);
it isn't slow, it just can't acquire a database connection. `ReaderDatabase` never
enabled Write-Ahead Logging, and with WAL disabled Android caps the connection pool at
a single connection for the whole reader DB. That serializes every read and write across
all threads, so a main-thread read stalls behind an in-progress background write
(`purge()` / `reset()` / `addOrUpdatePosts()`) and trips the ANR watchdog.

This PR enables WAL via `onConfigure`, allowing concurrent readers alongside a single
writer. The main-thread tag read now proceeds against a consistent snapshot instead of
parking on the writer's connection.

Note: WAL is a DB-wide behavior change (adds `-wal`/`-shm` files, different checkpoint
semantics). Reader code accesses the pool correctly via `getReadableDb()`/`getWritableDb()`,
so no call-site changes are needed. A follow-up could also move `getDefaultTag()` off the
main thread, but WAL removes the contention that caused this specific ANR.

## Testing instructions

Reader smoke test:

1. Open the app and go to the Reader (Followed Sites / a tag stream).
2. Pull to refresh so posts are fetched and written to the DB.
- [x] Verify the tag filter dropdown loads and posts appear without freezes or ANRs.
3. Background/foreground the Reader a few times to re-trigger `onStart`.
- [x] Verify no ANR or jank when returning to the Reader.
4. Leave the app to let a purge run (or trigger enough activity for one).
- [x] Verify the Reader stays responsive while background DB work happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)