### PR TITLE
Remove RS Pages experimental toggle; auto-enable for eligible sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -687,7 +687,7 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentBlogPages(@NonNull Context context, @NonNull SiteModel site) {
-        if (shouldUseNewPagesList(context, site)) {
+        if (shouldUseNewPagesList(site)) {
             context.startActivity(PagesRsListActivity.Companion.createIntent(context));
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);
             return;
@@ -698,15 +698,8 @@ public class ActivityLauncher {
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);
     }
 
-    private static boolean shouldUseNewPagesList(@NonNull Context context, @NonNull SiteModel site) {
-        if (!site.hasApplicationPassword()) {
-            return false;
-        }
-        ActivityLauncherEntryPoint entryPoint = EntryPointAccessors.fromApplication(
-                context.getApplicationContext(),
-                ActivityLauncherEntryPoint.class
-        );
-        return entryPoint.experimentalFeatures().isEnabled(Feature.RS_PAGES_LIST);
+    private static boolean shouldUseNewPagesList(@Nullable SiteModel site) {
+        return site != null && site.hasApplicationPassword();
     }
 
     public static void viewPostTypes(@NonNull Context context, @NonNull SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -40,11 +40,6 @@ class ExperimentalFeatures @Inject constructor(
             R.string.experimental_post_types,
             R.string.experimental_post_types_description
         ),
-        RS_PAGES_LIST(
-            "rs_pages_list",
-            R.string.experimental_rs_pages_list,
-            R.string.experimental_rs_pages_list_description
-        ),
         RS_UNIFIED_COMMENTS(
             "rs_unified_comments",
             R.string.experimental_rs_comments,

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -254,8 +254,6 @@ Language: ar
     <string name="scan_start_request_failed_subtitle">تعذر على Jetpack Scan إكمال فحص موقعك. يرجى التحقق لمعرفة ما إذا كان موقعك معطلاً أم لا.</string>
     <string name="stats_timeframe_hours">ساعات</string>
     <string name="post_rs_failed_to_load">فشل تحميل التدوينة</string>
-    <string name="experimental_rs_pages_list">قائمة الصفحات الجديدة</string>
-    <string name="experimental_rs_pages_list_description">إظهار قائمة الصفحات في واجهة مستخدم أكثر حداثة لموقع WordPress.com والمواقع المستضافة ذاتيًا باستخدام كلمات مرور التطبيقات</string>
     <string name="stats_error_no_site">لم يتم تحديد أي موقع</string>
     <string name="stats_error_api">فشل تحميل الإحصاءات</string>
     <string name="stats_error_unknown">حدث خطأ غير متوقع</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -256,8 +256,6 @@ Language: cs_CZ
     <string name="post_rs_confirm_delete_message">Tím trvale smažete tento příspěvek. Tuto akci nelze vrátit zpět.</string>
     <string name="post_rs_confirm_trash_message">Opravdu chcete přesunout tento příspěvek do koše?</string>
     <string name="post_rs_failed_to_load">Načtení příspěvku se nezdařilo</string>
-    <string name="experimental_rs_pages_list_description">Zobrazit seznam stránek v modernějším uživatelském rozhraní pro WordPress.com a weby s vlastním hostováním pomocí aplikačních hesel</string>
-    <string name="experimental_rs_pages_list">Seznam nových stránek</string>
     <string name="stats_error_admin_url_unavailable">Nelze otevřít WP Admin pro tento web</string>
     <string name="stats_error_parsing">Při načítání dat došlo k chybě. Zkuste to prosím znovu</string>
     <string name="stats_error_network">Chyba sítě. Zkontrolujte připojení a zkuste to znovu</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -256,8 +256,6 @@ Language: de
     <string name="post_rs_confirm_delete_message">Dadurch wird dieser Beitrag endgültig gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="post_rs_confirm_trash_message">Möchtest du diesen Beitrag wirklich in den Papierkorb verschieben?</string>
     <string name="post_rs_failed_to_load">Beitrag konnte nicht geladen werden</string>
-    <string name="experimental_rs_pages_list_description">Seitenliste in einer moderneren Benutzeroberfläche für WordPress.com und selbst gehostete Websites mit Anwendungspasswörtern anzeigen</string>
-    <string name="experimental_rs_pages_list">Neue Seitenliste</string>
     <string name="stats_error_admin_url_unavailable">WP Admin kann für diese Website nicht geöffnet werden</string>
     <string name="stats_error_parsing">Beim Laden der Daten ist ein Problem aufgetreten. Bitte erneut versuchen</string>
     <string name="stats_error_network">Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -256,8 +256,6 @@ Language: en_GB
     <string name="post_rs_confirm_delete_message">This will permanently delete this post. This action cannot be undone.</string>
     <string name="post_rs_confirm_trash_message">Are you sure you want to bin this post?</string>
     <string name="post_rs_failed_to_load">Failed to load post</string>
-    <string name="experimental_rs_pages_list_description">Show pages list in a more modern UI for WordPress.com and self-hosted sites with application passwords</string>
-    <string name="experimental_rs_pages_list">New Pages List</string>
     <string name="stats_error_admin_url_unavailable">Unable to open WP Admin for this site</string>
     <string name="stats_error_parsing">There was a problem loading the data. Please try again</string>
     <string name="stats_error_network">Network error. Please check your connection and try again</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -256,8 +256,6 @@ Language: es_CO
     <string name="post_rs_confirm_delete_message">Esto eliminará permanentemente esta entrada. Esta acción no se puede deshacer.</string>
     <string name="post_rs_confirm_trash_message">¿Seguro que quieres enviar a la papelera esta entrada?</string>
     <string name="post_rs_failed_to_load">No se ha podido cargar la entrada</string>
-    <string name="experimental_rs_pages_list_description">Mostrar la lista de páginas con una interfaz de usuario más moderna para WordPress.com y sitios autoalojados con contraseñas de aplicación</string>
-    <string name="experimental_rs_pages_list">Lista de páginas nuevas</string>
     <string name="stats_error_admin_url_unavailable">No se puede abrir WP Admin para este sitio</string>
     <string name="stats_error_parsing">Se ha producido un problema al cargar los datos. Inténtalo de nuevo.</string>
     <string name="stats_error_network">Error de red. Comprueba la conexión e inténtalo de nuevo</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -256,8 +256,6 @@ Language: es
     <string name="post_rs_confirm_delete_message">Esto eliminará permanentemente esta entrada. Esta acción no se puede deshacer.</string>
     <string name="post_rs_confirm_trash_message">¿Seguro que quieres enviar a la papelera esta entrada?</string>
     <string name="post_rs_failed_to_load">No se ha podido cargar la entrada</string>
-    <string name="experimental_rs_pages_list_description">Mostrar la lista de páginas con una interfaz de usuario más moderna para WordPress.com y sitios autoalojados con contraseñas de aplicación</string>
-    <string name="experimental_rs_pages_list">Lista de páginas nuevas</string>
     <string name="stats_error_admin_url_unavailable">No se puede abrir WP Admin para este sitio</string>
     <string name="stats_error_parsing">Se ha producido un problema al cargar los datos. Inténtalo de nuevo.</string>
     <string name="stats_error_network">Error de red. Comprueba la conexión e inténtalo de nuevo</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -244,8 +244,6 @@ Language: fr
     <string name="post_rs_confirm_delete_message">Cet article sera définitivement supprimé. Cette action est irréversible.</string>
     <string name="post_rs_confirm_trash_message">Voulez-vous vraiment déplacer cet article vers la corbeille ?</string>
     <string name="post_rs_failed_to_load">Échec du chargement de l’article</string>
-    <string name="experimental_rs_pages_list_description">Affiche la liste des pages dans une interface utilisateur plus moderne pour WordPress.com et les sites auto-hébergés avec des mots de passe d’application</string>
-    <string name="experimental_rs_pages_list">Nouvelle liste de pages</string>
     <string name="stats_error_admin_url_unavailable">Impossible d’ouvrir WP Admin pour ce site</string>
     <string name="stats_error_parsing">Un problème est survenu lors du chargement des données. Veuillez réessayer.</string>
     <string name="stats_error_network">Erreur réseau. Veuillez vérifier votre connexion et réessayer.</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -244,8 +244,6 @@ Language: fr
     <string name="post_rs_confirm_delete_message">Cet article sera définitivement supprimé. Cette action est irréversible.</string>
     <string name="post_rs_confirm_trash_message">Voulez-vous vraiment déplacer cet article vers la corbeille ?</string>
     <string name="post_rs_failed_to_load">Échec du chargement de l’article</string>
-    <string name="experimental_rs_pages_list_description">Affiche la liste des pages dans une interface utilisateur plus moderne pour WordPress.com et les sites auto-hébergés avec des mots de passe d’application</string>
-    <string name="experimental_rs_pages_list">Nouvelle liste de pages</string>
     <string name="stats_error_admin_url_unavailable">Impossible d’ouvrir WP Admin pour ce site</string>
     <string name="stats_error_parsing">Un problème est survenu lors du chargement des données. Veuillez réessayer.</string>
     <string name="stats_error_network">Erreur réseau. Veuillez vérifier votre connexion et réessayer.</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -253,8 +253,6 @@ Language: he_IL
     <string name="post_rs_confirm_delete_message">הפעולה הזאת תמחק את הפוסט לצמיתות. לא ניתן לבטל פעולה זו.</string>
     <string name="post_rs_confirm_trash_message">בחרת לשלוח פוסט זה לפח - האם ההחלטה סופית?</string>
     <string name="post_rs_failed_to_load">טעינת הפוסט נכשלה</string>
-    <string name="experimental_rs_pages_list_description">הצגת רשימת העמודים בממשק משתמש מודרני יותר עבור WordPress.com ואתרים באחסון עצמי עם סיסמאות אפליקציה</string>
-    <string name="experimental_rs_pages_list">רשימת עמודים חדשה</string>
     <string name="stats_error_admin_url_unavailable">לא ניתן לפתוח את WP Admin לאתר זה</string>
     <string name="stats_error_parsing">הייתה בעיה בטעינת הנתונים. יש לנסות שוב</string>
     <string name="stats_error_network">שגיאת רשת. יש לבדוק את החיבור ולנסות שוב</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -249,8 +249,6 @@ Language: id
     <string name="post_rs_confirm_delete_message">Tindakan ini akan menghapus pos secara permanen. Tindakan ini tidak dapat dibatalkan.</string>
     <string name="post_rs_confirm_trash_message">Anda yakin ingin membuang pos ini?</string>
     <string name="post_rs_failed_to_load">Gagal memuat pos</string>
-    <string name="experimental_rs_pages_list_description">Tampilkan daftar halaman di UI yang lebih modern untuk WordPress.com dan situs yang dihosting sendiri dengan kata sandi aplikasi</string>
-    <string name="experimental_rs_pages_list">Daftar Halaman Baru</string>
     <string name="stats_error_admin_url_unavailable">Tidak dapat membuka WP Admin untuk situs ini</string>
     <string name="stats_error_parsing">Terjadi masalah saat memuat data. Coba lagi</string>
     <string name="stats_error_network">Error jaringan. Periksa koneksi Anda dan coba lagi</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -256,8 +256,6 @@ Language: it
     <string name="post_rs_confirm_delete_message">Questo articolo verrà eliminato definitivamente. Questa azione non può essere annullata.</string>
     <string name="post_rs_confirm_trash_message">Sei sicuro di voler spostare questo articolo nel cestino?</string>
     <string name="post_rs_failed_to_load">Impossibile caricare l\'articolo</string>
-    <string name="experimental_rs_pages_list_description">Visualizza l\'elenco delle pagine in un\'interfaccia utente più moderna per WordPress.com e i siti ospitati personalmente con password delle applicazioni</string>
-    <string name="experimental_rs_pages_list">Nuovo elenco delle pagine</string>
     <string name="stats_error_admin_url_unavailable">Impossibile aprire WP Admin per questo sito</string>
     <string name="stats_error_parsing">Si è verificato un problema durante il caricamento dei dati. Riprova</string>
     <string name="stats_error_network">Errore di rete. Controlla la connessione e riprova</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -253,8 +253,6 @@ Language: ja_JP
     <string name="post_rs_confirm_delete_message">この投稿は完全に削除されます。 この操作を取り消すことはできません。</string>
     <string name="post_rs_confirm_trash_message">この投稿をゴミ箱へ移動してもよいですか ?</string>
     <string name="post_rs_failed_to_load">投稿の読み込みに失敗しました</string>
-    <string name="experimental_rs_pages_list_description">アプリケーションパスワードを使用して、WordPress.com やインストール型サイト用のより現代的な UI で固定ページリストを表示</string>
-    <string name="experimental_rs_pages_list">新しい固定ページリスト</string>
     <string name="stats_error_admin_url_unavailable">このサイトの WP 管理画面を開けません</string>
     <string name="stats_error_parsing">データの読み込み中に問題が発生しました もう一度お試しください</string>
     <string name="stats_error_network">ネットワークエラーです。 接続を確認して、もう一度お試しください</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -251,8 +251,6 @@ Language: ko_KR
     <string name="post_rs_confirm_delete_message">이 글은 영구적으로 삭제됩니다. 이 작업은 취소할 수 없습니다.</string>
     <string name="post_rs_confirm_trash_message">이 글을 휴지통으로 옮기시겠습니까?</string>
     <string name="post_rs_failed_to_load">글 로드 실패</string>
-    <string name="experimental_rs_pages_list_description">더 현대적인 UI로 페이지 목록을 표시하여 WordPress.com 및 애플리케이션 비밀번호가 있는 독립 호스트 사이트를 지원합니다</string>
-    <string name="experimental_rs_pages_list">새 페이지 목록</string>
     <string name="stats_error_admin_url_unavailable">이 사이트의 WP 관리자를 열 수 없습니다.</string>
     <string name="stats_error_parsing">데이터를 로드하는 데 문제가 발생했습니다. 다시 시도하세요.</string>
     <string name="stats_error_network">네트워크 오류가 발생했습니다. 연결을 확인하고 다시 시도하세요.</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -256,8 +256,6 @@ Language: nl
     <string name="post_rs_confirm_delete_message">Dit zal permanent dit bericht verwijderen. Deze actie kan niet ongedaan worden gemaakt.</string>
     <string name="post_rs_confirm_trash_message">Weet je zeker dat je dit bericht naar de prullenbak wil verplaatsen?</string>
     <string name="post_rs_failed_to_load">Bericht laden is mislukt</string>
-    <string name="experimental_rs_pages_list_description">Berichten weergeven in een modernere UI voor WordPress.com en zelf gehoste sites met applicatie wachtwoorden</string>
-    <string name="experimental_rs_pages_list">Lijst met nieuwe pagina\'s</string>
     <string name="stats_error_admin_url_unavailable">Kan WP Admin voor deze site niet openen</string>
     <string name="stats_error_parsing">Er is een probleem opgetreden bij het laden van de gegevens. Probeer het opnieuw</string>
     <string name="stats_error_network">Netwerkfout. Controleer je verbinding en probeer het nogmaals</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -256,8 +256,6 @@ Language: pl
     <string name="post_rs_confirm_delete_message">Spowoduje to trwałe usunięcie tego wpisu. Tej akcji nie można cofnąć.</string>
     <string name="post_rs_confirm_trash_message">Przenieść wpis do kosza?</string>
     <string name="post_rs_failed_to_load">Nie udało się wczytać wpisu</string>
-    <string name="experimental_rs_pages_list_description">Wyświetl listę stron w nowoczesnym interfejsie użytkownika dla WordPress.com i witryn z własnym hostingiem z hasłami aplikacji</string>
-    <string name="experimental_rs_pages_list">Lista nowych stron</string>
     <string name="stats_error_admin_url_unavailable">Nie można otworzyć WP Admin dla tej witryny</string>
     <string name="stats_error_parsing">Wystąpił problem z wczytywaniem danych. Spróbuj ponownie.</string>
     <string name="stats_error_network">Błąd sieci. Sprawdź połączenie i spróbuj ponownie</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -256,8 +256,6 @@ Language: ro
     <string name="post_rs_confirm_trash_message">Sigur vrei să arunci la gunoi acest articol?</string>
     <string name="scan_start_request_failed_subtitle">Scanare Jetpack nu a putut să finalizeze o scanare a site-ului tău. Verifică dacă site-ul tău este funcțional.</string>
     <string name="post_rs_failed_to_load">Încărcarea articolului a eșuat</string>
-    <string name="experimental_rs_pages_list">Listă cu pagini noi</string>
-    <string name="experimental_rs_pages_list_description">Afișezi lista cu pagini într-o interfață mai modernă pentru WordPress.com și site-urile auto-găzduite cu parole pentru aplicații</string>
     <string name="stats_error_admin_url_unavailable">Nu pot să deschid administrarea WP pentru acest site</string>
     <string name="stats_error_parsing">A fost o problemă la încărcarea datelor. Te rog să încerci din nou</string>
     <string name="stats_error_network">Eroare în rețea. Te rog să verifici conexiunea și să încerci din nou.</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -256,8 +256,6 @@ Language: ru
     <string name="post_rs_confirm_delete_message">Эта запись будет удалена навсегда. Это действие нельзя отменить.</string>
     <string name="post_rs_confirm_trash_message">Вы действительно хотите удалить эту запись?</string>
     <string name="post_rs_failed_to_load">Ошибка при загрузке записи</string>
-    <string name="experimental_rs_pages_list_description">Показывать список записей WordPress.com и на автономных сайтах с паролями приложений в более современном интерфейсе</string>
-    <string name="experimental_rs_pages_list">Список новых записей</string>
     <string name="stats_error_admin_url_unavailable">Не возможно открыть WP Admin на этом сайте</string>
     <string name="stats_error_parsing">При загрузке данных возникла ошибка. Повторите попытку</string>
     <string name="stats_error_network">Ошибка сети. Проверьте подключение и повторите попытку</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -252,8 +252,6 @@ Language: sv_SE
     <string name="post_rs_confirm_delete_message">Inlägget tas då bort permanent. Denna åtgärd kan inte ångras.</string>
     <string name="post_rs_confirm_trash_message">Är du säker på att du vill flytta det här inlägget till papperskorgen?</string>
     <string name="post_rs_failed_to_load">Det gick inte att hämta inlägg</string>
-    <string name="experimental_rs_pages_list_description">Visa sidlista i ett modernare gränssnitt för WordPress.com och webbplatser med applikationslösenord som drivs på egen server</string>
-    <string name="experimental_rs_pages_list">Ny sidlista</string>
     <string name="stats_error_admin_url_unavailable">Det gick inte att öppna WP Admin för den här webbplatsen</string>
     <string name="stats_error_parsing">Det uppstod ett problem när datan hämtades. Försök igen</string>
     <string name="stats_error_network">Nätverksfel. Kontrollera anslutningen och försök igen</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -256,8 +256,6 @@ Language: tr
     <string name="post_rs_confirm_delete_message">Bu işlem bu gönderiyi kalıcı olarak silecektir. Bu işlem geri alınamaz.</string>
     <string name="post_rs_confirm_trash_message">Bu gönderiyi çöpe atmak istediğinizden emin misiniz?</string>
     <string name="post_rs_failed_to_load">Gönderi yüklenemedi</string>
-    <string name="experimental_rs_pages_list_description">WordPress.com ve kullanıcı tarafından barındırılan siteler için uygulama şifreleri ile daha modern bir kullanıcı arayüzünde sayfa listesini gösterin</string>
-    <string name="experimental_rs_pages_list">Yeni Sayfa Listesi</string>
     <string name="stats_error_admin_url_unavailable">Bu site için WP Yöneticisi açılamıyor</string>
     <string name="stats_error_parsing">Veri yüklenirken bir sorun oluştu. Lütfen tekrar deneyin</string>
     <string name="stats_error_network">Ağ hatası. Lütfen bağlantınızı kontrol edip tekrar deneyin</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -254,8 +254,6 @@ Language: zh_CN
     <string name="post_rs_confirm_delete_message">这将永久删除此文章。 此操作无法撤销。</string>
     <string name="post_rs_confirm_trash_message">是否确定要将此文章移至回收站？</string>
     <string name="post_rs_failed_to_load">加载文章失败</string>
-    <string name="experimental_rs_pages_list_description">为 WordPress.com 和使用应用程序密码的自托管站点提供更现代化的 UI 来显示页面列表</string>
-    <string name="experimental_rs_pages_list">新页面列表</string>
     <string name="stats_error_admin_url_unavailable">无法为此站点打开 WP Admin</string>
     <string name="stats_error_parsing">加载数据时出现问题。 请重试</string>
     <string name="stats_error_network">网络错误。 请检查您的连接，然后重试</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -255,8 +255,6 @@ Language: zh_TW
     <string name="post_rs_confirm_delete_message">這將會永久刪除此文章。 此動作無法復原。</string>
     <string name="post_rs_confirm_trash_message">你確定要將這篇文章移至垃圾桶嗎？</string>
     <string name="post_rs_failed_to_load">無法載入文章</string>
-    <string name="experimental_rs_pages_list_description">以更現代的 UI 顯示頁面清單，適用於 WordPress.com 和使用應用程式密碼的自助託管網站</string>
-    <string name="experimental_rs_pages_list">全新頁面清單</string>
     <string name="stats_error_admin_url_unavailable">無法開啟此網站的 WP 管理員</string>
     <string name="stats_error_parsing">載入資料時發生問題。 請再試一次</string>
     <string name="stats_error_network">網路錯誤。 請檢查你的連線並再試一次</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -255,8 +255,6 @@ Language: zh_TW
     <string name="post_rs_confirm_delete_message">這將會永久刪除此文章。 此動作無法復原。</string>
     <string name="post_rs_confirm_trash_message">你確定要將這篇文章移至垃圾桶嗎？</string>
     <string name="post_rs_failed_to_load">無法載入文章</string>
-    <string name="experimental_rs_pages_list_description">以更現代的 UI 顯示頁面清單，適用於 WordPress.com 和使用應用程式密碼的自助託管網站</string>
-    <string name="experimental_rs_pages_list">全新頁面清單</string>
     <string name="stats_error_admin_url_unavailable">無法開啟此網站的 WP 管理員</string>
     <string name="stats_error_parsing">載入資料時發生問題。 請再試一次</string>
     <string name="stats_error_network">網路錯誤。 請檢查你的連線並再試一次</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1028,8 +1028,6 @@
     <string name="new_stats_intro_trends_title">Trends at a Glance</string>
     <string name="new_stats_intro_trends_desc">Every metric shows how it\'s trending compared to the previous period, so you always know if you\'re growing.</string>
     <string name="new_stats_intro_footer">You can turn off New Stats from the overflow menu in the Stats screen.</string>
-    <string name="experimental_rs_pages_list">New Pages List</string>
-    <string name="experimental_rs_pages_list_description">Show pages list in a more modern UI for WordPress.com and self-hosted sites with application passwords</string>
     <string name="experimental_rs_comments">RS Unified Comments</string>
     <string name="experimental_rs_comments_description">Show comments in a more modern UI for WordPress.com and self-hosted sites with application passwords</string>
     <string name="post_rs_failed_to_load">Failed to load post</string>


### PR DESCRIPTION
## Description

Removes the `RS_PAGES_LIST` experimental toggle and shows the RS Pages list automatically to eligible sites — those with an application password — mirroring how the RS Posts list already works.

## Testing

1. Me → Experimental Features — the "New Pages List" toggle is gone (RS Comments still present).
2. On a site **with** an application password, open Pages → the modern RS Pages list opens automatically, no toggle needed.
3. On a site **without** an application password, open Pages → the legacy Pages screen opens (unchanged fallback).
