### PR TITLE
Pick release notes during beta promotion

### DIFF
--- a/.buildkite/commands/promote-to-beta.sh
+++ b/.buildkite/commands/promote-to-beta.sh
@@ -4,12 +4,21 @@ set -eu
 
 # Promotes the build chosen in the preceding block step to the beta track. No build — just gems + secrets.
 
-# `beta_build_to_promote` must stay in sync with PROMOTION_META_DATA_KEY in fastlane/lanes/promote.rb,
-# which is the key the gather lane writes the block-step select field under.
+# `beta_build_to_promote` must stay in sync with BETA_META_DATA_KEY in fastlane/lanes/promote.rb,
+# which is the key the gather lane writes the block-step build select field under.
 VERSION_CODE="$(buildkite-agent meta-data get "beta_build_to_promote" --default "")"
+
+# `beta_release_notes_option` must stay in sync with BETA_RELEASE_NOTES_META_DATA_KEY in the same file
+# (the block step's release-notes select field).
+RELEASE_NOTES_OPTION="$(buildkite-agent meta-data get "beta_release_notes_option" --default "")"
 
 if [[ -z "${VERSION_CODE}" ]]; then
   echo "+++ :x: No build was selected to promote."
+  exit 1
+fi
+
+if [[ -z "${RELEASE_NOTES_OPTION}" ]]; then
+  echo "+++ :x: No release notes option was selected."
   exit 1
 fi
 
@@ -20,4 +29,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :rocket: Promoting ${VERSION_CODE} to the beta track"
-bundle exec fastlane promote_to_beta version_code:"${VERSION_CODE}"
+bundle exec fastlane promote_to_beta version_code:"${VERSION_CODE}" release_notes_option:"${RELEASE_NOTES_OPTION}"

--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -100,3 +100,6 @@ msgid ""
 "- Removed beta badge from Menus in My Site\n"
 msgstr ""
 
+msgctxt "release_note_static_serious"
+msgid "We're focused on making Jetpack more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using Jetpack."
+msgstr ""

--- a/WordPress/jetpack_metadata/release_notes_static/serious.txt
+++ b/WordPress/jetpack_metadata/release_notes_static/serious.txt
@@ -1,0 +1,1 @@
+We're focused on making Jetpack more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using Jetpack.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -154,3 +154,6 @@ msgid ""
 "- Removed beta badge from Menus in My Site\n"
 msgstr ""
 
+msgctxt "release_note_static_serious"
+msgid "We're focused on making WordPress more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using WordPress."
+msgstr ""

--- a/WordPress/metadata/release_notes_static/serious.txt
+++ b/WordPress/metadata/release_notes_static/serious.txt
@@ -1,0 +1,1 @@
+We're focused on making WordPress more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using WordPress.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,6 +39,14 @@ UPLOAD_TO_PLAY_STORE_JSON_KEY = File.join(Dir.home, '.configure', 'wordpress-and
 # writes a track release (AAB upload or beta promotion) keeps it in the release's version codes.
 PLAY_STORE_VERSION_CODES_TO_RETAIN = [1440].freeze
 
+# The "what's new" options shown in the beta-promotion picker. The picked one is set on the beta
+# release and carried to production by the promote. `key` names the source file
+# (`release_notes_static/<key>.txt`) and the GlotPress string (`release_note_static_<key>`); `label`
+# is shown in the picker. Add entries to offer more options.
+STATIC_RELEASE_NOTE_OPTIONS = [
+  { key: 'serious', label: 'Serious' }
+].freeze
+
 PROTOTYPE_BUILD_TYPE = 'Debug'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))

--- a/fastlane/jetpack_metadata/android/en-US/release_notes_static/serious.txt
+++ b/fastlane/jetpack_metadata/android/en-US/release_notes_static/serious.txt
@@ -1,0 +1,1 @@
+We're focused on making Jetpack more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using Jetpack.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -148,6 +148,15 @@ platform :android do
       }
     end
 
