### PR TITLE
Default new stats Views card to a bar chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCard.kt
@@ -946,7 +946,7 @@ private fun ViewsStatsCardLoadingPreview() {
     }
 }
 
-private fun sampleLoadedState(): ViewsStatsCardUiState.Content {
+private fun sampleLoadedState(chartType: ChartType): ViewsStatsCardUiState.Content {
     val currentPeriodLabels = listOf("Jan 14", "Jan 15", "Jan 16", "Jan 17", "Jan 18", "Jan 19", "Jan 20")
     val previousPeriodLabels = listOf("Jan 7", "Jan 8", "Jan 9", "Jan 10", "Jan 11", "Jan 12", "Jan 13")
 
@@ -966,7 +966,8 @@ private fun sampleLoadedState(): ViewsStatsCardUiState.Content {
                     ChartDataPoint(label, views)
                 }
             ),
-            periodAverage = SAMPLE_PERIOD_AVERAGE
+            periodAverage = SAMPLE_PERIOD_AVERAGE,
+            chartType = chartType
         ),
         bottomStats = BottomStatsUiState.Loaded(
             listOf(
@@ -985,7 +986,21 @@ private fun sampleLoadedState(): ViewsStatsCardUiState.Content {
 private fun ViewsStatsCardLoadedPreview() {
     AppThemeM3 {
         ViewsStatsCard(
-            uiState = sampleLoadedState(),
+            uiState = sampleLoadedState(ChartType.BAR),
+            onChartTypeChanged = {},
+            onBarTapped = {},
+            onRetry = {},
+            onRemoveCard = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ViewsStatsCardLoadedLineChartPreview() {
+    AppThemeM3 {
+        ViewsStatsCard(
+            uiState = sampleLoadedState(ChartType.LINE),
             onChartTypeChanged = {},
             onBarTapped = {},
             onRetry = {},
@@ -1015,7 +1030,7 @@ private fun ViewsStatsCardErrorPreview() {
 private fun ViewsStatsCardLoadedDarkPreview() {
     AppThemeM3 {
         ViewsStatsCard(
-            uiState = sampleLoadedState(),
+            uiState = sampleLoadedState(ChartType.BAR),
             onChartTypeChanged = {},
             onBarTapped = {},
             onRetry = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCardUiState.kt
@@ -37,7 +37,7 @@ sealed class ChartUiState {
         val previousPeriodDateRange: String,
         val chartData: ViewsStatsChartData,
         val periodAverage: Long,
-        val chartType: ChartType = ChartType.BAR
+        val chartType: ChartType
     ) : ChartUiState()
 
     data object Error : ChartUiState()
@@ -61,6 +61,11 @@ enum class ChartType(val storageKey: String) {
     BAR("bar");
 
     companion object {
+        /**
+         * Used when the user has never picked a chart type for the site.
+         */
+        val DEFAULT = BAR
+
         fun fromStorageKey(key: String?): ChartType? =
             entries.firstOrNull { it.storageKey == key }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsCardUiState.kt
@@ -37,7 +37,7 @@ sealed class ChartUiState {
         val previousPeriodDateRange: String,
         val chartData: ViewsStatsChartData,
         val periodAverage: Long,
-        val chartType: ChartType = ChartType.LINE
+        val chartType: ChartType = ChartType.BAR
     ) : ChartUiState()
 
     data object Error : ChartUiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
@@ -230,7 +230,7 @@ class ViewsStatsViewModel @Inject constructor(
     private fun restoreChartTypeFromSavedState(): ChartType {
         return ChartType.fromStorageKey(
             savedStateHandle.get<String>(KEY_CHART_TYPE)
-        ) ?: ChartType.BAR
+        ) ?: ChartType.DEFAULT
     }
 
     private suspend fun restoreChartTypeFromPreferences(): ChartType? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModel.kt
@@ -230,7 +230,7 @@ class ViewsStatsViewModel @Inject constructor(
     private fun restoreChartTypeFromSavedState(): ChartType {
         return ChartType.fromStorageKey(
             savedStateHandle.get<String>(KEY_CHART_TYPE)
-        ) ?: ChartType.LINE
+        ) ?: ChartType.BAR
     }
 
     private suspend fun restoreChartTypeFromPreferences(): ChartType? {

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/viewsstats/ViewsStatsViewModelTest.kt
@@ -642,10 +642,10 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
         initViewModel()
         advanceUntilIdle()
 
-        viewModel.onChartTypeChanged(ChartType.BAR)
+        viewModel.onChartTypeChanged(ChartType.LINE)
 
         val state = viewModel.uiState.value.chartLoaded()
-        assertThat(state.chartType).isEqualTo(ChartType.BAR)
+        assertThat(state.chartType).isEqualTo(ChartType.LINE)
     }
 
     // region Chart type persistence
@@ -668,9 +668,29 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when SavedStateHandle has bar chart type, then it is restored`() = test {
+    fun `when no chart type is stored, then it defaults to bar`() = test {
+        whenever(cardsConfigurationRepository.getConfiguration(any()))
+            .thenReturn(StatsCardsConfiguration())
+        val result = createPeriodStatsResult()
+        whenever(statsRepository.fetchStatsForPeriod(any(), any()))
+            .thenReturn(result)
+
+        viewModel = ViewsStatsViewModel(
+            selectedSiteRepository, accountStore, statsRepository,
+            resourceProvider, SavedStateHandle(),
+            cardsConfigurationRepository
+        )
+        viewModel.loadDataIfNeeded()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value.chartLoaded()
+        assertThat(state.chartType).isEqualTo(ChartType.BAR)
+    }
+
+    @Test
+    fun `when SavedStateHandle has line chart type, then it is restored`() = test {
         val savedState = SavedStateHandle(
-            mapOf("chart_type" to "bar")
+            mapOf("chart_type" to "line")
         )
         whenever(cardsConfigurationRepository.getConfiguration(any()))
             .thenReturn(StatsCardsConfiguration())
@@ -686,14 +706,14 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         val state = viewModel.uiState.value.chartLoaded()
-        assertThat(state.chartType).isEqualTo(ChartType.BAR)
+        assertThat(state.chartType).isEqualTo(ChartType.LINE)
     }
 
     @Test
-    fun `when preferences has bar chart type, then it is restored`() = test {
+    fun `when preferences has line chart type, then it is restored`() = test {
         whenever(cardsConfigurationRepository.getConfiguration(any()))
             .thenReturn(
-                StatsCardsConfiguration(selectedChartType = "bar")
+                StatsCardsConfiguration(selectedChartType = "line")
             )
         val result = createPeriodStatsResult()
         whenever(statsRepository.fetchStatsForPeriod(any(), any()))
@@ -708,7 +728,7 @@ class ViewsStatsViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         val state = viewModel.uiState.value.chartLoaded()
-        assertThat(state.chartType).isEqualTo(ChartType.BAR)
+        assertThat(state.chartType).isEqualTo(ChartType.LINE)
     }
 
     // endregion


### PR DESCRIPTION
## Description

**Fixes CMM-2204**

The Views card in the new stats defaults to using a line chart, but user feedback suggests a bar chart is more clear. In addition, [iOS changed the default to a bar chart](https://github.com/wordpress-mobile/WordPress-iOS/pull/24768), and we should match that. This is the purpose of this PR.

## Testing instructions

Default on a fresh site:

1. Clear data and sign into the app
2. Open Stats.
- [ ] Verify the Views card renders as a **bar** chart.

Saved preference still wins:

1. Open the Views card overflow menu and select **Lines**.
2. Background the app and relaunch it, then reopen Stats.
- [ ] Verify the Views card is still a line chart.
3. Switch back to **Bars** and relaunch again.
- [ ] Verify it stays on bars.
