### PR TITLE
Fix UploadService foreground service timeout crash on Android 15+

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -252,6 +252,19 @@ class PostUploadNotifier {
         return false;
     }
 
+    /**
+     * Clears the outstanding foreground notification and resets its state. Called when the service is
+     * force-stopped (e.g. a foreground-service timeout) outside the normal "all uploads complete" path,
+     * so the next upload starts a fresh foreground notification via startForeground().
+     */
+    void resetForegroundNotificationState() {
+        if (sNotificationData.mNotificationId != 0) {
+            mNotificationManager.cancel(sNotificationData.mNotificationId);
+            sNotificationData.mNotificationId = 0;
+        }
+        resetNotificationCounters();
+    }
+
     private void resetNotificationCounters() {
         sNotificationData.mCurrentPostItem = 0;
         sNotificationData.mCurrentMediaItem = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.SparseArrayCompat;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 import androidx.core.app.TaskStackBuilder;
 
 import org.greenrobot.eventbus.EventBus;
@@ -128,9 +129,7 @@ class PostUploadNotifier {
     }
 
     private synchronized void startOrUpdateForegroundNotification(@Nullable PostImmutableModel post) {
-        boolean isTotalPostsAndMediaItemsCountZero = sNotificationData.mTotalPostItems == 0
-                                                     && sNotificationData.mTotalMediaItems == 0;
-        if (isTotalPostsAndMediaItemsCountZero) {
+        if (hasNoForegroundItemsTracked()) {
             return;
         }
         updateNotificationBuilder(post);
@@ -214,6 +213,12 @@ class PostUploadNotifier {
     }
 
     void incrementUploadedPostCountFromForegroundNotification(@NonNull PostImmutableModel post, boolean force) {
+        // Ignore stale completion callbacks that arrive after the foreground state was reset (e.g.
+        // cancellations dispatched during a foreground-service timeout). With nothing being tracked,
+        // counting them would push the current counters past the zeroed totals and corrupt the state.
+        if (hasNoForegroundItemsTracked()) {
+            return;
+        }
         // first we need to check that we only count this post once as "ended" (either successfully or with error)
         // for every error we get. We'll then try to increment the Post count as it's been cancelled/failed because the
         // related media was cancelled or has failed too (i.e. we can't upload a Post with failed media, therefore
@@ -232,6 +237,11 @@ class PostUploadNotifier {
     }
 
     void incrementUploadedMediaCountFromProgressNotification(int mediaId) {
+        // Ignore stale completion callbacks that arrive after the foreground state was reset (see
+        // incrementUploadedPostCountFromForegroundNotification above).
+        if (hasNoForegroundItemsTracked()) {
+            return;
+        }
         sNotificationData.mCurrentMediaItem++;
         if (!removeNotificationAndStopForegroundServiceIfNoItemsInQueue()) {
             // update Notification now
@@ -242,23 +252,26 @@ class PostUploadNotifier {
     private boolean removeNotificationAndStopForegroundServiceIfNoItemsInQueue() {
         if (sNotificationData.mCurrentPostItem == sNotificationData.mTotalPostItems
             && sNotificationData.mCurrentMediaItem == sNotificationData.mTotalMediaItems) {
-            mNotificationManager.cancel(sNotificationData.mNotificationId);
-            // reset the notification id so a new one is generated next time the service is started
-            sNotificationData.mNotificationId = 0;
-            resetNotificationCounters();
-            mService.stopForeground(true);
+            resetForegroundNotificationState();
+            ServiceCompat.stopForeground(mService, ServiceCompat.STOP_FOREGROUND_REMOVE);
             return true;
         }
         return false;
     }
 
+    private boolean hasNoForegroundItemsTracked() {
+        return sNotificationData.mTotalPostItems == 0 && sNotificationData.mTotalMediaItems == 0;
+    }
+
     /**
-     * Clears the outstanding foreground notification and resets its state. Called when the service is
-     * force-stopped (e.g. a foreground-service timeout) outside the normal "all uploads complete" path,
+     * Clears the outstanding foreground notification and resets its state. Called both when all
+     * uploads complete and when the service is force-stopped (e.g. a foreground-service timeout),
      * so the next upload starts a fresh foreground notification via startForeground().
      */
     void resetForegroundNotificationState() {
         if (sNotificationData.mNotificationId != 0) {
+            // cancel the outstanding notification and reset the id so a new one is generated next
+            // time the service is started
             mNotificationManager.cancel(sNotificationData.mNotificationId);
             sNotificationData.mNotificationId = 0;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -9,6 +9,7 @@ import android.os.IBinder;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.core.app.ServiceCompat;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -176,26 +177,45 @@ public class UploadService extends Service {
     @Override
     public void onTimeout(int startId) {
         super.onTimeout(startId);
-        stopSelf(startId);
-        AppLog.i(T.MAIN, "UploadService > timed out");
+        handleForegroundServiceTimeout();
     }
 
     // Android 15+ enforces a 6-hour-per-24h cap on dataSync foreground services. The system calls
-    // this two-arg overload before throwing ForegroundServiceDidNotStopInTimeException; we have a
-    // few seconds to stop. Cancel in-flight uploads eagerly so onDestroy() finishes within budget.
+    // this two-arg overload before throwing ForegroundServiceDidNotStopInTimeException.
     @Override
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     public void onTimeout(int startId, int fgsType) {
         super.onTimeout(startId, fgsType);
-        AppLog.w(T.MAIN, "UploadService > foreground service timeout reached (type=" + fgsType
-                         + "); stopping service");
+        AppLog.w(T.MAIN, "UploadService > foreground service timeout reached (type=" + fgsType + ")");
+        handleForegroundServiceTimeout();
+    }
+
+    /**
+     * Stops the service after the system signals a foreground-service timeout, in the few seconds we
+     * have before {@link android.app.RemoteServiceException.ForegroundServiceDidNotStopInTimeException}
+     * is thrown.
+     *
+     * We intentionally do NOT use {@code stopSelf(startId)} here: that overload only stops the service
+     * when {@code startId} matches the most recent start, but the service is started once per queued
+     * upload, so the id delivered to onTimeout() is usually stale and the call would be a no-op. We
+     * also leave the foreground state right away rather than relying on onDestroy() finishing within
+     * the timeout budget.
+     */
+    private void handleForegroundServiceTimeout() {
         if (mMediaUploadHandler != null) {
             mMediaUploadHandler.cancelInProgressUploads();
         }
         if (mPostUploadHandler != null) {
             mPostUploadHandler.cancelInProgressUploads();
         }
-        stopSelf(startId);
+        // Leave the foreground state immediately so the system's timeout window is satisfied, and
+        // reset the notifier so the next upload re-enters the foreground via startForeground().
+        if (mPostUploadNotifier != null) {
+            mPostUploadNotifier.resetForegroundNotificationState();
+        }
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
+        stopSelf();
+        AppLog.i(T.MAIN, "UploadService > stopped after foreground service timeout");
     }
 
     private void unpackMediaIntent(@NonNull Intent intent) {


### PR DESCRIPTION
## Description

Fixes the `RemoteServiceException$ForegroundServiceDidNotStopInTimeException` crash reported in Sentry ([WORDPRESS-ANDROID-38SC](https://a8c.sentry.io/issues/WORDPRESS-ANDROID-38SC) / [JETPACK-ANDROID-1694](https://a8c.sentry.io/issues/JETPACK-ANDROID-1694)).

Android 15 enforces a 6-hour-per-24h cap on `dataSync` foreground services. When the cap is hit, the system calls `Service.onTimeout()` and expects the service to stop within a short window, otherwise it throws `ForegroundServiceDidNotStopInTimeException`.

`UploadService.onTimeout()` already existed but called **`stopSelf(startId)`**, which only stops the service when `startId` matches the most recent start. `UploadService` is started fresh (`startService`) for every queued post/media upload, so the id the system delivers on timeout is usually stale — the call becomes a no-op, the service stays in the foreground, and the exception is thrown anyway. This is why the previous fix (#22822, shipped in 26.8) reduced but did not eliminate the crash.

### Changes

- Both `onTimeout` overloads now delegate to a single `handleForegroundServiceTimeout()` that:
  - Cancels in-flight media/post uploads.
  - Resets the notifier's foreground-notification state via the new `PostUploadNotifier.resetForegroundNotificationState()` so the next upload re-enters the foreground correctly via `startForeground()`.
  - Calls `ServiceCompat.stopForeground(this, STOP_FOREGROUND_REMOVE)` to leave the foreground state immediately, satisfying the system's timeout window regardless of how long `onDestroy()` takes.
  - Calls the no-arg `stopSelf()` so the service stops unconditionally.

Shared code, so it covers both WordPress and Jetpack.

## Testing instructions

The real trigger (6h cumulative `dataSync` runtime) is impractical to reproduce, so testing focuses on confirming normal uploads still work. This change refactors the shared foreground-notification/counter code (the normal "all uploads complete" path now goes through `resetForegroundNotificationState()`, and the counter increments gained a guard). Verifying the upload itself succeeds is enough — the progress notification is silent and short-lived, so you may not see it.

1. Run a Jetpack/WordPress debug build.
2. Upload a single image from the Media browser.
- [x] The image finishes uploading successfully.
3. Publish a new post that contains one or more images.
- [x] The post publishes successfully, with its media.
4. Start several uploads at once (e.g. multiple media items and/or a post).
- [x] All items finish uploading successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