+    # The beta-promotion picker's "what's new" options. Stable keys (no version suffix) so each is
+    # translated once, unlike the per-version `release_note_*` keys.
+    STATIC_RELEASE_NOTE_OPTIONS.each do |option|
+      files[:"release_note_static_#{option[:key]}"] = {
+        path: File.join(metadata_folder, 'release_notes_static', "#{option[:key]}.txt"),
+        comment: 'translators: Generic "what\'s new" text shown in the Play Store. Limit to 500 characters including spaces.'
+      }
+    end
+
     update_po_file_for_metadata_localization(
       po_path: File.join(metadata_folder, 'PlayStoreStrings.po'),
       sources: files,
@@ -264,6 +273,52 @@ platform :android do
       message = "Update #{app_values[:display_name]} metadata translations"
       message += " for #{version}" unless version.nil?
       git_commit(path: metadata_download_path, message: message, allow_nothing_to_commit: true)
+    end
+  end
+
+  # Downloads the translated "what's new" options from GlotPress into the per-locale
+  # `release_notes_static/<option>.txt` files. Not part of the release path; run it whenever an
+  # option's copy changes.
+  #
+  # @param [Symbol|String] app The app to download for. If nil, does both WordPress and Jetpack.
+  # @param [Boolean] skip_commit If true, skips the `git add`/`git commit`. Default false.
+  #
+  lane :download_static_release_notes do |app: nil, skip_commit: false|
+    apps = app.nil? ? %i[wordpress jetpack] : Array(app.to_s.downcase.to_sym)
+
+    apps.each do |current_app|
+      app_values = APP_SPECIFIC_VALUES[current_app]
+      source_dir = File.join(PROJECT_ROOT_FOLDER, 'WordPress', app_values[:metadata_dir], 'release_notes_static')
+      download_path = File.join(FASTLANE_FOLDER, app_values[:metadata_dir], 'android')
+      locales = { wordpress: WP_RELEASE_NOTES_LOCALES, jetpack: JP_RELEASE_NOTES_LOCALES }[current_app]
+
+      target_files = STATIC_RELEASE_NOTE_OPTIONS.to_h do |option|
+        [
+          "release_note_static_#{option[:key]}",
+          { desc: File.join('release_notes_static', "#{option[:key]}.txt"), max_size: 500 }
+        ]
+      end
+
+      UI.header("Downloading static release notes for #{app_values[:display_name]}")
+      gp_downloadmetadata(
+        project_url: app_values[:glotpress_metadata_project],
+        target_files: target_files,
+        locales: locales,
+        download_path: download_path
+      )
+
+      # en-US is the source language and isn't exported from GlotPress; copy each source verbatim.
+      en_us_dir = File.join(download_path, 'en-US', 'release_notes_static')
+      FileUtils.mkdir_p(en_us_dir)
+      STATIC_RELEASE_NOTE_OPTIONS.each do |option|
+        FileUtils.cp(File.join(source_dir, "#{option[:key]}.txt"), File.join(en_us_dir, "#{option[:key]}.txt"))
+      end
+
+      next if skip_commit
+
+      git_add(path: download_path)
+      message = "Update #{app_values[:display_name]} static release notes translations"
+      git_commit(path: download_path, message: message, allow_nothing_to_commit: true)
     end
   end
 

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -496,12 +496,12 @@ platform :android do
   # `release_notes_static/<option>.txt` file. Missing locales fall back to Play's default language.
   def static_release_notes(app:, option:)
     metadata_dir = File.join(FASTLANE_FOLDER, APP_SPECIFIC_VALUES[app][:metadata_dir], 'android')
-    notes = Dir.glob(File.join(metadata_dir, '*', 'release_notes_static', "#{option}.txt")).sort.filter_map do |path|
+    notes = Dir.glob(File.join(metadata_dir, '*', 'release_notes_static', "#{option}.txt")).filter_map do |path|
       text = File.read(path).strip
       next if text.empty?
 
       # Path is <metadata_dir>/<locale>/release_notes_static/<option>.txt; the locale is two dirs up.
-      locale = File.basename(File.dirname(File.dirname(path)))
+      locale = File.basename(File.dirname(path, 2))
       AndroidPublisher::LocalizedText.new(language: locale, text: text)
     end
     UI.important("No static release notes found for option #{option.inspect} (#{app}).") if notes.empty?

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -874,23 +874,7 @@ platform :android do
           'prompt' => 'Choose the build to release to beta testers. This promotes the matching WordPress and Jetpack builds.',
           # Keep the build "running" (not green) while it waits for a human.
           'blocked_state' => 'running',
-          'fields' => [
-            {
-              'select' => 'Build to promote',
-              'key' => BETA_META_DATA_KEY,
-              # Required, no default: an un-actioned unblock can't silently promote a build.
-              'required' => true,
-              'options' => options
-            },
-            {
-              'select' => 'Release notes',
-              'key' => BETA_RELEASE_NOTES_META_DATA_KEY,
-              'hint' => 'Which "what\'s new" text to publish. Carries through to production.',
-              # Required, no default: the notes are a deliberate choice, not a silent fallback.
-              'required' => true,
-              'options' => STATIC_RELEASE_NOTE_OPTIONS.map { |o| { 'label' => o[:label], 'value' => o[:key] } }
-            }
-          ]
+          'fields' => beta_promotion_block_fields(options: options)
         },
         {
           'label' => ':rocket: Promote selected build to beta',
@@ -905,6 +889,27 @@ platform :android do
     # `line_width: -1` keeps each label on one line (no YAML folding).
     File.write(PROMOTION_STEPS_FILE, steps.to_yaml(line_width: -1))
     UI.message("Wrote promotion steps for #{candidates.count} build(s) to #{PROMOTION_STEPS_FILE}")
+  end
+
+  # The block step's input fields: pick a build, and pick the release note to publish with it.
+  def beta_promotion_block_fields(options:)
+    [
+      {
+        'select' => 'Build to promote',
+        'key' => BETA_META_DATA_KEY,
+        # Required, no default: an un-actioned unblock can't silently promote a build.
+        'required' => true,
+        'options' => options
+      },
+      {
+        'select' => 'Release notes',
+        'key' => BETA_RELEASE_NOTES_META_DATA_KEY,
+        'hint' => 'Which "what\'s new" text to publish. Carries through to production.',
+        # Required, no default: the notes are a deliberate choice, not a silent fallback.
+        'required' => true,
+        'options' => STATIC_RELEASE_NOTE_OPTIONS.map { |o| { 'label' => o[:label], 'value' => o[:key] } }
+      }
+    ]
   end
 
   # Writes the confirm → promote → finalize steps. There's no picker — the candidate is baked into the

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -24,6 +24,10 @@ BETA_CANDIDATE_LIMIT = 12
 # NOTE: `.buildkite/commands/promote-to-beta.sh` reads this same key as a bare string literal
 # (`meta-data get "beta_build_to_promote"`) — keep the two in sync.
 BETA_META_DATA_KEY = 'beta_build_to_promote'
+# The block step also writes the chosen release-note option here; the promote step reads it back.
+# NOTE: `.buildkite/commands/promote-to-beta.sh` reads this same key as a bare string literal
+# (`meta-data get "beta_release_notes_option"`) — keep the two in sync.
+BETA_RELEASE_NOTES_META_DATA_KEY = 'beta_release_notes_option'
 # Matched via the Buildkite API to find the block step's job and build its unblock URL.
 BETA_BLOCK_LABEL = ':android: Promote to beta'
 BETA_BLOCK_STEP_KEY = 'promote_to_beta_block'
@@ -110,7 +114,7 @@ platform :android do
   # @param [String] version_code The version code to promote, e.g. `269027172`.
   # @called_by CI (`.buildkite/commands/promote-to-beta.sh`)
   desc 'Promote an existing build to the beta track (WordPress + Jetpack)'
-  lane :promote_to_beta do |version_code: nil|
+  lane :promote_to_beta do |version_code: nil, release_notes_option: nil|
     # Set once the per-app result has been posted, so the rescue doesn't double-report it.
     result_posted = false
     ensure_promotion_on_trunk!
@@ -121,9 +125,11 @@ platform :android do
     UI.user_error!('`version_code` is required, e.g. `version_code:269027172`') if version_code.empty?
     UI.user_error!("`version_code` must be an integer, got #{version_code.inspect}") unless version_code.match?(/\A\d+\z/)
 
+    release_notes_option = validated_release_notes_option(release_notes_option)
+
     UI.important("Promoting version code #{version_code} to the beta track for WordPress and Jetpack")
 
-    results = distribute_to_beta(version_code: version_code)
+    results = distribute_to_beta(version_code: version_code, release_notes_option: release_notes_option)
 
     post_beta_result_to_slack(version_code: version_code, results: results)
     result_posted = true
@@ -422,13 +428,15 @@ platform :android do
 
   # Promotes a version code to beta for each app, returning a per-app `{ ok:, error: }` result.
   # A failure for one app doesn't stop the other.
-  def distribute_to_beta(version_code:)
+  def distribute_to_beta(version_code:, release_notes_option:)
     %i[wordpress jetpack].to_h do |app|
       result =
         begin
           promote_version_code_to_beta(
+            app: app,
             package_name: APP_SPECIFIC_VALUES[app][:package_name],
-            version_code: version_code
+            version_code: version_code,
+            release_notes_option: release_notes_option
           )
           { ok: true }
         rescue StandardError => e
@@ -444,7 +452,7 @@ platform :android do
   # `upload_to_play_store` can't do this: it only builds a track release from binaries uploaded in
   # the same run, so a bare `version_code:` with `skip_upload_aab` commits an empty edit. We create
   # the release directly instead, mirroring supply's own `update_track`.
-  def promote_version_code_to_beta(package_name:, version_code:)
+  def promote_version_code_to_beta(app:, package_name:, version_code:, release_notes_option:)
     require 'supply'
     require 'supply/options'
 
@@ -452,6 +460,10 @@ platform :android do
       Supply::Options.available_options,
       { json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY, package_name: package_name, track: BETA_TRACK }
     )
