### PR TITLE
CMM-2213: Attach selected site to My Site dashboard card impressions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.TodaysStatsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.TodaysStatsCard.TodaysStatsCardWithData
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.BlazeSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.StatsSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
@@ -17,7 +18,8 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 class CardsShownTracker @Inject constructor(
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository
 ) {
     private val cardsShownTracked = mutableListOf<Pair<String, String>>()
 
@@ -121,6 +123,7 @@ class CardsShownTracker @Inject constructor(
             cardsShownTracked.add(pair)
             analyticsTrackerWrapper.track(
                 Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
+                selectedSiteRepository.getSelectedSite(),
                 mapOf(
                     CardsTracker.TYPE to pair.first,
                     CardsTracker.SUBTYPE to pair.second

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -7,11 +7,14 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ActivityCard.ActivityCardWithItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
@@ -23,11 +26,17 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 class CardsShownTrackerTest {
     @Mock
     lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    private val site: SiteModel = mock()
     private lateinit var cardsShownTracker: CardsShownTracker
 
     @Before
     fun setUp() {
-        cardsShownTracker = CardsShownTracker(analyticsTracker)
+        cardsShownTracker = CardsShownTracker(analyticsTracker, selectedSiteRepository)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
     }
 
     @Test
@@ -50,6 +59,7 @@ class CardsShownTrackerTest {
 
         verify(analyticsTracker).track(
             Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
+            site,
             mapOf(CardsTracker.TYPE to Type.ERROR.label, CardsTracker.SUBTYPE to Type.ERROR.label)
         )
     }
@@ -64,6 +74,7 @@ class CardsShownTrackerTest {
     private fun verifyCardShownTracked(type: String, subtype: String) {
         verify(analyticsTracker).track(
             Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
+            site,
             mapOf(CardsTracker.TYPE to type, CardsTracker.SUBTYPE to subtype)
         )
     }


### PR DESCRIPTION
Fixes [CMM-2213](https://linear.app/a8c/issue/CMM-2213/my-site-dashboard-card-impressions-on-android-carry-no-blog-id). The My Site dashboard "card shown" impression event fires with no `blog_id`, even though the screen always displays exactly one, known site.

## Root Cause

`CardsShownTracker` fired `MY_SITE_DASHBOARD_CARD_SHOWN` through the plain `AnalyticsTrackerWrapper.track(stat, properties)`, which attaches no site details:

```kotlin
analyticsTrackerWrapper.track(
    Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
    mapOf(CardsTracker.TYPE to pair.first, CardsTracker.SUBTYPE to pair.second)
)
```

Data Science measured `blog_id` at **0.0%** on `jpandroid_my_site_dashboard_card_shown` (6.0M fires) and `wpandroid_my_site_dashboard_card_shown` (4k fires) across a 14-day window, versus **96.8%** on `jpandroid_my_site_tab_accessed` fired from the same screen. 100% of the rows are `useridtype = 'wpcom:user_id'`, so the user is known — only the site was absent. 19 funnels depend on the Jetpack event and 27 on the WordPress one.

## Fix

Route the call through the existing site-aware `track(stat, site, properties)` overload, passing the currently selected site from `SelectedSiteRepository`:

```kotlin
analyticsTrackerWrapper.track(
    Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
    selectedSiteRepository.getSelectedSite(),
    mapOf(CardsTracker.TYPE to pair.first, CardsTracker.SUBTYPE to pair.second)
)
```

That overload delegates to `AnalyticsUtils.trackWithSiteDetails(...)`, which adds `blog_id`, `is_jetpack`, and `site_type` for WP.com and Jetpack-connected sites while preserving `type` and `subtype`. It is one shared call site, so **both Android apps are fixed at once**.

Coverage is expected to land **at or above 95%** rather than 100% — `trackWithSiteDetails` only attaches `blog_id` for sites accessed via the WP.com REST API, so the small fraction of self-hosted, non-Jetpack sites remains without one by design.

## Description

- `CardsShownTracker` now injects `SelectedSiteRepository` and attaches the selected site to the impression event.
- Unit tests updated to assert the site is threaded through on every card-shown event.
- No user-facing behavior change, so no release note.

## Out of scope

- **Event registration (Part 2 of the issue).** Registering `jpandroid_my_site_dashboard_card_shown`, `wpandroid_my_site_dashboard_card_shown`, and `jpandroid_my_site_tab_accessed` happens in the Tracks event registry, not in this repo — tracked as a separate follow-up.
- **iOS.** `jpios_my_site_dashboard_card_shown` sits at 56.1% via a different code path; that is a separate defect and not addressed here.

## Testing instructions

Automated:

1. Run `./gradlew :WordPress:testJetpackDebugUnitTest --tests "*.CardsShownTrackerTest"`
- [ ] `CardsShownTrackerTest` passes; each card-shown assertion verifies the selected site is attached.

Manual (with Tracks debug logging):

1. Build a debug variant and open the My Site tab signed in to a WordPress.com or Jetpack-connected site so the dashboard cards render.
- [ ] `my_site_dashboard_card_shown` events include `blog_id` (and `is_jetpack` / `site_type`) alongside `type` and `subtype`.

Post-deploy verification:

- [ ] The issue's verification query reports `blog_id_pct` at or above 95 on both `card_shown` events.
