### PR TITLE
CMM-2190: Fix likes profile bottom sheet clipping at large font sizes

### DIFF
--- a/WordPress/src/main/res/layout/user_profile_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/user_profile_bottom_sheet.xml
@@ -1,154 +1,159 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
-    <include
-        layout="@layout/bottom_sheet_handle_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/user_data_container"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/margin_extra_large"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_extra_medium_large">
+        android:animateLayoutChanges="true"
+        android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/user_avatar"
-            android:layout_width="@dimen/user_profile_bottom_sheet_avatar_sz"
-            android:layout_height="@dimen/user_profile_bottom_sheet_avatar_sz"
-            android:importantForAccessibility="no"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@drawable/img_illustration_magician_hat_128" />
-
-        <ImageView
-            android:id="@+id/user_site_blavatar"
-            android:layout_width="@dimen/avatar_sz_medium"
-            android:layout_height="@dimen/avatar_sz_medium"
-            android:importantForAccessibility="no"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:src="@drawable/img_illustration_magician_hat_128"/>
+        <include
+            layout="@layout/bottom_sheet_handle_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
         <LinearLayout
-            android:id="@+id/user_data"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
+            android:id="@+id/user_data_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingEnd="0dp"
+            android:paddingBottom="@dimen/margin_extra_large"
+            android:paddingEnd="@dimen/margin_extra_large"
             android:paddingStart="@dimen/margin_extra_large"
-            app:layout_constraintBottom_toBottomOf="@+id/user_avatar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/user_avatar"
-            app:layout_constraintTop_toTopOf="@+id/user_avatar">
+            android:paddingTop="@dimen/margin_extra_medium_large">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/user_avatar"
+                    android:layout_width="@dimen/user_profile_bottom_sheet_avatar_sz"
+                    android:layout_height="@dimen/user_profile_bottom_sheet_avatar_sz"
+                    android:importantForAccessibility="no"
+                    tools:src="@drawable/img_illustration_magician_hat_128" />
+
+                <LinearLayout
+                    android:id="@+id/user_data"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:paddingEnd="0dp"
+                    android:paddingStart="@dimen/margin_extra_large">
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/user_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:fontFamily="serif"
+                        android:includeFontPadding="false"
+                        android:layout_marginBottom="@dimen/margin_small"
+                        android:maxLines="1"
+                        android:textAppearance="?attr/textAppearanceHeadline6"
+                        android:textColor="@color/material_on_surface_emphasis_high_type"
+                        android:textSize="@dimen/user_profile_bottom_sheet_user_name_text_size"
+                        android:textStyle="bold"
+                        tools:text="Pamela Nguyen" />
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/user_login"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:includeFontPadding="false"
+                        android:maxLines="1"
+                        android:textAppearance="?attr/textAppearanceBody1"
+                        android:textColor="@color/material_on_surface_emphasis_medium"
+                        tools:text="\@pamelanguyen" />
+
+                </LinearLayout>
+
+            </LinearLayout>
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/user_name"
-                android:layout_width="wrap_content"
+                android:id="@+id/user_bio"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
                 android:ellipsize="end"
-                android:fontFamily="serif"
-                android:includeFontPadding="false"
-                android:singleLine="true"
-                android:layout_marginBottom="@dimen/margin_small"
-                android:textAppearance="?attr/textAppearanceHeadline6"
-                android:textColor="@color/material_on_surface_emphasis_high_type"
-                android:textSize="@dimen/user_profile_bottom_sheet_user_name_text_size"
-                android:textStyle="bold"
-                tools:text="Pamela Nguyen" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/user_login"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:includeFontPadding="false"
-                android:singleLine="true"
-                android:textAppearance="?attr/textAppearanceBody1"
-                android:textColor="@color/material_on_surface_emphasis_medium"
-                tools:text="\@pamelanguyen" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/site_data"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:orientation="vertical"
-            android:paddingStart="@dimen/margin_extra_large"
-            android:paddingEnd="0dp"
-            android:background="?attr/selectableItemBackground"
-            app:layout_constraintBottom_toBottomOf="@+id/user_site_blavatar"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/user_site_blavatar"
-            app:layout_constraintTop_toTopOf="@+id/user_site_blavatar">
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/site_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:includeFontPadding="false"
-                android:layout_marginBottom="@dimen/margin_small"
-                android:singleLine="true"
-                android:textAppearance="?attr/textAppearanceBody1"
-                android:textColor="@color/material_on_surface_emphasis_high_type"
-                tools:text="Around the World with Pam" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/site_url"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:includeFontPadding="false"
-                android:singleLine="true"
+                android:lineSpacingMultiplier="1.2"
+                android:maxLines="5"
+                android:textAlignment="viewStart"
                 android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="@color/material_on_surface_emphasis_medium"
