### PR TITLE
CMM-2261: Show "Now" for fresh posts, pages and comments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentDetailsViewModel.kt
@@ -31,14 +31,15 @@ import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
 import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -67,7 +68,7 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
     private val siteCapabilityChecker: SiteCapabilityChecker,
     private val localCommentCacheUpdateHandler: LocalCommentCacheUpdateHandler,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
-    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val resourceProvider: ResourceProvider,
     private val notificationsActionsWrapper: NotificationsActionsWrapper,
     private val notificationsTableWrapper: NotificationsTableWrapper,
     private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
@@ -467,7 +468,8 @@ class UnifiedCommentDetailsViewModel @Inject constructor(
         contentVisible = true,
         authorName = authorName,
         authorAvatarUrl = authorAvatarUrl,
-        datePublished = dateTimeUtilsWrapper.javaDateToTimeSpan(dateGmt),
+        // Same formatter as the rs comments list, so the date doesn't change when you open a comment.
+        datePublished = RsDateFormatter.format(dateGmt, resourceProvider.getString(R.string.rs_date_now)),
         commentText = contentHtml,
         postTitle = cached?.postTitle?.takeIf { it.isNotBlank() } ?: fallbackPostTitle,
         commentUrl = url,

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListRow.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListRow.kt
@@ -10,8 +10,8 @@ sealed interface CommentsRsListRow {
 /**
  * Interleaves date subheaders into [comments] (already in display order), mirroring the legacy
  * list: a header before the first comment and before every comment whose date label differs from
- * the previous one. The label is the row's own [CommentRsUiModel.relativeDate] — the same
- * javaDateToTimeSpan value the legacy list groups by — so no extra date handling is needed here.
+ * the previous one. The label is the row's own [CommentRsUiModel.relativeDate], the shared
+ * RsDateFormatter value already shown on the row, so no extra date handling is needed here.
  *
  * Each header carries a unique [CommentsRsListRow.DateHeader.key] for the LazyColumn. Comments are
  * date-sorted, so a label normally maps to one contiguous group and the key is just the label —

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -578,7 +578,8 @@ class CommentsRsListViewModel @Inject constructor(
             .filter { it.postTitle != null }
             .associate { it.postId to it.postTitle }
         val visible = if (tab == CommentsRsListTab.UNREPLIED) filterUnreplied(raw, currentUserId) else raw
-        return visible.map { it.toUiModel().copy(postTitle = knownTitles[it.postId]) }
+        val nowLabel = resourceProvider.getString(R.string.rs_date_now)
+        return visible.map { it.toUiModel(nowLabel).copy(postTitle = knownTitles[it.postId]) }
     }
 
     /** Re-derives the Unreplied tab's rows from its raw comments (e.g. once [currentUserId] resolves). */
@@ -662,12 +663,12 @@ class CommentsRsListViewModel @Inject constructor(
         serverMessage?.takeIf { it.isNotBlank() }
             ?: PostRsErrorUtils.friendlyErrorMessage(null, null, resourceProvider, networkUtilsWrapper)
 
-    private fun RsComment.toUiModel() = CommentRsUiModel(
+    private fun RsComment.toUiModel(nowLabel: String) = CommentRsUiModel(
         remoteCommentId = remoteCommentId,
         authorName = authorName.ifBlank { resourceProvider.getString(R.string.anonymous) },
         avatarUrl = avatarUtilsWrapper.rewriteAvatarUrlWithResource(authorAvatarUrl, R.dimen.avatar_sz_medium),
         snippet = HtmlUtils.fastStripHtml(contentHtml).trim(),
-        relativeDate = RsDateFormatter.format(dateGmt, resourceProvider.getString(R.string.now)),
+        relativeDate = RsDateFormatter.format(dateGmt, nowLabel),
         status = status,
         postId = postId
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModel.kt
@@ -38,7 +38,7 @@ import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.postsrs.PostRsErrorUtils
 import org.wordpress.android.ui.postsrs.SnackbarMessage
-import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPAvatarUtilsWrapper
@@ -60,7 +60,6 @@ class CommentsRsListViewModel @Inject constructor(
     private val siteCapabilityChecker: SiteCapabilityChecker,
     private val resourceProvider: ResourceProvider,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
-    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val avatarUtilsWrapper: WPAvatarUtilsWrapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val commentBrowsingSession: CommentBrowsingSession,
@@ -668,7 +667,7 @@ class CommentsRsListViewModel @Inject constructor(
         authorName = authorName.ifBlank { resourceProvider.getString(R.string.anonymous) },
         avatarUrl = avatarUtilsWrapper.rewriteAvatarUrlWithResource(authorAvatarUrl, R.dimen.avatar_sz_medium),
         snippet = HtmlUtils.fastStripHtml(contentHtml).trim(),
-        relativeDate = dateTimeUtilsWrapper.javaDateToTimeSpan(dateGmt),
+        relativeDate = RsDateFormatter.format(dateGmt, resourceProvider.getString(R.string.now)),
         status = status,
         postId = postId
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.ui.pagesrs
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
-import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.ui.postsrs.toLabel
+import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import uniffi.wp_api.AnyPostWithEditContext
@@ -182,11 +182,7 @@ private fun FullEntityAnyPostWithEditContext.toPageUiModel(
                 ?: page.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = RsDateFormatter.format(
-            page.dateGmt,
-            nowLabel,
-            isScheduled = page.status is PostStatus.Future
-        ),
+        date = RsDateFormatter.format(page.dateGmt, nowLabel, isScheduled = page.status is PostStatus.Future),
         lastModified = DateTimeUtils.iso8601UTCFromDate(page.modifiedGmt),
         link = page.link,
         hasPassword = !page.password.isNullOrEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PageRsListUiState.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.pagesrs
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
-import org.wordpress.android.ui.postsrs.PostRsDateFormatter
+import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.ui.postsrs.toLabel
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
@@ -139,14 +139,15 @@ internal enum class PageRsMenuAction(
 
 internal fun PostItemState.toPageUiModel(
     pageId: Long,
+    nowLabel: String,
     showStatus: Boolean = false
 ): PageRsUiModel = when (this) {
-    is PostItemState.Fresh -> data.toPageUiModel(showStatus)
-    is PostItemState.Stale -> data.toPageUiModel(showStatus)
+    is PostItemState.Fresh -> data.toPageUiModel(showStatus, nowLabel)
+    is PostItemState.Stale -> data.toPageUiModel(showStatus, nowLabel)
     is PostItemState.FetchingWithData ->
-        data.toPageUiModel(showStatus, PageRsDisplayState.FETCHING_WITH_DATA)
+        data.toPageUiModel(showStatus, nowLabel, PageRsDisplayState.FETCHING_WITH_DATA)
     is PostItemState.FailedWithData ->
-        data.toPageUiModel(showStatus, PageRsDisplayState.FAILED_WITH_DATA)
+        data.toPageUiModel(showStatus, nowLabel, PageRsDisplayState.FAILED_WITH_DATA)
     is PostItemState.Missing,
     is PostItemState.Fetching -> PageRsUiModel(
         remotePageId = pageId,
@@ -166,6 +167,7 @@ internal fun PostItemState.toPageUiModel(
 
 private fun FullEntityAnyPostWithEditContext.toPageUiModel(
     showStatus: Boolean,
+    nowLabel: String,
     displayState: PageRsDisplayState = PageRsDisplayState.NORMAL
 ): PageRsUiModel {
     val page: AnyPostWithEditContext = data
@@ -180,7 +182,11 @@ private fun FullEntityAnyPostWithEditContext.toPageUiModel(
                 ?: page.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = PostRsDateFormatter.format(page.dateGmt, page.status),
+        date = RsDateFormatter.format(
+            page.dateGmt,
+            nowLabel,
+            isScheduled = page.status is PostStatus.Future
+        ),
         lastModified = DateTimeUtils.iso8601UTCFromDate(page.modifiedGmt),
         link = page.link,
         hasPassword = !page.password.isNullOrEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
@@ -728,8 +728,9 @@ internal class PagesRsListViewModel @Inject constructor(
         val collection = parentPickerCollection ?: return
         @Suppress("TooGenericExceptionCaught")
         try {
+            val nowLabel = resourceProvider.getString(R.string.now)
             val (items, listInfo) = withContext(Dispatchers.IO) {
-                collection.loadItems().map { it.state.toPageUiModel(it.id) } to collection.listInfo()
+                collection.loadItems().map { it.state.toPageUiModel(it.id, nowLabel) } to collection.listInfo()
             }
             val candidates = items
                 .filter { it.remotePageId !in parentPickerExcludedIds }
@@ -1158,9 +1159,10 @@ internal class PagesRsListViewModel @Inject constructor(
         @Suppress("TooGenericExceptionCaught")
         try {
             val isSearch = _searchQuery.value.isNotBlank()
+            val nowLabel = resourceProvider.getString(R.string.now)
             val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
-                    item.state.toPageUiModel(item.id, showStatus = isSearch)
+                    item.state.toPageUiModel(item.id, nowLabel, showStatus = isSearch)
                 }
             }
             val uiModels = mergeCachedFields(tab, items)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
@@ -728,7 +728,7 @@ internal class PagesRsListViewModel @Inject constructor(
         val collection = parentPickerCollection ?: return
         @Suppress("TooGenericExceptionCaught")
         try {
-            val nowLabel = resourceProvider.getString(R.string.now)
+            val nowLabel = resourceProvider.getString(R.string.rs_date_now)
             val (items, listInfo) = withContext(Dispatchers.IO) {
                 collection.loadItems().map { it.state.toPageUiModel(it.id, nowLabel) } to collection.listInfo()
             }
@@ -1159,7 +1159,7 @@ internal class PagesRsListViewModel @Inject constructor(
         @Suppress("TooGenericExceptionCaught")
         try {
             val isSearch = _searchQuery.value.isNotBlank()
-            val nowLabel = resourceProvider.getString(R.string.now)
+            val nowLabel = resourceProvider.getString(R.string.rs_date_now)
             val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
                     item.state.toPageUiModel(item.id, nowLabel, showStatus = isSearch)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.postsrs
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.rs.RsDateFormatter
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import uniffi.wp_api.AnyPostWithEditContext
@@ -115,21 +116,24 @@ enum class PostRsMenuAction(
 
 fun PostItemState.toUiModel(
     postId: Long,
+    nowLabel: String,
     showStatus: Boolean = false
 ): PostRsUiModel {
     return when (this) {
         is PostItemState.Fresh ->
-            data.toUiModel(showStatus)
+            data.toUiModel(showStatus, nowLabel)
         is PostItemState.Stale ->
-            data.toUiModel(showStatus)
+            data.toUiModel(showStatus, nowLabel)
         is PostItemState.FetchingWithData ->
             data.toUiModel(
                 showStatus,
+                nowLabel,
                 PostDisplayState.FETCHING_WITH_DATA
             )
         is PostItemState.FailedWithData ->
             data.toUiModel(
                 showStatus,
+                nowLabel,
                 PostDisplayState.FAILED_WITH_DATA
             )
         is PostItemState.Missing,
@@ -152,6 +156,7 @@ fun PostItemState.toUiModel(
 
 private fun FullEntityAnyPostWithEditContext.toUiModel(
     showStatus: Boolean,
+    nowLabel: String,
     displayState: PostDisplayState = PostDisplayState.NORMAL
 ): PostRsUiModel {
     val post: AnyPostWithEditContext = data
@@ -165,8 +170,10 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
                 ?: post.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = PostRsDateFormatter.format(
-            post.dateGmt, post.status
+        date = RsDateFormatter.format(
+            post.dateGmt,
+            nowLabel,
+            isScheduled = post.status is PostStatus.Future
         ),
         lastModified = DateTimeUtils.iso8601UTCFromDate(
             post.modifiedGmt

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListUiState.kt
@@ -125,17 +125,9 @@ fun PostItemState.toUiModel(
         is PostItemState.Stale ->
             data.toUiModel(showStatus, nowLabel)
         is PostItemState.FetchingWithData ->
-            data.toUiModel(
-                showStatus,
-                nowLabel,
-                PostDisplayState.FETCHING_WITH_DATA
-            )
+            data.toUiModel(showStatus, nowLabel, PostDisplayState.FETCHING_WITH_DATA)
         is PostItemState.FailedWithData ->
-            data.toUiModel(
-                showStatus,
-                nowLabel,
-                PostDisplayState.FAILED_WITH_DATA
-            )
+            data.toUiModel(showStatus, nowLabel, PostDisplayState.FAILED_WITH_DATA)
         is PostItemState.Missing,
         is PostItemState.Fetching -> PostRsUiModel(
             remotePostId = postId,
@@ -170,11 +162,7 @@ private fun FullEntityAnyPostWithEditContext.toUiModel(
                 ?: post.excerpt?.rendered
                 ?: ""
             ).let { HtmlUtils.fastStripHtml(it).trim() },
-        date = RsDateFormatter.format(
-            post.dateGmt,
-            nowLabel,
-            isScheduled = post.status is PostStatus.Future
-        ),
+        date = RsDateFormatter.format(post.dateGmt, nowLabel, isScheduled = post.status is PostStatus.Future),
         lastModified = DateTimeUtils.iso8601UTCFromDate(
             post.modifiedGmt
         ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -785,9 +785,10 @@ class PostRsListViewModel @Inject constructor(
         @Suppress("TooGenericExceptionCaught")
         try {
             val isSearch = _searchQuery.value.isNotBlank()
+            val nowLabel = resourceProvider.getString(R.string.now)
             val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
-                    item.state.toUiModel(item.id, showStatus = isSearch)
+                    item.state.toUiModel(item.id, nowLabel, showStatus = isSearch)
                 }
             }
             val existingPosts = getTabUiState(tab).posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -785,7 +785,7 @@ class PostRsListViewModel @Inject constructor(
         @Suppress("TooGenericExceptionCaught")
         try {
             val isSearch = _searchQuery.value.isNotBlank()
-            val nowLabel = resourceProvider.getString(R.string.now)
+            val nowLabel = resourceProvider.getString(R.string.rs_date_now)
             val items = withContext(Dispatchers.IO) {
                 collection.loadItems().map { item ->
                     item.state.toUiModel(item.id, nowLabel, showStatus = isSearch)

--- a/WordPress/src/main/java/org/wordpress/android/ui/rs/RsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/rs/RsDateFormatter.kt
@@ -32,33 +32,22 @@ object RsDateFormatter {
     fun format(dateGmt: Date, nowLabel: String, isScheduled: Boolean = false): String {
         val millis = dateGmt.time
         val now = System.currentTimeMillis()
-        val secondsSince = (now - millis) / MILLIS_PER_SECOND
         // The server's date can sit slightly ahead of the device clock, so treat a sub-minute
         // gap in either direction as "now" rather than letting it read "In 0 minutes".
-        val isNow = !isScheduled && abs(secondsSince) < SECONDS_PER_MINUTE
-        val useRelative = !isScheduled && abs(secondsSince) < SECONDS_PER_WEEK
+        val secondsSince = abs((now - millis) / MILLIS_PER_SECOND)
 
         return when {
-            isNow -> nowLabel
-            useRelative -> DateUtils.getRelativeTimeSpanString(
-                millis,
-                now,
-                DateUtils.MINUTE_IN_MILLIS
-            ).toString()
             isScheduled -> formatAbbrDateTime(millis)
+            secondsSince < SECONDS_PER_MINUTE -> nowLabel
+            secondsSince < SECONDS_PER_WEEK ->
+                DateUtils.getRelativeTimeSpanString(millis, now, DateUtils.MINUTE_IN_MILLIS).toString()
             else -> formatAbbrDate(millis)
         }
     }
 
-    private fun formatAbbrDate(millis: Long): String {
-        val dateFormat =
-            DateFormat.getDateInstance(DateFormat.MEDIUM)
-        return dateFormat.format(Date(millis))
-    }
+    private fun formatAbbrDate(millis: Long) =
+        DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(millis))
 
-    private fun formatAbbrDateTime(millis: Long): String {
-        val dateFormat =
-            DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
-        return dateFormat.format(Date(millis))
-    }
+    private fun formatAbbrDateTime(millis: Long) =
+        DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(millis))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/rs/RsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/rs/RsDateFormatter.kt
@@ -1,19 +1,19 @@
-package org.wordpress.android.ui.postsrs
+package org.wordpress.android.ui.rs
 
 import android.text.format.DateUtils
-import uniffi.wp_api.PostStatus
 import java.text.DateFormat
 import java.util.Date
 import kotlin.math.abs
 
 /**
- * Formats post dates from the wordpress-rs API for display in the
- * posts and pages lists. Mirrors the iOS app's date formatting
- * (see AbstractPostHelper / NSDate+Helpers): relative time only for
- * the last week, an absolute medium date beyond that.
+ * Formats dates from the wordpress-rs API for display in the posts, pages and comments
+ * lists, so all three read the same way. Mirrors the iOS app's date formatting
+ * (see AbstractPostHelper / NSDate+Helpers): relative time only for the last week,
+ * an absolute medium date beyond that.
  */
-object PostRsDateFormatter {
+object RsDateFormatter {
     private const val MILLIS_PER_SECOND = 1000L
+    private const val SECONDS_PER_MINUTE = 60L
     private const val SECONDS_PER_HOUR = 3600L
     private const val HOURS_PER_DAY = 24L
     private const val DAYS_PER_WEEK = 7L
@@ -22,19 +22,24 @@ object PostRsDateFormatter {
 
     /**
      * Formats a GMT [Date] for display, matching the iOS posts/pages list:
-     * - Scheduled posts show an absolute date with the time of day (e.g. "Dec 15, 2025, 9:00 AM")
-     *   so the user can see when the post or page will publish.
-     * - Other posts within the last week show relative time ("2 days ago", "Yesterday").
-     * - Older posts show an abbreviated absolute date ("Dec 15, 2025").
+     * - Scheduled posts ([isScheduled]) show an absolute date with the time of day
+     *   (e.g. "Dec 15, 2025, 9:00 AM") so the user can see when it will publish.
+     * - Anything less than a minute old shows [nowLabel], since the relative formatter would
+     *   otherwise render a just-created post or a fresh comment as "0 minutes ago".
+     * - Anything else within the last week shows relative time ("2 days ago", "Yesterday").
+     * - Older dates show an abbreviated absolute date ("Dec 15, 2025").
      */
-    fun format(dateGmt: Date, status: PostStatus?): String {
+    fun format(dateGmt: Date, nowLabel: String, isScheduled: Boolean = false): String {
         val millis = dateGmt.time
         val now = System.currentTimeMillis()
-        val isScheduled = status is PostStatus.Future
         val secondsSince = (now - millis) / MILLIS_PER_SECOND
+        // The server's date can sit slightly ahead of the device clock, so treat a sub-minute
+        // gap in either direction as "now" rather than letting it read "In 0 minutes".
+        val isNow = !isScheduled && abs(secondsSince) < SECONDS_PER_MINUTE
         val useRelative = !isScheduled && abs(secondsSince) < SECONDS_PER_WEEK
 
         return when {
+            isNow -> nowLabel
             useRelative -> DateUtils.getRelativeTimeSpanString(
                 millis,
                 now,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1029,6 +1029,8 @@
     <string name="new_stats_intro_trends_title">Trends at a Glance</string>
     <string name="new_stats_intro_trends_desc">Every metric shows how it\'s trending compared to the previous period, so you always know if you\'re growing.</string>
     <string name="new_stats_intro_footer">You can turn off New Stats from the overflow menu in the Stats screen.</string>
+    <!-- Timespan shown in the rs posts, pages and comments lists for anything under a minute old -->
+    <string name="rs_date_now">Now</string>
     <string name="post_rs_failed_to_load">Failed to load post</string>
     <string name="page_rs_failed_to_load">Failed to load page</string>
     <string name="page_rs_copy_url">Copy URL</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentDetailsViewModelTest.kt
@@ -47,10 +47,10 @@ import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
 import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils.AnalyticsCommentActionSource
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -71,7 +71,7 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
     lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
     @Mock
-    lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    lateinit var resourceProvider: ResourceProvider
 
     @Mock
     lateinit var notificationsActionsWrapper: NotificationsActionsWrapper
@@ -105,7 +105,7 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
         whenever(commentsRsDataSource.createReply(eq(site), any(), any(), any())).thenReturn(RsResult.Success)
         whenever(commentsStore.likeComment(eq(site), eq(REMOTE_COMMENT_ID), eq(null), any()))
             .thenReturn(successPayload())
-        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn("2 hours ago")
+        whenever(resourceProvider.getString(any())).thenReturn("Now")
         whenever(notificationsActionsWrapper.downloadNoteAndUpdateDB(any())).thenReturn(true)
         // Default to allowed for any site; the restricted-capability tests override for [site].
         whenever(siteCapabilityChecker.canModerateComments(any())).thenReturn(true)
@@ -714,7 +714,7 @@ class UnifiedCommentDetailsViewModelTest : BaseUnitTest() {
         siteCapabilityChecker = siteCapabilityChecker,
         localCommentCacheUpdateHandler = localCommentCacheUpdateHandler,
         networkUtilsWrapper = networkUtilsWrapper,
-        dateTimeUtilsWrapper = dateTimeUtilsWrapper,
+        resourceProvider = resourceProvider,
         notificationsActionsWrapper = notificationsActionsWrapper,
         notificationsTableWrapper = notificationsTableWrapper,
         analyticsUtilsWrapper = analyticsUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/commentsrs/CommentsRsListViewModelTest.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsComments
 import org.wordpress.android.ui.comments.unified.CommentsRsDataSource.RsResult
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.items.listitem.SiteCapabilityChecker
-import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPAvatarUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -48,7 +47,6 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
     @Mock lateinit var siteCapabilityChecker: SiteCapabilityChecker
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
-    @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
     @Mock lateinit var avatarUtilsWrapper: WPAvatarUtilsWrapper
     @Mock lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
@@ -65,7 +63,6 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(siteCapabilityChecker.canModerateComments(site)).thenReturn(true)
         whenever(resourceProvider.getString(any())).thenReturn("string")
-        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn("2 hours ago")
         whenever(avatarUtilsWrapper.rewriteAvatarUrlWithResource(any(), any())).thenAnswer { it.arguments[0] }
         whenever(commentsRsDataSource.firstPageParams(any(), anyOrNull())).thenReturn(FIRST_PAGE)
         whenever(commentsRsDataSource.fetchPostTitles(any(), any())).thenReturn(emptyMap())
@@ -84,7 +81,6 @@ class CommentsRsListViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         siteCapabilityChecker = siteCapabilityChecker,
         resourceProvider = resourceProvider,
         networkUtilsWrapper = networkUtilsWrapper,
-        dateTimeUtilsWrapper = dateTimeUtilsWrapper,
         avatarUtilsWrapper = avatarUtilsWrapper,
         analyticsTracker = analyticsTracker,
         commentBrowsingSession = commentBrowsingSession,

--- a/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
@@ -90,7 +90,7 @@ class RsDateFormatterTest {
         private const val FIVE_SECONDS_MILLIS = 5L * 1000
         private const val THIRTY_SECONDS_MILLIS = 30L * 1000
 
-        // Stands in for R.string.now, which the ViewModels resolve before mapping.
+        // Stands in for R.string.rs_date_now, which the ViewModels resolve before mapping.
         private const val NOW_LABEL = "Now"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
@@ -1,20 +1,19 @@
-package org.wordpress.android.ui.postsrs
+package org.wordpress.android.ui.rs
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import uniffi.wp_api.PostStatus
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
-class PostRsDateFormatterTest {
+class RsDateFormatterTest {
     @Test
     fun `scheduled date includes the time of day`() {
         withFixedLocaleAndZone {
             val date = Date(FIXED_MILLIS)
 
-            val formatted = PostRsDateFormatter.format(date, PostStatus.Future)
+            val formatted = RsDateFormatter.format(date, NOW_LABEL, isScheduled = true)
             val dateOnly = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
 
             // Scheduled dates show the medium date plus the time of day (iOS parity).
@@ -30,10 +29,44 @@ class PostRsDateFormatterTest {
             // absolute medium date here, where legacy Android still showed relative time.
             val date = Date(System.currentTimeMillis() - THIRTY_DAYS_MILLIS)
 
-            val formatted = PostRsDateFormatter.format(date, PostStatus.Publish)
+            val formatted = RsDateFormatter.format(date, NOW_LABEL)
             val expected = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
 
             assertThat(formatted).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `date seconds in the past shows the now label`() {
+        withFixedLocaleAndZone {
+            // Without this the relative formatter renders a just-published post as "0 minutes ago".
+            val date = Date(System.currentTimeMillis() - FIVE_SECONDS_MILLIS)
+
+            assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
+        }
+    }
+
+    @Test
+    fun `date seconds in the future shows the now label`() {
+        withFixedLocaleAndZone {
+            // The server's date can sit just ahead of the device clock; that shouldn't read
+            // "In 0 minutes".
+            val date = Date(System.currentTimeMillis() + THIRTY_SECONDS_MILLIS)
+
+            assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
+        }
+    }
+
+    @Test
+    fun `scheduled date seconds away still shows its date and time`() {
+        withFixedLocaleAndZone {
+            // A page about to publish should say when, not "Now".
+            val date = Date(System.currentTimeMillis() + THIRTY_SECONDS_MILLIS)
+
+            val formatted = RsDateFormatter.format(date, NOW_LABEL, isScheduled = true)
+
+            assertThat(formatted).isNotEqualTo(NOW_LABEL)
+            assertThat(formatted).startsWith(DateFormat.getDateInstance(DateFormat.MEDIUM).format(date))
         }
     }
 
@@ -54,5 +87,10 @@ class PostRsDateFormatterTest {
         // A fixed instant so the formatted output is deterministic under the pinned locale/zone.
         private const val FIXED_MILLIS = 1_765_792_800_000L
         private const val THIRTY_DAYS_MILLIS = 30L * 24 * 60 * 60 * 1000
+        private const val FIVE_SECONDS_MILLIS = 5L * 1000
+        private const val THIRTY_SECONDS_MILLIS = 30L * 1000
+
+        // Stands in for R.string.now, which the ViewModels resolve before mapping.
+        private const val NOW_LABEL = "Now"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/rs/RsDateFormatterTest.kt
@@ -36,25 +36,23 @@ class RsDateFormatterTest {
         }
     }
 
+    // The two now-label cases return the label verbatim without reaching DateFormat, so unlike
+    // the others they don't need withFixedLocaleAndZone.
     @Test
     fun `date seconds in the past shows the now label`() {
-        withFixedLocaleAndZone {
-            // Without this the relative formatter renders a just-published post as "0 minutes ago".
-            val date = Date(System.currentTimeMillis() - FIVE_SECONDS_MILLIS)
+        // Without this the relative formatter renders a just-published post as "0 minutes ago".
+        val date = Date(System.currentTimeMillis() - THIRTY_SECONDS_MILLIS)
 
-            assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
-        }
+        assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
     }
 
     @Test
     fun `date seconds in the future shows the now label`() {
-        withFixedLocaleAndZone {
-            // The server's date can sit just ahead of the device clock; that shouldn't read
-            // "In 0 minutes".
-            val date = Date(System.currentTimeMillis() + THIRTY_SECONDS_MILLIS)
+        // The server's date can sit just ahead of the device clock; that shouldn't read
+        // "In 0 minutes".
+        val date = Date(System.currentTimeMillis() + THIRTY_SECONDS_MILLIS)
 
-            assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
-        }
+        assertThat(RsDateFormatter.format(date, NOW_LABEL)).isEqualTo(NOW_LABEL)
     }
 
     @Test
@@ -87,7 +85,6 @@ class RsDateFormatterTest {
         // A fixed instant so the formatted output is deterministic under the pinned locale/zone.
         private const val FIXED_MILLIS = 1_765_792_800_000L
         private const val THIRTY_DAYS_MILLIS = 30L * 24 * 60 * 60 * 1000
-        private const val FIVE_SECONDS_MILLIS = 5L * 1000
         private const val THIRTY_SECONDS_MILLIS = 30L * 1000
 
         // Stands in for R.string.rs_date_now, which the ViewModels resolve before mapping.


### PR DESCRIPTION
Fixes [CMM-2261](https://linear.app/a8c/issue/CMM-2261/android-fresh-pages-say-0-seconds-ago).

## Description

During today's walkthrough we noticed a page added to the RS page list showed up as "0 minutes ago" instead of "Now". The same problem was later noticed with new posts added to the RS post list.

Anything less than a minute old now reads "Now" and the three RS lists (posts, pages, and comments) now use the same RS date formatter.

## Testing instructions

- Create a post, page, and comment, and note that they all show "Now" instead of "0 seconds"