### PR TITLE
Request a review from wpmobile-team on the translations PR

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -432,6 +432,11 @@ platform :android do
 
   TRANSLATIONS_SYNC_BRANCH = 'translations/daily-update'
 
+  # Slug (no org prefix) of the GitHub team asked to review the translations PR. The team's
+  # "Code review assignments" setting picks a single member, so the request lands on one person
+  # rather than the whole team.
+  TRANSLATIONS_REVIEWER_TEAM = 'wpmobile-team'
+
   #####################################################################################
   # update_translations
   # -----------------------------------------------------------------------------------
@@ -491,7 +496,8 @@ platform :android do
       BODY
       head: TRANSLATIONS_SYNC_BRANCH,
       base: DEFAULT_BRANCH,
-      labels: ['Localization']
+      labels: ['Localization'],
+      team_reviewers: [TRANSLATIONS_REVIEWER_TEAM]
     )
     UI.success("Translations PR: #{pr_url}")
   end


### PR DESCRIPTION
The daily `translations/daily-update` PR opens with no reviewer, so it sits unnoticed. Ask the `wpmobile-team` GitHub team to review it; the team's code review assignment setting narrows that to a single member.

Changes:
- Add `TRANSLATIONS_REVIEWER_TEAM` constant
- Pass `team_reviewers` to `find_or_create_pull_request` in `update_translations`