### PR TITLE
Anchor new stats date ranges to the site timezone, not the device

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -33,13 +33,16 @@ import org.wordpress.android.ui.newstats.datasource.StatsEmailsSummaryDataResult
 import org.wordpress.android.ui.newstats.datasource.UtmDataResult
 import org.wordpress.android.ui.newstats.mostviewed.MostViewedDataSource
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.newstats.StatsPeriod
 import androidx.annotation.StringRes
 import org.wordpress.android.ui.newstats.datasource.StatsErrorType
 import org.wordpress.android.util.AppLog
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
@@ -110,6 +113,7 @@ private const val REFERRERS_DETAIL_MAX = 0
 @Suppress("LargeClass")
 class StatsRepository @Inject constructor(
     private val statsDataSource: StatsDataSource,
+    private val siteStore: SiteStore,
     private val appLogWrapper: AppLogWrapper,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
 ) {
@@ -119,13 +123,26 @@ class StatsRepository @Inject constructor(
     }
 
     /**
+     * The site's timezone as a [ZoneId]. Stats are bucketed by the *site's* timezone, not the
+     * device's, so every "today"/range calculation below is anchored here (mirroring the legacy stats
+     * path, which converts via [SiteUtils.getNormalizedTimezone]). Resolves the site from its .COM
+     * [siteId]; falls back to GMT when the site or its timezone is unknown, exactly as the legacy
+     * normalization does.
+     */
+    private fun siteZoneId(siteId: Long): ZoneId =
+        SiteUtils.getNormalizedTimezone(siteStore.getSiteBySiteId(siteId)?.timezone).toZoneId()
+
+    /** The current calendar day in the site's timezone (see [siteZoneId]). */
+    private fun siteToday(siteId: Long): LocalDate = LocalDate.now(siteZoneId(siteId))
+
+    /**
      * Fetches today's aggregated stats (views, visitors, likes, comments).
      *
      * @param siteId The WordPress.com site ID
      * @return Today's aggregated stats or error
      */
     suspend fun fetchTodayAggregates(siteId: Long): TodayAggregatesResult = withContext(ioDispatcher) {
-        val dateString = LocalDate.now().format(dateFormatter)
+        val dateString = siteToday(siteId).format(dateFormatter)
 
         val result = statsDataSource.fetchStatsVisits(
             siteId = siteId,
@@ -177,7 +194,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         offsetDays: Int = 0
     ): HourlyViewsResult = withContext(ioDispatcher) {
-        val day = LocalDate.now().minusDays(offsetDays.toLong())
+        val day = siteToday(siteId).minusDays(offsetDays.toLong())
 
         val result = statsDataSource.fetchStatsVisits(
             siteId = siteId,
@@ -213,7 +230,7 @@ class StatsRepository @Inject constructor(
      */
     suspend fun fetchWeeklyStats(siteId: Long, weeksAgo: Int = 0): WeeklyStatsResult =
         withContext(ioDispatcher) {
-            val (startDate, endDate) = calculateWeekDateRange(weeksAgo)
+            val (startDate, endDate) = calculateWeekDateRange(siteToday(siteId), weeksAgo)
             val endDateString = endDate.format(dateFormatter)
 
             val result = statsDataSource.fetchStatsVisits(
@@ -265,7 +282,7 @@ class StatsRepository @Inject constructor(
      */
     suspend fun fetchDailyViewsForWeek(siteId: Long, weeksAgo: Int = 0): DailyViewsResult =
         withContext(ioDispatcher) {
-            val (_, endDate) = calculateWeekDateRange(weeksAgo)
+            val (_, endDate) = calculateWeekDateRange(siteToday(siteId), weeksAgo)
             val endDateString = endDate.format(dateFormatter)
 
             val result = statsDataSource.fetchStatsVisits(
@@ -305,7 +322,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         weeksAgo: Int = 0
     ): WeeklyStatsWithDailyDataResult = withContext(ioDispatcher) {
-        val (startDate, endDate) = calculateWeekDateRange(weeksAgo)
+        val (startDate, endDate) = calculateWeekDateRange(siteToday(siteId), weeksAgo)
         val endDateString = endDate.format(dateFormatter)
 
         val result = statsDataSource.fetchStatsVisits(
@@ -371,7 +388,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): PeriodStatsResult = withContext(ioDispatcher) {
-        val periodRange = calculatePeriodDates(period)
+        val periodRange = calculatePeriodDates(siteToday(siteId), period)
 
         val currentEndString = formatApiEndDate(periodRange.currentEnd, periodRange.unit)
         val previousEndString = formatApiEndDate(periodRange.previousEnd, periodRange.unit)
@@ -462,7 +479,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): BottomStatsResult = withContext(ioDispatcher) {
-        val bottomRange = calculateBottomStatsRange(period)
+        val bottomRange = calculateBottomStatsRange(siteToday(siteId), period)
 
         val (currentResult, previousResult) = coroutineScope {
             val currentDeferred = async {
@@ -661,8 +678,8 @@ class StatsRepository @Inject constructor(
      * span-based rule is kept so a caller that does need a standalone total for a longer window gets a
      * correct one rather than a silently wrong bucket.
      */
-    private fun calculateBottomStatsRange(period: StatsPeriod): PeriodDateRange {
-        val (currentStart, currentEnd) = currentPeriodWindow(period)
+    private fun calculateBottomStatsRange(today: LocalDate, period: StatsPeriod): PeriodDateRange {
+        val (currentStart, currentEnd) = currentPeriodWindow(today, period)
         val (unit, currentQuantity) = unitAndQuantityFor(currentStart, currentEnd)
         val (previousStart, previousEnd) = previousWindowMirror(currentStart, currentEnd)
         val (_, previousQuantity) = unitAndQuantityFor(previousStart, previousEnd)
@@ -739,12 +756,12 @@ class StatsRepository @Inject constructor(
     }
 
     @Suppress("ReturnCount")
-    private fun calculatePeriodDates(period: StatsPeriod): PeriodDateRange {
-        if (period is StatsPeriod.Today) return calculateTodayPeriodDates()
+    private fun calculatePeriodDates(today: LocalDate, period: StatsPeriod): PeriodDateRange {
+        if (period is StatsPeriod.Today) return calculateTodayPeriodDates(today)
         if (period is StatsPeriod.Custom) return calculateCustomPeriodDates(period.startDate, period.endDate)
 
         val config = getPeriodConfig(period)
-        val (currentStart, currentEnd) = currentPeriodWindow(period)
+        val (currentStart, currentEnd) = currentPeriodWindow(today, period)
         val (previousStart, previousEnd) = previousWindowForConfig(currentStart, config)
 
         // [previousWindowForConfig] spans exactly config.quantity units back, so both windows request
@@ -767,9 +784,10 @@ class StatsRepository @Inject constructor(
      *
      * Note: [calculatePeriodDates] handles the hourly cases (Today and single-day Custom) separately
      * before reaching here, so those build their own window ending at "<day> 23:00:00".
+     *
+     * @param today The current calendar day in the site's timezone (see [siteToday]).
      */
-    private fun currentPeriodWindow(period: StatsPeriod): Pair<LocalDate, LocalDate> {
-        val today = LocalDate.now()
+    private fun currentPeriodWindow(today: LocalDate, period: StatsPeriod): Pair<LocalDate, LocalDate> {
         return when (period) {
             is StatsPeriod.Today -> today to today
             is StatsPeriod.Last7Days -> today.minusDays((DAYS_IN_7_DAYS - 1).toLong()) to today
@@ -799,9 +817,10 @@ class StatsRepository @Inject constructor(
      * Calculates period dates for TODAY (hourly data). The hourly window ends at the day itself
      * ([formatApiEndDate] appends "23:00:00"), so the 24 buckets cover today's 00:00–23:00 and the
      * previous window covers yesterday's — matching the day-level totals shown in the bottom row.
+     *
+     * @param today The current calendar day in the site's timezone (see [siteToday]).
      */
-    private fun calculateTodayPeriodDates(): PeriodDateRange {
-        val today = LocalDate.now()
+    private fun calculateTodayPeriodDates(today: LocalDate): PeriodDateRange {
         val yesterday = today.minusDays(1)
         return PeriodDateRange(
             currentStart = today,
@@ -859,11 +878,12 @@ class StatsRepository @Inject constructor(
     /**
      * Calculates the start and end dates for a given week.
      *
+     * @param today The current calendar day in the site's timezone (see [siteToday]).
      * @param weeksAgo Number of weeks to go back (0 = current week, 1 = previous week)
      * @return Pair of (startDate, endDate) LocalDates representing the 7-day period
      */
-    private fun calculateWeekDateRange(weeksAgo: Int): Pair<LocalDate, LocalDate> {
-        val endDate = LocalDate.now().minusWeeks(weeksAgo.toLong())
+    private fun calculateWeekDateRange(today: LocalDate, weeksAgo: Int): Pair<LocalDate, LocalDate> {
+        val endDate = today.minusWeeks(weeksAgo.toLong())
         val startDate = endDate.plusDays(DAYS_BEFORE_END_DATE.toLong())
         return startDate to endDate
     }
@@ -883,7 +903,7 @@ class StatsRepository @Inject constructor(
         period: StatsPeriod,
         dataSource: MostViewedDataSource
     ): MostViewedResult = withContext(ioDispatcher) {
-        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(period)
+        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(siteToday(siteId), period)
 
         when (dataSource) {
             MostViewedDataSource.POSTS_AND_PAGES -> {
@@ -904,7 +924,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): MostViewedResult = withContext(ioDispatcher) {
-        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(period)
+        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(siteToday(siteId), period)
         fetchReferrersWithComparison(siteId, currentDateRange, previousDateRange, REFERRERS_DETAIL_MAX)
     }
 
@@ -1036,8 +1056,7 @@ class StatsRepository @Inject constructor(
      * Calculates current and previous date ranges for comparison stats.
      * Used by multiple stats types (MostViewed, Countries, etc.)
      */
-    private fun calculateCurrentDateRange(period: StatsPeriod): StatsDateRange {
-        val today = LocalDate.now()
+    private fun calculateCurrentDateRange(today: LocalDate, period: StatsPeriod): StatsDateRange {
         val todayString = today.format(dateFormatter)
         return when (period) {
             is StatsPeriod.Today ->
@@ -1058,8 +1077,10 @@ class StatsRepository @Inject constructor(
         }
     }
 
-    private fun calculateComparisonDateRanges(period: StatsPeriod): Pair<StatsDateRange, StatsDateRange> {
-        val today = LocalDate.now()
+    private fun calculateComparisonDateRanges(
+        today: LocalDate,
+        period: StatsPeriod
+    ): Pair<StatsDateRange, StatsDateRange> {
         val todayString = today.format(dateFormatter)
 
         return when (period) {
@@ -1112,7 +1133,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): CountryViewsResult = withContext(ioDispatcher) {
-        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(period)
+        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(siteToday(siteId), period)
 
         // Fetch both periods in parallel
         val (currentResult, previousResult) = coroutineScope {
@@ -1184,7 +1205,7 @@ class StatsRepository @Inject constructor(
         period: StatsPeriod
     ): RegionViewsResult = withContext(ioDispatcher) {
         val (currentDateRange, previousDateRange) =
-            calculateComparisonDateRanges(period)
+            calculateComparisonDateRanges(siteToday(siteId), period)
 
         val (currentResult, previousResult) = coroutineScope {
             val currentDeferred = async {
@@ -1267,7 +1288,7 @@ class StatsRepository @Inject constructor(
         period: StatsPeriod
     ): CityViewsResult = withContext(ioDispatcher) {
         val (currentDateRange, previousDateRange) =
-            calculateComparisonDateRanges(period)
+            calculateComparisonDateRanges(siteToday(siteId), period)
 
         val (currentResult, previousResult) = coroutineScope {
             val currentDeferred = async {
@@ -1351,7 +1372,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): TopAuthorsResult = withContext(ioDispatcher) {
-        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(period)
+        val (currentDateRange, previousDateRange) = calculateComparisonDateRanges(siteToday(siteId), period)
 
         // Fetch both periods in parallel
         val (currentResult, previousResult) = coroutineScope {
@@ -1412,6 +1433,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): ClicksResult = fetchWithComparison(
+        siteId = siteId,
         period = period,
         fetch = { dateRange ->
             when (val r = statsDataSource.fetchClicks(
@@ -1443,6 +1465,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): SearchTermsResult = fetchWithComparison(
+        siteId = siteId,
         period = period,
         fetch = { dateRange ->
             when (val r = statsDataSource.fetchSearchTerms(
@@ -1474,6 +1497,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): VideoPlaysResult = fetchWithComparison(
+        siteId = siteId,
         period = period,
         fetch = { dateRange ->
             when (val r = statsDataSource.fetchVideoPlays(
@@ -1505,6 +1529,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): FileDownloadsResult = fetchWithComparison(
+        siteId = siteId,
         period = period,
         fetch = { dateRange ->
             when (val r = statsDataSource.fetchFileDownloads(
@@ -1541,7 +1566,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): DevicesResult = withContext(ioDispatcher) {
-        val dateRange = calculateCurrentDateRange(period)
+        val dateRange = calculateCurrentDateRange(siteToday(siteId), period)
         fetchDevicesData { statsDataSource.fetchDevicesScreensize(siteId, dateRange) }
     }
 
@@ -1552,7 +1577,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): DevicesResult = withContext(ioDispatcher) {
-        val dateRange = calculateCurrentDateRange(period)
+        val dateRange = calculateCurrentDateRange(siteToday(siteId), period)
         fetchDevicesData { statsDataSource.fetchDevicesBrowser(siteId, dateRange) }
     }
 
@@ -1563,7 +1588,7 @@ class StatsRepository @Inject constructor(
         siteId: Long,
         period: StatsPeriod
     ): DevicesResult = withContext(ioDispatcher) {
-        val dateRange = calculateCurrentDateRange(period)
+        val dateRange = calculateCurrentDateRange(siteToday(siteId), period)
         fetchDevicesData { statsDataSource.fetchDevicesPlatform(siteId, dateRange) }
     }
 
@@ -1605,7 +1630,7 @@ class StatsRepository @Inject constructor(
         period: StatsPeriod
     ): UtmResult = withContext(ioDispatcher) {
         val curRange =
-            calculateCurrentDateRange(period)
+            calculateCurrentDateRange(siteToday(siteId), period)
         val curResult = statsDataSource.fetchUtm(
             siteId, keys,
             curRange.dateString(),
@@ -1698,6 +1723,7 @@ class StatsRepository @Inject constructor(
      */
     @Suppress("LongParameterList")
     private suspend fun <Raw, Output, R> fetchWithComparison(
+        siteId: Long,
         period: StatsPeriod,
         fetch: suspend (StatsDateRange) -> DataSourceResult<Raw>,
         keyOf: (Raw) -> String,
@@ -1708,7 +1734,7 @@ class StatsRepository @Inject constructor(
         logLabel: String
     ): R = withContext(ioDispatcher) {
         val (curRange, prevRange) =
-            calculateComparisonDateRanges(period)
+            calculateComparisonDateRanges(siteToday(siteId), period)
 
         val (curResult, prevResult) = coroutineScope {
             val c = async { fetch(curRange) }
@@ -1869,7 +1895,7 @@ class StatsRepository @Inject constructor(
     private suspend fun fetchAllTimeResults(
         siteId: Long
     ): List<StatsSubscribersDataResult> {
-        val today = java.time.LocalDate.now()
+        val today = LocalDate.now(siteZoneId(siteId))
         val dateFormat =
             java.time.format.DateTimeFormatter
                 .ISO_LOCAL_DATE

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.newstats.repository.HourlyViewsDataPoint
 import org.wordpress.android.ui.newstats.repository.HourlyViewsResult
@@ -172,7 +173,7 @@ class TodaysStatsViewModel @Inject constructor(
         return when (result) {
             is HourlyViewsResult.Success -> {
                 val dataPoints = if (offsetDays == 0) {
-                    trimFutureHours(result.dataPoints)
+                    trimFutureHours(result.dataPoints, site)
                 } else {
                     result.dataPoints
                 }
@@ -190,12 +191,18 @@ class TodaysStatsViewModel @Inject constructor(
     /**
      * Filters out data points for hours after the current hour
      * to avoid showing a misleading drop to zero in the sparkline.
+     *
+     * "Current hour" is resolved in the *site's* timezone, not the device's: the hourly buckets are
+     * the site's calendar hours, so trimming against the device clock would cut the wrong hours
+     * whenever the two timezones differ.
      */
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun trimFutureHours(
-        dataPoints: List<HourlyViewsDataPoint>
+        dataPoints: List<HourlyViewsDataPoint>,
+        site: SiteModel
     ): List<HourlyViewsDataPoint> {
-        val currentHour = LocalDateTime.now(clock).hour
+        val siteZone = SiteUtils.getNormalizedTimezone(site.timezone).toZoneId()
+        val currentHour = LocalDateTime.now(clock.withZone(siteZone)).hour
         return dataPoints.filter { dataPoint ->
             try {
                 val dateTime = LocalDateTime.parse(

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryAuthorsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryAuthorsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
@@ -26,6 +27,9 @@ class StatsRepositoryAuthorsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -34,6 +38,7 @@ class StatsRepositoryAuthorsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryClicksTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryClicksTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.ClickDataItem
@@ -25,6 +26,9 @@ class StatsRepositoryClicksTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -33,6 +37,7 @@ class StatsRepositoryClicksTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryCountryViewsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryCountryViewsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.CountryViewItem
@@ -26,6 +27,9 @@ class StatsRepositoryCountryViewsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -34,6 +38,7 @@ class StatsRepositoryCountryViewsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryDevicesTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryDevicesTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.DevicesData
@@ -22,6 +23,9 @@ class StatsRepositoryDevicesTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -30,6 +34,7 @@ class StatsRepositoryDevicesTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryFileDownloadsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryFileDownloadsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.FileDownloadDataItem
@@ -25,6 +26,9 @@ class StatsRepositoryFileDownloadsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -33,6 +37,7 @@ class StatsRepositoryFileDownloadsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryInsightsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryInsightsTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
 import org.wordpress.android.ui.newstats.datasource.StatsErrorType
@@ -22,6 +23,9 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -30,6 +34,7 @@ class StatsRepositoryInsightsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryReferrersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryReferrersTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.ReferrerChildDataItem
@@ -26,6 +27,9 @@ class StatsRepositoryReferrersTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -34,6 +38,7 @@ class StatsRepositoryReferrersTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositorySearchTermsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositorySearchTermsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.SearchTermDataItem
@@ -25,6 +26,9 @@ class StatsRepositorySearchTermsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -33,6 +37,7 @@ class StatsRepositorySearchTermsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositorySubscribersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositorySubscribersTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.datasource.EmailSummaryItem
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
@@ -29,6 +30,9 @@ class StatsRepositorySubscribersTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -37,6 +41,7 @@ class StatsRepositorySubscribersTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTagsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTagsTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
 import org.wordpress.android.ui.newstats.datasource.StatsErrorType
@@ -24,6 +25,9 @@ class StatsRepositoryTagsTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -32,6 +36,7 @@ class StatsRepositoryTagsTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
@@ -31,14 +31,21 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @ExperimentalCoroutinesApi
 @Suppress("LargeClass")
 class StatsRepositoryTest : BaseUnitTest() {
     @Mock
     private lateinit var statsDataSource: StatsDataSource
+
+    @Mock
+    private lateinit var siteStore: SiteStore
 
     @Mock
     private lateinit var appLogWrapper: AppLogWrapper
@@ -49,9 +56,16 @@ class StatsRepositoryTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )
+    }
+
+    /** Makes the repository resolve [TEST_SITE_ID] to a site configured with [timezone]. */
+    private fun stubSiteTimezone(timezone: String) {
+        whenever(siteStore.getSiteBySiteId(TEST_SITE_ID))
+            .thenReturn(SiteModel().apply { setTimezone(timezone) })
     }
 
     // region init
@@ -122,6 +136,30 @@ class StatsRepositoryTest : BaseUnitTest() {
         assertThat(result).isInstanceOf(TodayAggregatesResult.Error::class.java)
         assertThat((result as TodayAggregatesResult.Error).message).isEqualTo(TEST_ERROR_TYPE.name)
     }
+
+    @Test
+    fun `given a site in another timezone, when fetchTodayAggregates, then endDate is the site-timezone day`() =
+        test {
+            // Stats are bucketed by the site's timezone, not the device's. A far-east offset (UTC+14)
+            // gives the site a calendar day that is reliably distinct from UTC, so the endDate the
+            // repository sends must be the site-timezone day, never LocalDate.now() on the device.
+            val siteZone = "Pacific/Kiritimati"
+            stubSiteTimezone(siteZone)
+            whenever(statsDataSource.fetchStatsVisits(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
+                .thenReturn(StatsVisitsDataResult.Success(createStatsVisitsData()))
+
+            repository.fetchTodayAggregates(TEST_SITE_ID)
+
+            val expected = LocalDate.now(ZoneId.of(siteZone)).format(DateTimeFormatter.ISO_LOCAL_DATE)
+            verify(statsDataSource).fetchStatsVisits(
+                siteId = eq(TEST_SITE_ID),
+                unit = eq(StatsUnit.DAY),
+                quantity = eq(1),
+                endDate = eq(expected),
+                startDate = anyOrNull(),
+                statFields = anyOrNull()
+            )
+        }
     // endregion
 
     // region fetchHourlyViews
@@ -189,6 +227,7 @@ class StatsRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given offsetDays, when fetchHourlyViews, then the window ends at 23-00-00 of that calendar day`() = test {
+        stubSiteTimezone(TEST_SITE_TIMEZONE)
         whenever(statsDataSource.fetchStatsVisits(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(StatsVisitsDataResult.Success(createHourlyStatsVisitsData()))
 
@@ -197,8 +236,8 @@ class StatsRepositoryTest : BaseUnitTest() {
 
         // The 24 hourly buckets must cover 00:00–23:00 of the requested day. Passing the *next* day's
         // date ended the window at 00:00, shifting it back an hour: the day's own 00:00 bucket was
-        // dropped in favour of the following day's.
-        val today = LocalDate.now()
+        // dropped in favour of the following day's. "Today" is the site-timezone day, not the device's.
+        val today = LocalDate.now(TEST_SITE_ZONE)
         verify(statsDataSource).fetchStatsVisits(
             siteId = eq(TEST_SITE_ID),
             unit = eq(StatsUnit.HOUR),
@@ -522,12 +561,14 @@ class StatsRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given Today, when fetchStatsForPeriod, then hourly window ends at 23-00-00 of the calendar day`() = test {
+        stubSiteTimezone(TEST_SITE_TIMEZONE)
         whenever(statsDataSource.fetchStatsVisits(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(StatsVisitsDataResult.Success(createHourlyStatsVisitsData()))
 
         repository.fetchStatsForPeriod(TEST_SITE_ID, StatsPeriod.Today)
 
-        val today = LocalDate.now()
+        // "Today"/"yesterday" are the site-timezone calendar days, not the device's.
+        val today = LocalDate.now(TEST_SITE_ZONE)
         val yesterday = today.minusDays(1)
         // The hourly window must end at "<day> 23:00:00" so its 24 buckets cover 00:00–23:00 of that
         // calendar day. Using the next day at 00:00 shifted the window an hour, dropping the day's
@@ -1189,6 +1230,10 @@ class StatsRepositoryTest : BaseUnitTest() {
     companion object {
         private const val TEST_SITE_ID = 123L
         private const val TEST_ACCESS_TOKEN = "test_access_token"
+        // A named site timezone that observes DST, distinct from the device's, so the tests exercise
+        // the site-timezone path deterministically rather than the device clock.
+        private const val TEST_SITE_TIMEZONE = "America/Los_Angeles"
+        private val TEST_SITE_ZONE: ZoneId = ZoneId.of(TEST_SITE_TIMEZONE)
         private val TEST_ERROR_TYPE = StatsErrorType.NETWORK_ERROR
         private val EXPECTED_CARD_STAT_FIELDS = listOf(
             StatsVisitField.VIEWS,

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryVideoPlaysTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryVideoPlaysTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.newstats.StatsPeriod
 import org.wordpress.android.ui.newstats.datasource.StatsDataSource
@@ -25,6 +26,9 @@ class StatsRepositoryVideoPlaysTest : BaseUnitTest() {
     private lateinit var statsDataSource: StatsDataSource
 
     @Mock
+    private lateinit var siteStore: SiteStore
+
+    @Mock
     private lateinit var appLogWrapper: AppLogWrapper
 
     private lateinit var repository: StatsRepository
@@ -33,6 +37,7 @@ class StatsRepositoryVideoPlaysTest : BaseUnitTest() {
     fun setUp() {
         repository = StatsRepository(
             statsDataSource = statsDataSource,
+            siteStore = siteStore,
             appLogWrapper = appLogWrapper,
             ioDispatcher = testDispatcher()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/todaysstats/TodaysStatsViewModelTest.kt
@@ -567,6 +567,33 @@ class TodaysStatsViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `when site timezone is behind the device, then trimming uses the site's current hour`() =
+        test {
+            // The site is America/New_York (UTC-5 in January). The clock reads 14:30 UTC, so the
+            // site's local hour is 9 — every bucket (12–16) lies in the site's future and must be
+            // trimmed. Trimming against the device's 14:00 hour instead would wrongly keep three.
+            testSite.setTimezone("America/New_York")
+            val aggregates = createTodayAggregates()
+            val hourlyData = createHourlyViewsResultWithHours()
+
+            whenever(statsRepository.fetchTodayAggregates(any()))
+                .thenReturn(TodayAggregatesResult.Success(aggregates))
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(0))
+            ).thenReturn(hourlyData)
+            whenever(
+                statsRepository.fetchHourlyViews(eq(TEST_SITE_ID), eq(1))
+            ).thenReturn(hourlyData)
+
+            initViewModelWithClock(CLOCK_HOUR)
+            advanceUntilIdle()
+
+            val state =
+                viewModel.uiState.value as TodaysStatsCardUiState.Loaded
+            assertThat(state.chartData.currentPeriod).isEmpty()
+        }
+
+    @Test
     fun `when previous period, then future hours are not filtered`() =
         test {
             val aggregates = createTodayAggregates()


### PR DESCRIPTION
## Description

The new stats stack (`ui/newstats/…`) computed "today" and every date range from the
**device** clock (`LocalDate.now()` / `Clock.systemDefaultZone()`) and sent those dates to
the stats API without converting to the **site's** timezone. Because WordPress stats are
bucketed by the site's timezone, whenever the device timezone differs from the site's, the
whole day window is shifted and stats can appear wrong / reset early or late (off by the tz
delta, up to a full day near midnight).

This is the same class of bug as CMM-1095, but a separate code path. The CMM-1095 fix only
corrected the legacy stats screen (which converts via `SiteUtils.getNormalizedTimezone`);
the new screen had no equivalent conversion. It bites any user whose device tz ≠ site tz
(travelling, or a site deliberately set to a different city than the phone).

### Fix

`StatsRepository` now injects `SiteStore` and resolves the site's `ZoneId` from its
`siteId` via `SiteUtils.getNormalizedTimezone(...).toZoneId()` — the same normalization the
legacy path uses (falling back to GMT when the site/timezone is unknown). A site-local
`today` is threaded into every date-window calculation, so all stats requests use the
site-local calendar day. This centralizes the fix without touching any of the ~26 callers.

- **`StatsRepository.kt`**: added `siteZoneId`/`siteToday` helpers; threaded `today` through
  `fetchTodayAggregates`, `fetchHourlyViews`, the weekly fetches, `fetchStatsForPeriod`,
  `fetchBottomStats`, most-viewed / referrers / locations / authors, the
  `fetchWithComparison` family (clicks / search terms / video plays / file downloads),
  devices, UTM, and `fetchSubscribersAllTime`. No bare `LocalDate.now()` remains.
- **`TodaysStatsViewModel.kt`**: `trimFutureHours` now derives the current hour in the
  site's zone (`clock.withZone(siteZone)`) instead of the device clock, so the sparkline
  trims the correct hours. The existing `"23:00:00"` hourly-window scheme is preserved,
  anchored on the site-local day.

## Testing instructions

Timezone shift (chart & Today card):

1. Set the **device** timezone several hours from the **site's** (e.g. device
   `America/Los_Angeles`, site `Europe/Madrid`), ideally near local midnight.
2. Open the new Stats screen and view the Today and Views cards.
- [ ] Verify the Today/Views cards show the same day and totals as the legacy Stats screen
      and the web Jetpack stats (previously they were off by the timezone delta).
- [ ] Verify the Today sparkline trims at the site's current hour, not the device's.
3. Set device and site to the **same** timezone.
- [ ] Verify stats are unchanged (no regression for the common case).

Automated:

1. Run `./gradlew :WordPress:testJetpackDebugUnitTest --tests "org.wordpress.android.ui.newstats.repository.*" --tests "org.wordpress.android.ui.newstats.todaysstats.*"`
- [ ] Verify all tests pass, including the new site-timezone assertions in
      `StatsRepositoryTest` and `TodaysStatsViewModelTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)