### PR TITLE
Harden REST taxonomy fetches against pagination truncation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/PostRsRestClient.kt
@@ -221,27 +221,39 @@ class PostRsRestClient @Inject constructor(
         if (uncached.isEmpty()) return result
 
         val client = wpApiClientProvider.getWpApiClient(site)
-        val response = client.request {
-            it.terms().listWithViewContext(
-                endpointType,
-                TermListParams(include = uncached)
-            )
-        }
-        when (response) {
-            is WpRequestResult.Success -> {
-                for (term in response.response.data) {
-                    cache[term.id] = term.name
-                    result[term.id] = term.name
-                }
-            }
-            else -> {
-                val msg =
-                    (response as? WpRequestResult.WpError<*>)
-                        ?.errorMessage
-                AppLog.w(
-                    AppLog.T.POSTS,
-                    "fetchTermNames failed: $msg"
+        // The REST API caps results per page (defaulting to 10), so request a larger page size
+        // and follow the pagination params until every requested term has been fetched.
+        // Otherwise a post with more than one page of assigned terms would lose the names past
+        // the first page.
+        var params: TermListParams? = TermListParams(
+            include = uncached,
+            perPage = PER_PAGE,
+        )
+        while (params != null) {
+            val currentParams = params
+            val response = client.request {
+                it.terms().listWithViewContext(
+                    endpointType, currentParams
                 )
+            }
+            when (response) {
+                is WpRequestResult.Success -> {
+                    for (term in response.response.data) {
+                        cache[term.id] = term.name
+                        result[term.id] = term.name
+                    }
+                    params = response.response.nextPageParams
+                }
+                else -> {
+                    val msg =
+                        (response as? WpRequestResult.WpError<*>)
+                            ?.errorMessage
+                    AppLog.w(
+                        AppLog.T.POSTS,
+                        "fetchTermNames failed: $msg"
+                    )
+                    params = null
+                }
             }
         }
         return result

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -292,28 +292,26 @@ class TaxonomyRsApiRestClient @Inject constructor(
         }
         appLogWrapper.d(AppLog.T.POSTS, "Fetched $taxonomyName list: ${allTerms.size} (complete=${!hadError})")
         val termsResponsePayload = FetchTermsResponsePayload(
-            TermsModel(
-                allTerms.map { term ->
-                    TermModel(
-                        term.id.toInt(),
-                        site.id,
-                        term.id,
-                        taxonomyName,
-                        term.name,
-                        term.slug,
-                        term.description,
-                        term.parent ?: 0,
-                        term.parent != null,
-                        term.count.toInt()
-                    )
-                },
-            ),
+            TermsModel(allTerms.map { it.toTermModel(site, taxonomyName) }),
             site,
             taxonomyName,
             !hadError
         )
         dispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(termsResponsePayload))
     }
+
+    private fun AnyTermWithEditContext.toTermModel(site: SiteModel, taxonomyName: String) = TermModel(
+        id.toInt(),
+        site.id,
+        id,
+        taxonomyName,
+        name,
+        slug,
+        description,
+        parent ?: 0,
+        parent != null,
+        count.toInt()
+    )
 
 
     private fun TermEndpointType.toTaxonomyName(): String = when (this) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -309,7 +309,8 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 },
             ),
             site,
-            taxonomyName
+            taxonomyName,
+            !hadError
         )
         dispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(termsResponsePayload))
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -254,6 +254,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         // follow the pagination params until all terms have been fetched (see CMM-2122).
         val allTerms = mutableListOf<AnyTermWithEditContext>()
         var params: TermListParams? = TermListParams(perPage = TERMS_PER_PAGE)
+        var hadError = false
         while (params != null) {
             val currentParams = params
             val termsResponse = client.request { requestBuilder ->
@@ -268,20 +269,28 @@ class TaxonomyRsApiRestClient @Inject constructor(
                     params = termsResponse.response.nextPageParams
                 }
                 else -> {
+                    // Keep any terms already fetched from earlier pages so a transient failure
+                    // mid-pagination degrades gracefully instead of dropping the whole list.
                     appLogWrapper.e(AppLog.T.POSTS, "Fetch $termEndpointType list failed: $termsResponse")
-                    dispatcher.dispatch(
-                        TaxonomyActionBuilder.newFetchedTermsAction(
-                            FetchTermsResponsePayload(
-                                TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
-                                taxonomyName
-                            )
-                        )
-                    )
-                    return
+                    hadError = true
+                    break
                 }
             }
         }
