### PR TITLE
CMM-2258: Fix pixelated featured image in post settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -152,11 +152,9 @@ class FeaturedImageHelper @Inject constructor(
             null
         )
 
-        // Get max width/height for photon thumbnail - we load a smaller image so it's loaded quickly
+        // Resize from the full-size media URL so it loads quickly without being pixelated.
+        // MediaModel.thumbnailUrl is WP.com's 150px render and Photon can't upscale it.
         val maxDimen = resourceProvider.getDimensionPixelSize(R.dimen.post_settings_featured_image_height_max)
-
-        // Always resize from the full-size media URL. MediaModel.thumbnailUrl is WP.com's 150px
-        // render, and Photon can't upscale it, so using it here produces a pixelated image.
         val mediaUri = StringUtils.notNullStr(media.url)
 
         val photonUrl = if (site.isSelfHostedAdmin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.net.Uri
-import android.text.TextUtils
 import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -156,13 +155,9 @@ class FeaturedImageHelper @Inject constructor(
         // Get max width/height for photon thumbnail - we load a smaller image so it's loaded quickly
         val maxDimen = resourceProvider.getDimensionPixelSize(R.dimen.post_settings_featured_image_height_max)
 
-        val mediaUri = StringUtils.notNullStr(
-            if (site.isSelfHostedAdmin || TextUtils.isEmpty(media.thumbnailUrl)) {
-                media.url
-            } else {
-                media.thumbnailUrl
-            }
-        )
+        // Always resize from the full-size media URL. MediaModel.thumbnailUrl is WP.com's 150px
+        // render, and Photon can't upscale it, so using it here produces a pixelated image.
+        val mediaUri = StringUtils.notNullStr(media.url)
 
         val photonUrl = if (site.isSelfHostedAdmin) {
             mediaUri

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -300,13 +300,12 @@ class FeaturedImageHelperTest {
     }
 
     @Test
-    fun `createCurrent-State uses media url when thumbnailUrl is empty`() {
+    fun `createCurrent-State resizes the full-size media url, not the thumbnail`() {
         // Arrange
         val post: PostImmutableModel = mock()
         whenever(post.hasFeaturedImage()).thenReturn(true)
 
         val media: MediaModel = mock()
-        whenever(media.thumbnailUrl).thenReturn(null)
         whenever(media.url).thenReturn("https://testing.com/url.jpg")
         whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
 
@@ -319,33 +318,6 @@ class FeaturedImageHelperTest {
         // Assert
         verify(readerUtilsWrapper).getResizedImageUrl(
             eq("https://testing.com/url.jpg"),
-            anyInt(),
-            anyInt(),
-            eq(siteAccessibilityInfo)
-        )
-    }
-
-    @Test
-    fun `createCurrent-State uses thumbnailUrl if it is not empty`() {
-        // Arrange
-        val post: PostImmutableModel = mock()
-        whenever(post.hasFeaturedImage()).thenReturn(true)
-
-        val media: MediaModel = mock()
-        whenever(media.thumbnailUrl).thenReturn("https://testing.com/thumbnail.jpg")
-        whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
-
-        val site = createSiteModel().apply {
-            origin = SiteModel.ORIGIN_WPCOM_REST
-        }
-
-        // Act
-        featuredImageHelper.createCurrentFeaturedImageState(site, post)
-        // Assert
-        verify(readerUtilsWrapper).getResizedImageUrl(
-            eq(
-                "https://testing.com/thumbnail.jpg"
-            ),
             anyInt(),
             anyInt(),
             eq(siteAccessibilityInfo)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mockito.lenient
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
@@ -307,6 +308,9 @@ class FeaturedImageHelperTest {
 
         val media: MediaModel = mock()
         whenever(media.url).thenReturn("https://testing.com/url.jpg")
+        // lenient(): the helper no longer reads thumbnailUrl, but it has to be set for this test
+        // to fail against the old behavior of preferring the thumbnail over the full-size url
+        lenient().`when`(media.thumbnailUrl).thenReturn("https://testing.com/thumbnail.jpg")
         whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
 
         val site = createSiteModel().apply {


### PR DESCRIPTION
## Description

Fixes [CMM-2258](https://linear.app/a8c/issue/CMM-2258/android-post-settings-shows-pixelated-featured-image). The legacy (FluxC) post settings screen showed the featured image blurry; the new wp-rs settings screen did not.

The problem was caused by the app choosing to resize the **thumbnail** Url if one was available. The fix is to always resize from the **full-size** `media.url`. Nothing else changes — same requested size, same `FIT_CENTER` layout, same self-hosted-admin behavior. The requested square already matches the image view's `maxHeight` (300dp), so it now renders roughly 1:1.

Note that Photon-capable sites resize server-side, so this costs no extra bandwidth. Private non-Atomic sites and self-hosted non-admins skip Photon and fall back to `?w=&h=`, so where those params aren't honored the app now downloads the original rather than a 150px render. Self-hosted admins are unaffected — they already loaded the unresized url.

## Testing instructions

Sites that skip Photon:

1. Add a featured image in post settings using a non-Atomic site (this is the path that changed).
- [x] Verify the featured image displays correctly and loads in reasonable time.
2. Repeat the step above on a self-hosted site (unchanged for admins - sanity check only).
- [x] Verify the featured image still displays correctly.

For reference, this is what the FluxC post settings looks like - if you see the featured image at the top of the screen, that's the RS post settings, which is not impacted by this change.

<img width="356" src="https://github.com/user-attachments/assets/59dae6ed-305a-4278-9d7d-f27fd036cd5a" />


Also for reference, here's how the featured image appeared prior to this change.

<img width="600" src="https://github.com/user-attachments/assets/3e4d12fd-6d2d-4482-9ece-12198d8ec8f5" />


