### PR TITLE
Bump version name to 27.0

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=26.9
+versionName=27.0
 versionCode=1498


### PR DESCRIPTION
We'll be trying our new release from trunk flow for which the version name needs to be manually bumped for the first release.