-        appLogWrapper.d(AppLog.T.POSTS, "Fetched $taxonomyName list: ${allTerms.size}")
+        // Only surface the error (leaving the cached list untouched) when nothing at all could be
+        // fetched; otherwise persist whatever pages we managed to retrieve.
+        if (hadError && allTerms.isEmpty()) {
+            dispatcher.dispatch(
+                TaxonomyActionBuilder.newFetchedTermsAction(
+                    FetchTermsResponsePayload(
+                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
+                        taxonomyName
+                    )
+                )
+            )
+            return
+        }
+        appLogWrapper.d(AppLog.T.POSTS, "Fetched $taxonomyName list: ${allTerms.size} (complete=${!hadError})")
         val termsResponsePayload = FetchTermsResponsePayload(
             TermsModel(
                 allTerms.map { term ->

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -48,11 +48,23 @@ public class TaxonomyStore extends Store {
         @NonNull public TermsModel terms;
         @NonNull public SiteModel site;
         @NonNull public String taxonomy; // This field is also included in error payload.
+        // True when the fetched list is exhaustive (all pages retrieved). When false, the list is
+        // partial (e.g. a mid-pagination failure) and existing cached terms must not be cleared.
+        public boolean complete = true;
 
         public FetchTermsResponsePayload(@NonNull TermsModel terms, @NonNull SiteModel site, @NonNull String taxonomy) {
             this.terms = terms;
             this.site = site;
             this.taxonomy = taxonomy;
+        }
+
+        public FetchTermsResponsePayload(
+                @NonNull TermsModel terms,
+                @NonNull SiteModel site,
+                @NonNull String taxonomy,
+                boolean complete) {
+            this(terms, site, taxonomy);
+            this.complete = complete;
         }
 
         public FetchTermsResponsePayload(@NonNull TaxonomyError error, @NonNull String taxonomy) {
@@ -361,11 +373,14 @@ public class TaxonomyStore extends Store {
             onTaxonomyChanged = new OnTaxonomyChanged(0, payload.taxonomy);
             onTaxonomyChanged.error = payload.error;
         } else {
-            // Clear existing terms for this taxonomy
-            // This is the simplest way of keeping our local terms in sync with their remote versions
-            // (in case of deletions,or if the user manually changed some term IDs)
-            // TODO: This may have to change when we support large numbers of terms and require multiple requests
-            TaxonomySqlUtils.clearTaxonomyForSite(payload.site, payload.taxonomy);
+            // Clear existing terms for this taxonomy before inserting the fresh list. This is the
+            // simplest way of keeping our local terms in sync with their remote versions (in case of
+            // deletions, or if the user manually changed some term IDs). We only do this for a
+            // complete fetch: a partial list (e.g. a mid-pagination failure) would otherwise wipe
+            // terms we still have cached and shrink the list the user sees.
+            if (payload.complete) {
+                TaxonomySqlUtils.clearTaxonomyForSite(payload.site, payload.taxonomy);
+            }
 
             int rowsAffected = 0;
             for (TermModel term : payload.terms.getTerms()) {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -267,6 +269,8 @@ class TaxonomyRsApiRestClientTest {
         assertEquals(testSite, payload.site)
         assertEquals(5, payload.terms.terms.size)
         assertNull(payload.error)
+        // All pages retrieved, so the store is free to replace the cached list.
+        assertTrue(payload.complete)
     }
 
     @Test
@@ -299,6 +303,8 @@ class TaxonomyRsApiRestClientTest {
         assertEquals(testSite, payload.site)
         assertEquals(2, payload.terms.terms.size)
         assertNull(payload.error)
+        // Marked incomplete so the store keeps existing cached terms instead of clearing them.
+        assertFalse(payload.complete)
     }
 
     @Test

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -270,7 +270,7 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
-    fun `fetchTerms categories with error on a later page dispatches single error action`() = runTest {
+    fun `fetchTerms categories with error on a later page keeps already-fetched terms`() = runTest {
         val firstPage = createListResponse(
             terms = List(2) { createTestAnyTermWithEditContext() },
             nextPageParams = TermListParams(perPage = 100u)
@@ -287,7 +287,35 @@ class TaxonomyRsApiRestClientTest {
 
         taxonomyClient.fetchTerms(testSite, testCategoryTaxonomyName)
 
-        // Only the error action should be dispatched - no partial success
+        // A transient failure mid-pagination degrades gracefully: the terms already fetched from
+        // the first page are dispatched as a success instead of the whole list being dropped.
+        val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
+        verify(dispatcher).dispatch(actionCaptor.capture())
+
+        val capturedAction = actionCaptor.value
+        val payload = capturedAction.payload as FetchTermsResponsePayload
+        assertEquals(capturedAction.type, TaxonomyAction.FETCHED_TERMS)
+        assertEquals(testCategoryTaxonomyName, payload.taxonomy)
+        assertEquals(testSite, payload.site)
+        assertEquals(2, payload.terms.terms.size)
+        assertNull(payload.error)
+    }
+
+    @Test
+    fun `fetchTerms categories with error on the first page dispatches error action`() = runTest {
+        val errorResponse = WpRequestResult.UnknownError<TermsRequestListWithEditContextResponse>(
+            statusCode = 500u,
+            response = "Internal Server Error",
+            requestUrl = "",
+            requestMethod = RequestMethod.GET
+        )
+
+        whenever(wpApiClient.request<TermsRequestListWithEditContextResponse>(any()))
+            .thenReturn(errorResponse)
+
+        taxonomyClient.fetchTerms(testSite, testCategoryTaxonomyName)
+
+        // Nothing could be fetched, so the error is surfaced and the cached list is left untouched.
         val actionCaptor = ArgumentCaptor.forClass(Action::class.java)
         verify(dispatcher).dispatch(actionCaptor.capture())
 


### PR DESCRIPTION
## Description

Two fixes that harden the migrated wp-rs taxonomy paths against category/tag
list truncation, follow-ups to the paginated fetch added in CMM-2122 and the
case-collision fix in CMM-2148.

**1. Category picker fetch no longer discards everything on a mid-pagination failure**

`TaxonomyRsApiRestClient.fetchTerms` follows `nextPageParams` across multiple
requests (100 terms/page). Previously, if any page after the first failed
(e.g. a transient 429/timeout — more likely on large term sets that need
several requests), it aborted with a `GENERIC_ERROR` and threw away the pages
already fetched. The store's error branch then left the DB untouched, so the
picker kept showing the previously cached (possibly short/stale) list.

Now a mid-pagination failure keeps the pages already retrieved and persists
them, degrading gracefully. The error is only surfaced (leaving the cache
untouched) when nothing at all could be fetched — i.e. the first page failed.
This mirrors the behaviour already used by the taxonomy-management screen
(`TermsViewModel`).

**2. `PostRsRestClient.fetchTermNames` now paginates**

This by-id name lookup (used by the new wp-rs post settings to display the
categories/tags already assigned to a post) sent a single request with no page
size, so it was capped at the REST default (~10). A post with more than 10
assigned categories/tags silently lost the names past the first page. It now
requests 100/page and follows the pagination params until exhausted.

The "stops at X" case-collision drop (CMM-2148) needed no change — that fix is
already on trunk.

## Known trade-offs (intentional)

The graceful-degradation path deliberately favours an optimistic outcome —
showing the user as complete a list as we have — over strict accuracy. Two
consequences are expected and accepted:

- **A partial fetch is indistinguishable from a complete one at the UI layer.**
  When a later page fails, the payload is dispatched as a success (`error ==
  null`) with `complete = false`; that flag is consumed inside `TaxonomyStore`
  and is not propagated to `OnTaxonomyChanged`. Consumers therefore can't tell
  the list may be incomplete. This is intentional: the merged cache is never
  worse than what was shown before, and a subsequent successful fetch will
  reconcile it.

- **Stale terms can survive a partial fetch.** Because we skip the
  clear-before-insert step on an incomplete fetch, terms deleted remotely (or
  re-IDed) remain cached until the next *complete* fetch replaces the list.
  This is preferred over the alternative of wiping terms we can no longer
  re-fetch and shrinking the list the user sees.

## Testing instructions

Category list stays complete on a flaky connection:

1. Sign into the Jetpack app with a self-hosted/Jetpack site that has more than
   one page of categories (100+), with the taxonomies REST migration enabled.
2. Open a post for editing and open **Settings → Categories**.
- [ ] Verify the full category list is shown.


Assigned category/tag names resolve past the first page (new wp-rs post editor):

1. On a site using the wp-rs post settings, assign more than 10 categories to a
   post.
2. Open the post's settings screen.
- [ ] Verify all assigned category names are displayed, not just the first ~10.

## Regression notes

- Unit tests updated/added in `TaxonomyRsApiRestClientTest` for the new
  graceful-degradation behaviour (partial success on a later-page failure;
  error still surfaced when the first page fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
