### PR TITLE
Replace site picker 'Add a site' button with an animated FAB

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
@@ -63,7 +63,9 @@ class MySitesPage {
 
     fun startNewSite() {
         switchSite()
-        WPSupportUtils.clickOn(R.id.button_add_site)
+        // the add-site FAB expands a menu; pick "Create WordPress.com site" to start creation
+        WPSupportUtils.clickOn(R.id.fab_add_site)
+        WPSupportUtils.clickOn(R.id.fab_wpcom)
     }
 
     fun goToSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.util.DeviceUtils
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.redirectContextClickToLongPressListener
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.WPDialogSnackbar
 import javax.inject.Inject
@@ -78,10 +79,15 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_DISMISSED)
             finish()
         }
-        binding.buttonAddSite.setOnClickListener {
+        binding.fabAddSite.setOnClickListener {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_ADD_SITE_TAPPED)
             AddSiteHandler.addSite(this, accountStore.hasAccessToken(), SiteCreationSource.MY_SITE)
         }
+        binding.fabAddSite.setOnLongClickListener {
+            ToastUtils.showToast(this, R.string.site_picker_add_a_site, ToastUtils.Duration.SHORT)
+            true
+        }
+        binding.fabAddSite.redirectContextClickToLongPressListener()
         binding.progress.isVisible = !appPrefsWrapper.hasFetchedSites
         setupRecycleView()
 
@@ -172,10 +178,10 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
     private fun setupMenuVisibility() {
         if (mode == SitePickerMode.DEFAULT) {
             menuEditPin.isVisible = true
-            binding.layoutAddSite.isVisible = true
+            binding.fabAddSite.show()
         } else {
             menuEditPin.isVisible = false
-            binding.layoutAddSite.isVisible = false
+            binding.fabAddSite.hide()
         }
     }
 
@@ -184,7 +190,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         searchView.maxWidth = Integer.MAX_VALUE
         menuSearch.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem): Boolean {
-                binding.layoutAddSite.isVisible = false
+                binding.fabAddSite.hide()
                 searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                     override fun onQueryTextSubmit(query: String): Boolean {
                         if (!DeviceUtils.getInstance().hasHardwareKeyboard(this@ChooseSiteActivity)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.isVisible
@@ -14,6 +15,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -26,6 +28,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved
 import org.wordpress.android.ui.ActivityId
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -53,6 +56,12 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
     private lateinit var menuEditPin: MenuItem
     private lateinit var refreshHelper: SwipeToRefreshHelper
     private var searchKeyword: String? = null
+    private var isAddSiteMenuOpen = false
+    private val addSiteMenuItems by lazy {
+        // ordered bottom-to-top so the stagger animates upward from the main FAB
+        listOf(binding.fabMenuItemSelfHosted, binding.fabMenuItemWpcom)
+    }
+    private val fabMenuItemOffset by lazy { resources.getDimension(R.dimen.margin_extra_large) }
 
     @Inject
     lateinit var accountStore: AccountStore
@@ -79,15 +88,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_DISMISSED)
             finish()
         }
-        binding.fabAddSite.setOnClickListener {
-            AnalyticsTracker.track(Stat.SITE_SWITCHER_ADD_SITE_TAPPED)
-            AddSiteHandler.addSite(this, accountStore.hasAccessToken(), SiteCreationSource.MY_SITE)
-        }
-        binding.fabAddSite.setOnLongClickListener {
-            ToastUtils.showToast(this, R.string.site_picker_add_a_site, ToastUtils.Duration.SHORT)
-            true
-        }
-        binding.fabAddSite.redirectContextClickToLongPressListener()
+        setupAddSiteFab()
         binding.progress.isVisible = !appPrefsWrapper.hasFetchedSites
         setupRecycleView()
 
@@ -109,6 +110,100 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         }
 
         viewModel.loadSites(mode)
