### PR TITLE
Fix app-password login aborting when apiRootUrl was recovered

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -89,7 +89,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
             currentUrlLogin = urlLogin
             // Store credentials if the site already exists
-            when (storeCredentials(urlLogin)) {
+            when (val storeResult = storeCredentials(urlLogin)) {
                 is StoreCredentialsResult.Success -> {
                     _onFinishedEvent.emit(
                         NavigationActionData(
@@ -102,11 +102,14 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 }
                 is StoreCredentialsResult.SiteNotFound -> {
                     waitingForFetchedSite = true
+                    // Use the effective login returned by the helper: it carries any apiRootUrl
+                    // recovered via fallback discovery, which the original urlLogin may still lack.
+                    val effectiveLogin = storeResult.urlLogin
                     fetchSites(
-                        urlLogin.user.orEmpty(),
-                        urlLogin.password.orEmpty(),
-                        urlLogin.siteUrl.orEmpty(),
-                        urlLogin.apiRootUrl.orEmpty()
+                        effectiveLogin.user.orEmpty(),
+                        effectiveLogin.password.orEmpty(),
+                        effectiveLogin.siteUrl.orEmpty(),
+                        effectiveLogin.apiRootUrl.orEmpty()
                     )
                 }
                 is StoreCredentialsResult.BadData -> {
@@ -186,9 +189,12 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 applicationPasswordLoginHelper.trackStoringFailed(
                     siteUrl, "empty_fetch_params", creationSource
                 )
+                // User-recoverable data condition (missing callback params), not a bug — the
+                // reason is preserved in analytics + AppLog above, so don't report it to Sentry.
                 emitError(
                     siteUrl = siteUrl,
-                    errorMessage = "empty_fetch_params"
+                    errorMessage = "empty_fetch_params",
+                    reportToSentry = false,
                 )
             } else {
                 discoverAndDispatchFetchSite(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -102,7 +102,9 @@ class ApplicationPasswordLoginHelper @Inject constructor(
 
     sealed class StoreCredentialsResult {
         object Success : StoreCredentialsResult()
-        object SiteNotFound : StoreCredentialsResult()
+        // Carries the effective login (with any recovered apiRootUrl) so the caller can fetch
+        // the site with valid params instead of the original, possibly-incomplete, urlLogin.
+        data class SiteNotFound(val urlLogin: UriLogin) : StoreCredentialsResult()
         object BadData : StoreCredentialsResult()
     }
 
@@ -156,7 +158,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 StoreCredentialsResult.Success
             } else {
                 logSiteNotFound(effectiveUrlLogin.siteUrl, normalizedUrl, sites)
-                StoreCredentialsResult.SiteNotFound
+                StoreCredentialsResult.SiteNotFound(effectiveUrlLogin)
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -201,7 +201,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 errorMessage = null
             )
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin), any()))
-                .thenReturn(StoreCredentialsResult.SiteNotFound)
+                .thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any())).thenThrow(RuntimeException())
 
             // When
@@ -224,7 +224,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             whenever(
                 applicationPasswordLoginHelper
                     .storeApplicationPasswordCredentialsFrom(eq(urlLogin), any())
-            ).thenReturn(StoreCredentialsResult.SiteNotFound)
+            ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(
                 selfHostedEndpointFinder
                     .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
@@ -266,7 +266,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             whenever(siteStore.hasSite()).thenReturn(true)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin), any()))
-                .thenReturn(StoreCredentialsResult.SiteNotFound)
+                .thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -304,7 +304,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             whenever(siteStore.hasSite()).thenReturn(false)
             whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin), any()))
-                .thenReturn(StoreCredentialsResult.SiteNotFound)
+                .thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -344,7 +344,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             whenever(
                 applicationPasswordLoginHelper
                     .storeApplicationPasswordCredentialsFrom(eq(urlLogin), any())
-            ).thenReturn(StoreCredentialsResult.SiteNotFound)
+            ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(
                 selfHostedEndpointFinder
                     .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)
