### PR TITLE
Fix crash when a deep link opens with no browser available

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] You can now browse Google Photos (albums, collections, and search) when adding photos or videos from your device.
 * [*] Stats now refresh when you return to the screen, so your latest data appears without a manual pull-to-refresh. [https://github.com/wordpress-mobile/WordPress-Android/pull/23112]
+* [*] Links from emails that open outside the app now show a clear message when no browser is available, instead of closing the app.
 
 
 26.9

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -130,6 +130,9 @@ class DeepLinkNavigator
      * Opens the uri with an external browser. The device may have no app able to handle a web link (no browser
      * installed, browser disabled or restricted by a work profile), so the missing handler is reported to the user
      * instead of crashing the deep link entry point.
+     *
+     * The receiver activity has no UI of its own, so it is finished when the hand-off fails. Otherwise the user is
+     * left on an empty screen after the toast. The toast still shows, since it does not depend on the activity.
      */
     private fun openInBrowser(activity: AppCompatActivity, uri: UriWrapper) {
         @SuppressWarnings("UnsafeImplicitIntentLaunch")
@@ -139,6 +142,7 @@ class DeepLinkNavigator
         } catch (e: ActivityNotFoundException) {
             ToastUtils.showToast(activity, R.string.cant_open_url, ToastUtils.Duration.LONG)
             AppLog.e(UTILS, "No app available on the device to open the deep link: $uri", e)
+            activity.finish()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.deeplinks
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityNavigator
@@ -34,6 +36,9 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.DEEP_LINK
 import org.wordpress.android.ui.sitemonitor.SiteMonitorType
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
@@ -52,11 +57,7 @@ class DeepLinkNavigator
                 activity,
                 navigateAction.site
             )
-            is OpenInBrowser -> {
-                @SuppressWarnings("UnsafeImplicitIntentLaunch")
-                val browserIntent = Intent(Intent.ACTION_VIEW, navigateAction.uri.uri)
-                activity.startActivity(browserIntent)
-            }
+            is OpenInBrowser -> openInBrowser(activity, navigateAction.uri)
             is OpenEditorForPost -> ActivityLauncher.openEditorForPostInNewStack(
                 activity,
                 navigateAction.site,
@@ -122,6 +123,22 @@ class DeepLinkNavigator
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
+        }
+    }
+
+    /**
+     * Opens the uri with an external browser. The device may have no app able to handle a web link (no browser
+     * installed, browser disabled or restricted by a work profile), so the missing handler is reported to the user
+     * instead of crashing the deep link entry point.
+     */
+    private fun openInBrowser(activity: AppCompatActivity, uri: UriWrapper) {
+        @SuppressWarnings("UnsafeImplicitIntentLaunch")
+        val browserIntent = Intent(Intent.ACTION_VIEW, uri.uri)
+        try {
+            activity.startActivity(browserIntent)
+        } catch (e: ActivityNotFoundException) {
+            ToastUtils.showToast(activity, R.string.cant_open_url, ToastUtils.Duration.LONG)
+            AppLog.e(UTILS, "No app available on the device to open the deep link: $uri", e)
         }
     }
 


### PR DESCRIPTION
## Description

Fixes an `ActivityNotFoundException` crash in `DeepLinkingIntentReceiverActivity`:

```
android.content.ActivityNotFoundException: No Activity found to handle Intent
{ act=android.intent.action.VIEW dat=https://www.wordpress.com/... }
    at org.wordpress.android.ui.deeplinks.DeepLinkNavigator.handleNavigationAction(DeepLinkNavigator.kt:58)
```

**How it happens.** A WordPress.com email link (`https://public-api.wordpress.com/mbar/...`) is caught by the
app's intent filter. `DeepLinkingIntentReceiverViewModel` unwraps its `redirect_to` parameter, finds no in-app
handler for the target, and emits `OpenInBrowser`. `DeepLinkNavigator` then fired an implicit `ACTION_VIEW`
intent with no guard, so on a device where nothing can handle a web link — no browser installed, browser
disabled, or restricted by a work profile — the deep link receiver crashed before it could tell the user
anything.

