### PR TITLE
CMM-952: Fix invisible back arrow on white images in Reader photo viewer

### DIFF
--- a/WordPress/src/main/res/drawable/reader_photo_viewer_toolbar_scrim.xml
+++ b/WordPress/src/main/res/drawable/reader_photo_viewer_toolbar_scrim.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:startColor="@android:color/transparent"
+        android:endColor="@color/black_translucent_50"
+        android:type="linear" />
+</shape>

--- a/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
+++ b/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
@@ -32,6 +32,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
+        android:background="@drawable/reader_photo_viewer_toolbar_scrim"
         android:elevation="@dimen/appbar_elevation"
         app:contentInsetEnd="@dimen/toolbar_content_offset_end"
         app:contentInsetLeft="@dimen/toolbar_content_offset"


### PR DESCRIPTION
## Description

In the Reader's full-screen photo viewer, the toolbar's back arrow is always rendered white (via `ThemeOverlay.AppCompat.Dark.ActionBar`) on a fully transparent toolbar. When the viewed image is white or very light, the arrow blends into it and becomes invisible.

This adds a dark gradient scrim behind the toolbar (`reader_photo_viewer_toolbar_scrim.xml`, set as the toolbar's background) so the white arrow always has contrast, regardless of image color.

## Testing instructions

Reader photo viewer contrast:

1. Open a Reader post that contains a white or very light image (one is attached below).
2. Tap the image to open the full-screen photo viewer.
- [x] Verify the back arrow is clearly visible against the light image.
3. Tap the screen to toggle the toolbar.
- [x] Verify the scrim fades in/out together with the arrow, with no leftover dark band when the toolbar auto-hides.
4. Repeat over a dark image and in dark mode.
- [x] Verify the arrow remains visible and the scrim is not distracting.
5. In a post with multiple images, swipe between pages.
- [x] Verify the scrim behaves consistently on every image.

<img width="1000" height="1000" alt="white-bordered" src="https://github.com/user-attachments/assets/fbb5efb9-78f5-4545-9718-4e1052824fcd" />
