### PR TITLE
Ready the continuous-release flow for its Buildkite schedules

### DIFF
--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -14,7 +14,7 @@ steps:
 
 # Slack backstop for any failed build — its unique value is failures that abort before the lane runs
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
-# message. Channel intentionally stays the test channel for now (see send_slack_message).
+# message.
 notify:
-  - slack: "#test-wpmobile-slack-integration"
+  - slack: "#build-and-ship"
     if: build.state == "failed"

--- a/.buildkite/promote-production.yml
+++ b/.buildkite/promote-production.yml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Production release — run manually via the `PIPELINE` env var. Determines the current beta build,
-# opens a block step to confirm the release, and releases it to the production track.
+# Production release — run by a weekly Buildkite schedule, or manually via the `PIPELINE` env var.
+# Determines the current beta build, opens a block step to confirm the release, and releases it to
+# the production track as a staged rollout that `advance-production-rollout.yml` then grows.
 
 agents:
   queue: "android"
@@ -14,7 +15,7 @@ steps:
 
 # Slack backstop for any failed build — its unique value is failures that abort before the lane runs
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
-# message. Channel intentionally stays the test channel for now (see send_slack_message).
+# message.
 notify:
-  - slack: "#test-wpmobile-slack-integration"
+  - slack: "#build-and-ship"
     if: build.state == "failed"

--- a/.buildkite/schedules/advance-production-rollout.yml
+++ b/.buildkite/schedules/advance-production-rollout.yml
@@ -4,8 +4,8 @@
 # Advances the live production staged rollout one step per run — reads the current rollout percentage
 # back from Play and bumps WordPress & Jetpack to the next step, finalizing to 100% past the top. Only
 # ever advances an `inProgress` rollout, so it never resumes one a developer paused (a paused rollout
-# is `halted`). Runs on a daily schedule (configured in the Buildkite UI); also triggerable manually
-# via the `PIPELINE` env var for testing.
+# is `halted`). Runs Tuesday–Friday on a schedule, so a Monday promotion reaches 100% within the
+# working week and no step lands on a weekend; also triggerable manually via the `PIPELINE` env var.
 
 agents:
   queue: "android"
@@ -17,7 +17,7 @@ steps:
 
 # Slack backstop for any failed build — its unique value is failures that abort before the lane runs
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
-# message. Channel intentionally stays the test channel for now (see send_slack_message).
+# message.
 notify:
-  - slack: "#test-wpmobile-slack-integration"
+  - slack: "#build-and-ship"
     if: build.state == "failed"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,10 +174,7 @@ end
 #####################################################################################
 
 # Sends a Slack message to the given channel via the incoming webhook.
-#
-# The default is intentionally the test channel while the continuous-release process is being built
-# out; it moves to #build-and-ship once the flow ships to real testers.
-def send_slack_message(message:, channel: '#test-wpmobile-slack-integration')
+def send_slack_message(message:, channel: '#build-and-ship')
   slack(
     username: 'WordPress Release Bot',
     icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -61,12 +61,18 @@ PROMOTION_STEPS_FILE = File.join(PROJECT_ROOT_FOLDER, PROMOTION_STEPS_RELATIVE_P
 BUILDKITE_ORGANIZATION = 'automattic'
 BUILDKITE_PIPELINE = 'wordpress-android'
 
-# Production staged-rollout growth (scheduled bump job).
-# The rollout ladder the scheduled job walks — it advances the live production rollout to the next
-# step each run. These are a starting point (Play accepts any fraction); adjust freely. "Next step" is
-# the smallest value strictly above the current fraction, so an off-ladder manual % still moves
-# forward. Past the top step the release is finalized to 100% (status `completed`).
-PRODUCTION_ROLLOUT_STEPS = [0.01, 0.02, 0.05, 0.10, 0.20, 0.50].freeze
+# Production staged-rollout growth.
+# The fraction the production promote starts the rollout at — the ladder's first rung, applied on
+# promotion day rather than by the bump job. A string because that's what supply's `rollout` takes.
+PRODUCTION_ROLLOUT_INITIAL_FRACTION = '0.10'
+
+# The rollout ladder the scheduled bump job walks — it advances the live production rollout to the
+# next step each run. Paired with a Monday promotion and a Tuesday–Friday schedule, so the rollout
+# reaches 100% within the working week and no step lands on a weekend. "Next step" is the smallest
+# value strictly above the current fraction, so an off-ladder manual % still moves forward. Past the
+# top step the release is finalized to 100% (status `completed`). Play accepts any fraction — adjust
+# freely, keeping the count in step with the days the bump job runs.
+PRODUCTION_ROLLOUT_STEPS = [0.25, 0.50, 0.75].freeze
 
 # Play `TrackRelease.status` values. A paused rollout — the Play Console "pause", or a Play auto-halt
 # (newer draft upload, policy/vitals) — is `halted`; there is no separate "paused" status. The growth
@@ -247,7 +253,7 @@ platform :android do
 
   # Advances the live production staged rollout one step — reads the current rollout percentage back
   # from Play and bumps WordPress + Jetpack to the next ladder step, finalizing to 100% once past the
-  # top. Runs on a daily schedule; stateless (one step per run). Pause-safe: it only ever advances an
+  # top. Runs Tuesday–Friday on a schedule; stateless (one step per run). Pause-safe: it only advances an
   # `inProgress` release, so it never resumes a rollout a developer paused (a paused rollout is
   # `halted`). WordPress and Jetpack must be in the same rollout state — a mismatch stops for a
   # developer to reconcile rather than guessing.
@@ -472,8 +478,8 @@ platform :android do
       committed = false
       begin
         release = AndroidPublisher::TrackRelease.new(
-          # TODO: switch to 'completed' once the feature is ready to distribute to beta testers.
-          status: 'draft',
+          # Submitted for review and distributed to beta testers as soon as it's approved.
+          status: 'completed',
           # Keep the pinned legacy code(s) on the track, same as the AAB-upload path.
           version_codes: [Integer(version_code), *PLAY_STORE_VERSION_CODES_TO_RETAIN],
           # Carried to production automatically by the promote.
@@ -550,9 +556,9 @@ platform :android do
       track_promote_to: PRODUCTION_TRACK,
       version_code: Integer(version_code),
       # Promote as a live staged rollout: a `rollout` in (0, 1) makes supply set the promoted
-      # release to `inProgress` at that user fraction. Starting tiny (0.1%) exercises the full
-      # production flow end to end; `advance_production_rollout` grows it from there.
-      rollout: '0.001',
+      # release to `inProgress` at that user fraction. This is the ladder's first rung;
+      # `advance_production_rollout` walks the rest.
+      rollout: PRODUCTION_ROLLOUT_INITIAL_FRACTION,
       # Promotion touches only the track release, never a binary — skip every upload path.
       skip_upload_apk: true,
       skip_upload_aab: true,


### PR DESCRIPTION
## Description
Beta promotions now publish instead of sitting as drafts, so a promoted build is submitted for review and reaches beta testers. The production staged rollout is resized to fit the working week: the promote starts it at 10% and four bump runs take it to 25/50/75/100, so no step lands on a weekend. Slack moves off the test channel now that the promotions are scheduled and their block steps need someone to see them.

Changes:
- Set the beta track release status to `completed`
- Add `PRODUCTION_ROLLOUT_INITIAL_FRACTION` and promote at 10%
- Shorten `PRODUCTION_ROLLOUT_STEPS` to `[0.25, 0.50, 0.75]`
- Point `send_slack_message` and the promotion pipelines' `notify:` blocks at `#build-and-ship`
- Describe the schedules that now drive the promotion pipelines