### PR TITLE
CMM-2271: Read stats date picker millis in UTC

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -31,8 +31,11 @@ fun StatsDateRangePickerDialog(
     onDismiss: () -> Unit,
     onDateRangeSelected: (startDate: LocalDate, endDate: LocalDate) -> Unit
 ) {
+    // Today as the device sees it, expressed as UTC midnight so it can be compared against the
+    // utcTimeMillis the picker passes to isSelectableDate. Using local midnight here leaves today
+    // unselectable east of UTC. See CMM-2271.
     val todayMillis = LocalDate.now()
-        .atStartOfDay(ZoneId.systemDefault())
+        .atStartOfDay(ZoneOffset.UTC)
         .toInstant()
         .toEpochMilli()
 
@@ -121,8 +124,13 @@ private fun rememberSelectionDescription(startMillis: Long?, endMillis: Long?): 
     }
 }
 
+/**
+ * The picker hands back the start of the selected day in UTC, so the millis have to be read back in
+ * that same frame. Reading them in the device zone lands on the previous day west of UTC, which
+ * silently queries a range one day earlier than the one tapped. See CMM-2271.
+ */
 private fun Long.toSelectedDate(): LocalDate = Instant.ofEpochMilli(this)
-    .atZone(ZoneId.systemDefault())
+    .atZone(ZoneOffset.UTC)
     .toLocalDate()
 
 private fun LocalDate.formatForSpeech(): String =

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
@@ -34,10 +34,7 @@ fun StatsDateRangePickerDialog(
     // Today as the device sees it, expressed as UTC midnight so it can be compared against the
     // utcTimeMillis the picker passes to isSelectableDate. Using local midnight here leaves today
     // unselectable east of UTC. See CMM-2271.
-    val todayMillis = LocalDate.now()
-        .atStartOfDay(ZoneOffset.UTC)
-        .toInstant()
-        .toEpochMilli()
+    val todayMillis = LocalDate.now().toUtcMillis()
 
     val dateRangePickerState = rememberDateRangePickerState(
         initialDisplayMode = DisplayMode.Picker,
@@ -129,9 +126,14 @@ private fun rememberSelectionDescription(startMillis: Long?, endMillis: Long?): 
  * that same frame. Reading them in the device zone lands on the previous day west of UTC, which
  * silently queries a range one day earlier than the one tapped. See CMM-2271.
  */
-private fun Long.toSelectedDate(): LocalDate = Instant.ofEpochMilli(this)
+internal fun Long.toSelectedDate(): LocalDate = Instant.ofEpochMilli(this)
     .atZone(ZoneOffset.UTC)
     .toLocalDate()
+
+/**
+ * Inverse of [toSelectedDate]: the start of this day in the frame the picker compares against.
+ */
+internal fun LocalDate.toUtcMillis(): Long = atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
 
 private fun LocalDate.formatForSpeech(): String =
     format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialog.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.newstats
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DateRangePicker
@@ -34,7 +35,7 @@ fun StatsDateRangePickerDialog(
     // Today as the device sees it, expressed as UTC midnight so it can be compared against the
     // utcTimeMillis the picker passes to isSelectableDate. Using local midnight here leaves today
     // unselectable east of UTC. See CMM-2271.
-    val todayMillis = LocalDate.now().toUtcMillis()
+    val todayMillis = LocalDate.now().toPickerMillis()
 
     val dateRangePickerState = rememberDateRangePickerState(
         initialDisplayMode = DisplayMode.Picker,
@@ -115,25 +116,29 @@ private fun rememberSelectionDescription(startMillis: Long?, endMillis: Long?): 
     return remember(title, startLabel, endLabel, startMillis, endMillis) {
         listOfNotNull(
             title,
-            startMillis?.let { "$startLabel: ${it.toSelectedDate().formatForSpeech()}" },
-            endMillis?.let { "$endLabel: ${it.toSelectedDate().formatForSpeech()}" }
+            startMillis?.let { "$startLabel: ${it.toPickerDate().formatForSpeech()}" },
+            endMillis?.let { "$endLabel: ${it.toPickerDate().formatForSpeech()}" }
         ).joinToString(", ")
     }
 }
 
 /**
- * The picker hands back the start of the selected day in UTC, so the millis have to be read back in
- * that same frame. Reading them in the device zone lands on the previous day west of UTC, which
- * silently queries a range one day earlier than the one tapped. See CMM-2271.
+ * Reads picker millis as a date. The picker hands back the start of the selected day in UTC, so the
+ * millis have to be read back in that same frame. Reading them in the device zone lands on the
+ * previous day west of UTC, which silently queries a range one day earlier than the one tapped.
+ * See CMM-2271.
  */
-internal fun Long.toSelectedDate(): LocalDate = Instant.ofEpochMilli(this)
+@VisibleForTesting
+internal fun Long.toPickerDate(): LocalDate = Instant.ofEpochMilli(this)
     .atZone(ZoneOffset.UTC)
     .toLocalDate()
 
 /**
- * Inverse of [toSelectedDate]: the start of this day in the frame the picker compares against.
+ * Inverse of [toPickerDate]: the start of this day as UTC midnight, the frame the picker compares
+ * against in [SelectableDates.isSelectableDate].
  */
-internal fun LocalDate.toUtcMillis(): Long = atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+@VisibleForTesting
+internal fun LocalDate.toPickerMillis(): Long = atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
 
 private fun LocalDate.formatForSpeech(): String =
     format(DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))
@@ -145,8 +150,8 @@ private fun onConfirmDateRange(
 ) {
     if (startMillis == null || endMillis == null) return
 
-    val startDate = startMillis.toSelectedDate()
-    val endDate = endMillis.toSelectedDate()
+    val startDate = startMillis.toPickerDate()
+    val endDate = endMillis.toPickerDate()
     // Ensure start date is before or equal to end date, swap if needed
     if (startDate.isAfter(endDate)) {
         onDateRangeSelected(endDate, startDate)

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
@@ -25,7 +25,7 @@ class StatsDateRangePickerDialogTest {
         ZONES.forEach { zone ->
             TimeZone.setDefault(TimeZone.getTimeZone(zone))
 
-            assertThat(TEST_DATE_UTC_MILLIS.toSelectedDate())
+            assertThat(TEST_DATE_UTC_MILLIS.toPickerDate())
                 .describedAs("selection read in %s", zone)
                 .isEqualTo(TEST_DATE)
         }
@@ -36,7 +36,7 @@ class StatsDateRangePickerDialogTest {
         ZONES.forEach { zone ->
             TimeZone.setDefault(TimeZone.getTimeZone(zone))
 
-            assertThat(TEST_DATE.toUtcMillis())
+            assertThat(TEST_DATE.toPickerMillis())
                 .describedAs("date converted in %s", zone)
                 .isEqualTo(TEST_DATE_UTC_MILLIS)
         }
@@ -51,7 +51,7 @@ class StatsDateRangePickerDialogTest {
             // from epoch days, so this fails if todayMillis ever drifts back to local midnight.
             val today = LocalDate.now()
 
-            assertThat(today.toUtcMillis())
+            assertThat(today.toPickerMillis())
                 .describedAs("today's cell in %s", zone)
                 .isEqualTo(today.toEpochDay() * MILLIS_PER_DAY)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
@@ -22,64 +22,46 @@ class StatsDateRangePickerDialogTest {
 
     @Test
     fun `when reading the picker selection, then the tapped day survives every device zone`() {
-        val tappedCell = Instant.parse("2026-08-02T00:00:00Z").toEpochMilli()
-
         ZONES.forEach { zone ->
             TimeZone.setDefault(TimeZone.getTimeZone(zone))
 
-            assertThat(tappedCell.toSelectedDate())
+            assertThat(TEST_DATE_UTC_MILLIS.toSelectedDate())
                 .describedAs("selection read in %s", zone)
-                .isEqualTo(LocalDate.of(2026, 8, 2))
+                .isEqualTo(TEST_DATE)
         }
     }
 
     @Test
     fun `when converting a date for the picker, then it lands on UTC midnight in every device zone`() {
-        val expected = Instant.parse("2026-08-02T00:00:00Z").toEpochMilli()
-
         ZONES.forEach { zone ->
             TimeZone.setDefault(TimeZone.getTimeZone(zone))
 
-            assertThat(LocalDate.of(2026, 8, 2).toUtcMillis())
+            assertThat(TEST_DATE.toUtcMillis())
                 .describedAs("date converted in %s", zone)
-                .isEqualTo(expected)
+                .isEqualTo(TEST_DATE_UTC_MILLIS)
         }
     }
 
     @Test
-    fun `when guarding future dates, then today is selectable and tomorrow is not in every zone`() {
+    fun `when guarding future dates, then today's cell matches the picker frame in every zone`() {
         ZONES.forEach { zone ->
             TimeZone.setDefault(TimeZone.getTimeZone(zone))
 
-            // The guard in StatsDateRangePickerDialog. Cells are derived independently from epoch
-            // days, so this fails if todayMillis ever drifts back to local midnight.
+            // The guard in StatsDateRangePickerDialog. The expected cell is derived independently
+            // from epoch days, so this fails if todayMillis ever drifts back to local midnight.
             val today = LocalDate.now()
-            val todayMillis = today.toUtcMillis()
 
-            assertThat(todayMillis)
+            assertThat(today.toUtcMillis())
                 .describedAs("today's cell in %s", zone)
                 .isEqualTo(today.toEpochDay() * MILLIS_PER_DAY)
-            assertThat(today.plusDays(1).toEpochDay() * MILLIS_PER_DAY <= todayMillis)
-                .describedAs("tomorrow selectable in %s", zone)
-                .isFalse()
-        }
-    }
-
-    @Test
-    fun `when a selection round trips, then the date is unchanged`() {
-        val date = LocalDate.of(2026, 8, 2)
-
-        ZONES.forEach { zone ->
-            TimeZone.setDefault(TimeZone.getTimeZone(zone))
-
-            assertThat(date.toUtcMillis().toSelectedDate())
-                .describedAs("round trip in %s", zone)
-                .isEqualTo(date)
         }
     }
 
     companion object {
         private const val MILLIS_PER_DAY = 86_400_000L
+
+        private val TEST_DATE: LocalDate = LocalDate.of(2026, 8, 2)
+        private val TEST_DATE_UTC_MILLIS: Long = Instant.parse("2026-08-02T00:00:00Z").toEpochMilli()
 
         // Spans both sides of UTC, including the half-hour offset of Asia/Kolkata.
         private val ZONES = listOf(

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/StatsDateRangePickerDialogTest.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.ui.newstats
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.TimeZone
+
+/**
+ * Material3's date picker works entirely in UTC start-of-day millis, so these conversions must not
+ * depend on the device zone. See CMM-2271: reading them locally shifted the applied range back a
+ * day west of UTC, and left today unselectable east of it.
+ */
+class StatsDateRangePickerDialogTest {
+    private val originalTimeZone: TimeZone = TimeZone.getDefault()
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(originalTimeZone)
+    }
+
+    @Test
+    fun `when reading the picker selection, then the tapped day survives every device zone`() {
+        val tappedCell = Instant.parse("2026-08-02T00:00:00Z").toEpochMilli()
+
+        ZONES.forEach { zone ->
+            TimeZone.setDefault(TimeZone.getTimeZone(zone))
+
+            assertThat(tappedCell.toSelectedDate())
+                .describedAs("selection read in %s", zone)
+                .isEqualTo(LocalDate.of(2026, 8, 2))
+        }
+    }
+
+    @Test
+    fun `when converting a date for the picker, then it lands on UTC midnight in every device zone`() {
+        val expected = Instant.parse("2026-08-02T00:00:00Z").toEpochMilli()
+
+        ZONES.forEach { zone ->
+            TimeZone.setDefault(TimeZone.getTimeZone(zone))
+
+            assertThat(LocalDate.of(2026, 8, 2).toUtcMillis())
+                .describedAs("date converted in %s", zone)
+                .isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `when guarding future dates, then today is selectable and tomorrow is not in every zone`() {
+        ZONES.forEach { zone ->
+            TimeZone.setDefault(TimeZone.getTimeZone(zone))
+
+            // The guard in StatsDateRangePickerDialog. Cells are derived independently from epoch
+            // days, so this fails if todayMillis ever drifts back to local midnight.
+            val today = LocalDate.now()
+            val todayMillis = today.toUtcMillis()
+
+            assertThat(todayMillis)
+                .describedAs("today's cell in %s", zone)
+                .isEqualTo(today.toEpochDay() * MILLIS_PER_DAY)
+            assertThat(today.plusDays(1).toEpochDay() * MILLIS_PER_DAY <= todayMillis)
+                .describedAs("tomorrow selectable in %s", zone)
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `when a selection round trips, then the date is unchanged`() {
+        val date = LocalDate.of(2026, 8, 2)
+
+        ZONES.forEach { zone ->
+            TimeZone.setDefault(TimeZone.getTimeZone(zone))
+
+            assertThat(date.toUtcMillis().toSelectedDate())
+                .describedAs("round trip in %s", zone)
+                .isEqualTo(date)
+        }
+    }
+
+    companion object {
+        private const val MILLIS_PER_DAY = 86_400_000L
+
+        // Spans both sides of UTC, including the half-hour offset of Asia/Kolkata.
+        private val ZONES = listOf(
+            "America/Los_Angeles",
+            "America/New_York",
+            "UTC",
+            "Europe/Madrid",
+            "Asia/Kolkata",
+            "Asia/Tokyo",
+            "Pacific/Auckland"
+        )
+    }
+}


### PR DESCRIPTION
Fixes [CMM-2271](https://linear.app/a8c/issue/CMM-2271/android-new-stats-custom-date-range-is-off-by-a-day-outside-utc).

Material3's `DateRangePicker` works entirely in **UTC start-of-day** millis — both the selection it hands back and the `utcTimeMillis` it passes to `SelectableDates`. The stats dialog was reading those millis in the device zone and building its no-future-dates guard from *local* midnight, so every timezone except UTC was wrong in one of two ways: west of UTC the applied range landed a day earlier than the days tapped (tapping Aug 2–10 queried Aug 1–9), and east of UTC — including all of Europe — today rendered disabled.

Both conversions now use `ZoneOffset.UTC`. `LocalDate.now()` stays zone-default in the guard on purpose, since "today" should remain the user's today, just re-expressed in the frame the picker compares against. Because #23193 consolidated the conversion into `toSelectedDate()`.

## Testing instructions

Custom range applies the days tapped:

1. Set the device to `America/New_York`.
2. Open Stats → tap the period label → **Custom**.
3. Pick a range, e.g. the 2nd through the 10th, and confirm.
- [ ] Verify the range in the app bar matches the days tapped.
- [ ] Verify the stats shown are for that range.

Today is selectable east of UTC:

1. Set the device to `Asia/Tokyo` or `Europe/Madrid`, then reopen the picker.
- [ ] Verify today is selectable.
- [ ] Verify future dates are still blocked.