### PR TITLE
CMM-2165: Fix broken editor toolbar when opening the Aztec media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -200,6 +200,7 @@ class MediaPickerFragment : Fragment(), MenuProvider {
     private lateinit var viewModel: MediaPickerViewModel
     private var binding: MediaPickerFragmentBinding? = null
     private lateinit var mediaPickerSetup: MediaPickerSetup
+    private var isEmbedded: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -222,7 +223,12 @@ class MediaPickerFragment : Fragment(), MenuProvider {
     @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
+        isEmbedded = requireArguments().getBoolean(KEY_EMBEDDED, false)
+        // an embedded picker must not add its items to the host's toolbar - the host surfaces the
+        // other media sources itself
+        if (!isEmbedded) {
+            requireActivity().addMenuProvider(this, viewLifecycleOwner)
+        }
 
         mediaPickerSetup = MediaPickerSetup.fromBundle(requireArguments())
         val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
@@ -732,16 +738,24 @@ class MediaPickerFragment : Fragment(), MenuProvider {
         private const val KEY_LAST_TAPPED_ICON_DATA_SOURCE = "last_tapped_icon_data_source"
         private const val KEY_SELECTED_IDS = "selected_ids"
         private const val KEY_LIST_STATE = "list_state"
+        private const val KEY_EMBEDDED = "key_embedded"
         const val NUM_COLUMNS = 3
 
+        /**
+         * @param isEmbedded pass true when the picker is hosted inside a screen that owns its own
+         * toolbar menu (ex: the editor's media picker). Embedded pickers don't contribute to the
+         * host's options menu, so the host is responsible for surfacing the other media sources.
+         */
         @JvmStatic
         fun newInstance(
             listener: MediaPickerListener,
             mediaPickerSetup: MediaPickerSetup,
-            site: SiteModel?
+            site: SiteModel?,
+            isEmbedded: Boolean = false
         ): MediaPickerFragment {
             val args = Bundle()
             mediaPickerSetup.toBundle(args)
+            args.putBoolean(KEY_EMBEDDED, isEmbedded)
             if (site != null) {
                 args.putSerializable(WordPress.SITE, site)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorPhotoPicker.kt
@@ -3,7 +3,9 @@ package org.wordpress.android.ui.posts.editor
 import android.content.res.Configuration
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView.Orientation
 import org.wordpress.android.R
 import org.wordpress.android.editor.MediaToolbarAction
@@ -89,9 +91,10 @@ class EditorPhotoPicker(
             val mediaPickerSetup = buildEditorMediaPickerSetup(site)
 
             MediaPickerFragment.newInstance(
-                this,
-                mediaPickerSetup,
-                site
+                listener = this,
+                mediaPickerSetup = mediaPickerSetup,
+                site = site,
+                isEmbedded = true
             ).let {
                 mediaPickerFragment = it
                 activity.supportFragmentManager
@@ -196,8 +199,13 @@ class EditorPhotoPicker(
         val siteModel = siteModelProvider()
         when (action) {
             MediaToolbarAction.GALLERY -> {
-                // Show the embedded photo picker for selecting media from device
-                showPhotoPicker(siteModel)
+                // Once the picker is showing, this button offers the other media sources in a
+                // popup anchored below it - otherwise it opens the picker
+                if (isPhotoPickerShowing()) {
+                    showMediaSourcePopup(action, siteModel)
+                } else {
+                    showPhotoPicker(siteModel)
+                }
             }
             MediaToolbarAction.CAMERA -> {
                 // Launch the camera to capture a photo (after checking permissions)
@@ -216,6 +224,45 @@ class EditorPhotoPicker(
                 )
             }
             null -> { /* no-op */ }
+        }
+    }
+
+    /**
+     * Shows the media sources that aren't part of the picker's device media grid in a popup
+     * anchored to the media toolbar button that was tapped.
+     */
+    private fun showMediaSourcePopup(action: MediaToolbarAction, site: SiteModel) {
+        val anchor = activity.findViewById<View>(action.buttonId) ?: return
+        if (!WPMediaUtils.currentUserCanUploadMedia(site)) {
+            showNoUploadPermissionSnackbar()
+            return
+        }
+        allowMultipleSelection = true
+        PopupMenu(activity, anchor).apply {
+            addItem(R.string.photo_picker_choose_photo) {
+                WPMediaUtils.launchPictureLibrary(activity, true)
+            }
+            addItem(R.string.photo_picker_choose_video) {
+                WPMediaUtils.launchVideoLibrary(activity, true)
+            }
+            if (site.isUsingWpComRestApi) {
+                addItem(R.string.photo_picker_stock_media) {
+                    mediaPickerLauncher.showStockMediaPickerForResult(
+                        activity,
+                        site,
+                        RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT,
+                        true
+                    )
+                }
+            }
+        }.show()
+    }
+
+    private fun PopupMenu.addItem(@StringRes title: Int, action: () -> Unit) {
+        menu.add(title).setOnMenuItemClickListener {
+            hidePhotoPicker()
+            action()
+            true
         }
     }
 


### PR DESCRIPTION
## Description

Fixes [CMM-2165](https://linear.app/a8c/issue/CMM-2165/opening-aztec-editor-media-picker-results-in-broken-navigation).

`MediaPickerFragment` registers itself as a `MenuProvider` on the host activity. That's correct for `MediaPickerActivity`, which owns a toolbar containing nothing else, but wrong for the editor. The picker's search + "Choose from…" items were merged into the post editor's menu, where they remained after the picker was dismissed.

Note that the popup has three items rather than the four in 26.4 — the Tenor/GIF picker has since been removed from the codebase.

## Testing instructions

Aztec media picker:

1. Disable the block editor for a site: My Site → More → Site settings
2. Create a new post and tap the `+` icon in the format bar
- [x] Verify the editor's top toolbar shows only editor items — no search icon, and no "Browse for items…" / "Choose from…" entries in the overflow
3. Dismiss the picker
- [x] Verify no picker items are left behind in the toolbar
4. With the picker open, tap the gallery (stacked images) icon in the media toolbar
- [x] Verify a popup appears anchored below it with "Choose photo from device", "Choose video from device" and "Choose from Free Photo Library"
5. Tap each item in turn
- [x] Verify the picker is dismissed and the correct picker opens, and that the chosen media is inserted into the post

Standalone media picker (must not regress):

1. Open Me → Site → Media → "+", and Post Settings → Featured image
- [x] Verify the picker's own toolbar still shows the search icon and the full "Choose from…" overflow
2. Choose "Choose from media library" from that overflow
- [x] Verify the newly launched picker also shows a normal toolbar menu
3. Expand and collapse search
- [x] Verify the browse items hide and reappear