### PR TITLE
CMM-1095: Fix stats off-by-an-hour by reading the site's named timezone

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1087,8 +1087,11 @@ class SiteRestClient @Inject constructor(
             site.hasWooCommerce = from.options.woocommerce_is_active
             site.adminUrl = from.options.admin_url
             site.loginUrl = from.options.login_url
-            site.timezone = if (!from.options.timezone_string.isNullOrEmpty()) {
-                from.options.timezone_string
+            // Prefer the named Olson timezone (e.g. "Europe/Madrid") over the numeric gmt_offset so
+            // DST is handled correctly. The numeric offset reflects only the offset at fetch time and
+            // goes stale across DST transitions, which shifts the stats "day" boundary by an hour.
+            site.timezone = if (!from.options.timezone.isNullOrEmpty()) {
+                from.options.timezone
             } else {
                 from.options.gmt_offset
             }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -23,7 +23,9 @@ public class SiteWPComRestResponse implements Response {
         public String admin_url;
         public String login_url;
         public String gmt_offset;
-        public String timezone_string;
+        // The site info endpoints (/me/sites, /sites/$id) expose the Olson timezone under "timezone"
+        // (e.g. "Europe/Madrid"). Note the site *settings* endpoint uses "timezone_string" instead.
+        public String timezone;
         public String frame_nonce;
         public String unmapped_url;
         public String max_upload_size;

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -99,6 +99,38 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `maps named Olson timezone from options timezone field`() = test {
+        val response = SiteWPComRestResponse()
+        response.ID = siteId
+        response.URL = "site.com"
+        response.options = SiteWPComRestResponse.Options().apply {
+            timezone = "Europe/Madrid"
+            gmt_offset = "1"
+        }
+
+        initSiteResponse(response)
+
+        val responseModel = restClient.fetchSite(site)
+        assertThat(responseModel.timezone).isEqualTo("Europe/Madrid")
+    }
+
+    @Test
+    fun `falls back to gmt_offset when options timezone is empty`() = test {
+        val response = SiteWPComRestResponse()
+        response.ID = siteId
+        response.URL = "site.com"
+        response.options = SiteWPComRestResponse.Options().apply {
+            timezone = ""
+            gmt_offset = "-5"
+        }
+
+        initSiteResponse(response)
+
+        val responseModel = restClient.fetchSite(site)
+        assertThat(responseModel.timezone).isEqualTo("-5")
+    }
+
+    @Test
     fun `fetchSite returns error when API call fails`() = test {
         val errorMessage = "message"
         initSiteResponse(


### PR DESCRIPTION
## Description

Daily stats reset to zero an hour early (e.g. at 23:00 instead of 00:00) for
users whose site uses a DST timezone, such as `Europe/Madrid`.

The previous fix (#22480) intended to make the stats "day" boundary DST-safe by
storing the site's **named** (Olson) timezone in `SiteModel.timezone` and letting
`SiteUtils.getNormalizedTimezone` resolve DST from it. However, it read the wrong
JSON field: the WP.com API exposes the named timezone under different keys
depending on the endpoint:

- Site **info** (`/me/sites`, `/sites/$id`) → `options.timezone` (e.g. `"Europe/Madrid"`)
- Site **settings** (`/sites/$id/settings`) → `settings.timezone_string`

Because the site-info response never contains `timezone_string`, the condition was
always false and `SiteModel.timezone` fell back to the numeric `gmt_offset`. A
numeric offset carries no DST rules and goes stale across DST transitions, so
"today" could be computed an hour ahead — at 23:00 Madrid (22:00 UTC → 00:00 in a
stale GMT+2) the app requested *tomorrow's* date and the server returned zeros.

This PR reads the correct `options.timezone` field. The DST-safe normalization
added in #22480 is unchanged and now actually receives a named zone.

Note: this affects the legacy stats screen (`ui/stats/refresh/…`), which derives
the request date from `SiteModel.timezone`. The newer `ui/newstats/…` screen uses
the device timezone and is out of scope here.

## Testing instructions

> [!NOTE]
> This fix only affects the **old** stats screen. To see the old stats screen you
> must log in with a **non-admin** user (admins are routed to the new stats screen).

1. Log in with a non-admin user on a WordPress.com/Jetpack site.
2. Open **Stats** and confirm the old stats screen is shown.
- [ ] Verify the stats (Traffic / Days, Today) load and show the correct data for
  the current day, matching the web Jetpack stats.