-                tools:text="pamelanguyen.com" />
+                tools:text="I live in Houston, by way of Taiwan, France, and Canada, and love to travel the world. Follow me as I try to visit 75 countries by the time I'm 75!" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/site_section_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:ellipsize="end"
+                android:includeFontPadding="true"
+                android:text="@string/user_profile_site_section_header"
+                android:textAlignment="viewStart"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                android:textSize="@dimen/text_sz_medium" />
+
+            <LinearLayout
+                android:id="@+id/site_data"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/user_site_blavatar"
+                    android:layout_width="@dimen/avatar_sz_medium"
+                    android:layout_height="@dimen/avatar_sz_medium"
+                    android:importantForAccessibility="no"
+                    tools:src="@drawable/img_illustration_magician_hat_128" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:paddingEnd="0dp"
+                    android:paddingStart="@dimen/margin_extra_large">
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/site_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:includeFontPadding="false"
+                        android:layout_marginBottom="@dimen/margin_small"
+                        android:maxLines="1"
+                        android:textAppearance="?attr/textAppearanceBody1"
+                        android:textColor="@color/material_on_surface_emphasis_high_type"
+                        tools:text="Around the World with Pam" />
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/site_url"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:includeFontPadding="false"
+                        android:maxLines="1"
+                        android:textAppearance="?attr/textAppearanceBody2"
+                        android:textColor="@color/material_on_surface_emphasis_medium"
+                        tools:text="pamelanguyen.com" />
+
+                </LinearLayout>
+
+            </LinearLayout>
 
         </LinearLayout>
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/user_bio"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:ellipsize="end"
-            android:maxLines="5"
-            android:textAlignment="viewStart"
-            android:lineSpacingMultiplier="1.2"
-            android:textAppearance="?attr/textAppearanceBody2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/user_avatar"
-            tools:text="I live in Houston, by way of Taiwan, France, and Canada, and love to travel the world. Follow me as I try to visit 75 countries by the time I'm 75!" />
+    </LinearLayout>
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/site_section_header"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:ellipsize="end"
-            android:includeFontPadding="true"
-            android:text="@string/user_profile_site_section_header"
-            android:textAlignment="viewStart"
-            android:textAppearance="?attr/textAppearanceSubtitle2"
-            android:textSize="@dimen/text_sz_medium"
-            app:layout_constraintBottom_toTopOf="@+id/user_site_blavatar"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/user_bio" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</LinearLayout>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
## Description

Fixes [CMM-2190](https://linear.app/a8c/issue/CMM-2190/android-likes-bottom-sheet-cutoff). At larger device font sizes, the user profile bottom sheet opened from the Reader likes list clipped the site title and URL at the bottom edge.

## Testing instructions

Likes profile sheet at increasing font sizes:

1. Set the device font size to Default (Settings → Display → Font size).
2. Open Reader, open a post that has likes, and tap the likes row at the bottom of the post.
3. Tap a liker to open the profile bottom sheet.
- [ ] Sheet looks unchanged from before this PR.
4. Raise the font size to Large, then to the largest accessibility size, repeating steps 2-3 each time.
- [ ] The name, `@username`, "Site" header, site title and site URL are all fully visible — nothing is cut off at the bottom edge.
- [ ] Long site URLs ellipsize on a single line rather than clipping.

## Before and after shots

<img width="726" height="792" alt="before" src="https://github.com/user-attachments/assets/d5f59319-35a3-4057-8ac8-b7348ca6dacb" />