+
+    # The picked release notes (needs supply loaded, above). nil when the option has no files.
+    release_notes = static_release_notes(app: app, option: release_notes_option)
+    release_notes = nil if release_notes.empty?
 
     with_play_edit_retries("Promoting #{version_code} to beta for #{package_name}") do
       client = Supply::Client.make_from_config
@@ -463,7 +475,9 @@ platform :android do
           # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
           status: 'draft',
           # Keep the pinned legacy code(s) on the track, same as the AAB-upload path.
-          version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN]
+          version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN],
+          # Carried to production automatically by the promote.
+          release_notes: release_notes
         )
         track = client.tracks(BETA_TRACK).first || AndroidPublisher::Track.new(track: BETA_TRACK)
         track.releases = [release]
@@ -476,6 +490,32 @@ platform :android do
         client.abort_current_edit unless committed
       end
     end
+  end
+
+  # The picked option's notes as Play `LocalizedText`, one per locale that has a
+  # `release_notes_static/<option>.txt` file. Missing locales fall back to Play's default language.
+  def static_release_notes(app:, option:)
+    metadata_dir = File.join(FASTLANE_FOLDER, APP_SPECIFIC_VALUES[app][:metadata_dir], 'android')
+    notes = Dir.glob(File.join(metadata_dir, '*', 'release_notes_static', "#{option}.txt")).sort.filter_map do |path|
+      text = File.read(path).strip
+      next if text.empty?
+
+      # Path is <metadata_dir>/<locale>/release_notes_static/<option>.txt; the locale is two dirs up.
+      locale = File.basename(File.dirname(File.dirname(path)))
+      AndroidPublisher::LocalizedText.new(language: locale, text: text)
+    end
+    UI.important("No static release notes found for option #{option.inspect} (#{app}).") if notes.empty?
+    notes
+  end
+
+  # Validates the picked option against the registry, raising on anything unknown.
+  def validated_release_notes_option(option)
+    option = option.to_s.strip
+    valid = STATIC_RELEASE_NOTE_OPTIONS.map { |o| o[:key] }
+    UI.user_error!("`release_notes_option` is required, one of: #{valid.join(', ')}") if option.empty?
+    return option if valid.include?(option)
+
+    UI.user_error!("Unknown `release_notes_option` #{option.inspect}; expected one of: #{valid.join(', ')}")
   end
 
   # Promotes a version code to production for each app, returning a per-app `{ ok:, error: }` result.
