### PR TITLE
Add Unreplied tab to the RS comments list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentsRsDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentsRsDataSource.kt
@@ -51,6 +51,11 @@ class CommentsRsDataSource @Inject constructor(
     /** A comment mapped from [CommentWithViewContext], shared by the detail and list screens. */
     data class RsComment(
         val remoteCommentId: Long,
+        // The commenter's WP user id (0 when anonymous), and the parent comment id (0 when
+        // top-level). Both feed the Unreplied tab's client-side threading — the view context has
+        // no author email, so "is this reply mine?" is a user-id comparison.
+        val authorId: Long = 0,
+        val parentId: Long = 0,
         val authorName: String,
         val authorAvatarUrl: String,
         val dateGmt: Date,
@@ -320,6 +325,8 @@ class CommentsRsDataSource @Inject constructor(
 
 internal fun CommentWithViewContext.toRsComment() = CommentsRsDataSource.RsComment(
     remoteCommentId = id,
+    authorId = author,
+    parentId = parent,
     authorName = authorName,
     authorAvatarUrl = pickAvatarUrl(),
     // dateGmt is a UTC java.util.Date (an absolute instant), so relative-time formatting is

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListTab.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListTab.kt
@@ -5,15 +5,17 @@ import org.wordpress.android.R
 import uniffi.wp_api.CommentStatus as RsCommentStatus
 
 /**
- * Filter tabs for the rs comments list, matching the legacy unified list minus Unreplied
- * (deferred; it needs client-side threading of ~100 comments).
+ * Filter tabs for the rs comments list, matching the legacy unified list.
  *
- * [queryStatus] is the `status` query param for `/wp/v2/comments`. Two tabs use
+ * [queryStatus] is the `status` query param for `/wp/v2/comments`. Three tabs use
  * [RsCommentStatus.Custom] because `WP_Comment_Query` only recognises the literal values
  * `approve` and `all` — wordpress-rs serialises [RsCommentStatus.Approved] as `approved`,
  * which WordPress core treats as an unknown status and returns nothing for (wordpress-rs
  * `comments.rs` serialisation test asserts `status=approved`). `all` means approved+hold,
  * matching the legacy ALL filter (APPROVED+UNAPPROVED).
+ *
+ * [UNREPLIED] has no server status: it queries `all` (like [ALL]) and is threaded client-side by
+ * [filterUnreplied] to keep only top-level comments the user hasn't replied to, mirroring legacy.
  */
 enum class CommentsRsListTab(
     @StringRes val labelResId: Int,
@@ -33,6 +35,12 @@ enum class CommentsRsListTab(
         R.string.comments_empty_list_filtered_pending,
         R.string.comment_tracker_label_pending,
         RsCommentStatus.Hold
+    ),
+    UNREPLIED(
+        R.string.comment_status_unreplied,
+        R.string.comments_empty_list_filtered_unreplied,
+        R.string.comment_tracker_label_unreplied,
+        RsCommentStatus.Custom("all")
     ),
     APPROVED(
         R.string.comment_status_approved,

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListUiState.kt
@@ -109,6 +109,13 @@ internal fun CommentsRsListTab.batchActions(): List<CommentsRsBatchAction> = whe
         CommentsRsBatchAction.SPAM,
         CommentsRsBatchAction.TRASH
     )
+    // Unreplied rows are approved or pending comments, so offer the same actions as ALL.
+    CommentsRsListTab.UNREPLIED -> listOf(
+        CommentsRsBatchAction.APPROVE,
+        CommentsRsBatchAction.UNAPPROVE,
+        CommentsRsBatchAction.SPAM,
+        CommentsRsBatchAction.TRASH
+    )
     CommentsRsListTab.APPROVED -> listOf(
         CommentsRsBatchAction.UNAPPROVE,
         CommentsRsBatchAction.SPAM,

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -508,14 +508,13 @@ class CommentsRsListViewModel @Inject constructor(
     private fun fetchFirstPage(tab: CommentsRsListTab, showErrorSnackbar: Boolean = true) {
         // Callers (initTab, refreshTab) guard against a null site, so the site getter below is safe.
         firstPageJobs[tab] = viewModelScope.launch {
-            val params = commentsRsDataSource.firstPageParams(
+            val base = commentsRsDataSource.firstPageParams(
                 status = tab.queryStatus,
                 search = _searchQuery.value.trim().ifBlank { null }
-            ).let {
-                // Unreplied over-fetches (like the legacy list) since client-side threading discards
-                // most of each page, so a single page still yields visible rows.
-                if (tab == CommentsRsListTab.UNREPLIED) it.copy(perPage = UNREPLIED_PAGE_SIZE) else it
-            }
+            )
+            // Unreplied over-fetches (like the legacy list) since client-side threading discards
+            // most of each page, so a single page still yields visible rows.
+            val params = if (tab == CommentsRsListTab.UNREPLIED) base.copy(perPage = UNREPLIED_PAGE_SIZE) else base
             val result = withContext(bgDispatcher) { commentsRsDataSource.fetchCommentsPage(site, params) }
             when (result) {
                 is RsCommentsPageResult.Success -> applyPage(tab, result, append = false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -103,6 +103,16 @@ class CommentsRsListViewModel @Inject constructor(
     private val _canModerate = MutableStateFlow(false)
     val canModerate: StateFlow<Boolean> = _canModerate.asStateFlow()
 
+    // The current user's WP user id, resolved once on init (from the same "me" fetch as
+    // canModerate); null until then, or if it couldn't be fetched. Used only to tell the user's
+    // own replies apart when threading the Unreplied tab. Read and written only on the main thread.
+    private var currentUserId: Long? = null
+
+    // Raw comments fetched per tab, accumulated across pages. The Unreplied tab derives its
+    // displayed rows from this via client-side threading, so a reply and the parent it answers can
+    // arrive on different pages and still be matched.
+    private val rawComments = mutableMapOf<CommentsRsListTab, List<RsComment>>()
+
     // Pagination cursors: the next-page params returned with each fetched page, per tab.
     private val nextPageParams = mutableMapOf<CommentsRsListTab, CommentListParams?>()
 
@@ -142,7 +152,12 @@ class CommentsRsListViewModel @Inject constructor(
             _events.trySend(CommentsRsListEvent.Finish)
         } else {
             viewModelScope.launch {
+                // Both values come from the same cached "me" fetch inside SiteCapabilityChecker.
                 _canModerate.value = withContext(bgDispatcher) { siteCapabilityChecker.canModerateComments(site) }
+                currentUserId = withContext(bgDispatcher) { siteCapabilityChecker.currentUserId(site) }
+                // If the Unreplied tab loaded before the id resolved, re-thread it now that the
+                // user's own replies can be identified.
+                rethreadUnreplied()
             }
             @OptIn(FlowPreview::class)
             viewModelScope.launch {
@@ -220,6 +235,7 @@ class CommentsRsListViewModel @Inject constructor(
         loadMoreJobs.clear()
         resolveTitleJobs.values.forEach { it.cancel() }
         resolveTitleJobs.clear()
+        rawComments.clear()
         nextPageParams.clear()
         pageGenerations.clear()
         _tabStates.value = emptyMap()
@@ -495,7 +511,11 @@ class CommentsRsListViewModel @Inject constructor(
             val params = commentsRsDataSource.firstPageParams(
                 status = tab.queryStatus,
                 search = _searchQuery.value.trim().ifBlank { null }
-            )
+            ).let {
+                // Unreplied over-fetches (like the legacy list) since client-side threading discards
+                // most of each page, so a single page still yields visible rows.
+                if (tab == CommentsRsListTab.UNREPLIED) it.copy(perPage = UNREPLIED_PAGE_SIZE) else it
+            }
             val result = withContext(bgDispatcher) { commentsRsDataSource.fetchCommentsPage(site, params) }
             when (result) {
                 is RsCommentsPageResult.Success -> applyPage(tab, result, append = false)
@@ -512,12 +532,18 @@ class CommentsRsListViewModel @Inject constructor(
     private fun applyPage(tab: CommentsRsListTab, result: RsCommentsPageResult.Success, append: Boolean) {
         if (!append) pageGenerations[tab] = (pageGenerations[tab] ?: 0) + 1
         nextPageParams[tab] = result.nextPageParams
-        val newRows = result.comments.map { it.toUiModel() }
+        // A comment can shift pages if the list changed server-side between requests, so dedupe
+        // the accumulated raw set on append. Displayed rows are always derived from this raw set,
+        // which lets Unreplied thread a reply against a parent fetched on an earlier page.
+        val raw = if (append) {
+            (rawComments[tab].orEmpty() + result.comments).distinctBy { it.remoteCommentId }
+        } else {
+            result.comments
+        }
+        rawComments[tab] = raw
         updateTabUiState(tab) {
             copy(
-                // A comment can shift pages if the list changed server-side between requests,
-                // so dedupe on append.
-                comments = if (append) (comments + newRows).distinctBy { it.remoteCommentId } else newRows,
+                comments = displayRows(tab, raw),
                 isLoading = false,
                 isRefreshing = false,
                 // A replacing page must clear isLoadingMore too: a load-more in flight when the
@@ -529,6 +555,23 @@ class CommentsRsListViewModel @Inject constructor(
             )
         }
         resolvePostTitles(tab)
+    }
+
+    /**
+     * Maps a tab's accumulated raw comments to displayed rows. The Unreplied tab is threaded
+     * client-side to only the comments the user hasn't replied to; every other tab shows its
+     * comments as-is.
+     */
+    private fun displayRows(tab: CommentsRsListTab, raw: List<RsComment>): List<CommentRsUiModel> {
+        val visible = if (tab == CommentsRsListTab.UNREPLIED) filterUnreplied(raw, currentUserId) else raw
+        return visible.map { it.toUiModel() }
+    }
+
+    /** Re-derives the Unreplied tab's rows from its raw comments (e.g. once [currentUserId] resolves). */
+    private fun rethreadUnreplied() {
+        val tab = CommentsRsListTab.UNREPLIED
+        val raw = rawComments[tab] ?: return
+        updateTabUiState(tab) { copy(comments = displayRows(tab, raw)) }
     }
 
     /**
@@ -610,5 +653,9 @@ class CommentsRsListViewModel @Inject constructor(
 
         private const val SEARCH_DEBOUNCE_MS = 250L
         private const val MIN_SEARCH_QUERY_LENGTH = 3
+
+        // Larger page for the Unreplied tab (matching the legacy list) to offset the rows that
+        // client-side threading filters out.
+        private const val UNREPLIED_PAGE_SIZE = 100u
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -329,12 +329,14 @@ class CommentsRsListViewModel @Inject constructor(
                 is RsCommentsPageResult.Success -> {
                     val sizeBefore = getTabUiState(tab).comments.size
                     applyPage(tab, result, append = true)
-                    // When a page adds no rows (it deduped away after a server-side shift, or
-                    // came back empty mid-shrink), the scroll position hasn't changed so the
-                    // load-more trigger won't re-fire; advance to the next page directly. The
-                    // depth cap keeps a pathological cursor chain (e.g. a proxy ignoring the
+                    // When a page doesn't grow the visible list, the scroll position hasn't moved
+                    // so the load-more trigger won't re-fire; advance to the next page directly.
+                    // `<=` (not `==`) also covers the shrink-to-empty case: an Unreplied page can
+                    // carry the user's reply to the last visible comment, dropping the visible
+                    // count to zero — with no rows there's no scroll trigger left to resume paging.
+                    // The depth cap keeps a pathological cursor chain (e.g. a proxy ignoring the
                     // page param) from firing unbounded unattended requests.
-                    if (getTabUiState(tab).comments.size == sizeBefore &&
+                    if (getTabUiState(tab).comments.size <= sizeBefore &&
                         nextPageParams[tab] != null &&
                         autoAdvanceDepth < CommentBrowsingSession.MAX_AUTO_ADVANCE_PAGES
                     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -365,7 +365,11 @@ class CommentsRsListViewModel @Inject constructor(
             // it can swipe between them and keep loading more (the cursor can't cross an Intent).
             val tab = currentTab ?: CommentsRsListTab.ALL
             val ids = _tabStates.value[tab]?.comments?.map { it.remoteCommentId } ?: listOf(remoteCommentId)
-            commentBrowsingSession.start(site, ids, nextPageParams[tab])
+            // Unreplied's rows are a client-side-threaded subset of the raw stream; the session
+            // pages the raw stream, so handing it the cursor would let the pager swipe into the
+            // replied-to and own comments the tab hides. Seed only the visible ids, no cursor.
+            val cursor = if (tab == CommentsRsListTab.UNREPLIED) null else nextPageParams[tab]
+            commentBrowsingSession.start(site, ids, cursor)
             _events.trySend(CommentsRsListEvent.OpenCommentDetail(site, remoteCommentId))
         }
     }
@@ -517,7 +521,10 @@ class CommentsRsListViewModel @Inject constructor(
             val params = if (tab == CommentsRsListTab.UNREPLIED) base.copy(perPage = UNREPLIED_PAGE_SIZE) else base
             val result = withContext(bgDispatcher) { commentsRsDataSource.fetchCommentsPage(site, params) }
             when (result) {
-                is RsCommentsPageResult.Success -> applyPage(tab, result, append = false)
+                is RsCommentsPageResult.Success -> {
+                    applyPage(tab, result, append = false)
+                    advanceIfFilteredEmpty(tab)
+                }
                 is RsCommentsPageResult.Error -> onFirstPageError(tab, result.message, showErrorSnackbar)
             }
         }
@@ -562,15 +569,42 @@ class CommentsRsListViewModel @Inject constructor(
      * comments as-is.
      */
     private fun displayRows(tab: CommentsRsListTab, raw: List<RsComment>): List<CommentRsUiModel> {
+        // Rows are rebuilt from title-less RsComments, so carry over any post titles already
+        // resolved for the tab (keyed by post — a title is the same for every comment on a post).
+        // Without this, each rebuild (load-more, re-thread) would blank titles until resolvePostTitles
+        // re-fetches them, and re-thread — which never re-resolves — would lose them for good.
+        val knownTitles = getTabUiState(tab).comments
+            .filter { it.postTitle != null }
+            .associate { it.postId to it.postTitle }
         val visible = if (tab == CommentsRsListTab.UNREPLIED) filterUnreplied(raw, currentUserId) else raw
-        return visible.map { it.toUiModel() }
+        return visible.map { it.toUiModel().copy(postTitle = knownTitles[it.postId]) }
     }
 
     /** Re-derives the Unreplied tab's rows from its raw comments (e.g. once [currentUserId] resolves). */
     private fun rethreadUnreplied() {
         val tab = CommentsRsListTab.UNREPLIED
         val raw = rawComments[tab] ?: return
-        updateTabUiState(tab) { copy(comments = displayRows(tab, raw)) }
+        val rows = displayRows(tab, raw)
+        updateTabUiState(tab) { copy(comments = rows) }
+        // Re-threading can drop rows that were over-reported while currentUserId was still null;
+        // clear any selection for comments no longer shown so an off-screen id can't intercept
+        // back presses or target a batch action (the same hazard refreshTab guards against).
+        val visibleIds = rows.mapTo(mutableSetOf()) { it.remoteCommentId }
+        _selectedIds.update { it intersect visibleIds }
+        // Re-threading with the now-known id can empty a page that previously over-reported, so
+        // keep paging rather than stranding matches behind a false empty state.
+        advanceIfFilteredEmpty(tab)
+    }
+
+    /**
+     * Keeps paging while a filtered tab (Unreplied) shows no rows but the raw stream has more:
+     * a full page can thread away to nothing, and the list's load-more trigger only fires once
+     * rows are on screen. Bounded by the same auto-advance cap as load-more.
+     */
+    private fun advanceIfFilteredEmpty(tab: CommentsRsListTab) {
+        if (getTabUiState(tab).comments.isEmpty() && nextPageParams[tab] != null) {
+            loadMoreInternal(tab, autoAdvanceDepth = 0)
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsUnrepliedFilter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsUnrepliedFilter.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.commentsrs
+
+import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
+
+/**
+ * Client-side "Unreplied" filter for the rs comments list, mirroring the legacy
+ * `UnrepliedCommentsUtils`. A comment is unreplied when it is a top-level comment
+ * ([RsComment.parentId] == 0) that the current user did not write and that has no direct reply
+ * written by the current user.
+ *
+ * Threading is computed over whatever comments have been loaded so far, so — exactly like the
+ * legacy list — a reply that lives on a not-yet-loaded page can briefly leave its parent showing
+ * as unreplied until that page arrives.
+ *
+ * "Mine" is a user-id comparison ([RsComment.authorId] == [myUserId]) because the view context
+ * carries no author email. When [myUserId] is null (the "me" fetch failed), nothing counts as
+ * mine and the filter over-reports rather than hiding comments — the same fallback the legacy
+ * util has when it can't resolve the account email.
+ */
+internal fun filterUnreplied(comments: List<RsComment>, myUserId: Long?): List<RsComment> {
+    val myReplyParentIds = comments
+        .filter { it.parentId != 0L && isMine(it, myUserId) }
+        .map { it.parentId }
+        .toSet()
+    return comments.filter { comment ->
+        comment.parentId == 0L &&
+                !isMine(comment, myUserId) &&
+                comment.remoteCommentId !in myReplyParentIds
+    }
+}
+
+private fun isMine(comment: RsComment, myUserId: Long?): Boolean =
+    myUserId != null && comment.authorId == myUserId

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
@@ -110,6 +110,7 @@ fun CommentsRsListScreen(
     val listStates = mapOf(
         CommentsRsListTab.ALL to rememberLazyListState(),
         CommentsRsListTab.PENDING to rememberLazyListState(),
+        CommentsRsListTab.UNREPLIED to rememberLazyListState(),
         CommentsRsListTab.APPROVED to rememberLazyListState(),
         CommentsRsListTab.SPAM to rememberLazyListState(),
         CommentsRsListTab.TRASHED to rememberLazyListState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityChecker.kt
@@ -42,6 +42,14 @@ class SiteCapabilityChecker @Inject constructor(
     suspend fun canModerateComments(site: SiteModel): Boolean =
         capabilities(site).canModerateComments
 
+    /**
+     * The current user's WP user id for the given site, or null if it couldn't be resolved. Read
+     * from the same "me" fetch as the capabilities above (no extra request). The rs comments list
+     * uses it to tell the user's own replies apart when computing the Unreplied filter.
+     */
+    suspend fun currentUserId(site: SiteModel): Long? =
+        capabilities(site).currentUserId
+
     private suspend fun capabilities(site: SiteModel): CapabilityCache {
         capabilityCache[site.id]?.let { return it }
         // Only a successful fetch is cached. On failure fall back to a fail-closed value for this
@@ -59,10 +67,11 @@ class SiteCapabilityChecker @Inject constructor(
             }
             when (response) {
                 is WpRequestResult.Success -> {
-                    val capabilities = response.response.data.capabilities
+                    val user = response.response.data
                     CapabilityCache(
-                        hasEditThemeOptions = capabilities.hasCap(UserCapability.EditThemeOptions),
-                        canModerateComments = capabilities.hasCap(UserCapability.ModerateComments)
+                        hasEditThemeOptions = user.capabilities.hasCap(UserCapability.EditThemeOptions),
+                        canModerateComments = user.capabilities.hasCap(UserCapability.ModerateComments),
+                        currentUserId = user.id
                     )
                 }
                 // Return null (not cached) so the next call retries rather than locking in a
@@ -84,6 +93,7 @@ class SiteCapabilityChecker @Inject constructor(
 
     private data class CapabilityCache(
         val hasEditThemeOptions: Boolean = false,
-        val canModerateComments: Boolean = false
+        val canModerateComments: Boolean = false,
+        val currentUserId: Long? = null
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/CommentsRsListMappingTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/CommentsRsListMappingTest.kt
@@ -20,6 +20,8 @@ class CommentsRsListMappingTest {
         val item = rsComment().toRsComment()
 
         assertThat(item.remoteCommentId).isEqualTo(COMMENT_ID)
+        assertThat(item.authorId).isEqualTo(7L)
+        assertThat(item.parentId).isEqualTo(0L)
         assertThat(item.authorName).isEqualTo("Jane")
         assertThat(item.authorAvatarUrl).isEqualTo("https://example.com/avatar96.png")
         assertThat(item.dateGmt).isEqualTo(DATE_GMT)
@@ -27,6 +29,11 @@ class CommentsRsListMappingTest {
         assertThat(item.url).isEqualTo("https://example.com/post/#comment-42")
         assertThat(item.postId).isEqualTo(POST_ID)
         assertThat(item.status).isEqualTo(APPROVED)
+    }
+
+    @Test
+    fun `toRsComment carries the parent id used for Unreplied threading`() {
+        assertThat(rsComment(parent = 42L).toRsComment().parentId).isEqualTo(42L)
     }
 
     @Test
@@ -73,6 +80,7 @@ class CommentsRsListMappingTest {
 
     private fun rsComment(
         status: RsCommentStatus = RsCommentStatus.Approved,
+        parent: Long = 0L,
         avatarUrls: Map<UserAvatarSize, String> = mapOf(
             UserAvatarSize.Size96 to "https://example.com/avatar96.png"
         )
@@ -85,7 +93,7 @@ class CommentsRsListMappingTest {
         date = "2026-07-01T12:00:00",
         dateGmt = DATE_GMT,
         link = "https://example.com/post/#comment-42",
-        parent = 0L,
+        parent = parent,
         post = POST_ID,
         status = status,
         commentType = CommentType.Comment,

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListTabTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListTabTest.kt
@@ -18,6 +18,20 @@ class CommentsRsListTabTest {
     }
 
     @Test
+    fun `unreplied tab queries status all and is threaded client-side`() {
+        // Unreplied has no server status: it fetches everything (approved + hold, like ALL) and
+        // filterUnreplied() narrows it to comments the user hasn't replied to.
+        assertThat(CommentsRsListTab.UNREPLIED.queryStatus).isEqualTo(RsCommentStatus.Custom("all"))
+    }
+
+    @Test
+    fun `unreplied tab sits between pending and approved, matching the legacy order`() {
+        assertThat(CommentsRsListTab.entries.map { it.name }).containsExactly(
+            "ALL", "PENDING", "UNREPLIED", "APPROVED", "SPAM", "TRASHED"
+        )
+    }
+
+    @Test
     fun `remaining tabs use the built-in statuses`() {
         assertThat(CommentsRsListTab.PENDING.queryStatus).isEqualTo(RsCommentStatus.Hold)
         assertThat(CommentsRsListTab.SPAM.queryStatus).isEqualTo(RsCommentStatus.Spam)

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
@@ -53,6 +53,7 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     @Mock lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     private lateinit var site: SiteModel
+    private lateinit var commentBrowsingSession: CommentBrowsingSession
     private var activeViewModel: CommentsRsListViewModel? = null
 
     @Before
@@ -68,6 +69,7 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         whenever(avatarUtilsWrapper.rewriteAvatarUrlWithResource(any(), any())).thenAnswer { it.arguments[0] }
         whenever(commentsRsDataSource.firstPageParams(any(), anyOrNull())).thenReturn(FIRST_PAGE)
         whenever(commentsRsDataSource.fetchPostTitles(any(), any())).thenReturn(emptyMap())
+        commentBrowsingSession = CommentBrowsingSession(commentsRsDataSource)
     }
 
     @After
@@ -85,7 +87,7 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         dateTimeUtilsWrapper = dateTimeUtilsWrapper,
         avatarUtilsWrapper = avatarUtilsWrapper,
         analyticsTracker = analyticsTracker,
-        commentBrowsingSession = CommentBrowsingSession(commentsRsDataSource),
+        commentBrowsingSession = commentBrowsingSession,
         bgDispatcher = testDispatcher()
     ).also { activeViewModel = it }
 
@@ -577,6 +579,41 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         val params = argumentCaptor<CommentListParams>()
         verify(commentsRsDataSource).fetchCommentsPage(eq(site), params.capture())
         assertThat(params.firstValue.perPage).isEqualTo(100u)
+    }
+
+    @Test
+    fun `unreplied tab pages past a first page that filters to nothing`() = test {
+        whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
+        // Page 1 is 100 raw comments that all thread away (here: authored by me), but a next page
+        // exists; page 2 carries the actual unreplied comment. Without auto-advancing, the tab
+        // would sit on a false empty state and never reach it.
+        whenever(commentsRsDataSource.fetchCommentsPage(eq(site), any())).thenReturn(
+            RsCommentsPageResult.Success(listOf(rsItem(id = 1, authorId = ME)), NEXT_PAGE),
+            RsCommentsPageResult.Success(listOf(rsItem(id = 2, authorId = OTHER)), null)
+        )
+        val viewModel = createViewModel()
+
+        viewModel.initTab(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        val state = viewModel.tabStates.value.getValue(CommentsRsListTab.UNREPLIED)
+        assertThat(state.comments.map { it.remoteCommentId }).containsExactly(2L)
+    }
+
+    @Test
+    fun `tapping an unreplied comment seeds the swipe session without a paging cursor`() = test {
+        whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
+        givenPage(listOf(rsItem(id = 1, authorId = OTHER)), nextPageParams = NEXT_PAGE)
+        val viewModel = createViewModel()
+        viewModel.onTabChanged(CommentsRsListTab.UNREPLIED)
+        viewModel.initTab(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        viewModel.onCommentClick(1L)
+
+        // A cursor would let the detail pager page the raw stream into the replied-to and own
+        // comments the tab filters out; Unreplied must seed only the visible ids.
+        assertThat(commentBrowsingSession.canLoadMore).isFalse()
     }
 
     private fun rsItem(id: Long, postId: Long = 99L, authorId: Long = 0L, parentId: Long = 0L) = RsComment(

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -543,8 +544,45 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         verify(commentsRsDataSource, never()).updateStatus(eq(site), any(), any())
     }
 
-    private fun rsItem(id: Long, postId: Long = 99L) = RsComment(
+    @Test
+    fun `unreplied tab shows only top-level comments the current user has not replied to`() = test {
+        whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
+        // id=1 top-level by someone else, answered by me (id=2) -> dropped.
+        // id=2 is my reply -> never a candidate. id=3 top-level by someone else, unanswered -> kept.
+        givenPage(
+            listOf(
+                rsItem(id = 1, authorId = OTHER),
+                rsItem(id = 2, authorId = ME, parentId = 1),
+                rsItem(id = 3, authorId = OTHER)
+            )
+        )
+        val viewModel = createViewModel()
+
+        viewModel.initTab(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        val state = viewModel.tabStates.value.getValue(CommentsRsListTab.UNREPLIED)
+        assertThat(state.comments.map { it.remoteCommentId }).containsExactly(3L)
+    }
+
+    @Test
+    fun `unreplied tab over-fetches a larger page`() = test {
+        whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
+        givenPage(emptyList())
+        val viewModel = createViewModel()
+
+        viewModel.initTab(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        val params = argumentCaptor<CommentListParams>()
+        verify(commentsRsDataSource).fetchCommentsPage(eq(site), params.capture())
+        assertThat(params.firstValue.perPage).isEqualTo(100u)
+    }
+
+    private fun rsItem(id: Long, postId: Long = 99L, authorId: Long = 0L, parentId: Long = 0L) = RsComment(
         remoteCommentId = id,
+        authorId = authorId,
+        parentId = parentId,
         authorName = "Jane",
         authorAvatarUrl = "https://example.com/avatar.png",
         dateGmt = Date(0),
@@ -555,6 +593,8 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     )
 
     companion object {
+        private const val ME = 7L
+        private const val OTHER = 42L
         private val FIRST_PAGE = CommentListParams()
         private val NEXT_PAGE = CommentListParams(page = 2u)
         private val THIRD_PAGE = CommentListParams(page = 3u)

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
@@ -601,6 +601,28 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
+    fun `unreplied load-more keeps paging when a page threads the visible list down to empty`() = test {
+        whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
+        // Page 1: one visible unreplied comment (A). Page 2: the user's reply to A and nothing new,
+        // so filtering drops A and the visible count shrinks 1 -> 0. Page 3 carries a real unreplied
+        // comment. Without advancing on the shrink, the tab would sit on a false empty state.
+        whenever(commentsRsDataSource.fetchCommentsPage(eq(site), any())).thenReturn(
+            RsCommentsPageResult.Success(listOf(rsItem(id = 1, authorId = OTHER)), NEXT_PAGE),
+            RsCommentsPageResult.Success(listOf(rsItem(id = 2, authorId = ME, parentId = 1)), THIRD_PAGE),
+            RsCommentsPageResult.Success(listOf(rsItem(id = 3, authorId = OTHER)), null)
+        )
+        val viewModel = createViewModel()
+        viewModel.initTab(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        viewModel.loadMore(CommentsRsListTab.UNREPLIED)
+        advanceUntilIdle()
+
+        val state = viewModel.tabStates.value.getValue(CommentsRsListTab.UNREPLIED)
+        assertThat(state.comments.map { it.remoteCommentId }).containsExactly(3L)
+    }
+
+    @Test
     fun `tapping an unreplied comment seeds the swipe session without a paging cursor`() = test {
         whenever(siteCapabilityChecker.currentUserId(site)).thenReturn(ME)
         givenPage(listOf(rsItem(id = 1, authorId = OTHER)), nextPageParams = NEXT_PAGE)

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsUnrepliedFilterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsUnrepliedFilterTest.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.commentsrs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComment
+import java.util.Date
+
+class CommentsRsUnrepliedFilterTest {
+    @Test
+    fun `keeps a top-level comment by someone else with no replies`() {
+        val comment = comment(id = 1, authorId = OTHER_USER)
+
+        assertThat(filterUnreplied(listOf(comment), MY_USER)).containsExactly(comment)
+    }
+
+    @Test
+    fun `keeps a top-level comment whose only reply is by another user`() {
+        val topLevel = comment(id = 1, authorId = OTHER_USER)
+        val otherReply = comment(id = 2, authorId = OTHER_USER, parentId = 1)
+
+        assertThat(filterUnreplied(listOf(topLevel, otherReply), MY_USER)).containsExactly(topLevel)
+    }
+
+    @Test
+    fun `drops a top-level comment once the current user has replied to it`() {
+        val topLevel = comment(id = 1, authorId = OTHER_USER)
+        val myReply = comment(id = 2, authorId = MY_USER, parentId = 1)
+
+        assertThat(filterUnreplied(listOf(topLevel, myReply), MY_USER)).isEmpty()
+    }
+
+    @Test
+    fun `drops a top-level comment authored by the current user`() {
+        val mine = comment(id = 1, authorId = MY_USER)
+
+        assertThat(filterUnreplied(listOf(mine), MY_USER)).isEmpty()
+    }
+
+    @Test
+    fun `ignores replies themselves as candidates`() {
+        // A reply (parentId != 0) is never a candidate, even when nobody has answered it.
+        val reply = comment(id = 2, authorId = OTHER_USER, parentId = 99)
+
+        assertThat(filterUnreplied(listOf(reply), MY_USER)).isEmpty()
+    }
+
+    @Test
+    fun `matches a reply against a parent fetched on an earlier page`() {
+        // The parent and the current user's reply can arrive on different pages; threading over the
+        // accumulated set still drops the parent.
+        val parent = comment(id = 1, authorId = OTHER_USER)
+        val laterMyReply = comment(id = 50, authorId = MY_USER, parentId = 1)
+
+        assertThat(filterUnreplied(listOf(parent, laterMyReply), MY_USER)).isEmpty()
+    }
+
+    @Test
+    fun `over-reports rather than hiding when the current user id is unknown`() {
+        // With a null id nothing counts as "mine", so a comment the user actually replied to still
+        // shows — the same fail-open behaviour the legacy util has when it can't resolve the email.
+        val topLevel = comment(id = 1, authorId = OTHER_USER)
+        val myReply = comment(id = 2, authorId = MY_USER, parentId = 1)
+
+        assertThat(filterUnreplied(listOf(topLevel, myReply), myUserId = null)).containsExactly(topLevel)
+    }
+
+    private fun comment(id: Long, authorId: Long, parentId: Long = 0) = RsComment(
+        remoteCommentId = id,
+        authorId = authorId,
+        parentId = parentId,
+        authorName = "Author $id",
+        authorAvatarUrl = "",
+        dateGmt = Date(0),
+        contentHtml = "content",
+        url = "",
+        postId = 99L,
+        status = CommentStatus.APPROVED
+    )
+
+    companion object {
+        private const val MY_USER = 7L
+        private const val OTHER_USER = 42L
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteCapabilityCheckerTest.kt
@@ -55,6 +55,13 @@ class SiteCapabilityCheckerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `currentUserId is null when the me fetch fails`() = test {
+        whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
+
+        assertThat(checker.currentUserId(site)).isNull()
+    }
+
+    @Test
     fun `a failed fetch is not cached and is retried on the next call`() = test {
         whenever(wpApiClientProvider.getWpApiClient(site)).thenThrow(RuntimeException("boom"))
 


### PR DESCRIPTION
## Description

This PR adds the **Unreplied** tab to the new RS comments list, matching the legacy comments feature but implemented natively against wordpress-rs, not FluxC. Note that there's no unreplied status on the server - as with the legacy list, it's a client-side feature.

## Known limitations (intentional, matching legacy)

- A reply on a not-yet-loaded page can briefly leave its parent showing as unreplied.
- Searching within the Unreplied tab can over-report (search results aren't full threads).

## Testing

1. Enable the RS unified experimental feature and select an application-password site (I recommend testing with our "content heavy" site).
2. Open Comments, swipe to the **Unreplied** tab.
3. Confirm it lists top-level comments you haven't replied to; reply to one and pull-to-refresh — it drops off the list.
