### PR TITLE
[Dependency Analysis] Fix `buildHealth` Failure on Kotlin 2.4.0 Metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,18 @@ import com.automattic.android.measure.reporters.SlowSlowTasksMetricsReporter
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    dependencies {
+        // TODO: Remove once dependency-analysis-gradle-plugin isolates its kotlin-metadata-jvm
+        //  dependency onto its own worker classpath, making this override moot (see PR below).
+        //  Interim workaround, endorsed by the plugin author, for reading Kotlin metadata newer
+        //  than DAGP's own bundled reader supports. Tracks this project's own Kotlin version.
+        //  https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1661
+        //  https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1719
+        classpath(libs.kotlin.metadata.jvm)
+    }
+}
+
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.automattic.measure.builds)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -239,6 +239,7 @@ jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-compile-testing-ksp = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing-ksp", version.ref = "kotlin-compile-testing" }
 kotlin-compile-testing-main = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing", version.ref = "kotlin-compile-testing" }
+kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin-main" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin-main" }
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin-main" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Closes: [AINFRA-2722](https://linear.app/a8c/issue/AINFRA-2722/dependency-analysis-investigate-and-fix-jpwpandroid-failing-on-ci)

---

## Description

The weekly scheduled `buildHealth` job (dependency analysis) has been failing on trunk since [#23086](https://github.com/wordpress-mobile/WordPress-Android/pull/23086), which bumped [Kotlin from 2.3.21 to 2.4.10](https://github.com/JetBrains/kotlin/releases/tag/v2.4.10). With the project itself now compiled by Kotlin 2.4.x, its own modules emit `kotlin.Metadata` version 2.4.0, and that metadata version lands on the classpath the plugin inspects. The dependency analysis plugin (DAGP) bundles a `kotlin-metadata-jvm` reader capped at Kotlin metadata 2.3.0, so its `ExplodeJarTask` fails with `Provided Metadata instance has version 2.4.0, while maximum supported version is 2.3.0` whenever it inspects one of those jars.

This PR fixes the failure without reverting the Kotlin bump:
- Forces a newer `kotlin-metadata-jvm` onto the root buildscript classpath, tracked to this project's own Kotlin version, so DAGP's `noIsolation()` worker resolves the newer reader instead of its own bundled 2.2.21. This is the interim workaround from [dependency-analysis-gradle-plugin#1661](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1661), [endorsed by the plugin author](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1661#issuecomment-4683380371), removable once upstream isolates this dependency onto its own worker classpath ([#1719](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1719)).

**Notes:**
- Root cause verified via Buildkite build history (last-green build [#27391](https://buildkite.com/automattic/wordpress-android/builds/27391) vs first-red [#27529](https://buildkite.com/automattic/wordpress-android/builds/27529)), and by git-tracing the trigger to [#23086](https://github.com/wordpress-mobile/WordPress-Android/pull/23086), which lifted the project's own Kotlin to 2.4.x so its modules now emit `kotlin.Metadata` version 2.4.0. Every red run fails on the same task, `:WordPress:explodeJarJetpackDebug` (latest red [#27686](https://buildkite.com/automattic/wordpress-android/builds/27686)).
- Confirmed the fix mechanism with `./gradlew buildEnvironment`: DAGP's own `kotlin-metadata-jvm:2.2.21` dependency and the added entry resolve into the same buildscript classpath configuration, so Gradle's ordinary "highest version wins" conflict resolution upgrades both (`2.2.21 -> 2.4.10`).

**Caveats:**
- The `kotlin-metadata-jvm` override is a TODO-flagged, removable shim, not a permanent fix. It should be deleted once DAGP ships [#1719](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1719) and the `dependency-analysis` catalog entry is bumped past it.
- Because it's pinned to this project's own Kotlin version (currently 2.4.10, which reads metadata up to 2.5.0), a future dependency shipping Kotlin 2.6.0-tagged metadata before this project's own Kotlin catches up would reintroduce the same failure.

---

## Testing instructions

1. Run `./gradlew buildHealth` locally on this branch and confirm it completes with `BUILD SUCCESSFUL` (no `explodeJar*` metadata-version failures).
2. Optionally, trigger the scheduled dependency-analysis pipeline manually on this branch (`PIPELINE=schedules/dependency-analysis.yml`) to validate against the exact CI job that was failing.
    - Manual `Dependency Analysis` Build: [27699](https://buildkite.com/automattic/wordpress-android/builds/27699)