@@ -841,6 +881,14 @@ platform :android do
               # Required, no default: an un-actioned unblock can't silently promote a build.
               'required' => true,
               'options' => options
+            },
+            {
+              'select' => 'Release notes',
+              'key' => BETA_RELEASE_NOTES_META_DATA_KEY,
+              'hint' => 'Which "what\'s new" text to publish. Carries through to production.',
+              # Required, no default: the notes are a deliberate choice, not a silent fallback.
+              'required' => true,
+              'options' => STATIC_RELEASE_NOTE_OPTIONS.map { |o| { 'label' => o[:label], 'value' => o[:key] } }
             }
           ]
         },

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -504,7 +504,7 @@ platform :android do
       locale = File.basename(File.dirname(path, 2))
       AndroidPublisher::LocalizedText.new(language: locale, text: text)
     end
-    UI.important("No static release notes found for option #{option.inspect} (#{app}).") if notes.empty?
+    UI.user_error!("No static release notes found for option #{option.inspect} (#{app}).") if notes.empty?
     notes
   end
 

--- a/fastlane/metadata/android/en-US/release_notes_static/serious.txt
+++ b/fastlane/metadata/android/en-US/release_notes_static/serious.txt
@@ -1,0 +1,1 @@
+We're focused on making WordPress more stable and dependable with every release. This update continues that work with ongoing improvements and fixes. Have feedback or need help? Reach us any time from Help & Support. Thank you for using WordPress.