@@ -594,7 +594,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
         whenever(
             applicationPasswordLoginHelper
                 .storeApplicationPasswordCredentialsFrom(eq(urlLogin), any())
-        ).thenReturn(StoreCredentialsResult.SiteNotFound)
+        ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
         whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any()))
             .thenThrow(RuntimeException("wrapped", IOException("offline")))
 
@@ -626,7 +626,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
         whenever(
             applicationPasswordLoginHelper
                 .storeApplicationPasswordCredentialsFrom(eq(urlLogin), any())
-        ).thenReturn(StoreCredentialsResult.SiteNotFound)
+        ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
         whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any()))
             .thenReturn("https://example.com/xmlrpc.php")
 
@@ -656,7 +656,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                     .storeApplicationPasswordCredentialsFrom(
                         eq(urlLogin), any()
                     )
-            ).thenReturn(StoreCredentialsResult.SiteNotFound)
+            ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
             whenever(
                 selfHostedEndpointFinder
                     .verifyOrDiscoverXMLRPCEndpoint(any())
@@ -679,12 +679,71 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             }
         }
 
+    @Test
+    fun `given SiteNotFound with recovered apiRootUrl, then fetchSites uses recovered login and dispatches`() =
+        runTest {
+            // Given — the parsed login is missing apiRootUrl (cache miss), but the helper
+            // recovers it and returns it via SiteNotFound. The ViewModel must fetch with the
+            // recovered login, not the original empty one, otherwise it aborts with empty_fetch_params.
+            val parsedLogin = urlLogin.copy(apiRootUrl = "")
+            val recoveredLogin = urlLogin.copy(apiRootUrl = "https://example.com/json")
+            whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData))
+                .thenReturn(parsedLogin)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(parsedLogin), any())
+            ).thenReturn(StoreCredentialsResult.SiteNotFound(recoveredLogin))
+            whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any()))
+                .thenReturn("https://example.com/xmlrpc.php")
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+
+                // Then — no error emitted, fetch is dispatched with the recovered params
+                expectNoEvents()
+                verify(dispatcher, times(1)).dispatch(
+                    argThat {
+                        type == SiteAction.FETCH_SITES_XML_RPC_FROM_APPLICATION_PASSWORD
+                    }
+                )
+                verify(crashLogging, never()).sendReport(any(), any(), any())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given SiteNotFound with empty fetch params, then emit error without Sentry report`() =
+        runTest {
+            // Given — helper returns a login still missing apiRootUrl, so fetchSites can't proceed.
+            val incompleteLogin = urlLogin.copy(apiRootUrl = "")
+            whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData))
+                .thenReturn(incompleteLogin)
+            whenever(
+                applicationPasswordLoginHelper
+                    .storeApplicationPasswordCredentialsFrom(eq(incompleteLogin), any())
+            ).thenReturn(StoreCredentialsResult.SiteNotFound(incompleteLogin))
+
+            // When
+            viewModel.onFinishedEvent.test {
+                viewModel.setupSite(rawData)
+
+                // Then — user-recoverable data condition surfaces in UI but is not noised into Sentry
+                val result = awaitItem()
+                assertTrue(result.isError)
+                assertEquals("empty_fetch_params", result.errorMessage)
+                verify(crashLogging, never()).sendReport(any(), any(), any())
+                verify(selfHostedEndpointFinder, never()).verifyOrDiscoverXMLRPCEndpoint(any())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private suspend fun setupFetchSitesFlow() {
         val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
         whenever(
             applicationPasswordLoginHelper
                 .storeApplicationPasswordCredentialsFrom(eq(urlLogin), any())
-        ).thenReturn(StoreCredentialsResult.SiteNotFound)
+        ).thenReturn(StoreCredentialsResult.SiteNotFound(urlLogin))
         whenever(
             selfHostedEndpointFinder
                 .verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!)

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -715,8 +715,10 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     @Test
     fun `given SiteNotFound with empty fetch params, then emit error without Sentry report`() =
         runTest {
-            // Given — helper returns a login still missing apiRootUrl, so fetchSites can't proceed.
-            val incompleteLogin = urlLogin.copy(apiRootUrl = "")
+            // Given — helper returns a login with an empty siteUrl, so fetchSites can't proceed.
+            // (An empty apiRootUrl would be rejected as BadData before ever reaching SiteNotFound;
+            // siteUrl is only guarded against null in the helper, so an empty string slips through.)
+            val incompleteLogin = urlLogin.copy(siteUrl = "")
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData))
                 .thenReturn(incompleteLogin)
             whenever(

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -185,6 +185,25 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     }
 
     @Test
+    fun `storeApplicationPasswordCredentialsFrom returns SiteNotFound carrying the recovered apiRootUrl`() = runTest {
+        // Given — apiRootUrl is missing and recovered via discovery, but the site is not found
+        // locally. The recovered value must be carried on SiteNotFound so the caller can fetch.
+        val autoDiscoveryAttemptSuccess = AutoDiscoveryAttemptSuccess(
+            mock(), mock(), mock(), DiscoveredAuthenticationMechanism.ApplicationPasswords(mock())
+        )
+        val apiDiscoveryResult = ApiDiscoveryResult.Success(autoDiscoveryAttemptSuccess)
+        whenever(wpLoginClient.apiDiscovery(any())).thenReturn(apiDiscoveryResult)
+        whenever(discoverSuccessWrapper.getApiRootUrl(eq(apiDiscoveryResult))).thenReturn(TEST_API_ROOT_URL)
+        whenever(siteStore.sites).thenReturn(listOf())
+
+        val loginWithoutApiRoot = UriLogin(TEST_URL, TEST_USER, TEST_PASSWORD, null)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(loginWithoutApiRoot)
+
+        assertIs<StoreCredentialsResult.SiteNotFound>(result)
+        assertEquals(TEST_API_ROOT_URL, result.urlLogin.apiRootUrl)
+    }
+
+    @Test
     fun `storeApplicationPasswordCredentialsFrom does not run discovery when apiRootUrl is present`() = runTest {
         val siteModel = SiteModel().apply { url = TEST_URL }
         whenever(siteStore.sites).thenReturn(listOf(siteModel))


### PR DESCRIPTION
## Description

Fixes application-password logins that were silently aborting with `empty_fetch_params`,
which was also being reported to Sentry as if it were a crash.

**Root cause (functional bug):** `fetchSites` is only reached from the `SiteNotFound`
branch, which means the credentials already passed the non-empty validation inside
`storeApplicationPasswordCredentialsFrom`. The empty param was the `apiRootUrl`: when it
was missing from the callback (cache miss — e.g. the process was killed between discovery
and the auth callback), the helper *recovered* it via fallback discovery into a local
`effectiveUrlLogin`. But `StoreCredentialsResult.SiteNotFound` carried no data, so the
ViewModel fell back to the original `urlLogin` whose `apiRootUrl` was still empty →
`fetchSites` saw an empty param and aborted an otherwise-valid login.

**Sentry noise:** the `empty_fetch_params` failure built a synthetic
`Exception("Application password login failed: empty_fetch_params")` purely to file a
Sentry report. It's a user-recoverable data condition (still logged + tracked via
analytics), not a bug — consistent with how `site_store_error` and the validation cases
are already handled in this file.

### Changes
- `ApplicationPasswordLoginHelper`: `SiteNotFound` is now
  `data class SiteNotFound(val urlLogin: UriLogin)` and returns the effective login with
  the recovered `apiRootUrl`.
- `ApplicationPasswordLoginViewModel`: the `SiteNotFound` branch fetches with the
  recovered login; the `empty_fetch_params` error now passes `reportToSentry = false`.
- Tests: updated existing `SiteNotFound` stubs and added regression coverage for the
  recovered-`apiRootUrl` propagation (helper + ViewModel) and for `empty_fetch_params`
  not hitting Sentry.

## Testing instructions


1. On a fresh install (no prior discovery cache), log into a self-hosted site using
   application-password authentication that requires REST API discovery.
2. Complete the authorization on the WordPress consent page.
- [ ] Verify the site is added successfully and no `empty_fetch_params` error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)