### PR TITLE
Fix crash when push notification icon URL has illegal characters

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -641,7 +641,10 @@ public class GCMMessageHandler {
                     if (largeIconBitmap != null && shouldCircularizeIcon) {
                         largeIconBitmap = ImageUtils.getCircularBitmap(largeIconBitmap);
                     }
-                } catch (UnsupportedEncodingException e) {
+                } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+                    // IllegalArgumentException is thrown by ImageUtils.downloadBitmap when the icon URL
+                    // contains illegal characters (e.g. an unencoded space). In that case just skip the
+                    // large icon instead of crashing the whole push notification handler.
                     AppLog.e(T.NOTIFS, e);
                 }
             }


### PR DESCRIPTION
## Description

Fixes JETPACK-ANDROID-1BYM

Incoming push notifications can carry an icon URL that, after `URLDecoder.decode`, contains an illegal character such as an unencoded space (e.g. `.../uploads/Board Logo/cropped-...png`). That decoded URL flows into `ImageUtils.downloadBitmap`, which builds a `java.net.URI` and throws an **unchecked** `IllegalArgumentException` ("Illegal character in path"). Because it was uncaught, a single malformed icon URL crashed the entire Firebase push-message handler (fatal, `UncaughtExceptionHandler`).

`ImageUtils.downloadBitmap` lives in the external `WordPress-Utils-Android` library and can't be changed here, so the fix is in the caller: the existing `catch` in `getLargeIconBitmap` now also handles `IllegalArgumentException`. A malformed icon URL is logged and the notification is shown **without** the large icon instead of crashing.

This is the only large-icon entry point, so the other notification code paths that call `getLargeIconBitmap` are covered as well.

## Testing instructions

This crash requires a push notification whose `icon` field decodes to a URL containing an illegal character (e.g. a space), which is hard to reproduce on demand. Since the PR just handling a new exception, green CI should be enough

