### PR TITLE
Fix NPE in media picker when device media title is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -253,7 +253,7 @@ class MediaPickerViewModel @Inject constructor(
                     clickAction = clickAction
                 )
                 AUDIO, DOCUMENT -> MediaPickerUiItem.FileItem(
-                    fileName = it.name ?: "",
+                    fileName = it.name ?: resourceProvider.getString(R.string.unknown),
                     fileExtension = fileExtension,
                     identifier = it.identifier,
                     isSelected = isSelected,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceMediaLoader.kt
@@ -153,7 +153,7 @@ class DeviceMediaLoader
 
     data class DeviceMediaList(val items: List<DeviceMediaItem>, val next: Long? = null)
 
-    data class DeviceMediaItem(val uri: UriWrapper, val title: String, val dateModified: Long)
+    data class DeviceMediaItem(val uri: UriWrapper, val title: String?, val dateModified: Long)
 
     companion object {
         private const val ID_COL = Media._ID


### PR DESCRIPTION
## Description
Fixes a `NullPointerException` crash in the media picker.

`MediaColumns.TITLE` can be `null` for some device media entries. Because
`Cursor.getString()` returns a Kotlin platform type, the null value slipped
through until the non-null `DeviceMediaItem.title` constructor rejected it,
crashing the media loader coroutine:

```
java.lang.NullPointerException
    at ...DeviceMediaLoader.loadMedia(DeviceMediaLoader.kt:70)
```

Changes:
- Make `DeviceMediaItem.title` nullable (`String?`) so a null title flows
  through cleanly. Both downstream consumers already tolerate it
  (`MediaItem.name` is nullable; the documents path sources from non-null
  `file.name`).
- When representing an item whose name is null, show the localized "Unknown"
  string (`R.string.unknown`) instead of an empty file name.

## Testing instructions

Media picker happy path:

1. Open the media picker (e.g. from a post → add media → choose from device).
- [ ] Verify the picker loads the device's media and documents without crashing.
- [ ] Verify each item is displayed with its file name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)