### PR DESCRIPTION
### Description

Part of the Faster Releases effort. Lets a developer choose a release note ("what's new") when promoting a build to the Play Store `beta` track, alongside picking the build. The note is set on the `beta` release; a later promotion to `production` reuses that release, so the same note follows the build.

The notes come from a fixed, translated set (`STATIC_RELEASE_NOTE_OPTIONS`, one option for now, `serious`) rather than being written per release. Adding an option is a data change: a `<key>.txt` source plus a row in the list.

### How it works

- The beta-promotion block step gains a second field, **Release notes**, populated from `STATIC_RELEASE_NOTE_OPTIONS` (`fastlane/Fastfile`).
- `promote_to_beta` takes the chosen option as `release_notes_option` (read from Buildkite meta-data by `promote-to-beta.sh`), validates it, and `static_release_notes` attaches the per-locale text to the `beta` release.
- `download_static_release_notes` (`fastlane/lanes/localization.rb`) pulls the translated options from GlotPress into `fastlane/{metadata,jetpack_metadata}/android/<locale>/release_notes_static/<option>.txt`.
- Each option's English source is in `WordPress/{metadata,jetpack_metadata}/release_notes_static/<option>.txt`; its GlotPress string `release_note_static_<option>` is registered in `generate_playstore_strings`.

### Translations

Each option is translated once through GlotPress (a stable key, so it doesn't change per release). `release_note_static_serious` is added to each `PlayStoreStrings.po` for GlotPress to pick up; `en-US` is committed. Until a locale is translated, the promotion attaches the `en-US` note and Play falls back to the default listing language.

The `.po` entry was added by hand rather than regenerating, which would also churn the per-version `release_note` key.

### Testing instructions

The promote lane is `trunk`-only and acts on the real Play Store (as a draft), so e2e-test from a throwaway branch with the guard removed.

Set up a test branch:

1. Branch off this PR (e.g. `task/static-release-notes-e2e`).
2. Remove the `ensure_promotion_on_trunk!` calls in `fastlane/lanes/promote.rb` and commit.

Run the picker:

3. Start a Buildkite build on the test branch with env `PIPELINE=promote-beta.yml`, with a promotable build above the current beta version code.
- [ ] Verify the block step shows both a "Build to promote" and a "Release notes" field.
4. Unblock the step, choosing a build and the **Serious** release note.
- [ ] Verify `promote_to_beta` runs and posts a per-app result to Slack.

Confirm in the Play Console:

5. Open the Play Console for WordPress, then Jetpack, beta track.
- [ ] Verify a draft release for the chosen version code carries the `en-US` "what's new" text for both apps.
- [ ] Discard the draft release(s) after verifying.
