### PR TITLE
CMM-2276: Request sized image renders on non-Photon sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/PagesRsListViewModel.kt
@@ -1245,7 +1245,9 @@ internal class PagesRsListViewModel @Inject constructor(
         resolveImageJobs[tab]?.cancel()
         resolveImageJobs[tab] = viewModelScope.launch {
             val urls = withContext(Dispatchers.IO) {
-                restClient.fetchMediaUrls(site, unresolvedIds, THUMBNAIL_SIZE_DP)
+                restClient.fetchMediaUrls(
+                    site, unresolvedIds, THUMBNAIL_SIZE_DP, THUMBNAIL_ASPECT
+                )
             }
             if (urls.isEmpty()) return@launch
             updateTabUiState(tab) {
@@ -1436,6 +1438,9 @@ internal class PagesRsListViewModel @Inject constructor(
         private const val SITE_EDITOR_LAUNCH_DEBOUNCE_MS = 1000L
         internal const val MIN_SEARCH_QUERY_LENGTH = 3
         private const val THUMBNAIL_SIZE_DP = 64
+
+        /** Rows show the thumbnail in a square slot, cropped to fill. */
+        private const val THUMBNAIL_ASPECT = 1f
         private val ALL_STATUSES = PageRsListTab.entries.flatMap { it.statuses }.distinct()
 
         private const val TRACKS_SELECTED_TAB = "selected_tab"

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/PostRsListViewModel.kt
@@ -869,7 +869,8 @@ class PostRsListViewModel @Inject constructor(
         resolveImageJobs[tab] = viewModelScope.launch {
             val urls = withContext(Dispatchers.IO) {
                 restClient.fetchMediaUrls(
-                    site, unresolvedIds, THUMBNAIL_SIZE_DP
+                    site, unresolvedIds, THUMBNAIL_SIZE_DP,
+                    THUMBNAIL_ASPECT
                 )
             }
             if (urls.isEmpty()) return@launch
@@ -1004,6 +1005,9 @@ class PostRsListViewModel @Inject constructor(
         private const val SEARCH_DEBOUNCE_MS = 250L
         internal const val MIN_SEARCH_QUERY_LENGTH = 3
         private const val THUMBNAIL_SIZE_DP = 64
+
+        /** Rows show the thumbnail in a square slot, cropped to fill. */
+        private const val THUMBNAIL_ASPECT = 1f
         private val ALL_STATUSES = PostRsListTab.entries.flatMap { it.statuses }.distinct()
 
         private const val TRACKS_SELECTED_TAB = "selected_tab"

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -78,7 +78,7 @@ class PostRsRestClient @Inject constructor(
             (widthDp * context.resources.displayMetrics.density)
                 .toInt()
         } else {
-            0
+            context.resources.displayMetrics.widthPixels
         }
         val result = mutableMapOf<Long, String>()
         val uncached = mutableListOf<Long>()
@@ -414,9 +414,9 @@ class PostRsRestClient @Inject constructor(
         SLUG_TO_FORMAT[slug] ?: PostFormat.Custom(slug)
 
     /**
-     * Reads the source URL and the available renders off [this]. The
-     * `mediaDetails` handle is owned by the response, so this has to be
-     * called while the response is still alive.
+     * Reads the source URL and the available renders off the media
+     * object. The `mediaDetails` handle is owned by the response, so
+     * this has to be called while the response is still alive.
      */
     private fun MediaWithEditContext.toMediaImage(): MediaImage {
         val image = mediaDetails.parseAsMimeType(mimeType)
@@ -430,36 +430,30 @@ class PostRsRestClient @Inject constructor(
     }
 
     /**
-     * Picks a URL to display [image] at [widthPx] (0 means full screen
-     * width). Photon-capable sites resize the original server-side.
-     * Everywhere else - self-hosted sites in particular, which ignore
-     * the `?w=` param - we ask for the smallest render WordPress
-     * already generated that's at least as wide as we need, so a 64dp
-     * thumbnail doesn't pull down the full-size upload. Never picks a
-     * render narrower than the target, so images can't end up
-     * pixelated.
+     * Picks a URL to display [image] at [widthPx]. Photon-capable
+     * sites resize the original server-side. Everywhere else -
+     * self-hosted sites in particular, which ignore the `?w=` param -
+     * we ask for the smallest render WordPress already generated
+     * that's at least as wide as we need, so a 64dp thumbnail doesn't
+     * pull down the full-size upload. Never picks a render narrower
+     * than the target, so images can't end up pixelated.
      */
     private fun toDisplayUrl(
         site: SiteModel,
         image: MediaImage,
-        widthPx: Int = 0,
+        widthPx: Int,
     ): String {
-        val width = if (widthPx > 0) {
-            widthPx
-        } else {
-            context.resources.displayMetrics.widthPixels
-        }
         val accessibilityInfo =
             SiteUtils.getAccessibilityInfoFromSite(site)
         val url = if (accessibilityInfo.isPhotonCapable) {
             image.sourceUrl
         } else {
-            image.sizes.firstOrNull { it.width >= width }?.url
+            image.sizes.firstOrNull { it.width >= widthPx }?.url
                 ?: image.sourceUrl
         }
         return ReaderUtils.getResizedImageUrl(
-            url, width, 0, accessibilityInfo
-        ).also { logImageChoice(image, accessibilityInfo, width, it) }
+            url, widthPx, 0, accessibilityInfo
+        ).also { logImageChoice(image, accessibilityInfo, widthPx, it) }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -89,11 +89,17 @@ class PostRsRestClient @Inject constructor(
      *
      * @param widthDp target display width in dp. Pass 0 to use the
      *     full screen width.
+     * @param displayAspect width/height the image will be displayed
+     *     at, when the caller crops to a fixed shape. Lets a render
+     *     WordPress cropped to that same shape be used - a square
+     *     thumbnail for a square slot, say. Leave null to accept only
+     *     renders that still match the original's proportions.
      */
     suspend fun fetchMediaUrls(
         site: SiteModel,
         mediaIds: List<Long>,
         widthDp: Int = 0,
+        displayAspect: Float? = null,
     ): Map<Long, String> {
         val widthPx = if (widthDp > 0) {
             (widthDp * context.resources.displayMetrics.density)
@@ -110,7 +116,8 @@ class PostRsRestClient @Inject constructor(
             val cached = mediaImageCache[mediaCacheKey(site, id)]
             if (cached != null) {
                 result[id] = toDisplayUrl(
-                    accessibilityInfo, isWpComRest, cached, widthPx
+                    accessibilityInfo, isWpComRest, cached, widthPx,
+                    displayAspect
                 )
             } else {
                 uncached.add(id)
@@ -131,7 +138,8 @@ class PostRsRestClient @Inject constructor(
                     mediaImageCache[mediaCacheKey(site, media.id)] =
                         image
                     result[media.id] = toDisplayUrl(
-                        accessibilityInfo, isWpComRest, image, widthPx
+                        accessibilityInfo, isWpComRest, image, widthPx,
+                        displayAspect
                     )
                 }
             }
@@ -469,17 +477,25 @@ class PostRsRestClient @Inject constructor(
     }
 
     /**
-     * The smallest render at least [targetWidth] wide, ignoring any
-     * whose aspect ratio no longer matches the original. Themes can
-     * register hard-cropped sizes (WordPress crops `thumbnail` by
-     * default), and handing one of those to a screen that crops again
-     * would quietly cut content out of the image.
+     * The smallest render at least [targetWidth] wide that we can use
+     * without losing content. Themes register hard-cropped sizes
+     * (WordPress crops `thumbnail` by default), and handing one of
+     * those to a screen that crops again would quietly cut the image
+     * down twice - so a render only qualifies if it still matches the
+     * original's proportions, or if it was cropped to the very shape
+     * the caller is about to display it at ([displayAspect]).
      */
-    private fun MediaImage.renderAtLeast(targetWidth: Int): String? {
+    private fun MediaImage.renderAtLeast(
+        targetWidth: Int,
+        displayAspect: Float?,
+    ): String? {
         if (sourceWidth <= 0 || sourceHeight <= 0) return null
         val sourceRatio = sourceWidth.toFloat() / sourceHeight
         return sizes.firstOrNull {
-            it.width >= targetWidth && it.matchesRatio(sourceRatio)
+            it.width >= targetWidth && (
+                it.matchesRatio(sourceRatio) ||
+                    (displayAspect != null && it.matchesRatio(displayAspect))
+                )
         }?.url
     }
 
@@ -502,11 +518,13 @@ class PostRsRestClient @Inject constructor(
         isWpComRest: Boolean,
         image: MediaImage,
         widthPx: Int,
+        displayAspect: Float?,
     ): String {
         val url = if (accessibilityInfo.isPhotonCapable) {
             image.sourceUrl
         } else {
-            image.renderAtLeast(widthPx) ?: image.sourceUrl
+            image.renderAtLeast(widthPx, displayAspect)
+                ?: image.sourceUrl
         }
         // Only WP.com-hosted media honors ?w=, and only Photon needs
         // the rewrite. Self-hosted ignores the param, and rewriting

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -82,10 +82,10 @@ class PostRsRestClient @Inject constructor(
     }
 
     /**
-     * Fetches media source URLs for the given [mediaIds] in a single
-     * network call using the `include` parameter, returning a map of
-     * media ID to a URL sized for display. IDs already in the local
-     * cache are returned immediately without a network round-trip.
+     * Fetches the given [mediaIds] in a single network call using the
+     * `include` parameter, returning a map of media ID to a URL sized
+     * for display. IDs already in the local cache are returned
+     * immediately without a network round-trip.
      *
      * @param widthDp target display width in dp. Pass 0 to use the
      *     full screen width.
@@ -475,23 +475,18 @@ class PostRsRestClient @Inject constructor(
      * default), and handing one of those to a screen that crops again
      * would quietly cut content out of the image.
      */
-    private fun MediaImage.renderAtLeast(targetWidth: Int): String? =
-        sizes.firstOrNull {
-            it.width >= targetWidth && it.matchesAspectOf(this)
+    private fun MediaImage.renderAtLeast(targetWidth: Int): String? {
+        if (sourceWidth <= 0 || sourceHeight <= 0) return null
+        val sourceRatio = sourceWidth.toFloat() / sourceHeight
+        return sizes.firstOrNull {
+            it.width >= targetWidth && it.matchesRatio(sourceRatio)
         }?.url
-
-    private fun ScaledSize.matchesAspectOf(image: MediaImage): Boolean {
-        if (height <= 0 ||
-            image.sourceWidth <= 0 ||
-            image.sourceHeight <= 0
-        ) {
-            return false
-        }
-        val sourceRatio =
-            image.sourceWidth.toFloat() / image.sourceHeight
-        val ratio = width.toFloat() / height
-        return abs(ratio - sourceRatio) <= sourceRatio * ASPECT_TOLERANCE
     }
+
+    private fun ScaledSize.matchesRatio(sourceRatio: Float): Boolean =
+        height > 0 &&
+            abs(width.toFloat() / height - sourceRatio) <=
+            sourceRatio * ASPECT_TOLERANCE
 
     /**
      * Picks a URL to display [image] at [widthPx]. Photon-capable

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.ui.postsrs.AuthorInfo
 import org.wordpress.android.ui.reader.utils.ReaderUtils
+import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SiteUtils
 import rs.wordpress.api.kotlin.WpRequestResult
@@ -458,6 +459,26 @@ class PostRsRestClient @Inject constructor(
         }
         return ReaderUtils.getResizedImageUrl(
             url, width, 0, accessibilityInfo
+        ).also { logImageChoice(image, accessibilityInfo, width, it) }
+    }
+
+    /**
+     * TODO CMM-2276: temporary review aid, remove before merge. Lets a
+     * reviewer confirm the right render is picked without a proxy.
+     */
+    private fun logImageChoice(
+        image: MediaImage,
+        accessibilityInfo: SiteAccessibilityInfo,
+        width: Int,
+        chosenUrl: String,
+    ) {
+        AppLog.d(
+            AppLog.T.POSTS,
+            "CMM-2276 want=${width}px " +
+                "photon=${accessibilityInfo.isPhotonCapable} " +
+                "renders=${image.sizes.map { it.width }} " +
+                "chose=${chosenUrl.substringAfterLast('/')} " +
+                "original=${image.sourceUrl.substringAfterLast('/')}"
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -492,17 +492,33 @@ class PostRsRestClient @Inject constructor(
         if (sourceWidth <= 0 || sourceHeight <= 0) return null
         val sourceRatio = sourceWidth.toFloat() / sourceHeight
         return sizes.firstOrNull {
-            it.width >= targetWidth && (
+            it.usableWidthFor(displayAspect) >= targetWidth && (
                 it.matchesRatio(sourceRatio) ||
                     (displayAspect != null && it.matchesRatio(displayAspect))
                 )
         }?.url
     }
 
-    private fun ScaledSize.matchesRatio(sourceRatio: Float): Boolean =
+    /**
+     * How much of this render's width survives being cropped to
+     * [displayAspect]. Cropping to a shape narrower than the render
+     * is limited by its height, so a wide render carries far less
+     * detail into a square slot than its own width suggests - a
+     * 300x169 thumbnail of a 16:9 photo only has 169px to give.
+     */
+    private fun ScaledSize.usableWidthFor(displayAspect: Float?): Int {
+        if (displayAspect == null || height <= 0) return width
+        return if (width.toFloat() / height > displayAspect) {
+            (height * displayAspect).toInt()
+        } else {
+            width
+        }
+    }
+
+    private fun ScaledSize.matchesRatio(ratio: Float): Boolean =
         height > 0 &&
-            abs(width.toFloat() / height - sourceRatio) <=
-            sourceRatio * ASPECT_TOLERANCE
+            abs(width.toFloat() / height - ratio) <=
+            ratio * ASPECT_TOLERANCE
 
     /**
      * Picks a URL to display [image] at [widthPx]. Photon-capable

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -25,9 +25,11 @@ import uniffi.wp_api.ThemeStatus
 import uniffi.wp_api.ThemeSupports
 import uniffi.wp_api.ThemeSupportsData
 import uniffi.wp_api.UserListParams
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 
 data class AuthorPage(
     val authors: List<AuthorInfo>,
@@ -35,10 +37,16 @@ data class AuthorPage(
 )
 
 /** One of the renders WordPress generated for an image at upload time. */
-private data class ScaledSize(val width: Int, val url: String)
+private data class ScaledSize(
+    val width: Int,
+    val height: Int,
+    val url: String,
+)
 
 private data class MediaImage(
     val sourceUrl: String,
+    val sourceWidth: Int,
+    val sourceHeight: Int,
     /** Renders from `media_details.sizes`, ascending by width. Empty for non-images. */
     val sizes: List<ScaledSize>,
 )
@@ -48,13 +56,26 @@ class PostRsRestClient @Inject constructor(
     @ApplicationContext private val context: Context,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
-    private val mediaUrlCache = ConcurrentHashMap<Long, MediaImage>()
+    /**
+     * Keyed by site and media ID, since media IDs only mean anything
+     * within a site. Bounded and least-recently-used, so scrolling a
+     * long list can't grow it without limit.
+     */
+    private val mediaImageCache = Collections.synchronizedMap(
+        object : LinkedHashMap<String, MediaImage>(
+            MEDIA_CACHE_CAPACITY, MEDIA_CACHE_LOAD_FACTOR, true
+        ) {
+            override fun removeEldestEntry(
+                eldest: MutableMap.MutableEntry<String, MediaImage>,
+            ): Boolean = size > MEDIA_CACHE_MAX_ENTRIES
+        }
+    )
     private val userNameCache = ConcurrentHashMap<Long, String>()
     private val categoryNameCache = ConcurrentHashMap<Long, String>()
     private val tagNameCache = ConcurrentHashMap<Long, String>()
 
     fun clearCaches() {
-        mediaUrlCache.clear()
+        mediaImageCache.clear()
         userNameCache.clear()
         categoryNameCache.clear()
         tagNameCache.clear()
@@ -80,12 +101,17 @@ class PostRsRestClient @Inject constructor(
         } else {
             context.resources.displayMetrics.widthPixels
         }
+        val accessibilityInfo =
+            SiteUtils.getAccessibilityInfoFromSite(site)
+        val isWpComRest = SiteUtils.isAccessedViaWPComRest(site)
         val result = mutableMapOf<Long, String>()
         val uncached = mutableListOf<Long>()
         for (id in mediaIds) {
-            val cached = mediaUrlCache[id]
+            val cached = mediaImageCache[mediaCacheKey(site, id)]
             if (cached != null) {
-                result[id] = toDisplayUrl(site, cached, widthPx)
+                result[id] = toDisplayUrl(
+                    accessibilityInfo, isWpComRest, cached, widthPx
+                )
             } else {
                 uncached.add(id)
             }
@@ -102,9 +128,10 @@ class PostRsRestClient @Inject constructor(
             is WpRequestResult.Success -> {
                 for (media in response.response.data) {
                     val image = media.toMediaImage()
-                    mediaUrlCache[media.id] = image
+                    mediaImageCache[mediaCacheKey(site, media.id)] =
+                        image
                     result[media.id] = toDisplayUrl(
-                        site, image, widthPx
+                        accessibilityInfo, isWpComRest, image, widthPx
                     )
                 }
             }
@@ -413,47 +440,92 @@ class PostRsRestClient @Inject constructor(
     private fun slugToPostFormat(slug: String): PostFormat =
         SLUG_TO_FORMAT[slug] ?: PostFormat.Custom(slug)
 
+    private fun mediaCacheKey(site: SiteModel, mediaId: Long): String =
+        "${site.id}:$mediaId"
+
     /**
      * Reads the source URL and the available renders off the media
      * object. The `mediaDetails` handle is owned by the response, so
      * this has to be called while the response is still alive.
      */
     private fun MediaWithEditContext.toMediaImage(): MediaImage {
-        val image = mediaDetails.parseAsMimeType(mimeType)
-            as? MediaDetailsPayload.Image
-        val sizes = image?.v1?.sizes.orEmpty()
+        val details = (mediaDetails.parseAsMimeType(mimeType)
+            as? MediaDetailsPayload.Image)?.v1
+        val sizes = details?.sizes.orEmpty()
             .map { (_, size) ->
-                ScaledSize(size.width.toInt(), size.sourceUrl)
+                ScaledSize(
+                    size.width.toInt(),
+                    size.height.toInt(),
+                    size.sourceUrl,
+                )
             }
             .sortedBy { it.width }
-        return MediaImage(sourceUrl, sizes)
+        return MediaImage(
+            sourceUrl = sourceUrl,
+            sourceWidth = details?.width?.toInt() ?: 0,
+            sourceHeight = details?.height?.toInt() ?: 0,
+            sizes = sizes,
+        )
+    }
+
+    /**
+     * The smallest render at least [targetWidth] wide, ignoring any
+     * whose aspect ratio no longer matches the original. Themes can
+     * register hard-cropped sizes (WordPress crops `thumbnail` by
+     * default), and handing one of those to a screen that crops again
+     * would quietly cut content out of the image.
+     */
+    private fun MediaImage.renderAtLeast(targetWidth: Int): String? =
+        sizes.firstOrNull {
+            it.width >= targetWidth && it.matchesAspectOf(this)
+        }?.url
+
+    private fun ScaledSize.matchesAspectOf(image: MediaImage): Boolean {
+        if (height <= 0 ||
+            image.sourceWidth <= 0 ||
+            image.sourceHeight <= 0
+        ) {
+            return false
+        }
+        val sourceRatio =
+            image.sourceWidth.toFloat() / image.sourceHeight
+        val ratio = width.toFloat() / height
+        return abs(ratio - sourceRatio) <= sourceRatio * ASPECT_TOLERANCE
     }
 
     /**
      * Picks a URL to display [image] at [widthPx]. Photon-capable
-     * sites resize the original server-side. Everywhere else -
-     * self-hosted sites in particular, which ignore the `?w=` param -
-     * we ask for the smallest render WordPress already generated
-     * that's at least as wide as we need, so a 64dp thumbnail doesn't
-     * pull down the full-size upload. Never picks a render narrower
-     * than the target, so images can't end up pixelated.
+     * sites resize the original server-side. Everywhere else - self
+     * hosted sites in particular - we ask for the smallest render
+     * WordPress already generated that's at least as wide as we need,
+     * so a 64dp thumbnail doesn't pull down the full-size upload.
+     * Never picks a render narrower than the target, so images can't
+     * end up pixelated.
      */
     private fun toDisplayUrl(
-        site: SiteModel,
+        accessibilityInfo: SiteAccessibilityInfo,
+        isWpComRest: Boolean,
         image: MediaImage,
         widthPx: Int,
     ): String {
-        val accessibilityInfo =
-            SiteUtils.getAccessibilityInfoFromSite(site)
         val url = if (accessibilityInfo.isPhotonCapable) {
             image.sourceUrl
         } else {
-            image.sizes.firstOrNull { it.width >= widthPx }?.url
-                ?: image.sourceUrl
+            image.renderAtLeast(widthPx) ?: image.sourceUrl
         }
-        return ReaderUtils.getResizedImageUrl(
-            url, widthPx, 0, accessibilityInfo
-        ).also { logImageChoice(image, accessibilityInfo, widthPx, it) }
+        // Only WP.com-hosted media honors ?w=, and only Photon needs
+        // the rewrite. Self-hosted ignores the param, and rewriting
+        // the URL there would drop any signed or CDN query string it
+        // carries, breaking the image outright.
+        val displayUrl = if (isWpComRest) {
+            ReaderUtils.getResizedImageUrl(
+                url, widthPx, 0, accessibilityInfo
+            )
+        } else {
+            url
+        }
+        logImageChoice(image, accessibilityInfo, widthPx, displayUrl)
+        return displayUrl
     }
 
     /**
@@ -488,6 +560,17 @@ class PostRsRestClient @Inject constructor(
     companion object {
         internal const val AUTHORS_PER_PAGE: UInt = 20u
         private const val PER_PAGE = 100u
+
+        private const val MEDIA_CACHE_MAX_ENTRIES = 500
+        private const val MEDIA_CACHE_CAPACITY = 64
+        private const val MEDIA_CACHE_LOAD_FACTOR = 0.75f
+
+        /**
+         * How far a render's aspect ratio may drift from the original
+         * before we treat it as cropped rather than scaled. Generous
+         * enough for rounding, far tighter than any real crop.
+         */
+        private const val ASPECT_TOLERANCE = 0.05f
 
         private val SLUG_TO_FORMAT = mapOf(
             "standard" to PostFormat.Standard,

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -5,12 +5,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.ui.postsrs.AuthorInfo
+import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.SiteUtils
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.AnyTermWithViewContext
+import uniffi.wp_api.MediaDetailsPayload
 import uniffi.wp_api.MediaListParams
+import uniffi.wp_api.MediaWithEditContext
 import uniffi.wp_api.PostFormat
 import uniffi.wp_api.TermCreateParams
 import uniffi.wp_api.TermEndpointType
@@ -31,12 +33,21 @@ data class AuthorPage(
     val nextPageParams: UserListParams?,
 )
 
+/** One of the renders WordPress generated for an image at upload time. */
+private data class ScaledSize(val width: Int, val url: String)
+
+private data class MediaImage(
+    val sourceUrl: String,
+    /** Renders from `media_details.sizes`, ascending by width. Empty for non-images. */
+    val sizes: List<ScaledSize>,
+)
+
 @Singleton
 class PostRsRestClient @Inject constructor(
     @ApplicationContext private val context: Context,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
-    private val mediaUrlCache = ConcurrentHashMap<Long, String>()
+    private val mediaUrlCache = ConcurrentHashMap<Long, MediaImage>()
     private val userNameCache = ConcurrentHashMap<Long, String>()
     private val categoryNameCache = ConcurrentHashMap<Long, String>()
     private val tagNameCache = ConcurrentHashMap<Long, String>()
@@ -51,11 +62,11 @@ class PostRsRestClient @Inject constructor(
     /**
      * Fetches media source URLs for the given [mediaIds] in a single
      * network call using the `include` parameter, returning a map of
-     * media ID to Photon-optimized URL. IDs already in the local cache
-     * are returned immediately without a network round-trip.
+     * media ID to a URL sized for display. IDs already in the local
+     * cache are returned immediately without a network round-trip.
      *
-     * @param widthDp target display width in dp for Photon resizing.
-     *     Pass 0 to use the full screen width.
+     * @param widthDp target display width in dp. Pass 0 to use the
+     *     full screen width.
      */
     suspend fun fetchMediaUrls(
         site: SiteModel,
@@ -73,7 +84,7 @@ class PostRsRestClient @Inject constructor(
         for (id in mediaIds) {
             val cached = mediaUrlCache[id]
             if (cached != null) {
-                result[id] = toPhotonUrl(site, cached, widthPx)
+                result[id] = toDisplayUrl(site, cached, widthPx)
             } else {
                 uncached.add(id)
             }
@@ -89,9 +100,10 @@ class PostRsRestClient @Inject constructor(
         when (response) {
             is WpRequestResult.Success -> {
                 for (media in response.response.data) {
-                    mediaUrlCache[media.id] = media.sourceUrl
-                    result[media.id] = toPhotonUrl(
-                        site, media.sourceUrl, widthPx
+                    val image = media.toMediaImage()
+                    mediaUrlCache[media.id] = image
+                    result[media.id] = toDisplayUrl(
+                        site, image, widthPx
                     )
                 }
             }
@@ -400,19 +412,52 @@ class PostRsRestClient @Inject constructor(
     private fun slugToPostFormat(slug: String): PostFormat =
         SLUG_TO_FORMAT[slug] ?: PostFormat.Custom(slug)
 
-    private fun toPhotonUrl(
+    /**
+     * Reads the source URL and the available renders off [this]. The
+     * `mediaDetails` handle is owned by the response, so this has to be
+     * called while the response is still alive.
+     */
+    private fun MediaWithEditContext.toMediaImage(): MediaImage {
+        val image = mediaDetails.parseAsMimeType(mimeType)
+            as? MediaDetailsPayload.Image
+        val sizes = image?.v1?.sizes.orEmpty()
+            .map { (_, size) ->
+                ScaledSize(size.width.toInt(), size.sourceUrl)
+            }
+            .sortedBy { it.width }
+        return MediaImage(sourceUrl, sizes)
+    }
+
+    /**
+     * Picks a URL to display [image] at [widthPx] (0 means full screen
+     * width). Photon-capable sites resize the original server-side.
+     * Everywhere else - self-hosted sites in particular, which ignore
+     * the `?w=` param - we ask for the smallest render WordPress
+     * already generated that's at least as wide as we need, so a 64dp
+     * thumbnail doesn't pull down the full-size upload. Never picks a
+     * render narrower than the target, so images can't end up
+     * pixelated.
+     */
+    private fun toDisplayUrl(
         site: SiteModel,
-        sourceUrl: String,
+        image: MediaImage,
         widthPx: Int = 0,
     ): String {
-        if (!SiteUtils.isPhotonCapable(site)) return sourceUrl
         val width = if (widthPx > 0) {
             widthPx
         } else {
             context.resources.displayMetrics.widthPixels
         }
-        return PhotonUtils.getPhotonImageUrl(
-            sourceUrl, width, 0, site.isPrivateWPComAtomic
+        val accessibilityInfo =
+            SiteUtils.getAccessibilityInfoFromSite(site)
+        val url = if (accessibilityInfo.isPhotonCapable) {
+            image.sourceUrl
+        } else {
+            image.sizes.firstOrNull { it.width >= width }?.url
+                ?: image.sourceUrl
+        }
+        return ReaderUtils.getResizedImageUrl(
+            url, width, 0, accessibilityInfo
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -546,35 +546,13 @@ class PostRsRestClient @Inject constructor(
         // the rewrite. Self-hosted ignores the param, and rewriting
         // the URL there would drop any signed or CDN query string it
         // carries, breaking the image outright.
-        val displayUrl = if (isWpComRest) {
+        return if (isWpComRest) {
             ReaderUtils.getResizedImageUrl(
                 url, widthPx, 0, accessibilityInfo
             )
         } else {
             url
         }
-        logImageChoice(image, accessibilityInfo, widthPx, displayUrl)
-        return displayUrl
-    }
-
-    /**
-     * TODO CMM-2276: temporary review aid, remove before merge. Lets a
-     * reviewer confirm the right render is picked without a proxy.
-     */
-    private fun logImageChoice(
-        image: MediaImage,
-        accessibilityInfo: SiteAccessibilityInfo,
-        width: Int,
-        chosenUrl: String,
-    ) {
-        AppLog.d(
-            AppLog.T.POSTS,
-            "CMM-2276 want=${width}px " +
-                "photon=${accessibilityInfo.isPhotonCapable} " +
-                "renders=${image.sizes.map { it.width }} " +
-                "chose=${chosenUrl.substringAfterLast('/')} " +
-                "original=${image.sourceUrl.substringAfterLast('/')}"
-        )
     }
 
     private fun termCache(


### PR DESCRIPTION
Fixes [CMM-2276](https://linear.app/a8c/issue/CMM-2276/android-rs-screens-download-full-size-images-on-self-hosted-sites).

**Update:** This PR originally had logging to make reviewing easier, but that has since been removed.

## Description

The RS screens rely on `PostRsRestClient.toPhotonUrl()` when requesting featured images, but this returned the raw wp/v2 `source_url` on any site that isn't Photon-capable. So self-hosted sites always downloaded the full-size original for every featured image — including the 64dp thumbnails in the posts and pages lists, once per row.

This PR addresses this problem.

## How to read the temporary log

One line is emitted per resolved image, tagged `WordPress-POSTS`:

```
CMM-2276 want=192px photon=false renders=[150, 300, 768, 1024] chose=beach-300x200.jpg original=beach.jpg
```

`want` is the target width in px, `renders` is what the site offers, and `chose` vs `original` is the fix at work. To view these log entries, in terminal enter:

```
adb -s emulator-5554 logcat -s WordPress-POSTS | grep CMM-2276
```

## Testing instructions

Self-hosted site (the case being fixed):

1. Log into a self-hosted site with an application password, on a site with large featured images.
2. Open the Posts list, then the Pages list.
- [x] Featured image thumbnails still render sharply at 64dp.
- [x] The log shows `photon=false` and `chose=` a `-300x200`-style render, not the original filename.
3. Open a post's settings screen.
- [x] The featured image hero looks the same as on trunk (no softness or pixelation).
- [x] The log shows a much larger `want=` here, so `chose=` may fall back to the original — that's expected when the site registers nothing that wide.
