### PR TITLE
Fix Sentry JETPACK-ANDROID-1G9S and 1J82: avoid openUrl with empty url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -348,8 +348,17 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         });
 
         mViewModel.getOpenExternalBrowser().observe(this, unit -> {
-            ReaderActivityLauncher.openUrl(WPWebViewActivity.this, mWebView.getUrl(),
-                    ReaderActivityLauncher.OpenUrlType.EXTERNAL);
+            // Prefer the currently loaded URL, but fall back to the requested URL when the page
+            // hasn't finished loading yet (mWebView.getUrl() is null before the first load).
+            String urlToOpen = mWebView.getUrl();
+            if (TextUtils.isEmpty(urlToOpen)) {
+                Bundle extras = getIntent().getExtras();
+                urlToOpen = extras != null ? extras.getString(URL_TO_LOAD) : null;
+            }
+            if (!TextUtils.isEmpty(urlToOpen)) {
+                ReaderActivityLauncher.openUrl(WPWebViewActivity.this, urlToOpen,
+                        ReaderActivityLauncher.OpenUrlType.EXTERNAL);
+            }
         });
 
         mViewModel.getPreviewModeSelector().observe(this, previewModelSelectorStatus -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -831,7 +831,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         updateStatusViews(binding, actionBinding, site, comment, note);
 
         // navigate to author's blog when avatar or name clicked
-        if (comment.getAuthorUrl() != null) {
+        if (!TextUtils.isEmpty(comment.getAuthorUrl())) {
             View.OnClickListener authorListener =
                     v -> ReaderActivityLauncher.openUrl(getActivity(), comment.getAuthorUrl());
             binding.imageAvatar.setOnClickListener(authorListener);


### PR DESCRIPTION
## Description

Fixes two Sentry issues that share a root cause:

- [JETPACK-ANDROID-1G9S](https://a8c.sentry.io/issues/JETPACK-ANDROID-1G9S) — 204 users / 519 events
- [JETPACK-ANDROID-1J82](https://a8c.sentry.io/issues/JETPACK-ANDROID-1J82) — 81 users / 269 events

Neither is a crash. `ReaderActivityLauncher.openUrl()` already guards null/empty urls by logging a Sentry report and returning (added in #22830 to stop the original crash), so what's left is two call sites passing empty urls — each of which also leaves the user tapping a button that silently does nothing.

`CommentDetailFragment` only checked `getAuthorUrl() != null`, so an empty author url still wired up a dead click listener on the commenter's name/avatar; it now falls through to the existing non-clickable styling. `WPWebViewActivity`'s "open in external browser" used `mWebView.getUrl()`, which is null until the first page load completes; it now falls back to the `URL_TO_LOAD` extra, so the button works before load instead of no-opping. The `openUrl` guard itself is left in place as a safety net for other callers.

## Testing steps

1. Open a comment whose author has no website set. Confirm the author name/avatar is not clickable and tapping it does nothing (no `READER` warning in logcat).
2. Open a comment whose author *does* have a website. Confirm tapping the name/avatar still opens their blog.
3. Open any in-app web view (e.g. a Reader post link) and tap "Open in external browser" immediately, before the page finishes loading. Confirm it opens the correct url in the browser rather than doing nothing.
4. Repeat step 3 after the page has fully loaded to confirm no regression.