**The fix.** The `OpenInBrowser` branch moves into a small `openInBrowser()` helper that catches
`ActivityNotFoundException` and reports it with a toast plus an `AppLog` entry. This matches how the rest of
the app already opens external URLs (`ActivityLauncher.openUrlExternal`, `ReaderActivityLauncher`,
`StatsNavigator`, `ActivityNavigator`) — this call site was the outlier.

The helper also calls `finish()` on the failure path. The receiver activity has no UI of its own: it uses an
opaque theme (`WordPress.NoActionBar`) and never calls `setContentView`, and nothing on the `OpenInBrowser`
path finishes it — the view model only emits `finish` for links it could not build a navigation action for.
Without the `finish()` call the user tapping a link from an email would get the toast and then be parked on a
blank screen until they pressed back. The toast is unaffected, since it does not depend on the activity
staying alive.

No tests added: there is no existing `DeepLinkNavigatorTest`, and `handleNavigationAction` takes a raw
`AppCompatActivity`, so covering this would need a wrapper refactor beyond the scope of a crash fix.

### Follow-up (not in this PR)

While tracing the crash I found a related gap worth its own issue: the failing URL was on `www.wordpress.com`,
but every link handler compares the host with exact equality against `HOST_WORDPRESS_COM = "wordpress.com"`
(`StatsLinkHandler`, `PagesLinkHandler`, `ReaderLinkHandler`, `DeepLinkUriUtils.isWpLoginUrl`), and the
manifest web-link filters only declare `android:host="wordpress.com"`. So email links redirecting to the `www.`
host bounce out to the browser instead of opening in-app, even on devices that have a browser. Fixing that
means normalising the host across the handlers, plus `assetlinks.json` verification for the `www.` hostname if
the app should intercept those links directly.

## Testing instructions

Both checks use the same deep link. Trigger it either via `adb`:

```
adb shell am start -n <applicationId>/org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity \
  -a android.intent.action.VIEW \
  -d "https://public-api.wordpress.com/mbar/?redirect_to=https%3A%2F%2Fwww.wordpress.com%2Fsupport%2F"
```

...or by tapping the same link from an external app (an email or a notes app).

**1. Normal hand-off (device with a browser)**

1. Install this branch on a device or emulator that has a browser.
2. Trigger the deep link.
- [ ] Verify the app opens and handles the deep link (no crash).
- [ ] Verify it then hands off to the browser, which loads the redirect target.

**2. Crash scenario (device with no browser available)**

3. Disable every app that can handle a web link. List the handlers:
   ```
   adb shell cmd package query-activities -a android.intent.action.VIEW \
     -c android.intent.category.BROWSABLE -d "https://www.wordpress.com/support/" --brief
   ```
   Disable each one it reports (`adb shell pm disable-user --user 0 <package>`), then run the query
   again. Repeat until it prints `No activities found` — the query surfaces the preferred handler first,
   so a second browser can stay hidden behind the default one until that one is disabled.
4. Trigger the deep link again.
- [ ] Verify the app does not crash (before this change it did).
- [ ] Verify an "Unable to open the link" toast is shown.
- [ ] Verify the app closes itself instead of leaving a blank screen on top — you should land back on whatever
      you triggered the link from (the launcher, or the email/notes app).
5. Re-enable each browser afterwards (`adb shell pm enable <package>`). If you disabled the default
   browser, Android reassigns the browser role to another app, so check and restore it:
   ```
   adb shell cmd role get-role-holders --user 0 android.app.role.BROWSER
   adb shell cmd role add-role-holder --user 0 android.app.role.BROWSER <package>
   ```

**3. Regression check on a deep link the app handles itself**

6. Run `adb shell am start -a android.intent.action.VIEW -d "wordpress://stats"`.
- [ ] Verify it opens Stats in the app as before, without going to the browser.

Why the explicit component (`-n`) in the deep link command: on a debug build the `public-api.wordpress.com`
host is not App Links–verified (`adb shell pm get-app-links <applicationId>` reports it unverified), so
Android 12+ routes the implicit intent straight to the default browser and the app is never launched. Naming
the component bypasses that and exercises the real deep link code. Tapping the link from an external app on a
*production* build works without this, since the host is verified there.
