### PR TITLE
Reader: never leave the post detail stuck on an endless spinner (CMM-2254)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCase.kt
@@ -24,6 +24,7 @@ class ReaderFetchPostUseCase @Inject constructor(
     // AlreadyRunning. Synchronized because the request callbacks fire on a background thread.
     private val inFlightRequests = Collections.synchronizedSet(mutableSetOf<FetchPostRequestParams>())
 
+    @Suppress("ReturnCount") // early guard clauses (no network / already in flight) read cleaner than nesting
     suspend fun fetchPost(blogId: Long, postId: Long, isFeed: Boolean): FetchReaderPostState {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return NoNetwork

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCase.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader.usecases
 
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchReaderPostState.AlreadyRunning
@@ -11,50 +12,60 @@ import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchRead
 import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchReaderPostState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 import java.net.HttpURLConnection
+import java.util.Collections
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
 class ReaderFetchPostUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val readerPostActionsWrapper: ReaderPostActionsWrapper
 ) {
-    private val continuations: MutableMap<FetchPostRequestParams, Continuation<Int>?> = mutableMapOf()
+    // Tracks in-flight fetches so a second request for the same post short-circuits to
+    // AlreadyRunning. Synchronized because the request callbacks fire on a background thread.
+    private val inFlightRequests = Collections.synchronizedSet(mutableSetOf<FetchPostRequestParams>())
 
     suspend fun fetchPost(blogId: Long, postId: Long, isFeed: Boolean): FetchReaderPostState {
-        return if (!networkUtilsWrapper.isNetworkAvailable()) {
-            NoNetwork
-        } else {
-            val requestParams = FetchPostRequestParams(blogId, postId, isFeed)
-            // There is already an action running for this request
-            if (continuations[requestParams] != null) {
-                AlreadyRunning
-            } else {
-                when (fetchPostAndWaitForResult(requestParams)) {
-                    HttpURLConnection.HTTP_OK -> Success
-                    HttpURLConnection.HTTP_UNAUTHORIZED, HttpURLConnection.HTTP_FORBIDDEN -> NotAuthorised
-                    HttpURLConnection.HTTP_NOT_FOUND -> PostNotFound
-                    else -> RequestFailed
-                }
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            return NoNetwork
+        }
+
+        val requestParams = FetchPostRequestParams(blogId, postId, isFeed)
+        // add() returns false when an identical request is already in flight
+        if (!inFlightRequests.add(requestParams)) {
+            return AlreadyRunning
+        }
+
+        return try {
+            // Never wait forever: a request that neither succeeds nor fails (e.g. a stalled
+            // connection) resolves to RequestFailed so the caller can leave the loading state.
+            val statusCode = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
+                fetchPostAndWaitForResult(requestParams)
             }
+            when (statusCode) {
+                HttpURLConnection.HTTP_OK -> Success
+                HttpURLConnection.HTTP_UNAUTHORIZED, HttpURLConnection.HTTP_FORBIDDEN -> NotAuthorised
+                HttpURLConnection.HTTP_NOT_FOUND -> PostNotFound
+                else -> RequestFailed
+            }
+        } finally {
+            // Always release the slot, including on timeout or coroutine cancellation, so a
+            // later retry of the same post isn't wrongly rejected as AlreadyRunning.
+            inFlightRequests.remove(requestParams)
         }
     }
 
-    private suspend fun fetchPostAndWaitForResult(requestParams: FetchPostRequestParams): Int {
-        val listener = object : ReaderActions.OnRequestListener<String> {
-            override fun onSuccess(result: String?) {
-                continuations[requestParams]?.resume(HttpURLConnection.HTTP_OK)
-                continuations[requestParams] = null
-            }
+    private suspend fun fetchPostAndWaitForResult(requestParams: FetchPostRequestParams): Int =
+        suspendCancellableCoroutine { cont ->
+            val listener = object : ReaderActions.OnRequestListener<String> {
+                override fun onSuccess(result: String?) {
+                    // Guard against resuming an already-cancelled (e.g. timed-out) request
+                    if (cont.isActive) cont.resume(HttpURLConnection.HTTP_OK)
+                }
 
-            override fun onFailure(statusCode: Int) {
-                continuations[requestParams]?.resume(statusCode)
-                continuations[requestParams] = null
+                override fun onFailure(statusCode: Int) {
+                    if (cont.isActive) cont.resume(statusCode)
+                }
             }
-        }
-
-        return suspendCancellableCoroutine { cont ->
-            continuations[requestParams] = cont
 
             if (requestParams.isFeed) {
                 readerPostActionsWrapper.requestFeedPost(
@@ -70,7 +81,6 @@ class ReaderFetchPostUseCase @Inject constructor(
                 )
             }
         }
-    }
 
     sealed class FetchReaderPostState {
         object Success : FetchReaderPostState()
@@ -88,4 +98,8 @@ class ReaderFetchPostUseCase @Inject constructor(
         val postId: Long,
         val isFeed: Boolean
     )
+
+    companion object {
+        private const val FETCH_TIMEOUT_MS = 30_000L
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -391,9 +391,11 @@ class ReaderPostDetailViewModel @Inject constructor(
     private suspend fun getOrFetchReaderPost(blogId: Long, postId: Long) {
         getReaderPostFromDb(blogId = blogId, postId = postId)
 
-        // Show cached content immediately if available, otherwise show loading
-        val hasCachedPost = post != null
-        if (hasCachedPost) {
+        // Only render the cached copy immediately if it actually has body content. A
+        // header-only post (whose body hasn't been fetched yet) would otherwise leave the
+        // user staring at a blank article, so keep the loading state until the fetch lands.
+        val hasRenderableContent = post?.hasText() == true
+        if (hasRenderableContent) {
             updatePostDetailsUi()
         } else {
             _uiState.value = LoadingUiState
@@ -404,39 +406,43 @@ class ReaderPostDetailViewModel @Inject constructor(
         when (readerFetchPostUseCase.fetchPost(blogId = blogId, postId = postId, isFeed = isFeed)) {
             FetchReaderPostState.Success -> {
                 getReaderPostFromDb(blogId, postId)
-                // Update UI if content changed, or we didn't have cached content
-                if (!hasCachedPost || post?.text != oldPostText) {
+                if (post == null) {
+                    // The fetch reported success but produced no post to render; surface an
+                    // error instead of leaving the loading spinner up forever.
+                    _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
+                } else if (!hasRenderableContent || post?.text != oldPostText) {
+                    // Update UI if content changed, or we didn't already have renderable content
                     updatePostDetailsUi()
                 }
             }
 
             FetchReaderPostState.AlreadyRunning -> {
-                if (!hasCachedPost) {
+                if (!hasRenderableContent) {
                     AppLog.i(T.READER, "reader post detail > fetch post already running")
                     _uiState.value = ErrorUiState(null)
                 }
             }
 
             FetchReaderPostState.Failed.NoNetwork -> {
-                if (!hasCachedPost) {
+                if (!hasRenderableContent) {
                     _uiState.value = ErrorUiState(UiStringRes(R.string.no_network_message))
                 }
             }
 
             FetchReaderPostState.Failed.RequestFailed -> {
-                if (!hasCachedPost) {
+                if (!hasRenderableContent) {
                     _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
                 }
             }
 
             FetchReaderPostState.Failed.NotAuthorised -> {
-                if (!hasCachedPost) {
+                if (!hasRenderableContent) {
                     trackAndUpdateNotAuthorisedErrorState()
                 }
             }
 
             FetchReaderPostState.Failed.PostNotFound -> {
-                if (!hasCachedPost) {
+                if (!hasRenderableContent) {
                     _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_not_found))
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -387,7 +387,6 @@ class ReaderPostDetailViewModel @Inject constructor(
         launch { getOrFetchReaderPost(blogId = blogId, postId = postId) }
     }
 
-    @Suppress("CyclomaticComplexMethod")
     private suspend fun getOrFetchReaderPost(blogId: Long, postId: Long) {
         getReaderPostFromDb(blogId = blogId, postId = postId)
 
@@ -403,49 +402,55 @@ class ReaderPostDetailViewModel @Inject constructor(
 
         // Always fetch fresh content from the server
         val oldPostText = post?.text
-        when (readerFetchPostUseCase.fetchPost(blogId = blogId, postId = postId, isFeed = isFeed)) {
-            FetchReaderPostState.Success -> {
-                getReaderPostFromDb(blogId, postId)
-                if (post == null) {
-                    // The fetch reported success but produced no post to render; surface an
-                    // error instead of leaving the loading spinner up forever.
-                    _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
-                } else if (!hasRenderableContent || post?.text != oldPostText) {
-                    // Update UI if content changed, or we didn't already have renderable content
-                    updatePostDetailsUi()
-                }
-            }
+        val fetchState = readerFetchPostUseCase.fetchPost(blogId = blogId, postId = postId, isFeed = isFeed)
+        if (fetchState is FetchReaderPostState.Success) {
+            renderFetchedPost(blogId, postId, hadRenderableContent = hasRenderableContent, oldPostText = oldPostText)
+        } else if (!hasRenderableContent) {
+            // A non-success outcome only changes the UI when there's nothing on screen yet; a
+            // rendered post is kept rather than torn down by a failed background refresh.
+            showFetchOutcomeWithoutContent(fetchState)
+        }
+    }
 
+    private suspend fun renderFetchedPost(
+        blogId: Long,
+        postId: Long,
+        hadRenderableContent: Boolean,
+        oldPostText: String?
+    ) {
+        getReaderPostFromDb(blogId, postId)
+        // Apply the same renderability test as the loading gate: a fetch that "succeeds" but
+        // leaves us with no post, or a post whose body is still empty, must not fall through
+        // to a blank article — that's the CMM-2254 symptom.
+        if (post?.hasText() == true) {
+            // Render when the body changed, or we didn't already have renderable content
+            if (!hadRenderableContent || post?.text != oldPostText) {
+                updatePostDetailsUi()
+            }
+        } else if (!hadRenderableContent) {
+            // Success but nothing renderable (a missing post or an empty body). Surface an
+            // error rather than a blank article or an endless spinner.
+            _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
+        }
+    }
+
+    private fun showFetchOutcomeWithoutContent(fetchState: FetchReaderPostState) {
+        when (fetchState) {
             FetchReaderPostState.AlreadyRunning -> {
-                if (!hasRenderableContent) {
-                    AppLog.i(T.READER, "reader post detail > fetch post already running")
-                    _uiState.value = ErrorUiState(null)
-                }
+                // A sibling fetch for this post is already in flight (e.g. a re-entry after a
+                // config change); stay on loading and let it resolve the UI.
+                AppLog.i(T.READER, "reader post detail > fetch post already running")
+                _uiState.value = LoadingUiState
             }
-
-            FetchReaderPostState.Failed.NoNetwork -> {
-                if (!hasRenderableContent) {
-                    _uiState.value = ErrorUiState(UiStringRes(R.string.no_network_message))
-                }
-            }
-
-            FetchReaderPostState.Failed.RequestFailed -> {
-                if (!hasRenderableContent) {
-                    _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
-                }
-            }
-
-            FetchReaderPostState.Failed.NotAuthorised -> {
-                if (!hasRenderableContent) {
-                    trackAndUpdateNotAuthorisedErrorState()
-                }
-            }
-
-            FetchReaderPostState.Failed.PostNotFound -> {
-                if (!hasRenderableContent) {
-                    _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_not_found))
-                }
-            }
+            FetchReaderPostState.Failed.NoNetwork ->
+                _uiState.value = ErrorUiState(UiStringRes(R.string.no_network_message))
+            FetchReaderPostState.Failed.RequestFailed ->
+                _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic))
+            FetchReaderPostState.Failed.NotAuthorised ->
+                trackAndUpdateNotAuthorisedErrorState()
+            FetchReaderPostState.Failed.PostNotFound ->
+                _uiState.value = ErrorUiState(UiStringRes(R.string.reader_err_get_post_not_found))
+            FetchReaderPostState.Success -> Unit // handled by renderFetchedPost
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderFetchPostUseCaseTest.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.reader.usecases
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -13,6 +15,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
+import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchReaderPostState.AlreadyRunning
 import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchReaderPostState.Failed
 import org.wordpress.android.ui.reader.usecases.ReaderFetchPostUseCase.FetchReaderPostState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -131,5 +134,24 @@ class ReaderFetchPostUseCaseTest : BaseUnitTest() {
         val result = useCase.fetchPost(postId = postId, blogId = blogId, isFeed = false)
 
         assertThat(result).isEqualTo(Failed.RequestFailed)
+    }
+
+    @Test
+    fun `given the request never responds, when reader post is fetched, then request failed is returned`() = test {
+        // The request mock never invokes its listener, so resolution relies on the timeout
+        val result = useCase.fetchPost(postId = postId, blogId = blogId, isFeed = false)
+
+        assertThat(result).isEqualTo(Failed.RequestFailed)
+    }
+
+    @Test
+    fun `given a request for the same post is running, when fetched again, then already running is returned`() = test {
+        // The first request stays in flight because its listener is never invoked
+        val firstRequest = launch { useCase.fetchPost(postId = postId, blogId = blogId, isFeed = false) }
+
+        val secondResult = useCase.fetchPost(postId = postId, blogId = blogId, isFeed = false)
+
+        assertThat(secondResult).isEqualTo(AlreadyRunning)
+        firstRequest.cancelAndJoin()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -454,7 +454,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given request already running, when post is fetched, then no error is shown`() =
+    fun `given request already running, when post is fetched, then loading is kept and no error is shown`() =
         testWithoutLocalPost {
             whenever(readerFetchPostUseCase.fetchPost(readerPost.blogId, readerPost.postId, viewModel.isFeed))
                 .thenReturn(FetchReaderPostState.Success)
@@ -464,7 +464,9 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
 
             viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
 
-            assertThat(observers.uiStates.filterIsInstance<ErrorUiState>().last().message).isNull()
+            // A sibling fetch is still in flight, so we stay on loading rather than showing
+            // a (message-less) error that would blank the screen mid-load.
+            assertThat(observers.uiStates.last()).isEqualTo(LoadingUiState)
         }
 
     @Test
@@ -519,6 +521,36 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
             assertThat(observers.uiStates.last())
                 .isEqualTo(ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic)))
         }
+
+    @Test
+    fun `given fetch succeeds but body is empty, when show post is triggered, then error is shown`() = test {
+        val bodylessPost = createDummyReaderPost(readerPost.postId).apply { text = null }
+        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean())).thenReturn(Pair(bodylessPost, false))
+        whenever(readerFetchPostUseCase.fetchPost(anyLong(), anyLong(), anyBoolean()))
+            .thenReturn(FetchReaderPostState.Success)
+        val observers = init(showPost = false)
+
+        viewModel.onShowPost(blogId = bodylessPost.blogId, postId = bodylessPost.postId)
+
+        assertThat(observers.uiStates.last())
+            .isEqualTo(ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic)))
+    }
+
+    @Test
+    fun `given rendered post and empty refetch, when show post is triggered, then content is kept`() = test {
+        val bodylessPost = createDummyReaderPost(readerPost.postId).apply { text = null }
+        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean()))
+            .thenReturn(Pair(readerPost, false))
+            .thenReturn(Pair(bodylessPost, false))
+        whenever(readerFetchPostUseCase.fetchPost(anyLong(), anyLong(), anyBoolean()))
+            .thenReturn(FetchReaderPostState.Success)
+        val observers = init(showPost = false)
+
+        viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
+
+        assertThat(observers.uiStates.last()).isInstanceOf(ReaderPostDetailsUiState::class.java)
+        assertThat(observers.uiStates.none { it is ErrorUiState }).isTrue
+    }
 
     @Test
     fun `given unauthorised, when post is fetched, then error ui is shown`() = testWithoutLocalPost {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -481,6 +481,45 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
             .isEqualTo(ErrorUiState(UiStringRes(R.string.reader_err_get_post_not_found)))
     }
 
+    /* SHOW POST - LOAD ALWAYS TERMINATES (CMM-2254) */
+    @Test
+    fun `given cached post has no body, when show post is triggered, then loading state is shown`() = test {
+        val bodylessPost = createDummyReaderPost(readerPost.postId).apply { text = null }
+        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean())).thenReturn(Pair(bodylessPost, false))
+        val observers = init(showPost = false)
+
+        viewModel.onShowPost(blogId = bodylessPost.blogId, postId = bodylessPost.postId)
+
+        assertThat(observers.uiStates.first()).isEqualTo(LoadingUiState)
+    }
+
+    @Test
+    fun `given cached post has no body and fetch fails, when show post is triggered, then error is shown`() = test {
+        val bodylessPost = createDummyReaderPost(readerPost.postId).apply { text = null }
+        whenever(readerGetPostUseCase.get(anyLong(), anyLong(), anyBoolean())).thenReturn(Pair(bodylessPost, false))
+        whenever(readerFetchPostUseCase.fetchPost(anyLong(), anyLong(), anyBoolean()))
+            .thenReturn(Failed.RequestFailed)
+        val observers = init(showPost = false)
+
+        viewModel.onShowPost(blogId = bodylessPost.blogId, postId = bodylessPost.postId)
+
+        assertThat(observers.uiStates.last())
+            .isEqualTo(ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic)))
+    }
+
+    @Test
+    fun `given fetch succeeds but post is still missing, when show post is triggered, then error is shown`() =
+        testWithoutLocalPost {
+            whenever(readerFetchPostUseCase.fetchPost(anyLong(), anyLong(), anyBoolean()))
+                .thenReturn(FetchReaderPostState.Success)
+            val observers = init(showPost = false)
+
+            viewModel.onShowPost(blogId = readerPost.blogId, postId = readerPost.postId)
+
+            assertThat(observers.uiStates.last())
+                .isEqualTo(ErrorUiState(UiStringRes(R.string.reader_err_get_post_generic)))
+        }
+
     @Test
     fun `given unauthorised, when post is fetched, then error ui is shown`() = testWithoutLocalPost {
         whenever(readerFetchPostUseCase.fetchPost(readerPost.blogId, readerPost.postId, viewModel.isFeed))
@@ -1241,6 +1280,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
             this.blogId = id * 100
             this.feedId = id * 1000
             this.title = "DummyPost"
+            this.text = "<p>Dummy post content</p>"
             this.featuredVideo = id.toString()
             this.featuredImage = "/featured_image/$id/url"
             this.isExternal = !isWpComPost


### PR DESCRIPTION
Fixes a bug where opening a Reader post could hang on a spinner (or a blank article body) indefinitely, with no error and no way forward. Reported in CMM-2254 for private P2 posts on 27.0.

## Summary
- The post detail now always resolves to **content or an error** — never a permanent spinner.
- Root cause: fetch failures were silently swallowed whenever *any* cached post object existed, even a header-only one with no body.
- Hardens `ReaderFetchPostUseCase` with a fetch timeout and leak-free in-flight tracking so the fetch itself can't hang.

## Root Cause
`ReaderPostDetailViewModel.getOrFetchReaderPost()` gated both its "show cached content vs. loading" decision and every fetch-failure branch on `post != null`. A post cached from the feed is often **header-only** — its body hasn't been fetched yet. So when the body fetch then failed or stalled, all error branches (`if (!hasCachedPost)`) were skipped, `updatePostDetailsUi()` had already shown the (unmanaged) WebView progress bar, and the screen was left showing a header over a blank body with a spinner that never stopped. Confirmed against the CMM-2254 screenshots: header rendered, body blank/spinner.

## Fix

### 1. Resolve the detail load to a terminal state — `ReaderPostDetailViewModel`
- Gate the optimistic render on `post?.hasText()` (a renderable body) instead of `post != null`. A header-only post now shows the **managed** `progress_loading` spinner — which the existing `ErrorUiState` path already tears down — instead of the unmanaged WebView progress bar.
- Surface an error on every terminal non-success outcome that leaves us without renderable content (`NoNetwork`, `RequestFailed`, `NotAuthorised`, `PostNotFound`).
- Apply the same `hasText()` test on `Success`: a fetch that yields no renderable body — a missing post *or* an empty body — surfaces an error rather than a blank article or a stuck spinner, while any content already on screen is kept, not clobbered.
- `AlreadyRunning` — a concurrent fetch for the same post (e.g. a re-entry after rotation) — holds the loading state and lets the in-flight request resolve the UI, rather than blanking the screen.
- Posts that already have a body are **unchanged** — they render immediately and a background-refresh failure stays silent.

### 2. Harden the fetch — `ReaderFetchPostUseCase`
- Wrap the request in `withTimeoutOrNull` (30s) so a stalled connection that never calls back resolves to `RequestFailed` instead of suspending forever.
- Replace the nullable `continuations` map + resume-by-key with an in-flight `Set` released in a `finally`, so a request cancelled mid-flight (user backs out) or timed out no longer leaves a sticky `AlreadyRunning`. The callback now resumes its own continuation guarded by `isActive`, so a late callback can't resume a later retry of the same post.

The server-side degradation that triggered the report — the private-P2 content fetch failing for some regions — is **not** addressed here; this change makes the client fail gracefully instead of hanging.

## Test plan
- [x] `ReaderPostDetailViewModelTest` (63 cases pass) — body-less cached post shows loading; body-less + fetch failure shows an error; `Success` with a missing post *or* an empty body shows an error; an empty background refetch keeps the rendered content; a concurrent `AlreadyRunning` fetch holds the loading state.
- [x] `ReaderFetchPostUseCaseTest` (10 cases pass) — a request that never responds resolves to `RequestFailed` (timeout); a second request for the same post returns `AlreadyRunning`.

## Related issues
- CMM-2254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