+    }
+
+    private fun setupAddSiteFab() {
+        binding.fabAddSite.setOnClickListener {
+            AnalyticsTracker.track(Stat.SITE_SWITCHER_ADD_SITE_TAPPED)
+            // when the user is signed in and can add a self-hosted site there are two choices, so
+            // expand the FAB menu; otherwise there's only one action, so trigger it directly
+            if (accountStore.hasAccessToken() && BuildConfig.ENABLE_ADD_SELF_HOSTED_SITE) {
+                toggleAddSiteMenu()
+            } else {
+                AddSiteHandler.addSite(this, accountStore.hasAccessToken(), SiteCreationSource.MY_SITE)
+            }
+        }
+        binding.fabAddSite.setOnLongClickListener {
+            ToastUtils.showToast(this, R.string.site_picker_add_a_site, ToastUtils.Duration.SHORT)
+            true
+        }
+        binding.fabAddSite.redirectContextClickToLongPressListener()
+
+        binding.fabMenuScrim.setOnClickListener { closeAddSiteMenu() }
+        val createWpcomSite = {
+            closeAddSiteMenu()
+            ActivityLauncher.newBlogForResult(this, SiteCreationSource.MY_SITE)
+        }
+        val addSelfHostedSite = {
+            closeAddSiteMenu()
+            ActivityLauncher.addSelfHostedSiteForResult(this)
+        }
+        binding.fabWpcom.setOnClickListener { createWpcomSite() }
+        binding.fabMenuItemWpcom.setOnClickListener { createWpcomSite() }
+        binding.fabSelfHosted.setOnClickListener { addSelfHostedSite() }
+        binding.fabMenuItemSelfHosted.setOnClickListener { addSelfHostedSite() }
+
+        onBackPressedDispatcher.addCallback(this) {
+            if (isAddSiteMenuOpen) {
+                closeAddSiteMenu()
+            } else {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
+
+    private fun toggleAddSiteMenu() {
+        if (isAddSiteMenuOpen) closeAddSiteMenu() else openAddSiteMenu()
+    }
+
+    private fun openAddSiteMenu() {
+        if (isAddSiteMenuOpen) return
+        isAddSiteMenuOpen = true
+        AnalyticsTracker.track(
+            Stat.ADD_SITE_ALERT_DISPLAYED,
+            mapOf(KEY_SOURCE to SiteCreationSource.MY_SITE.label)
+        )
+
+        binding.fabMenuScrim.animate().cancel()
+        binding.fabMenuScrim.isVisible = true
+        binding.fabMenuScrim.animate().alpha(SCRIM_ALPHA).setDuration(FAB_MENU_ANIM_DURATION).start()
+        binding.fabAddSite.animate().rotation(FAB_ICON_ROTATION).setDuration(FAB_MENU_ANIM_DURATION).start()
+
+        addSiteMenuItems.forEachIndexed { index, item ->
+            item.animate().cancel()
+            item.alpha = 0f
+            item.translationY = fabMenuItemOffset
+            item.isVisible = true
+            item.animate()
+                .alpha(1f)
+                .translationY(0f)
+                .setStartDelay(index * FAB_MENU_STAGGER)
+                .setDuration(FAB_MENU_ANIM_DURATION)
+                .withEndAction(null)
+                .start()
+        }
+    }
+
+    private fun closeAddSiteMenu() {
+        if (!isAddSiteMenuOpen) return
+        isAddSiteMenuOpen = false
+
+        binding.fabMenuScrim.animate().cancel()
+        binding.fabMenuScrim.animate().alpha(0f).setDuration(FAB_MENU_ANIM_DURATION)
+            .withEndAction { binding.fabMenuScrim.isVisible = false }.start()
+        binding.fabAddSite.animate().rotation(0f).setDuration(FAB_MENU_ANIM_DURATION).start()
+
+        addSiteMenuItems.forEachIndexed { index, item ->
+            item.animate().cancel()
+            item.animate()
+                .alpha(0f)
+                .translationY(fabMenuItemOffset)
+                .setStartDelay(index * FAB_MENU_STAGGER)
+                .setDuration(FAB_MENU_ANIM_DURATION)
+                .withEndAction { item.isVisible = false }
+                .start()
+        }
     }
 
     override fun onStart() {
@@ -190,6 +285,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         searchView.maxWidth = Integer.MAX_VALUE
         menuSearch.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem): Boolean {
+                closeAddSiteMenu()
                 binding.fabAddSite.hide()
                 searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                     override fun onQueryTextSubmit(query: String): Boolean {
@@ -382,6 +478,10 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         private const val TRACK_PROPERTY_STATE_EDIT = "edit"
         private const val TRACK_PROPERTY_STATE_DONE = "done"
         private const val TRACK_PROPERTY_SECTION = "section"
+        private const val SCRIM_ALPHA = 0.4f
+        private const val FAB_ICON_ROTATION = 45f
+        private const val FAB_MENU_ANIM_DURATION = 200L
+        private const val FAB_MENU_STAGGER = 40L
 
         @JvmStatic
         var isRunning = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -502,8 +502,11 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
             adapter.setActionMode(ActionMode.from(actionMode))
         }
 
-        // restore the expanded add-site menu (the menu can't be open while pinning)
-        if (savedInstanceState.getBoolean(KEY_ADD_SITE_MENU_OPEN) && adapter.mode != ActionMode.Pin) {
+        // restore the expanded add-site menu (the menu only exists in DEFAULT mode and can't be
+        // open while pinning)
+        if (savedInstanceState.getBoolean(KEY_ADD_SITE_MENU_OPEN) &&
+            mode == SitePickerMode.DEFAULT && adapter.mode != ActionMode.Pin
+        ) {
             expandAddSiteMenuInstantly()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -273,11 +273,24 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
     private fun setupMenuVisibility() {
         if (mode == SitePickerMode.DEFAULT) {
             menuEditPin.isVisible = true
-            binding.fabAddSite.show()
+            // hide the FAB while editing pins, otherwise reveal it
+            if (adapter.mode == ActionMode.Pin) {
+                binding.fabAddSite.hide()
+            } else {
+                showAddSiteFab()
+            }
         } else {
             menuEditPin.isVisible = false
             binding.fabAddSite.hide()
         }
+    }
+
+    private fun showAddSiteFab() {
+        val fab = binding.fabAddSite
+        // FloatingActionButton.show() only plays its entrance animation once the view is laid out.
+        // setupMenuVisibility() runs from onPrepareOptionsMenu during the first layout pass, before
+        // the FAB is laid out, so post the initial reveal to guarantee the animation.
+        if (fab.isLaidOut) fab.show() else fab.post { fab.show() }
     }
 
     private fun setupSearchView() {
@@ -357,6 +370,8 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         menuEditPin.setIcon(null)
         menuEditPin.title = getString(R.string.label_done_button)
         adapter.setActionMode(ActionMode.Pin)
+        closeAddSiteMenu()
+        binding.fabAddSite.hide()
     }
 
     /**
@@ -367,6 +382,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         menuEditPin.setIcon(R.drawable.pin_filled)
         menuEditPin.title = getString(R.string.site_picker_edit_pins)
         adapter.setActionMode(ActionMode.None)
+        showAddSiteFab()
     }
 
     private fun setupRecycleView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -285,8 +285,15 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         val fab = binding.fabAddSite
         // FloatingActionButton.show() only plays its entrance animation once the view is laid out.
         // setupMenuVisibility() runs from onPrepareOptionsMenu during the first layout pass, before
-        // the FAB is laid out, so post the initial reveal to guarantee the animation.
-        if (fab.isLaidOut) fab.show() else fab.post { fab.show() }
+        // the FAB is laid out, so post the initial reveal to guarantee the animation. Re-check state
+        // when the posted reveal runs: a search may have been expanded in the meantime (e.g. a search
+        // restored after rotation), in which case the FAB must stay hidden.
+        if (fab.isLaidOut) fab.show() else fab.post { if (shouldShowAddSiteFab()) fab.show() }
+    }
+
+    private fun shouldShowAddSiteFab(): Boolean {
+        val searchExpanded = ::menuSearch.isInitialized && menuSearch.isActionViewExpanded
+        return mode == SitePickerMode.DEFAULT && adapter.mode != ActionMode.Pin && !searchExpanded
     }
 
     private fun setupSearchView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -118,7 +118,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
             // when the user is signed in and can add a self-hosted site there are two choices, so
             // expand the FAB menu; otherwise there's only one action, so trigger it directly
             if (accountStore.hasAccessToken() && BuildConfig.ENABLE_ADD_SELF_HOSTED_SITE) {
-                toggleAddSiteMenu()
+                if (isAddSiteMenuOpen) closeAddSiteMenu() else openAddSiteMenu()
             } else {
                 AddSiteHandler.addSite(this, accountStore.hasAccessToken(), SiteCreationSource.MY_SITE)
             }
@@ -151,10 +151,6 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
                 onBackPressedDispatcher.onBackPressed()
             }
         }
-    }
-
-    private fun toggleAddSiteMenu() {
-        if (isAddSiteMenuOpen) closeAddSiteMenu() else openAddSiteMenu()
     }
 
     private fun openAddSiteMenu() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteActivity.kt
@@ -202,6 +202,24 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         }
     }
 
+    /**
+     * Restores the expanded menu after a configuration change by jumping straight to the open
+     * end state — no entrance animation and no analytics, both of which belong to a user-initiated
+     * open. Setting the FAB visible directly (rather than via show()) skips its scale animation.
+     */
+    private fun expandAddSiteMenuInstantly() {
+        isAddSiteMenuOpen = true
+        binding.fabAddSite.isVisible = true
+        binding.fabAddSite.rotation = FAB_ICON_ROTATION
+        binding.fabMenuScrim.isVisible = true
+        binding.fabMenuScrim.alpha = SCRIM_ALPHA
+        addSiteMenuItems.forEach { item ->
+            item.isVisible = true
+            item.alpha = 1f
+            item.translationY = 0f
+        }
+    }
+
     override fun onStart() {
         super.onStart()
         dispatcher.register(this)
@@ -472,6 +490,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         super.onSaveInstanceState(outState)
         outState.putString(KEY_SEARCH_KEYWORD, searchKeyword)
         outState.putString(KEY_ACTION_MODE, adapter.mode.value)
+        outState.putBoolean(KEY_ADD_SITE_MENU_OPEN, isAddSiteMenuOpen)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -481,6 +500,11 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
 
         savedInstanceState.getString(KEY_ACTION_MODE)?.let { actionMode ->
             adapter.setActionMode(ActionMode.from(actionMode))
+        }
+
+        // restore the expanded add-site menu (the menu can't be open while pinning)
+        if (savedInstanceState.getBoolean(KEY_ADD_SITE_MENU_OPEN) && adapter.mode != ActionMode.Pin) {
+            expandAddSiteMenuInstantly()
         }
     }
 
@@ -493,6 +517,7 @@ class ChooseSiteActivity : BaseAppCompatActivity() {
         const val KEY_SITE_CREATED_BUT_NOT_FETCHED = "key_site_created_but_not_fetched"
         const val KEY_SEARCH_KEYWORD = "key_search_keyword"
         const val KEY_ACTION_MODE = "key_action_mode"
+        const val KEY_ADD_SITE_MENU_OPEN = "key_add_site_menu_open"
         private const val TRACK_PROPERTY_STATE = "state"
         private const val TRACK_PROPERTY_STATE_EDIT = "edit"
         private const val TRACK_PROPERTY_STATE_DONE = "done"

--- a/WordPress/src/main/res/drawable/bg_fab_menu_label.xml
+++ b/WordPress/src/main/res/drawable/bg_fab_menu_label.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurface" />
+    <corners android:radius="@dimen/margin_small" />
+</shape>

--- a/WordPress/src/main/res/layout/choose_site_activity.xml
+++ b/WordPress/src/main/res/layout/choose_site_activity.xml
@@ -5,7 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinatorLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"

--- a/WordPress/src/main/res/layout/choose_site_activity.xml
+++ b/WordPress/src/main/res/layout/choose_site_activity.xml
@@ -58,16 +58,103 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fab_add_site"
+    <View
+        android:id="@+id/fab_menu_scrim"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0"
+        android:background="@android:color/black"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        tools:alpha="0.4"
+        tools:visibility="visible" />
+
+    <LinearLayout
+        android:id="@+id/fab_menu_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/fab_margin"
-        android:contentDescription="@string/site_picker_add_a_site"
-        android:src="@drawable/ic_plus_white_24dp"
-        android:visibility="gone"
-        app:borderWidth="0dp"
-        tools:visibility="visible" />
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginBottom="@dimen/site_picker_fab_margin_bottom"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:gravity="end"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/fab_menu_item_wpcom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_fab_menu_label"
+                android:elevation="@dimen/margin_small"
+                android:paddingHorizontal="@dimen/margin_large"
+                android:paddingVertical="@dimen/margin_medium"
+                android:text="@string/site_picker_create_wpcom"
+                android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_wpcom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_medium"
+                android:contentDescription="@string/site_picker_create_wpcom"
+                android:src="@drawable/ic_wordpress_white_24dp"
+                app:borderWidth="0dp"
+                app:fabSize="mini" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/fab_menu_item_self_hosted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_fab_menu_label"
+                android:elevation="@dimen/margin_small"
+                android:paddingHorizontal="@dimen/margin_large"
+                android:paddingVertical="@dimen/margin_medium"
+                android:text="@string/site_picker_add_self_hosted"
+                android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_self_hosted"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_medium"
+                android:contentDescription="@string/site_picker_add_self_hosted"
+                android:src="@drawable/ic_globe_white_24dp"
+                app:borderWidth="0dp"
+                app:fabSize="mini" />
+        </LinearLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_add_site"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/site_picker_add_a_site"
+            android:src="@drawable/ic_plus_white_24dp"
+            android:visibility="gone"
+            app:borderWidth="0dp"
+            tools:visibility="visible" />
+    </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/choose_site_activity.xml
+++ b/WordPress/src/main/res/layout/choose_site_activity.xml
@@ -154,7 +154,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/site_picker_add_a_site"
             android:src="@drawable/ic_plus_white_24dp"
-            android:visibility="gone"
+            android:visibility="invisible"
             app:borderWidth="0dp"
             tools:visibility="visible" />
     </LinearLayout>

--- a/WordPress/src/main/res/layout/choose_site_activity.xml
+++ b/WordPress/src/main/res/layout/choose_site_activity.xml
@@ -58,27 +58,16 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <FrameLayout
-        android:id="@+id/layout_add_site"
-        android:layout_width="match_parent"
-        android:background="?colorSurface"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_add_site"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom">
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1px"
-            android:alpha="0.6"
-            android:background="#3C3C43"/>
-
-        <com.google.android.material.button.MaterialButton
-            style="@style/Widget.SitePicker.Button"
-            android:id="@+id/button_add_site"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_extra_large"
-            android:layout_marginVertical="@dimen/margin_medium"
-            android:text="@string/site_picker_add_a_site"/>
-    </FrameLayout>
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        android:contentDescription="@string/site_picker_add_a_site"
+        android:src="@drawable/ic_plus_white_24dp"
+        android:visibility="gone"
+        app:borderWidth="0dp"
+        tools:visibility="visible" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -15,6 +15,9 @@
     <dimen name="fab_margin">@dimen/fab_margin_default</dimen>
     <dimen name="fab_margin_default">16dp</dimen>
     <dimen name="fab_margin_tablet">24dp</dimen>
+    <!-- The site picker has no bottom navigation bar, so lift its FAB to match the create FAB on
+         the My Site screen, which floats above the bottom nav (bottom nav height + fab_margin). -->
+    <dimen name="site_picker_fab_margin_bottom">72dp</dimen>
 
     <item name="primary_button_disabled_alpha" format="float" type="dimen">
         @dimen/disabled_alpha

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1661,11 +1661,6 @@
         <item name="android:alpha">@dimen/material_emphasis_medium</item>
     </style>
 
-    <style name="Widget.SitePicker.Button" parent="Widget.LoginFlow.Button.Primary">
-        <item name="android:textColor">?attr/colorSurface</item>
-        <item name="android:backgroundTint">?attr/colorOnBackground</item>
-    </style>
-
     <style name="AvatarShapeAppearanceOverlay">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/blavatar_sz_radius</item>


### PR DESCRIPTION
Replaces the site picker's full-width "Add a site" button with a bottom-end floating action button, matching the create-content FAB used for posts and pages. Tapping it expands an animated speed-dial menu with the two add-site options instead of showing a dialog.

### Testing
1. Open the site picker by tapping the current site.
2. The FAB animates in at the bottom-end; long-press shows the "Add a site" tooltip.
3. Tap it → the two options fan out. Pick one to launch the corresponding flow.
4. Tap to Search or Pin → the FAB and menu hide.
