### PR TITLE
Gate RS comment moderation on the moderate_comments capability

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -760,9 +760,10 @@ public class ActivityLauncher {
      * be used for {@code site} instead of the legacy (FluxC) ones.
      */
     public static boolean shouldUseRsComments(@NonNull Context context, @NonNull SiteModel site) {
-        // The rs client can only authenticate WP.com-accessed sites or self-hosted sites with an
-        // application password; everywhere else keep the legacy (FluxC) comments screens.
-        if (!site.isUsingWpComRestApi() && !site.hasApplicationPassword()) {
+        // Match the RS posts/pages gate: use the rs comments screens only for self-hosted sites
+        // with an application password, and keep the legacy (FluxC) comments screens everywhere
+        // else (including WP.com-accessed sites).
+        if (!site.hasApplicationPassword()) {
             return false;
         }
         ActivityLauncherEntryPoint entryPoint = EntryPointAccessors.fromApplication(

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -121,8 +121,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
 
     private fun loadModerationCapability() {
         launch {
-            val canModerate = withContext(bgDispatcher) { siteCapabilityChecker.canModerateComments(site) }
-            this@UnifiedCommentDetailsViewModel.canModerate = canModerate
+            canModerate = withContext(bgDispatcher) { siteCapabilityChecker.canModerateComments(site) }
             _uiState.value?.let { _uiState.value = it.copy(canModerate = canModerate) }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -242,6 +242,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     fun onEditClicked() {
         if (loadedComment == null) return
         // Editing a comment needs moderation rights; the button is disabled without them, but guard

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -294,9 +294,12 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
                 trackCommentReply(comment)
                 _commentChanged.value = Event(Unit)
                 // Replying to an unapproved comment implicitly approves it, matching legacy
-                // behaviour — but only for moderators; a non-moderator can reply without gaining
-                // the right to approve, so skip the implicit approve the server would reject.
-                if (currentStatus() == UNAPPROVED && canModerate) {
+                // behaviour. Always attempt it rather than gating on canModerate: that flag is
+                // fetched asynchronously and may still be unresolved when a moderator replies
+                // (e.g. from a notification, reply field pre-focused), which would silently drop
+                // the approve. approveAfterReply() flips the status optimistically and reverts if
+                // the server rejects it, so a non-moderator's reply self-heals either way.
+                if (currentStatus() == UNAPPROVED) {
                     approveAfterReply()
                 }
                 _uiActionEvent.value = Event(ReplySent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.comments.unified.CommentIdentifier.NotificationC
 import org.wordpress.android.ui.comments.unified.CommentIdentifier.SiteCommentIdentifier
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
+import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString
@@ -63,6 +64,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val commentsRsDataSource: CommentsRsDataSource,
     private val commentsStore: CommentsStore,
+    private val siteCapabilityChecker: SiteCapabilityChecker,
     private val localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
@@ -102,6 +104,11 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
     private var isLikeInProgress = false
     private var isModerationInProgress = false
 
+    // Whether the current user may moderate comments on this site (moderate_comments capability).
+    // Fetched asynchronously in [start]; false until it resolves so the moderation controls start
+    // disabled and enable once confirmed, rather than flashing enabled then greying out.
+    private var canModerate = false
+
     fun start(site: SiteModel, remoteCommentId: Long, noteId: String? = null) {
         if (isStarted) return
         isStarted = true
@@ -109,6 +116,15 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         this.remoteCommentId = remoteCommentId
         this.noteId = noteId
         loadComment()
+        loadModerationCapability()
+    }
+
+    private fun loadModerationCapability() {
+        launch {
+            val canModerate = withContext(bgDispatcher) { siteCapabilityChecker.canModerateComments(site) }
+            this@UnifiedCommentDetailsViewModel.canModerate = canModerate
+            _uiState.value?.let { _uiState.value = it.copy(canModerate = canModerate) }
+        }
     }
 
     /**
@@ -228,6 +244,9 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
 
     fun onEditClicked() {
         if (loadedComment == null) return
+        // Editing a comment needs moderation rights; the button is disabled without them, but guard
+        // the action too so nothing (e.g. a stale recomposition) can slip past the disabled UI.
+        if (!canModerate) return
         // The editor loads the comment from the network, so don't open it offline.
         if (isOffline()) return
         trackCommentAction(Stat.COMMENT_EDITOR_OPENED)
@@ -273,8 +292,10 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
             } else {
                 trackCommentReply(comment)
                 _commentChanged.value = Event(Unit)
-                // Replying to an unapproved comment implicitly approves it, matching legacy behaviour
-                if (currentStatus() == UNAPPROVED) {
+                // Replying to an unapproved comment implicitly approves it, matching legacy
+                // behaviour — but only for moderators; a non-moderator can reply without gaining
+                // the right to approve, so skip the implicit approve the server would reject.
+                if (currentStatus() == UNAPPROVED && canModerate) {
                     approveAfterReply()
                 }
                 _uiActionEvent.value = Event(ReplySent)
@@ -314,6 +335,9 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         // before the load completes the ui state holds a default status and the toggle handlers
         // would compute (and apply server-side) the wrong target status.
         if (loadedComment == null) return
+        // Moderation controls are disabled without the capability; guard the action too so a stale
+        // recomposition can't fire a request the server would only reject with a 403.
+        if (!canModerate) return
         if (isOffline()) return
         // Guard against a second moderation while one is in flight (fast double-tap): the target
         // status is derived from the optimistic ui state, so racing requests could compute (and
@@ -445,7 +469,8 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         postTitle = cached?.postTitle?.takeIf { it.isNotBlank() } ?: fallbackPostTitle,
         commentUrl = url,
         status = status,
-        isLiked = cached?.iLike ?: fallbackIsLiked
+        isLiked = cached?.iLike ?: fallbackIsLiked,
+        canModerate = canModerate
     )
 
     private data class CommentLoadResult(
@@ -466,7 +491,8 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         val commentUrl: String = "",
         val status: CommentStatus = CommentStatus.ALL,
         val isLiked: Boolean = false,
-        val isReplyInProgress: Boolean = false
+        val isReplyInProgress: Boolean = false,
+        val canModerate: Boolean = false
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/CommentActionFooter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/CommentActionFooter.kt
@@ -38,8 +38,10 @@ import org.wordpress.android.ui.compose.theme.AppThemeM3
 /**
  * The row of comment actions pinned above the reply box: moderate (approve/unapprove/untrash),
  * spam, like and a "more" overflow menu (edit, trash, copy/share link, delete permanently).
- * Mirrors the legacy comment_action_footer layout: equal-width icon+label buttons, accent colour
- * at full opacity when a toggle is on, on-surface at medium opacity when off.
+ * Mirrors the legacy comment_action_footer layout: equal-width icon+label buttons in on-surface
+ * at medium emphasis. An enabled on toggle (approved or liked) is highlighted with the accent
+ * colour at full opacity; once disabled it dims to on-surface at the reduced disabled opacity, so
+ * a moderation action the user can't perform no longer shows a tappable-looking tint.
  *
  * When [canModerate] is false (the current user lacks the moderate_comments capability) the
  * moderation controls — moderate, spam, edit, trash and delete permanently — stay visible but are
@@ -65,15 +67,15 @@ fun CommentActionFooter(
     modifier: Modifier = Modifier
 ) {
     Row(modifier = modifier.fillMaxWidth()) {
-        val (moderateIconRes, moderateLabelRes, moderateIsOn) = when (status) {
-            APPROVED -> Triple(R.drawable.ic_checkmark_white_24dp, R.string.comment_status_approved, true)
-            TRASH -> Triple(R.drawable.ic_undo_white_24dp, R.string.mnu_comment_untrash, false)
-            else -> Triple(R.drawable.ic_checkmark_white_24dp, R.string.mnu_comment_approve, false)
+        val (moderateIconRes, moderateLabelRes) = when (status) {
+            APPROVED -> Pair(R.drawable.ic_checkmark_white_24dp, R.string.comment_status_approved)
+            TRASH -> Pair(R.drawable.ic_undo_white_24dp, R.string.mnu_comment_untrash)
+            else -> Pair(R.drawable.ic_checkmark_white_24dp, R.string.mnu_comment_approve)
         }
         ActionButton(
             iconRes = moderateIconRes,
             labelRes = moderateLabelRes,
-            isOn = moderateIsOn,
+            isOn = status == APPROVED,
             enabled = canModerate,
             onClick = onModerateClick,
             modifier = Modifier.weight(1f)
@@ -82,7 +84,6 @@ fun CommentActionFooter(
         ActionButton(
             iconRes = R.drawable.ic_spam_white_24dp,
             labelRes = if (status == SPAM) R.string.mnu_comment_unspam else R.string.mnu_comment_spam,
-            isOn = false,
             enabled = canModerate,
             onClick = onSpamClick,
             modifier = Modifier.weight(1f)
@@ -132,7 +133,6 @@ private fun MoreActionButton(
         ActionButton(
             iconRes = R.drawable.ic_more_horiz_white_24dp,
             labelRes = R.string.more,
-            isOn = false,
             onClick = { isMenuExpanded = true },
             // Fill the Box (which carries this button's share of the row) so the icon centres in
             // its slot like the sibling buttons, instead of hugging the slot's start edge
@@ -186,7 +186,9 @@ private fun MoreMenuItem(
     onClick: () -> Unit
 ) {
     DropdownMenuItem(
-        text = { Text(text = stringResource(labelRes), color = color) },
+        // Only apply the explicit colour (e.g. the destructive red) while enabled; when disabled,
+        // defer to the menu item's disabled content colour so it greys out instead of staying red.
+        text = { Text(text = stringResource(labelRes), color = if (enabled) color else Color.Unspecified) },
         enabled = enabled,
         onClick = onClick
     )
@@ -196,14 +198,15 @@ private fun MoreMenuItem(
 private fun ActionButton(
     @DrawableRes iconRes: Int,
     @StringRes labelRes: Int,
-    isOn: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    isOn: Boolean = false
 ) {
-    val color = if (isOn) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.onSurface
-    // A disabled button reads as unavailable at the same reduced opacity Material uses for
-    // disabled content; enabled buttons keep the footer's on/off emphasis.
+    // An on toggle (approved or liked) is highlighted with the accent colour at full opacity, but
+    // only while it's actionable; once disabled it drops to on-surface at the reduced disabled
+    // opacity so a moderation action the user can't perform no longer shows a tappable-looking tint.
+    val color = if (isOn && enabled) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.onSurface
     val alpha = when {
         !enabled -> DISABLED_EMPHASIS_ALPHA
         isOn -> 1f
@@ -231,7 +234,7 @@ private fun ActionButton(
     }
 }
 
-/** Matches material_emphasis_medium, used by the legacy footer for "off" action buttons. */
+/** Matches material_emphasis_medium, used by the footer for enabled "off" action buttons. */
 internal const val MEDIUM_EMPHASIS_ALPHA = 0.6f
 
 /** Material's disabled-content opacity, used to dim moderation buttons the user can't use. */

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/CommentActionFooter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/CommentActionFooter.kt
@@ -40,6 +40,11 @@ import org.wordpress.android.ui.compose.theme.AppThemeM3
  * spam, like and a "more" overflow menu (edit, trash, copy/share link, delete permanently).
  * Mirrors the legacy comment_action_footer layout: equal-width icon+label buttons, accent colour
  * at full opacity when a toggle is on, on-surface at medium opacity when off.
+ *
+ * When [canModerate] is false (the current user lacks the moderate_comments capability) the
+ * moderation controls — moderate, spam, edit, trash and delete permanently — stay visible but are
+ * disabled and dimmed, mirroring the legacy detail screen's per-capability gating. Like and the
+ * copy/share-link actions are unaffected; the reply box (rendered separately) also stays active.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -48,6 +53,7 @@ fun CommentActionFooter(
     isLiked: Boolean,
     showLikeButton: Boolean,
     showCommentUrlActions: Boolean,
+    canModerate: Boolean,
     onModerateClick: () -> Unit,
     onSpamClick: () -> Unit,
     onLikeClick: () -> Unit,
@@ -68,6 +74,7 @@ fun CommentActionFooter(
             iconRes = moderateIconRes,
             labelRes = moderateLabelRes,
             isOn = moderateIsOn,
+            enabled = canModerate,
             onClick = onModerateClick,
             modifier = Modifier.weight(1f)
         )
@@ -76,6 +83,7 @@ fun CommentActionFooter(
             iconRes = R.drawable.ic_spam_white_24dp,
             labelRes = if (status == SPAM) R.string.mnu_comment_unspam else R.string.mnu_comment_spam,
             isOn = false,
+            enabled = canModerate,
             onClick = onSpamClick,
             modifier = Modifier.weight(1f)
         )
@@ -93,6 +101,7 @@ fun CommentActionFooter(
         MoreActionButton(
             status = status,
             showCommentUrlActions = showCommentUrlActions,
+            canModerate = canModerate,
             onEditClick = onEditClick,
             onTrashClick = onTrashClick,
             onCopyLinkClick = onCopyLinkClick,
@@ -108,6 +117,7 @@ fun CommentActionFooter(
 private fun MoreActionButton(
     status: CommentStatus,
     showCommentUrlActions: Boolean,
+    canModerate: Boolean,
     onEditClick: () -> Unit,
     onTrashClick: () -> Unit,
     onCopyLinkClick: () -> Unit,
@@ -117,6 +127,8 @@ private fun MoreActionButton(
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
     Box(modifier = modifier) {
+        // The button itself stays enabled even without moderation rights so the copy/share-link
+        // items remain reachable; the moderation items inside are individually disabled instead.
         ActionButton(
             iconRes = R.drawable.ic_more_horiz_white_24dp,
             labelRes = R.string.more,
@@ -131,17 +143,17 @@ private fun MoreActionButton(
             onDismissRequest = { isMenuExpanded = false }
         ) {
             val errorColor = MaterialTheme.colorScheme.error
-            MoreMenuItem(R.string.edit) {
+            MoreMenuItem(R.string.edit, enabled = canModerate) {
                 isMenuExpanded = false
                 onEditClick()
             }
             if (status == TRASH) {
-                MoreMenuItem(R.string.mnu_comment_untrash) {
+                MoreMenuItem(R.string.mnu_comment_untrash, enabled = canModerate) {
                     isMenuExpanded = false
                     onTrashClick()
                 }
             } else {
-                MoreMenuItem(R.string.mnu_comment_trash, color = errorColor) {
+                MoreMenuItem(R.string.mnu_comment_trash, color = errorColor, enabled = canModerate) {
                     isMenuExpanded = false
                     onTrashClick()
                 }
@@ -157,7 +169,7 @@ private fun MoreActionButton(
                 }
             }
             if (status == TRASH || status == SPAM) {
-                MoreMenuItem(R.string.mnu_comment_delete_permanently, color = errorColor) {
+                MoreMenuItem(R.string.mnu_comment_delete_permanently, color = errorColor, enabled = canModerate) {
                     isMenuExpanded = false
                     onDeletePermanentlyClick()
                 }
@@ -170,10 +182,12 @@ private fun MoreActionButton(
 private fun MoreMenuItem(
     @StringRes labelRes: Int,
     color: Color = Color.Unspecified,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     DropdownMenuItem(
         text = { Text(text = stringResource(labelRes), color = color) },
+        enabled = enabled,
         onClick = onClick
     )
 }
@@ -184,13 +198,20 @@ private fun ActionButton(
     @StringRes labelRes: Int,
     isOn: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ) {
     val color = if (isOn) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.onSurface
-    val alpha = if (isOn) 1f else MEDIUM_EMPHASIS_ALPHA
+    // A disabled button reads as unavailable at the same reduced opacity Material uses for
+    // disabled content; enabled buttons keep the footer's on/off emphasis.
+    val alpha = when {
+        !enabled -> DISABLED_EMPHASIS_ALPHA
+        isOn -> 1f
+        else -> MEDIUM_EMPHASIS_ALPHA
+    }
     Column(
         modifier = modifier
-            .clickable(onClick = onClick)
+            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 4.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -213,6 +234,9 @@ private fun ActionButton(
 /** Matches material_emphasis_medium, used by the legacy footer for "off" action buttons. */
 internal const val MEDIUM_EMPHASIS_ALPHA = 0.6f
 
+/** Material's disabled-content opacity, used to dim moderation buttons the user can't use. */
+private const val DISABLED_EMPHASIS_ALPHA = 0.38f
+
 @Preview(showBackground = true)
 @Composable
 private fun CommentActionFooterPreview() {
@@ -222,6 +246,7 @@ private fun CommentActionFooterPreview() {
             isLiked = true,
             showLikeButton = true,
             showCommentUrlActions = true,
+            canModerate = true,
             onModerateClick = {},
             onSpamClick = {},
             onLikeClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/UnifiedCommentDetailsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/compose/UnifiedCommentDetailsScreen.kt
@@ -104,6 +104,7 @@ fun UnifiedCommentDetailsScreen(
                     isLiked = uiState.isLiked,
                     showLikeButton = showLikeButton,
                     showCommentUrlActions = uiState.commentUrl.isNotEmpty(),
+                    canModerate = uiState.canModerate,
                     onModerateClick = actions.onModerateClick,
                     onSpamClick = actions.onSpamClick,
                     onLikeClick = actions.onLikeClick,
@@ -281,7 +282,8 @@ private fun UnifiedCommentDetailsScreenPreview() {
                 commentText = "This is a <b>great</b> post, thanks for sharing!",
                 postTitle = "My first post",
                 commentUrl = "https://example.com/post#comment-1",
-                status = UNAPPROVED
+                status = UNAPPROVED,
+                canModerate = true
             ),
             replyText = TextFieldValue(""),
             onReplyTextChange = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListActivity.kt
@@ -42,6 +42,7 @@ class CommentsRsListActivity : BaseAppCompatActivity() {
         setContent {
             val tabStates by viewModel.tabStates.collectAsState()
             val selectedIds by viewModel.selectedIds.collectAsState()
+            val canModerate by viewModel.canModerate.collectAsState()
             val confirmation by viewModel.pendingConfirmation.collectAsState()
             val isSearchActive by viewModel.isSearchActive.collectAsState()
             val searchQuery by viewModel.searchQuery.collectAsState()
@@ -50,6 +51,7 @@ class CommentsRsListActivity : BaseAppCompatActivity() {
                 CommentsRsListScreen(
                     tabStates = tabStates,
                     selectedIds = selectedIds,
+                    canModerate = canModerate,
                     pendingConfirmation = confirmation,
                     isSearchActive = isSearchActive,
                     searchQuery = searchQuery,

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListUiState.kt
@@ -125,13 +125,17 @@ internal fun CommentsRsListTab.batchActions(): List<CommentsRsBatchAction> = whe
 }
 
 /**
- * Whether [this] action can act on a selection whose comments have [selectedStatuses]. Approve and
- * unapprove are disabled when they would be a no-op — nothing unapproved to approve, or nothing
- * approved to unapprove; every other action is always enabled.
+ * Whether [this] action can act on a selection whose comments have [selectedStatuses]. Every batch
+ * action requires [canModerate] (the moderate_comments capability) — without it they stay visible
+ * but disabled, mirroring the detail screen's footer. Approve and unapprove are additionally
+ * disabled when they would be a no-op — nothing unapproved to approve, or nothing approved to
+ * unapprove; every other action is enabled whenever the user can moderate.
  */
-internal fun CommentsRsBatchAction.isEnabledFor(selectedStatuses: Set<CommentStatus>): Boolean =
-    when (this) {
-        CommentsRsBatchAction.APPROVE -> CommentStatus.UNAPPROVED in selectedStatuses
-        CommentsRsBatchAction.UNAPPROVE -> CommentStatus.APPROVED in selectedStatuses
-        else -> true
-    }
+internal fun CommentsRsBatchAction.isEnabledFor(
+    selectedStatuses: Set<CommentStatus>,
+    canModerate: Boolean
+): Boolean = canModerate && when (this) {
+    CommentsRsBatchAction.APPROVE -> CommentStatus.UNAPPROVED in selectedStatuses
+    CommentsRsBatchAction.UNAPPROVE -> CommentStatus.APPROVED in selectedStatuses
+    else -> true
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsCommentsPageResult
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.postsrs.PostRsErrorUtils
 import org.wordpress.android.ui.postsrs.SnackbarMessage
 import org.wordpress.android.util.DateTimeUtilsWrapper
@@ -56,6 +57,7 @@ import javax.inject.Named
 class CommentsRsListViewModel @Inject constructor(
     selectedSiteRepository: SelectedSiteRepository,
     private val commentsRsDataSource: CommentsRsDataSource,
+    private val siteCapabilityChecker: SiteCapabilityChecker,
     private val resourceProvider: ResourceProvider,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
@@ -95,6 +97,12 @@ class CommentsRsListViewModel @Inject constructor(
     private val _pendingConfirmation = MutableStateFlow<PendingConfirmation?>(null)
     val pendingConfirmation: StateFlow<PendingConfirmation?> = _pendingConfirmation.asStateFlow()
 
+    // Whether the current user may moderate comments on this site (moderate_comments capability).
+    // Fetched once on init; false until it resolves so the batch actions start disabled and enable
+    // once confirmed, rather than briefly offering actions the server would reject.
+    private val _canModerate = MutableStateFlow(false)
+    val canModerate: StateFlow<Boolean> = _canModerate.asStateFlow()
+
     // Pagination cursors: the next-page params returned with each fetched page, per tab.
     private val nextPageParams = mutableMapOf<CommentsRsListTab, CommentListParams?>()
 
@@ -133,6 +141,9 @@ class CommentsRsListViewModel @Inject constructor(
             _events.trySend(CommentsRsListEvent.ShowToast(R.string.blog_not_found))
             _events.trySend(CommentsRsListEvent.Finish)
         } else {
+            viewModelScope.launch {
+                _canModerate.value = withContext(bgDispatcher) { siteCapabilityChecker.canModerateComments(site) }
+            }
             @OptIn(FlowPreview::class)
             viewModelScope.launch {
                 _searchQuery
@@ -391,6 +402,9 @@ class CommentsRsListViewModel @Inject constructor(
      * tabs (moderated comments move between tabs). Failures are aggregated into one snackbar.
      */
     private fun performBatchModeration(ids: List<Long>, newStatus: CommentStatus, tab: CommentsRsListTab) {
+        // Batch actions are disabled without moderation rights; guard here too so nothing can reach
+        // the server with a request it would only reject with a 403.
+        if (!_canModerate.value) return
         if (!checkNetwork()) return
         trackBatchModeration(newStatus)
         onClearSelection()

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
@@ -80,6 +80,7 @@ private enum class TopBarMode { SELECTION, SEARCH, NORMAL }
 fun CommentsRsListScreen(
     tabStates: Map<CommentsRsListTab, CommentsTabUiState>,
     selectedIds: Set<Long>,
+    canModerate: Boolean,
     pendingConfirmation: PendingConfirmation?,
     isSearchActive: Boolean,
     searchQuery: String,
@@ -186,6 +187,7 @@ fun CommentsRsListScreen(
                         selectedCount = selectedIds.size,
                         actions = activeTab.batchActions(),
                         selectedStatuses = selectedStatuses,
+                        canModerate = canModerate,
                         onClearSelection = onClearSelection,
                         onBatchAction = { action -> onBatchAction(action, activeTab) }
                     )
@@ -322,6 +324,7 @@ private fun SelectionTopBar(
     selectedCount: Int,
     actions: List<CommentsRsBatchAction>,
     selectedStatuses: Set<CommentStatus>,
+    canModerate: Boolean,
     onClearSelection: () -> Unit,
     onBatchAction: (CommentsRsBatchAction) -> Unit
 ) {
@@ -345,8 +348,9 @@ private fun SelectionTopBar(
         actions = {
             iconActions.forEach { action ->
                 // An action that would be a no-op for the selection (e.g. approve when nothing is
-                // unapproved) stays visible but disabled.
-                val enabled = action.isEnabledFor(selectedStatuses)
+                // unapproved), or that the user lacks the capability to perform, stays visible but
+                // disabled.
+                val enabled = action.isEnabledFor(selectedStatuses, canModerate)
                 IconButton(onClick = { onBatchAction(action) }, enabled = enabled) {
                     Icon(
                         painter = painterResource(action.iconResId),
@@ -358,7 +362,12 @@ private fun SelectionTopBar(
                 }
             }
             if (menuActions.isNotEmpty()) {
-                BatchActionsOverflowMenu(actions = menuActions, onBatchAction = onBatchAction)
+                BatchActionsOverflowMenu(
+                    actions = menuActions,
+                    selectedStatuses = selectedStatuses,
+                    canModerate = canModerate,
+                    onBatchAction = onBatchAction
+                )
             }
         }
     )
@@ -421,6 +430,8 @@ private fun SearchTopBar(
 @Composable
 private fun BatchActionsOverflowMenu(
     actions: List<CommentsRsBatchAction>,
+    selectedStatuses: Set<CommentStatus>,
+    canModerate: Boolean,
     onBatchAction: (CommentsRsBatchAction) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -429,13 +440,18 @@ private fun BatchActionsOverflowMenu(
     }
     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
         actions.forEach { action ->
-            val color = if (action.confirmation != null) {
+            // Without moderation rights the items stay visible but disabled, matching the icon
+            // actions in the bar and the detail screen's overflow.
+            val enabled = action.isEnabledFor(selectedStatuses, canModerate)
+            val baseColor = if (action.confirmation != null) {
                 MaterialTheme.colorScheme.error
             } else {
                 MaterialTheme.colorScheme.onSurface
             }
+            val color = if (enabled) baseColor else baseColor.copy(alpha = DISABLED_ICON_ALPHA)
             DropdownMenuItem(
                 text = { Text(text = stringResource(action.labelResId), color = color) },
+                enabled = enabled,
                 leadingIcon = {
                     Icon(
                         painter = painterResource(action.iconResId),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -174,7 +174,7 @@ class MySiteViewModel @Inject constructor(
         if (isPullToRefresh) analyticsTrackerWrapper.track(Stat.MY_SITE_PULL_TO_REFRESH)
         selectedSiteRepository.getSelectedSite()?.let { site ->
             if (isPullToRefresh) {
-                siteCapabilityChecker.clearCacheForSite(site.siteId)
+                siteCapabilityChecker.clearCacheForSite(site)
             }
             buildDashboardOrSiteItems(site, forceRefresh = isPullToRefresh)
             siteConnectivityBannerViewModelSlice.fetchCapabilities(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.UserCapability
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +23,9 @@ class SiteCapabilityChecker @Inject constructor(
 ) {
     // Keyed by the local site id (site.id), not site.siteId: the latter (the WP.com blog id) is 0
     // for every self-hosted application-password site, which would collide their capabilities.
-    private val capabilityCache = mutableMapOf<Int, CapabilityCache>()
+    // Concurrent because it's a @Singleton read/written from multiple screens' ViewModels on the
+    // multi-threaded default dispatcher.
+    private val capabilityCache = ConcurrentHashMap<Int, CapabilityCache>()
 
     /**
      * Checks if the current user has the edit_theme_options capability for the given site.
@@ -41,13 +44,14 @@ class SiteCapabilityChecker @Inject constructor(
 
     private suspend fun capabilities(site: SiteModel): CapabilityCache {
         capabilityCache[site.id]?.let { return it }
-        val fetched = fetchCapabilities(site)
-        capabilityCache[site.id] = fetched
-        return fetched
+        // Only a successful fetch is cached. On failure fall back to a fail-closed value for this
+        // call but don't cache it, so a transient error doesn't disable the capability for the
+        // whole session — the next call retries (the comments screens never clear this cache).
+        return fetchCapabilities(site)?.also { capabilityCache[site.id] = it } ?: CapabilityCache()
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun fetchCapabilities(site: SiteModel): CapabilityCache {
+    private suspend fun fetchCapabilities(site: SiteModel): CapabilityCache? {
         return try {
             val client = wpApiClientProvider.getWpApiClient(site)
             val response = client.request { requestBuilder ->
@@ -61,13 +65,13 @@ class SiteCapabilityChecker @Inject constructor(
                         canModerateComments = capabilities.hasCap(UserCapability.ModerateComments)
                     )
                 }
-                // Fail closed: an unresolved capability disables the guarded action rather than
-                // offering it and letting the server reject the request after the fact.
-                else -> CapabilityCache()
+                // Return null (not cached) so the next call retries rather than locking in a
+                // fail-closed result from a transient error.
+                else -> null
             }
         } catch (e: Exception) {
             appLogWrapper.e(AppLog.T.API, "Failed to fetch user capabilities: ${e.message}")
-            CapabilityCache()
+            null
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
@@ -11,36 +11,43 @@ import javax.inject.Singleton
 
 /**
  * Checks user capabilities for a site using the WordPress REST API via wordpress-rs.
- * Results are cached per site to avoid redundant network requests. For now we only
- * handle the edit_theme_options capability but this can be expanded later.
+ * Results are cached per site to avoid redundant network requests. The full set of the
+ * current user's capabilities is fetched once and the flags we care about are cached
+ * together, so screens needing more than one capability don't trigger extra requests.
  */
 @Singleton
 class SiteCapabilityChecker @Inject constructor(
     private val wpApiClientProvider: WpApiClientProvider,
     private val appLogWrapper: AppLogWrapper
 ) {
-    private val capabilityCache = mutableMapOf<Long, CapabilityCache>()
+    // Keyed by the local site id (site.id), not site.siteId: the latter (the WP.com blog id) is 0
+    // for every self-hosted application-password site, which would collide their capabilities.
+    private val capabilityCache = mutableMapOf<Int, CapabilityCache>()
 
     /**
      * Checks if the current user has the edit_theme_options capability for the given site.
-     * Results are cached per site ID.
+     * Results are cached per site.
      */
-    suspend fun hasEditThemeOptionsCapability(site: SiteModel): Boolean {
-        val siteId = site.siteId
+    suspend fun hasEditThemeOptionsCapability(site: SiteModel): Boolean =
+        capabilities(site).hasEditThemeOptions
 
-        // Return cached value if available
-        capabilityCache[siteId]?.let { cache ->
-            return cache.hasEditThemeOptions
-        }
+    /**
+     * Checks if the current user has the moderate_comments capability for the given site — i.e.
+     * whether they may approve/unapprove, spam, trash, delete or edit comments. Results are
+     * cached per site.
+     */
+    suspend fun canModerateComments(site: SiteModel): Boolean =
+        capabilities(site).canModerateComments
 
-        // Fetch from API and cache
-        val hasCapability = fetchEditThemeOptionsCapability(site)
-        capabilityCache[siteId] = CapabilityCache(hasEditThemeOptions = hasCapability)
-        return hasCapability
+    private suspend fun capabilities(site: SiteModel): CapabilityCache {
+        capabilityCache[site.id]?.let { return it }
+        val fetched = fetchCapabilities(site)
+        capabilityCache[site.id] = fetched
+        return fetched
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun fetchEditThemeOptionsCapability(site: SiteModel): Boolean {
+    private suspend fun fetchCapabilities(site: SiteModel): CapabilityCache {
         return try {
             val client = wpApiClientProvider.getWpApiClient(site)
             val response = client.request { requestBuilder ->
@@ -48,25 +55,31 @@ class SiteCapabilityChecker @Inject constructor(
             }
             when (response) {
                 is WpRequestResult.Success -> {
-                    response.response.data.capabilities
-                        .hasCap(UserCapability.EditThemeOptions)
+                    val capabilities = response.response.data.capabilities
+                    CapabilityCache(
+                        hasEditThemeOptions = capabilities.hasCap(UserCapability.EditThemeOptions),
+                        canModerateComments = capabilities.hasCap(UserCapability.ModerateComments)
+                    )
                 }
-                else -> false
+                // Fail closed: an unresolved capability disables the guarded action rather than
+                // offering it and letting the server reject the request after the fact.
+                else -> CapabilityCache()
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Failed to fetch edit_theme_options capability: ${e.message}")
-            false
+            appLogWrapper.e(AppLog.T.API, "Failed to fetch user capabilities: ${e.message}")
+            CapabilityCache()
         }
     }
 
     /**
      * Clears the cached capabilities for a specific site.
      */
-    fun clearCacheForSite(siteId: Long) {
-        capabilityCache.remove(siteId)
+    fun clearCacheForSite(site: SiteModel) {
+        capabilityCache.remove(site.id)
     }
 
     private data class CapabilityCache(
-        val hasEditThemeOptions: Boolean
+        val hasEditThemeOptions: Boolean = false,
+        val canModerateComments: Boolean = false
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
 import org.wordpress.android.ui.comments.unified.UnifiedCommentDetailsViewModel
 import org.wordpress.android.ui.comments.unified.UnifiedCommentDetailsViewModel.CommentDetailsUiState
+import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -59,6 +60,9 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var commentsStore: CommentsStore
+
+    @Mock
+    lateinit var siteCapabilityChecker: SiteCapabilityChecker
 
     @Mock
     lateinit var localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler
@@ -103,6 +107,8 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
             .thenReturn(successPayload())
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn("2 hours ago")
         whenever(notificationsActionsWrapper.downloadNoteAndUpdateDB(any())).thenReturn(true)
+        // Default to allowed for any site; the restricted-capability tests override for [site].
+        whenever(siteCapabilityChecker.canModerateComments(any())).thenReturn(true)
 
         viewModel = createViewModel()
 
@@ -198,6 +204,44 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
         verify(commentsRsDataSource).delete(site, REMOTE_COMMENT_ID)
         verify(commentsStore).removeCommentByRemoteId(site, REMOTE_COMMENT_ID)
         assertThat(uiActionEvents).contains(Close)
+    }
+
+    @Test
+    fun `ui state exposes canModerate from the capability checker`() = test {
+        viewModel.start(site, REMOTE_COMMENT_ID)
+
+        assertThat(uiStates.last().canModerate).isTrue
+    }
+
+    @Test
+    fun `canModerate is false and moderation is a no-op without the capability`() = test {
+        whenever(siteCapabilityChecker.canModerateComments(site)).thenReturn(false)
+        val restrictedViewModel = createViewModel()
+        val restrictedStates = mutableListOf<CommentDetailsUiState>()
+        restrictedViewModel.uiState.observeForever { restrictedStates.add(it) }
+
+        restrictedViewModel.start(site, REMOTE_COMMENT_ID)
+        restrictedViewModel.onApproveClicked()
+        restrictedViewModel.onSpamClicked()
+        restrictedViewModel.onTrashClicked()
+        restrictedViewModel.onDeletePermanentlyClicked()
+
+        assertThat(restrictedStates.last().canModerate).isFalse
+        verify(commentsRsDataSource, times(0)).updateStatus(eq(site), eq(REMOTE_COMMENT_ID), any())
+        verify(commentsRsDataSource, times(0)).delete(site, REMOTE_COMMENT_ID)
+    }
+
+    @Test
+    fun `edit is a no-op without the moderate capability`() = test {
+        whenever(siteCapabilityChecker.canModerateComments(site)).thenReturn(false)
+        val restrictedViewModel = createViewModel()
+        val restrictedEvents = mutableListOf<CommentDetailsActionEvent>()
+        restrictedViewModel.uiActionEvent.observeForever { it.applyIfNotHandled { restrictedEvents.add(this) } }
+
+        restrictedViewModel.start(site, REMOTE_COMMENT_ID)
+        restrictedViewModel.onEditClicked()
+
+        assertThat(restrictedEvents.filterIsInstance<LaunchEditComment>()).isEmpty()
     }
 
     @Test
@@ -667,6 +711,7 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
         bgDispatcher = testDispatcher(),
         commentsRsDataSource = commentsRsDataSource,
         commentsStore = commentsStore,
+        siteCapabilityChecker = siteCapabilityChecker,
         localCommentCacheUpdateHandler = localCommentCacheUpdateHandler,
         networkUtilsWrapper = networkUtilsWrapper,
         dateTimeUtilsWrapper = dateTimeUtilsWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
@@ -24,11 +24,14 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsCommentsPageResult
+import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPAvatarUtilsWrapper
@@ -41,6 +44,7 @@ import java.util.Date
 class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
     @Mock lateinit var commentsRsDataSource: CommentsRsDataSource
+    @Mock lateinit var siteCapabilityChecker: SiteCapabilityChecker
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
     @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
@@ -57,6 +61,7 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             siteId = 123L
         }
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(siteCapabilityChecker.canModerateComments(site)).thenReturn(true)
         whenever(resourceProvider.getString(any())).thenReturn("string")
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn("2 hours ago")
         whenever(avatarUtilsWrapper.rewriteAvatarUrlWithResource(any(), any())).thenAnswer { it.arguments[0] }
@@ -73,6 +78,7 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     private fun createViewModel() = CommentsRsListViewModel(
         selectedSiteRepository = selectedSiteRepository,
         commentsRsDataSource = commentsRsDataSource,
+        siteCapabilityChecker = siteCapabilityChecker,
         resourceProvider = resourceProvider,
         networkUtilsWrapper = networkUtilsWrapper,
         dateTimeUtilsWrapper = dateTimeUtilsWrapper,
@@ -494,6 +500,47 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
 
         val state = viewModel.tabStates.value.getValue(CommentsRsListTab.ALL)
         assertThat(state.comments.map { it.postTitle }).containsExactly("First post", "Second post")
+    }
+
+    @Test
+    fun `canModerate reflects the capability checker`() = test {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.canModerate.value).isTrue()
+    }
+
+    @Test
+    fun `batch moderation applies the new status to the selection when the user can moderate`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(commentsRsDataSource.updateStatus(eq(site), any(), any())).thenReturn(RsResult.Success)
+        givenPage(listOf(rsItem(id = 1)), nextPageParams = null)
+        val viewModel = createViewModel()
+        viewModel.initTab(CommentsRsListTab.ALL)
+        advanceUntilIdle()
+
+        viewModel.onCommentLongClick(1)
+        viewModel.onBatchAction(CommentsRsBatchAction.SPAM, CommentsRsListTab.ALL)
+        advanceUntilIdle()
+
+        verify(commentsRsDataSource).updateStatus(site, 1, SPAM)
+    }
+
+    @Test
+    fun `batch moderation is a no-op without the moderate capability`() = test {
+        // No network stub needed: the capability guard short-circuits before the network check.
+        whenever(siteCapabilityChecker.canModerateComments(site)).thenReturn(false)
+        givenPage(listOf(rsItem(id = 1)), nextPageParams = null)
+        val viewModel = createViewModel()
+        viewModel.initTab(CommentsRsListTab.ALL)
+        advanceUntilIdle()
+
+        viewModel.onCommentLongClick(1)
+        viewModel.onBatchAction(CommentsRsBatchAction.SPAM, CommentsRsListTab.ALL)
+        advanceUntilIdle()
+
+        assertThat(viewModel.canModerate.value).isFalse()
+        verify(commentsRsDataSource, never()).updateStatus(eq(site), any(), any())
     }
 
     private fun rsItem(id: Long, postId: Long = 99L) = RsComment(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.mysite.items.listitem
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+
+@ExperimentalCoroutinesApi
+class SiteCapabilityCheckerTest : BaseUnitTest() {
+    @Mock
+    lateinit var wpApiClientProvider: WpApiClientProvider
+
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+
+    private lateinit var checker: SiteCapabilityChecker
+
+    private val site = SiteModel().apply {
+        id = 1
+        siteId = 0L // self-hosted application-password sites report a WP.com blog id of 0
+    }
+
+    @Before
+    fun setUp() {
+        checker = SiteCapabilityChecker(wpApiClientProvider, appLogWrapper)
+    }
+
+    @Test
+    fun `canModerateComments fails closed when the capability cannot be fetched`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        assertThat(checker.canModerateComments(site)).isFalse
+    }
+
+    @Test
+    fun `hasEditThemeOptionsCapability fails closed when the capability cannot be fetched`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        assertThat(checker.hasEditThemeOptionsCapability(site)).isFalse
+    }
+
+    @Test
+    fun `capabilities are fetched once and cached across calls`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        checker.canModerateComments(site)
+        checker.canModerateComments(site)
+        // A different capability reads from the same cached fetch rather than triggering another.
+        checker.hasEditThemeOptionsCapability(site)
+
+        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
+    }
+
+    @Test
+    fun `clearing the cache forces a refetch`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        checker.canModerateComments(site)
+        checker.clearCacheForSite(site)
+        checker.canModerateComments(site)
+
+        verify(wpApiClientProvider, times(2)).getWpApiClient(site)
+    }
+
+    @Test
+    fun `capabilities are cached per local site id, not the WP-com blog id`() = test {
+        // Two distinct self-hosted sites both report siteId 0; keying by the local id keeps their
+        // capabilities from colliding.
+        val otherSite = SiteModel().apply {
+            id = 2
+            siteId = 0L
+        }
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+        whenever(wpApiClientProvider.getWpApiClient(otherSite)).thenThrow(RuntimeException("boom"))
+
+        checker.canModerateComments(site)
+        checker.canModerateComments(otherSite)
+
+        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
+        verify(wpApiClientProvider, times(1)).getWpApiClient(otherSite)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
@@ -5,6 +5,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -12,6 +15,12 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.UserCapabilitiesMap
+import uniffi.wp_api.UserCapability
+import uniffi.wp_api.UserWithEditContext
+import uniffi.wp_api.UsersRequestRetrieveMeWithEditContextResponse
 
 @ExperimentalCoroutinesApi
 class SiteCapabilityCheckerTest : BaseUnitTest() {
@@ -34,6 +43,31 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `canModerateComments returns true when the user has the capability`() = test {
+        stubSuccess(site, canModerate = true)
+
+        assertThat(checker.canModerateComments(site)).isTrue
+    }
+
+    @Test
+    fun `canModerateComments returns false when the user lacks the capability`() = test {
+        stubSuccess(site, canModerate = false)
+
+        assertThat(checker.canModerateComments(site)).isFalse
+    }
+
+    @Test
+    fun `both capabilities come from a single fetch that is cached across calls`() = test {
+        stubSuccess(site, canModerate = true, editThemeOptions = true)
+
+        assertThat(checker.canModerateComments(site)).isTrue
+        assertThat(checker.canModerateComments(site)).isTrue
+        assertThat(checker.hasEditThemeOptionsCapability(site)).isTrue
+
+        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
+    }
+
+    @Test
     fun `canModerateComments fails closed when the capability cannot be fetched`() = test {
         whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
 
@@ -41,27 +75,19 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hasEditThemeOptionsCapability fails closed when the capability cannot be fetched`() = test {
-        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
-
-        assertThat(checker.hasEditThemeOptionsCapability(site)).isFalse
-    }
-
-    @Test
-    fun `capabilities are fetched once and cached across calls`() = test {
+    fun `a failed fetch is not cached and is retried on the next call`() = test {
         whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
 
         checker.canModerateComments(site)
         checker.canModerateComments(site)
-        // A different capability reads from the same cached fetch rather than triggering another.
-        checker.hasEditThemeOptionsCapability(site)
 
-        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
+        // A transient failure must not lock in a fail-closed result for the whole session.
+        verify(wpApiClientProvider, times(2)).getWpApiClient(site)
     }
 
     @Test
     fun `clearing the cache forces a refetch`() = test {
-        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+        stubSuccess(site, canModerate = true)
 
         checker.canModerateComments(site)
         checker.clearCacheForSite(site)
@@ -78,13 +104,33 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
             id = 2
             siteId = 0L
         }
-        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
-        whenever(wpApiClientProvider.getWpApiClient(otherSite)).thenThrow(RuntimeException("boom"))
+        stubSuccess(site, canModerate = true)
+        stubSuccess(otherSite, canModerate = false)
 
-        checker.canModerateComments(site)
-        checker.canModerateComments(otherSite)
+        assertThat(checker.canModerateComments(site)).isTrue
+        assertThat(checker.canModerateComments(otherSite)).isFalse
+        // A repeat call for the first site reads its own cached value, not the other site's.
+        assertThat(checker.canModerateComments(site)).isTrue
 
         verify(wpApiClientProvider, times(1)).getWpApiClient(site)
         verify(wpApiClientProvider, times(1)).getWpApiClient(otherSite)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun stubSuccess(
+        site: SiteModel,
+        canModerate: Boolean,
+        editThemeOptions: Boolean = false
+    ) {
+        val caps = mock<UserCapabilitiesMap> {
+            on { hasCap(UserCapability.ModerateComments) } doReturn canModerate
+            on { hasCap(UserCapability.EditThemeOptions) } doReturn editThemeOptions
+        }
+        val user = mock<UserWithEditContext> { on { capabilities } doReturn caps }
+        val response = mock<UsersRequestRetrieveMeWithEditContextResponse> { on { data } doReturn user }
+        val client = mock<WpApiClient>()
+        whenever(client.request<Any>(any()))
+            .thenReturn(WpRequestResult.Success(response) as WpRequestResult<Any>)
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenReturn(client)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
@@ -5,9 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -15,13 +12,14 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.utils.AppLogWrapper
-import rs.wordpress.api.kotlin.WpApiClient
-import rs.wordpress.api.kotlin.WpRequestResult
-import uniffi.wp_api.UserCapabilitiesMap
-import uniffi.wp_api.UserCapability
-import uniffi.wp_api.UserWithEditContext
-import uniffi.wp_api.UsersRequestRetrieveMeWithEditContextResponse
 
+/**
+ * Note: the success path isn't unit-tested here. Exercising it would require a real
+ * [uniffi.wp_api.UserCapabilitiesMap] (its `hasCap` calls into native code, unavailable in JVM
+ * tests) or mocking the wordpress-rs data classes (forbidden by the DoNotMockDataClass lint rule).
+ * The capability-gating behavior that depends on the result is covered by the ViewModel tests,
+ * which stub [SiteCapabilityChecker.canModerateComments] directly.
+ */
 @ExperimentalCoroutinesApi
 class SiteCapabilityCheckerTest : BaseUnitTest() {
     @Mock
@@ -43,35 +41,17 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `canModerateComments returns true when the user has the capability`() = test {
-        stubSuccess(site, canModerate = true)
-
-        assertThat(checker.canModerateComments(site)).isTrue
-    }
-
-    @Test
-    fun `canModerateComments returns false when the user lacks the capability`() = test {
-        stubSuccess(site, canModerate = false)
-
-        assertThat(checker.canModerateComments(site)).isFalse
-    }
-
-    @Test
-    fun `both capabilities come from a single fetch that is cached across calls`() = test {
-        stubSuccess(site, canModerate = true, editThemeOptions = true)
-
-        assertThat(checker.canModerateComments(site)).isTrue
-        assertThat(checker.canModerateComments(site)).isTrue
-        assertThat(checker.hasEditThemeOptionsCapability(site)).isTrue
-
-        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
-    }
-
-    @Test
     fun `canModerateComments fails closed when the capability cannot be fetched`() = test {
         whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
 
         assertThat(checker.canModerateComments(site)).isFalse
+    }
+
+    @Test
+    fun `hasEditThemeOptionsCapability fails closed when the capability cannot be fetched`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        assertThat(checker.hasEditThemeOptionsCapability(site)).isFalse
     }
 
     @Test
@@ -83,54 +63,5 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
 
         // A transient failure must not lock in a fail-closed result for the whole session.
         verify(wpApiClientProvider, times(2)).getWpApiClient(site)
-    }
-
-    @Test
-    fun `clearing the cache forces a refetch`() = test {
-        stubSuccess(site, canModerate = true)
-
-        checker.canModerateComments(site)
-        checker.clearCacheForSite(site)
-        checker.canModerateComments(site)
-
-        verify(wpApiClientProvider, times(2)).getWpApiClient(site)
-    }
-
-    @Test
-    fun `capabilities are cached per local site id, not the WP-com blog id`() = test {
-        // Two distinct self-hosted sites both report siteId 0; keying by the local id keeps their
-        // capabilities from colliding.
-        val otherSite = SiteModel().apply {
-            id = 2
-            siteId = 0L
-        }
-        stubSuccess(site, canModerate = true)
-        stubSuccess(otherSite, canModerate = false)
-
-        assertThat(checker.canModerateComments(site)).isTrue
-        assertThat(checker.canModerateComments(otherSite)).isFalse
-        // A repeat call for the first site reads its own cached value, not the other site's.
-        assertThat(checker.canModerateComments(site)).isTrue
-
-        verify(wpApiClientProvider, times(1)).getWpApiClient(site)
-        verify(wpApiClientProvider, times(1)).getWpApiClient(otherSite)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private suspend fun stubSuccess(
-        site: SiteModel,
-        canModerate: Boolean,
-        editThemeOptions: Boolean = false
-    ) {
-        val caps = mock<UserCapabilitiesMap> {
-            on { hasCap(UserCapability.ModerateComments) } doReturn canModerate
-            on { hasCap(UserCapability.EditThemeOptions) } doReturn editThemeOptions
-        }
-        val user = mock<UserWithEditContext> { on { capabilities } doReturn caps }
-        val response = mock<UsersRequestRetrieveMeWithEditContextResponse> { on { data } doReturn user }
-        val client = mock<WpApiClient>()
-        whenever(client.request<Any>(any()))
-            .thenReturn(WpRequestResult.Success(response) as WpRequestResult<Any>)
-        whenever(wpApiClientProvider.getWpApiClient(site)).thenReturn(client)
     }
 }


### PR DESCRIPTION
## Description

In the new RS comments screens, moderation controls (approve/unapprove, spam, trash, delete, edit) were shown to every user unconditionally. A non-admin — an Author, Contributor, or any app-password user whose role lacks `moderate_comments` — could tap them, only for the request to fail server-side with a 403. This PR resolves this by disabling moderation features for non-moderators.

## Testing

1. Enable **Me → Experimental Features → RS Unified Comments**.
2. With a self-hosted (app-password) site signed in as an **Author/Contributor**: open Comments → the detail Moderate/Spam/overflow-moderation items are greyed and non-tappable; Like/Copy/Share/**Reply** still work. In the list, long-press to select → batch actions are greyed.
3. Sign in as an **Administrator/Editor** on the same site → all moderation controls are active and work.