### PR TITLE
Fix preventBackNavigation crash by clearing the pending activity result

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
@@ -75,10 +76,23 @@ class ActivityLauncherWrapper @Inject constructor() {
      * user can't press Back to return to it — completing the "switch over" flow in one direction. Only invoked
      * when the target app was already installed; if it wasn't, we leave the source app intact so the user can
      * return after visiting the Play Store.
+     *
+     * [Activity.finishAffinity] throws IllegalStateException when the Activity still has a result to deliver
+     * (its result code isn't RESULT_CANCELED, or it has result data). This is reachable here because
+     * openPlayStoreLink() is called from fragments hosted by a wide range of activities, several of which
+     * set a result — so we can't assume the host has none.
      */
     private fun preventBackNavigation(activity: Activity, shouldPrevent: Boolean) {
-        if (shouldPrevent && !activity.isFinishing && !activity.isDestroyed) {
+        if (!shouldPrevent || activity.isFinishing || activity.isDestroyed) return
+        // We're finishing the whole task to hand the user over to the target app, so the Activity that would
+        // have received this result is being torn down too — clearing it is safe here.
+        activity.setResult(Activity.RESULT_CANCELED, null)
+        try {
             activity.finishAffinity()
+        } catch (e: IllegalStateException) {
+            // The only remaining throw path is an embedded (ActivityGroup) child activity.
+            AppLog.e(AppLog.T.UTILS, "finishAffinity failed, finishing the activity only", e)
+            activity.finish()
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
@@ -11,6 +11,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -36,6 +39,7 @@ class ActivityLauncherWrapperTest {
         classToTest.openPlayStoreLink(activity, "packageName")
 
         verify(activity, never()).finishAffinity()
+        verify(activity, never()).setResult(any(), anyOrNull())
     }
 
     @Test
@@ -48,6 +52,31 @@ class ActivityLauncherWrapperTest {
     }
 
     @Test
+    fun `openPlayStoreLink, when target app is preinstalled, should clear the pending result before finishing`() {
+        val activity = mockAppPreinstalled(true)
+
+        classToTest.openPlayStoreLink(activity, "packageName")
+
+        // finishAffinity() throws if the Activity still has a result to deliver, so the result
+        // has to be cleared first.
+        inOrder(activity) {
+            verify(activity).setResult(Activity.RESULT_CANCELED, null)
+            verify(activity).finishAffinity()
+        }
+    }
+
+    @Test
+    fun `openPlayStoreLink, when finishAffinity throws, should finish the activity instead of crashing`() {
+        val activity = mockAppPreinstalled(true)
+        doThrow(IllegalStateException("Can not be called to deliver a result"))
+            .whenever(activity).finishAffinity()
+
+        classToTest.openPlayStoreLink(activity, "packageName")
+
+        verify(activity).finish()
+    }
+
+    @Test
     fun `openPlayStoreLink, when activity is finishing, should not call finishAffinity`() {
         val activity = mockAppPreinstalled(true)
         whenever(activity.isFinishing).thenReturn(true)
@@ -55,6 +84,7 @@ class ActivityLauncherWrapperTest {
         classToTest.openPlayStoreLink(activity, "packageName")
 
         verify(activity, never()).finishAffinity()
+        verify(activity, never()).setResult(any(), anyOrNull())
     }
 
     @Test
@@ -65,6 +95,7 @@ class ActivityLauncherWrapperTest {
         classToTest.openPlayStoreLink(activity, "packageName")
 
         verify(activity, never()).finishAffinity()
+        verify(activity, never()).setResult(any(), anyOrNull())
     }
 
     @Test


### PR DESCRIPTION
## Problem

`Activity.finishAffinity()` throws `IllegalStateException("Can not be called to deliver a result")` when the activity's result code isn't `RESULT_CANCELED` or it has result data. `openPlayStoreLink()` is called from fragments hosted by a wide range of activities, several of which set a result — so the host can have one pending.

#22838 tried to fix this by guarding on `isFinishing`/`isDestroyed`. That's orthogonal to the precondition AOSP actually checks, so it was a no-op: the crash continued through 26.8 and 26.9 and is still present in 27.0 (~239 users across the three Sentry groups). This clears the result before finishing instead, plus a `finish()` fallback for the remaining embedded-activity throw path.

Sentry: WORDPRESS-ANDROID-3F23, WORDPRESS-ANDROID-3F1V, WORDPRESS-ANDROID-3F3X

## Verified end to end

Reproduced and fixed on a Pixel 8 / API 35 emulator. Two temporary local edits were needed to reach the code path (**neither is in this PR**): pointing `JETPACK_PACKAGE_NAME` at `com.jetpack.android.prealpha` so a debug Jetpack install counts as installed, and adding `requireActivity().setResult(RESULT_OK, Intent())` in `JetpackStaticPosterFragment.onViewCreated` to give the host a pending result.

**Before the fix** — WordPress app → Reader tab (JetpackStaticPoster) → "Switch to the Jetpack app":

```
java.lang.IllegalStateException: Can not be called to deliver a result
	at android.app.Activity.finishAffinity(Activity.java:7350)
	at org.wordpress.android.ui.ActivityLauncherWrapper.preventBackNavigation(ActivityLauncherWrapper.kt:81)
	at org.wordpress.android.ui.ActivityLauncherWrapper.openPlayStoreLink(ActivityLauncherWrapper.kt:53)
	at ...JetpackStaticPosterFragment.observeEvents$lambda$0(JetpackStaticPosterFragment.kt:64)
```

Same frames as WORDPRESS-ANDROID-3F23 (line numbers differ by the 3 added lines; `Activity.java:7350` vs `7150` is the API level).

**After the fix**, same steps: 0 fatal exceptions, Jetpack in the foreground, 0 remaining WordPress activity records (the task was finished), and Back goes to the launcher rather than WordPress — so the feature's intent is preserved. The `catch` fallback did **not** fire, meaning `finishAffinity()` itself succeeded rather than being rescued.

## Still open

1. **Side effect.** Clearing the result is a behavior change. `finishAffinity()` only finishes activities sharing this affinity, so an activity in a *different* task that started this one for a result now receives `RESULT_CANCELED` instead of whatever was pending. That looks right for a "hand the user to Jetpack and tear down the task" flow, but I haven't proven no caller depends on it. **This is the part worth reviewing.**
2. **No automated regression test.** The unit tests mock `Activity`, so `finishAffinity()` is a stub and they cannot exercise this precondition — exactly why #22838 shipped green. A real-`Activity` instrumented test would catch it, but `androidTest` doesn't compile on trunk in three independent pre-existing places (`MySitesPage.kt` `Matchers.isA<Any>(...)` type mismatch, `MySitesPage.kt` unresolved `R.id.quick_link_item`, `BaseTest.java:49` `createComposeRule` signature). I left that test out rather than ship code I couldn't compile.
3. **The production trigger is still unidentified.** My repro manufactures the pending result. Every `setResult` I found on a reachable host is immediately followed by `finish()`, which the existing `isFinishing` guard already short-circuits; the only long-lived one is `ReaderPostListFragment.onAttach()`, which can't run in the WordPress app because the poster replaces the Reader. So something sets a result on these hosts by a path I haven't found. The fix is unconditional and doesn't depend on knowing it, but it means we can't yet write a test that fails for the *real* reason.

## Testing

`./gradlew :WordPress:testWordPressDebugUnitTest --tests "*ActivityLauncherWrapperTest*"` — 8/8 pass. The two new cases assert `setResult(RESULT_CANCELED, null)` runs before `finishAffinity()`, and that an `IllegalStateException` from `finishAffinity()` falls back to `finish()` instead of propagating.

## Follow-ups

- `androidTest` is broken on trunk (see above) — worth fixing independently.
- `ReaderPostListFragment.onAttach()` sets `RESULT_OK` unconditionally on its host, whether or not anything changed.
