### PR TITLE
CMM-2290: Replace internal "Oddie bot" label with "AI Assistant"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/unified/ui/UnifiedConversationDetailScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/unified/ui/UnifiedConversationDetailScreen.kt
@@ -374,7 +374,7 @@ private fun MessageBubble(
     ) {
         if (!message.isUser) {
             Text(
-                text = stringResource(R.string.unified_support_status_bot),
+                text = stringResource(R.string.unified_support_status_ai_assistant),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 2.dp, start = 4.dp, end = 4.dp)

--- a/WordPress/src/main/java/org/wordpress/android/support/unified/ui/UnifiedConversationsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/unified/ui/UnifiedConversationsListScreen.kt
@@ -133,7 +133,7 @@ private fun UnifiedStatusBadge(
 ) {
     if (conversation.isBot) {
         Text(
-            text = stringResource(R.string.unified_support_status_bot),
+            text = stringResource(R.string.unified_support_status_ai_assistant),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onPrimaryContainer,
             modifier = modifier

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -8,7 +8,6 @@ Language: ar
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="unified_support_message_input_placeholder">جارٍ كتابة رسالة…</string>
     <string name="unified_support_bot_typing_content_description">روبوت الدعم يكتب</string>
-    <string name="unified_support_status_bot">روبوت Oddie</string>
     <string name="unified_support_attachment_match_score">%1$d%% تطابق</string>
     <string name="support_screen_unified_support_title">الحصول على مساعدة</string>
     <string name="support_screen_unified_support_description">احصل على إجابات من فريق الدعم لدينا في أي وقت</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -9,7 +9,6 @@ Language: cs_CZ
     <string name="support_screen_unified_support_description">Získejte odpovědi od našeho týmu podpory, kdykoli budete potřebovat</string>
     <string name="support_screen_unified_support_title">Získat pomoc</string>
     <string name="unified_support_attachment_match_score">%1$d%% shoda</string>
-    <string name="unified_support_status_bot">Boty Oddie</string>
     <string name="unified_support_bot_typing_content_description">Podpůrný bot právě píše</string>
     <string name="unified_support_message_input_placeholder">Napište zprávu…</string>
     <string name="unified_support_conversations_title">Získat pomoc</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -9,7 +9,6 @@ Language: de
     <string name="support_screen_unified_support_description">Erhalte jederzeit Antworten von unserem Support-Team</string>
     <string name="support_screen_unified_support_title">Hilfe erhalten</string>
     <string name="unified_support_attachment_match_score">%1$d %% Übereinstimmung</string>
-    <string name="unified_support_status_bot">Oddie-Bot</string>
     <string name="unified_support_bot_typing_content_description">Der Support-Bot schreibt gerade</string>
     <string name="unified_support_message_input_placeholder">Schreib eine Nachricht …</string>
     <string name="unified_support_conversations_title">Hilfe erhalten</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -9,7 +9,6 @@ Language: en_GB
     <string name="support_screen_unified_support_description">Get answers from our support team, anytime</string>
     <string name="support_screen_unified_support_title">Get help</string>
     <string name="unified_support_attachment_match_score">%1$d%% match</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_bot_typing_content_description">Support bot is typing</string>
     <string name="unified_support_message_input_placeholder">Type a message…</string>
     <string name="unified_support_conversations_title">Get help</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -9,7 +9,6 @@ Language: es_CO
     <string name="unified_support_message_input_placeholder">Escribe un mensaje…</string>
     <string name="support_screen_unified_support_description">Consigue respuestas de nuestro equipo de atención al cliente en cualquier momento</string>
     <string name="unified_support_attachment_match_score">%1$d%% coincidencia</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_bot_typing_content_description">El bot de asistencia está escribiendo</string>
     <string name="support_screen_unified_support_title">Obtén ayuda</string>
     <string name="page_rs_copy_url">Copiar URL</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -9,7 +9,6 @@ Language: es
     <string name="support_screen_unified_support_description">Consigue respuestas de nuestro equipo de atención al cliente en cualquier momento</string>
     <string name="support_screen_unified_support_title">Obtén ayuda</string>
     <string name="unified_support_attachment_match_score">%1$d%% coincidencia</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_bot_typing_content_description">El bot de asistencia está escribiendo</string>
     <string name="unified_support_message_input_placeholder">Escribe un mensaje…</string>
     <string name="unified_support_conversations_title">Obtén ayuda</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -9,7 +9,6 @@ Language: he_IL
     <string name="support_screen_unified_support_description">קבלת תשובות מצוות התמיכה שלנו בכל עת</string>
     <string name="support_screen_unified_support_title">קבלת עזרה</string>
     <string name="unified_support_attachment_match_score">%1$d%% התאמה</string>
-    <string name="unified_support_status_bot">אודי הבוט</string>
     <string name="unified_support_bot_typing_content_description">בוט התמיכה מקליד</string>
     <string name="unified_support_message_input_placeholder">יש להקליד הודעה…</string>
     <string name="unified_support_conversations_title">קבלת עזרה</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -9,7 +9,6 @@ Language: id
     <string name="support_screen_unified_support_description">Dapatkan jawaban dari tim dukungan kami, kapan saja</string>
     <string name="support_screen_unified_support_title">Dapatkan bantuan</string>
     <string name="unified_support_attachment_match_score">%1$d%% pertandingan</string>
-    <string name="unified_support_status_bot">Bot Oddie</string>
     <string name="unified_support_bot_typing_content_description">Bot dukungan sedang mengetik</string>
     <string name="unified_support_message_input_placeholder">Ketik pesan…</string>
     <string name="unified_support_conversations_title">Dapatkan bantuan</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -9,7 +9,6 @@ Language: it
     <string name="support_screen_unified_support_description">Ottieni risposte dal nostro team di supporto, in qualsiasi momento</string>
     <string name="support_screen_unified_support_title">Richiedi supporto</string>
     <string name="unified_support_attachment_match_score">corrispondenza al %1$d%%</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_bot_typing_content_description">Il bot di supporto sta digitando</string>
     <string name="unified_support_message_input_placeholder">Invia un messaggio…</string>
     <string name="unified_support_conversations_title">Richiedi supporto</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -9,7 +9,6 @@ Language: ja_JP
     <string name="support_screen_unified_support_description">いつでもサポートチームから回答を得られます</string>
     <string name="support_screen_unified_support_title">ヘルプ</string>
     <string name="unified_support_attachment_match_score">%1$d%% 一致</string>
-    <string name="unified_support_status_bot">Oddie ボット</string>
     <string name="unified_support_bot_typing_content_description">サポートボットが入力中</string>
     <string name="unified_support_message_input_placeholder">メッセージを入力…</string>
     <string name="unified_support_conversations_title">ヘルプ</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -9,7 +9,6 @@ Language: ko_KR
     <string name="support_screen_unified_support_description">언제든지 지원팀의 답변 받기</string>
     <string name="support_screen_unified_support_title">도움말 이용</string>
     <string name="unified_support_attachment_match_score">%1$d%% 일치</string>
-    <string name="unified_support_status_bot">Oddie 봇</string>
     <string name="unified_support_bot_typing_content_description">지원 봇이 입력 중</string>
     <string name="unified_support_message_input_placeholder">메시지 입력…</string>
     <string name="unified_support_conversations_title">도움말 이용</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -9,7 +9,6 @@ Language: nl
     <string name="support_screen_unified_support_description">Je kunt altijd antwoorden krijgen van ons ondersteuningsteam</string>
     <string name="support_screen_unified_support_title">Krijg hulp</string>
     <string name="unified_support_attachment_match_score">%1$d%% overeenkomst</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_bot_typing_content_description">De ondersteuningsbot is aan het typen</string>
     <string name="unified_support_message_input_placeholder">Typ een bericht in…</string>
     <string name="unified_support_conversations_title">Krijg hulp</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -9,7 +9,6 @@ Language: pl
     <string name="support_screen_unified_support_description">Uzyskaj odpowiedzi od naszego zespołu pomocy technicznej – o każdej porze</string>
     <string name="support_screen_unified_support_title">Uzyskaj pomoc</string>
     <string name="unified_support_attachment_match_score">%1$d%% pasuje</string>
-    <string name="unified_support_status_bot">Dziwny bot</string>
     <string name="unified_support_bot_typing_content_description">Bot pomocy technicznej pisze</string>
     <string name="unified_support_message_input_placeholder">Wpisz wiadomość…</string>
     <string name="unified_support_conversations_title">Uzyskaj pomoc</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -10,7 +10,6 @@ Language: ro
     <string name="support_screen_unified_support_title">Primești ajutor</string>
     <string name="unified_support_message_input_placeholder">Scrie un mesaj…</string>
     <string name="unified_support_bot_typing_content_description">Botul pentru suport tastează</string>
-    <string name="unified_support_status_bot">Bot ciudat</string>
     <string name="unified_support_attachment_match_score">Potrivire %1$d%%</string>
     <string name="unified_support_conversations_title">Primești ajutor</string>
     <string name="page_rs_move_trashed_page_to_draft_dialog_message">Paginile aruncate la gunoi nu pot fi editate. Vrei să modifici starea acestei pagini în „ciornă” pentru a o putea edita?</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -9,7 +9,6 @@ Language: ru
     <string name="support_screen_unified_support_description">Получайте ответы от нашей службы поддержки в любое время</string>
     <string name="support_screen_unified_support_title">Справка</string>
     <string name="unified_support_attachment_match_score">Совпадение %1$d%%</string>
-    <string name="unified_support_status_bot">Бот Oddie</string>
     <string name="unified_support_bot_typing_content_description">Бот поддержки вводит текст</string>
     <string name="unified_support_message_input_placeholder">Написать сообщение…</string>
     <string name="unified_support_conversations_title">Справка</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -9,7 +9,6 @@ Language: sv_SE
     <string name="support_screen_unified_support_description">Få svar från vårt supportteam när som helst</string>
     <string name="support_screen_unified_support_title">Skaffa hjälp</string>
     <string name="unified_support_attachment_match_score">%1$d%% matcha</string>
-    <string name="unified_support_status_bot">Oddie-bot</string>
     <string name="unified_support_bot_typing_content_description">Supportroboten skriver</string>
     <string name="unified_support_message_input_placeholder">Skriv ett meddelande …</string>
     <string name="unified_support_conversations_title">Skaffa hjälp</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -9,7 +9,6 @@ Language: tr
     <string name="support_screen_unified_support_description">Destek ekibimizden dilediğiniz zaman yanıt alın</string>
     <string name="support_screen_unified_support_title">Yardım al</string>
     <string name="unified_support_attachment_match_score">%1$d%% eşleşme</string>
-    <string name="unified_support_status_bot">Esrarengiz robot</string>
     <string name="unified_support_bot_typing_content_description">Destek robotu yazıyor</string>
     <string name="unified_support_message_input_placeholder">Bir mesaj yazın…</string>
     <string name="unified_support_conversations_title">Yardım alın</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,6 @@ Language: zh_CN
     <string name="support_screen_unified_support_description">随时向我们的支持团队寻求解答</string>
     <string name="support_screen_unified_support_title">获取帮助</string>
     <string name="unified_support_attachment_match_score">%1$d%% 匹配</string>
-    <string name="unified_support_status_bot">Oddie 机器人</string>
     <string name="unified_support_bot_typing_content_description">支持机器人正在输入</string>
     <string name="unified_support_message_input_placeholder">输入消息…</string>
     <string name="unified_support_conversations_title">获取帮助</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -9,7 +9,6 @@ Language: zh_TW
     <string name="support_screen_unified_support_description">隨時取得支援團隊的解答</string>
     <string name="support_screen_unified_support_title">取得協助</string>
     <string name="unified_support_attachment_match_score">%1$d%% 相符</string>
-    <string name="unified_support_status_bot">Oddie 機器人</string>
     <string name="unified_support_bot_typing_content_description">支援機器人正在輸入訊息</string>
     <string name="unified_support_message_input_placeholder">輸入訊息…</string>
     <string name="unified_support_conversations_title">取得協助</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,6 @@ Language: zh_TW
     <string name="support_screen_unified_support_description">隨時取得支援團隊的解答</string>
     <string name="support_screen_unified_support_title">取得協助</string>
     <string name="unified_support_attachment_match_score">%1$d%% 相符</string>
-    <string name="unified_support_status_bot">Oddie 機器人</string>
     <string name="unified_support_bot_typing_content_description">支援機器人正在輸入訊息</string>
     <string name="unified_support_message_input_placeholder">輸入訊息…</string>
     <string name="unified_support_conversations_title">取得協助</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4780,7 +4780,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="unified_support_message_input_placeholder">Type a message…</string>
     <string name="unified_support_bot_typing_content_description">Support bot is typing</string>
     <string name="unified_support_new_conversation_content_description">New conversation</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
+    <string name="unified_support_status_ai_assistant">AI Assistant</string>
     <string name="unified_support_attachment_match_score">%1$d%% match</string>
     <string name="unified_support_attachment_link_content_description">Open link: %1$s</string>
     <string name="support_screen_unified_support_title">Get help</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4768,7 +4768,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="unified_support_message_input_placeholder">Type a message…</string>
     <string name="unified_support_bot_typing_content_description">Support bot is typing</string>
     <string name="unified_support_new_conversation_content_description">New conversation</string>
-    <string name="unified_support_status_ai_assistant">AI Assistant</string>
+    <string name="unified_support_status_bot">Oddie bot</string>
     <string name="unified_support_attachment_match_score">%1$d%% match</string>
     <string name="support_screen_unified_support_title">Get help</string>
     <string name="support_screen_unified_support_description">Get answers from our support team, anytime</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4768,7 +4768,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="unified_support_message_input_placeholder">Type a message…</string>
     <string name="unified_support_bot_typing_content_description">Support bot is typing</string>
     <string name="unified_support_new_conversation_content_description">New conversation</string>
-    <string name="unified_support_status_bot">Oddie bot</string>
+    <string name="unified_support_status_ai_assistant">AI Assistant</string>
     <string name="unified_support_attachment_match_score">%1$d%% match</string>
     <string name="support_screen_unified_support_title">Get help</string>
     <string name="support_screen_unified_support_description">Get answers from our support team, anytime</string>


### PR DESCRIPTION
## Description

The support (Get help) flow displayed the label **"Oddie bot"** to users in
two places — the green badge on the conversation list and the bot's sender
label in the chat detail screen. This was flagged in CMM-2290 because:

- "Oddie" is a typo (the internal codename is "Odie"), and
- more importantly, it exposes an **internal name** users don't recognize.

Both surfaces are driven by a single string resource, so the fix updates that
string to a neutral, user-facing **"AI Assistant"**.

### What changed

- Renamed the string key `unified_support_status_bot` →
  `unified_support_status_ai_assistant` and set the English value to
  `AI Assistant` (in `values/strings.xml` and the `fastlane/resources` copy).
- Updated both usages (`UnifiedConversationDetailScreen.kt`,
  `UnifiedConversationsListScreen.kt`).
- **Renaming the key** ensures the stale GlotPress translations (which still
  contained localized "Oddie" variants) are no longer applied — every locale
  now falls back to the new English string until re-translated.
- Removed the 20 orphaned translated `unified_support_status_bot` entries so
  the internal name is no longer present anywhere in the repo and to avoid
  `ExtraTranslation` lint warnings.

## Testing instructions

<img width="564" height="587" alt="Screenshot 2026-08-13 at 13 47 27" src="https://github.com/user-attachments/assets/dd193c07-a636-4329-a9fb-08b90275e0c5" />


Verify the label in the support flow:

1. Open the app and go to **Me → Help & Support → Get help** (unified support).
2. Start or open a conversation with the support bot.
- [ ] Verify the bot's sender label in the chat reads **"AI Assistant"** (not "Oddie bot").
3. Return to the conversations list.
- [ ] Verify the badge on a bot conversation reads **"AI Assistant"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)