### PR TITLE
CMM-2301: Always show the Me row when the bottom nav is hidden

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,5 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
-27.1
------
-* [**] Fixed the Me screen being unreachable in the WordPress app after signing in to a self-hosted site with an application password.
-
 27.0
 -----
 * [*] You can now browse Google Photos (albums, collections, and search) when adding photos or videos from your device.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+27.1
+-----
+* [**] Fixed the Me screen being unreachable in the WordPress app after signing in to a self-hosted site with an application password.
+
 27.0
 -----
 * [*] You can now browse Google Photos (albums, collections, and search) when adding photos or videos from your device.

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.ui.about.UnifiedAboutActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.ME_SCREEN_HELP
 import org.wordpress.android.ui.debug.DebugSettingsActivity
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.main.MeViewModel.RecommendAppUiState
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationBanner
@@ -130,9 +129,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     lateinit var uiHelpers: UiHelpers
 
     @Inject
-    lateinit var jetpackFeatureRemovalUtils: JetpackFeatureRemovalOverlayUtil
-
-    @Inject
     lateinit var domainManagementFeatureConfig: DomainManagementFeatureConfig
 
     @Inject
@@ -168,7 +164,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     @Suppress("LongMethod")
     private fun MeFragmentBinding.setupViews() {
-        if (!BuildConfig.IS_JETPACK_APP && jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()) {
+        // MeActivity hosts this fragment on its own, so it needs a toolbar; inside the bottom
+        // navigation's pager the host activity already provides one.
+        if (requireActivity() is MeActivity) {
             with(requireActivity() as AppCompatActivity) {
                 setSupportActionBar(toolbarMain)
                 supportActionBar?.apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -11,7 +11,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.View.OnClickListener
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -166,8 +165,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     private fun MeFragmentBinding.setupViews() {
         // MeActivity hosts this fragment on its own, so it needs a toolbar; inside the bottom
         // navigation's pager the host activity already provides one.
-        if (requireActivity() is MeActivity) {
-            with(requireActivity() as AppCompatActivity) {
+        val meActivity = activity as? MeActivity
+        if (meActivity != null) {
+            with(meActivity) {
                 setSupportActionBar(toolbarMain)
                 supportActionBar?.apply {
                     setHomeButtonEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -132,7 +132,7 @@ class SiteItemsBuilder @Inject constructor(
             List<MySiteCardAndItem> {
         return listOfNotNull(
             siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
-            siteListItemBuilder.buildMeItemIfAvailable(params.site, params.onClick),
+            siteListItemBuilder.buildMeItemIfAvailable(params.onClick),
             siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildApplicationPasswordsItemIfAvailable(params.site, params.onClick),
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -195,14 +195,13 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
-    @Suppress("ComplexCondition")
-    fun buildMeItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if ((!buildConfigWrapper.isJetpackApp &&
-                    jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() &&
-                    site.hasCapabilityManageOptions) ||
-            (!buildConfigWrapper.isJetpackApp &&
-                    site.isSelfHostedAdmin)
-        ) {
+    /**
+     * The Me item replaces the bottom navigation's Me tab when that nav is hidden, so it's gated on
+     * exactly the same condition WPMainActivity uses to hide it. Me is account-level, so site
+     * capabilities deliberately play no part here.
+     */
+    fun buildMeItemIfAvailable(onClick: (ListItemAction) -> Unit): ListItem? {
+        return if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
             ListItem(
                 R.drawable.ic_user_primary_white_24,
                 UiStringRes(R.string.me),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -199,6 +199,11 @@ class SiteListItemBuilder @Inject constructor(
      * The Me item replaces the bottom navigation's Me tab when that nav is hidden, so it's gated on
      * exactly the same condition WPMainActivity uses to hide it. Me is account-level, so site
      * capabilities deliberately play no part here.
+     *
+     * There's no explicit Jetpack app check because there doesn't need to be one:
+     * [JetpackFeatureRemovalPhaseHelper.getCurrentPhase] returns null for the Jetpack app, so
+     * [JetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures] is always false there and the
+     * item is never built.
      */
     fun buildMeItemIfAvailable(onClick: (ListItemAction) -> Unit): ListItem? {
         return if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -201,7 +201,8 @@ class SiteListItemBuilder @Inject constructor(
      * capabilities deliberately play no part here.
      *
      * No explicit Jetpack app check is needed: [JetpackFeatureRemovalPhaseHelper.getCurrentPhase]
-     * returns null there, so [shouldRemoveJetpackFeatures] is always false and the item never builds.
+     * returns null there, so [JetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures] is
+     * always false and the item never builds.
      */
     fun buildMeItemIfAvailable(onClick: (ListItemAction) -> Unit): ListItem? {
         return if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -200,10 +200,8 @@ class SiteListItemBuilder @Inject constructor(
      * exactly the same condition WPMainActivity uses to hide it. Me is account-level, so site
      * capabilities deliberately play no part here.
      *
-     * There's no explicit Jetpack app check because there doesn't need to be one:
-     * [JetpackFeatureRemovalPhaseHelper.getCurrentPhase] returns null for the Jetpack app, so
-     * [JetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures] is always false there and the
-     * item is never built.
+     * No explicit Jetpack app check is needed: [JetpackFeatureRemovalPhaseHelper.getCurrentPhase]
+     * returns null there, so [shouldRemoveJetpackFeatures] is always false and the item never builds.
      */
     fun buildMeItemIfAvailable(onClick: (ListItemAction) -> Unit): ListItem? {
         return if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -113,6 +113,13 @@ val DOMAINS_ITEM = ListItem(
     onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION),
     listItemAction = DOMAINS
 )
+val ME_ITEM = ListItem(
+    R.drawable.ic_user_primary_white_24,
+    UiStringRes(R.string.me),
+    onClick = ListItemInteraction.create(ListItemAction.ME, SITE_ITEM_ACTION),
+    disablePrimaryIconTint = true,
+    listItemAction = ListItemAction.ME
+)
 val SITE_MONITORING_ITEM = ListItem(
     R.drawable.gb_ic_tool,
     UiStringRes(R.string.site_monitoring),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mysite.items.ACTIVITY_ITEM
 import org.wordpress.android.ui.mysite.items.ADMIN_ITEM
 import org.wordpress.android.ui.mysite.items.BACKUP_ITEM
+import org.wordpress.android.ui.mysite.items.ME_ITEM
 import org.wordpress.android.ui.mysite.items.PAGES_ITEM
 import org.wordpress.android.ui.mysite.items.PEOPLE_ITEM
 import org.wordpress.android.ui.mysite.items.PLUGINS_ITEM
@@ -211,6 +212,27 @@ class SiteListItemBuilderTest {
     private fun setupPagesItem(isSelfHostedAdmin: Boolean = false, canEditPages: Boolean = false) {
         whenever(siteModel.isSelfHostedAdmin).thenReturn(isSelfHostedAdmin)
         whenever(siteModel.hasCapabilityEditPages).thenReturn(canEditPages)
+    }
+
+    // The Me item stands in for the hidden bottom navigation, so it must be built for every site
+    // once Jetpack features are removed - including app-password sites, which report no
+    // capabilities at all.
+    @Test
+    fun `me item built when jetpack features are removed, regardless of site capabilities`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+
+        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
+
+        assertThat(item).isEqualTo(ME_ITEM)
+    }
+
+    @Test
+    fun `me item not built when jetpack features are not removed`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
+
+        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -214,27 +214,6 @@ class SiteListItemBuilderTest {
         whenever(siteModel.hasCapabilityEditPages).thenReturn(canEditPages)
     }
 
-    // The Me item stands in for the hidden bottom navigation, so it must be built for every site
-    // once Jetpack features are removed - including app-password sites, which report no
-    // capabilities at all.
-    @Test
-    fun `me item built when jetpack features are removed, regardless of site capabilities`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
-
-        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
-
-        assertThat(item).isEqualTo(ME_ITEM)
-    }
-
-    @Test
-    fun `me item not built when jetpack features are not removed`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
-
-        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
-
-        assertThat(item).isNull()
-    }
-
     @Test
     fun `admin item built when site is not WPCom`() {
         setupAdminItem(isWPCom = false)
@@ -355,6 +334,26 @@ class SiteListItemBuilderTest {
         setupSiteSettings(canManageOptions = false, isAccessedViaWPComRest = true)
 
         val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    // Me stands in for the bottom navigation once Jetpack features are removed, so it is built
+    // for every site regardless of capabilities.
+    @Test
+    fun `me item built when jetpack features are removed, regardless of site capabilities`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+
+        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
+
+        assertThat(item).isEqualTo(ME_ITEM)
+    }
+
+    @Test
+    fun `me item not built when jetpack features are not removed`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
+
+        val item = siteListItemBuilder.buildMeItemIfAvailable(SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }


### PR DESCRIPTION
## Description

Fixes [CMM-2301](https://linear.app/a8c/issue/CMM-2301). 

In the WordPress app, signing in to a self-hosted site with an application password could leave the user with no route to the Me screen at all — no Account Settings, App Settings, Experimental Features or Help & Support. The bottom nav is hidden by design once Jetpack features are removed, and the My Site "Me" row that replaces it was never added.

## Testing instructions

Me is reachable on WPAndroid with the nav hidden:

1. Sign in to a self-hosted site using an application password
- [x] My Site shows a **Me** row under Manage.
3. Tap it.
- [x] Me screen opens with a "Me" title and a back arrow

Jetpack app regression:

1. Open the Jetpack app on any site.
- [x] No Me row in My Site; the bottom nav Me tab is unchanged.

## Before and after shot

<img width="735" height="792" alt="wp" src="https://github.com/user-attachments/assets/52aa3e71-cf23-4409-88c0-380b75be6c87" />
