### PR TITLE
CMM-2141: Fix subscriber email stats missing for recent posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/datasource/StatsDataSourceImpl.kt
@@ -1367,9 +1367,9 @@ class StatsDataSourceImpl @Inject constructor(
         quantity: Int
     ): StatsEmailsSummaryDataResult {
         val params = StatsEmailsSummaryParams(
-            period = StatsEmailsSummaryPeriod.MONTH,
+            period = StatsEmailsSummaryPeriod.ALL_TIME,
             quantity = quantity.toUInt(),
-            sortField = StatsEmailsSummarySortField.OPENS,
+            sortField = StatsEmailsSummarySortField.POST_DATE,
             sortOrder = WpApiParamOrder.DESC
         )
         val result = getOrCreateClient().request { requestBuilder ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsCardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsCardViewModel.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.ui.newstats.subscribers.BaseSubscribersCardViewMode
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
-private const val CARD_MAX_ITEMS = 5
+private const val CARD_MAX_ITEMS = 10
 
 @HiltViewModel
 class EmailsCardViewModel @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCase.kt
@@ -35,7 +35,9 @@ class EmailsUseCase @Inject constructor(
     private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<PostsModel>(EMAILS, mainDispatcher, bgDispatcher) {
     private val itemsToShow = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_SIZE else BLOCK_ITEM_COUNT
-    private val sortField = if (useCaseMode == VIEW_ALL) SortField.OPENS else SortField.POST_DATE
+    // Both the block and the "Latest emails" View All list are sorted by post date (newest first) to
+    // match the web, so recently emailed posts (which have few/zero opens) are never dropped.
+    private val sortField = SortField.POST_DATE
 
     override suspend fun fetchRemoteData(forced: Boolean): State<PostsModel> {
         val response = emailsStore.fetchEmails(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCase.kt
@@ -35,7 +35,7 @@ class EmailsUseCase @Inject constructor(
     private val useCaseMode: UseCaseMode
 ) : StatelessUseCase<PostsModel>(EMAILS, mainDispatcher, bgDispatcher) {
     private val itemsToShow = if (useCaseMode == VIEW_ALL) VIEW_ALL_ITEM_SIZE else BLOCK_ITEM_COUNT
-    private val sortField = if (useCaseMode == VIEW_ALL) SortField.OPENS else SortField.POST_ID
+    private val sortField = if (useCaseMode == VIEW_ALL) SortField.OPENS else SortField.POST_DATE
 
     override suspend fun fetchRemoteData(forced: Boolean): State<PostsModel> {
         val response = emailsStore.fetchEmails(

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsCardViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/subscribers/emails/EmailsCardViewModelTest.kt
@@ -104,8 +104,8 @@ class EmailsCardViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when data loads successfully, then loaded state has items truncated to 5`() = test {
-        val items = (1..10).map {
+    fun `when data loads successfully, then loaded state has items truncated to 10`() = test {
+        val items = (1..15).map {
             EmailItemData(
                 title = "Email $it",
                 opens = it.toLong() * 100,
@@ -120,11 +120,11 @@ class EmailsCardViewModelTest : BaseUnitTest() {
 
         val state = viewModel.uiState.value
         assertThat(state).isInstanceOf(EmailsCardUiState.Loaded::class.java)
-        assertThat((state as EmailsCardUiState.Loaded).items).hasSize(5)
+        assertThat((state as EmailsCardUiState.Loaded).items).hasSize(10)
     }
 
     @Test
-    fun `when data has fewer than 5 items, then all items are shown`() = test {
+    fun `when data has fewer than 10 items, then all items are shown`() = test {
         val items = (1..3).map {
             EmailItemData(
                 title = "Email $it",

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
@@ -6,6 +6,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
@@ -18,6 +20,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.subscribers.EmailsStore
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -120,6 +123,31 @@ class EmailsUseCaseTest : BaseUnitTest() {
         val result = loadPosts(true, forced)
 
         assertThat(result.state).isEqualTo(UseCaseState.ERROR)
+    }
+
+    @Test
+    fun `view all list is sorted by post date, not opens`() = test {
+        val forced = false
+        val viewAllUseCase = EmailsUseCase(
+            testDispatcher(),
+            testDispatcher(),
+            emailsStore,
+            statsSiteProvider,
+            statsUtils,
+            contentDescriptionHelper,
+            tracker,
+            VIEW_ALL
+        )
+        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE, forced))
+            .thenReturn(OnStatsFetched(PostsModel(listOf(firstPost, secondPost))))
+
+        var result: UseCaseModel? = null
+        viewAllUseCase.liveData.observeForever { result = it }
+        viewAllUseCase.fetch(true, forced)
+        advanceUntilIdle()
+
+        verify(emailsStore).fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE, forced)
+        verify(emailsStore, never()).fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.OPENS, forced)
     }
 
     private fun assertTitle(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
@@ -78,8 +78,8 @@ class EmailsUseCaseTest : BaseUnitTest() {
     fun `maps emails summary to UI model`() = test {
         val forced = false
         val model = PostsModel(listOf(firstPost, secondPost))
-        whenever(emailsStore.getEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_ID)).thenReturn(model)
-        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_ID, forced))
+        whenever(emailsStore.getEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE)).thenReturn(model)
+        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE, forced))
             .thenReturn(OnStatsFetched(model))
 
         val result = loadPosts(true, forced)
@@ -97,7 +97,7 @@ class EmailsUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty posts to UI model`() = test {
         val forced = false
-        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_ID, forced)).thenReturn(
+        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE, forced)).thenReturn(
             OnStatsFetched(PostsModel(listOf()))
         )
 
@@ -114,7 +114,7 @@ class EmailsUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val forced = false
         val message = "Generic error"
-        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_ID, forced))
+        whenever(emailsStore.fetchEmails(site, LimitMode.Top(itemsToLoad), SortField.POST_DATE, forced))
             .thenReturn(OnStatsFetched(StatsError(GENERIC_ERROR, message)))
 
         val result = loadPosts(true, forced)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -355,7 +355,7 @@ class InsightsMapper @Inject constructor(val statsUtils: StatsUtils) {
         }.map { post -> PostModel(post.id ?: 0, post.href ?: "", post.title ?: "", post.opens ?: 0, post.clicks ?: 0) }
             .sortedByDescending {
                 when (sortField) {
-                    SortField.POST_ID -> it.id
+                    SortField.POST_DATE -> it.id
                     SortField.OPENS -> it.opens.toLong()
                 }
             }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -353,10 +353,11 @@ class InsightsMapper @Inject constructor(val statsUtils: StatsUtils) {
                 return@let it
             }
         }.map { post -> PostModel(post.id ?: 0, post.href ?: "", post.title ?: "", post.opens ?: 0, post.clicks ?: 0) }
-            .sortedByDescending {
+            .let { posts ->
+                // POST_DATE keeps the server ordering (post_date desc); only OPENS needs a client-side sort.
                 when (sortField) {
-                    SortField.POST_DATE -> it.id
-                    SortField.OPENS -> it.opens.toLong()
+                    SortField.POST_DATE -> posts
+                    SortField.OPENS -> posts.sortedByDescending { it.opens.toLong() }
                 }
             }
     )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
@@ -37,8 +37,9 @@ class EmailsRestClient @Inject constructor(
         val url = WPCOMREST.sites.site(site.siteId).stats.emails.summary.urlV1_1
 
         val params = mapOf(
+            "period" to "alltime",
             "quantity" to quantity.toString(),
-            "sort_field" to sortField.toString(),
+            "sort_field" to sortField.sortField,
             "sort_order" to "desc"
         )
 
@@ -56,7 +57,7 @@ class EmailsRestClient @Inject constructor(
         }
     }
 
-    enum class SortField(val sortField: String) { POST_ID("post_id"), OPENS("opens") }
+    enum class SortField(val sortField: String) { POST_DATE("post_date"), OPENS("opens") }
 
     data class EmailsSummaryResponse(@SerializedName("posts") val posts: List<Post>) {
         data class Post(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -43,30 +43,44 @@ constructor(
         data: RESPONSE_TYPE,
         requestedItems: Int? = null,
         replaceExistingData: Boolean = true,
-        postId: Long? = null
+        postId: Long? = null,
+        cacheKey: String? = null
     ) {
-        statsSqlUtils.insert(site, blockType, INSIGHTS, data, replaceExistingData, postId = postId)
+        statsSqlUtils.insert(site, blockType, INSIGHTS, data, replaceExistingData, date = cacheKey, postId = postId)
         if (replaceExistingData) {
             statsRequestSqlUtils.insert(
                     site,
                     blockType,
                     INSIGHTS,
                     requestedItems,
+                    date = cacheKey,
                     postId = postId
             )
         }
     }
 
-    fun select(site: SiteModel, postId: Long? = null): RESPONSE_TYPE? {
-        return statsSqlUtils.select(site, blockType, INSIGHTS, classOfResponse, postId = postId)
+    fun select(site: SiteModel, postId: Long? = null, cacheKey: String? = null): RESPONSE_TYPE? {
+        return statsSqlUtils.select(site, blockType, INSIGHTS, classOfResponse, date = cacheKey, postId = postId)
     }
 
     fun selectAll(site: SiteModel): List<RESPONSE_TYPE> {
         return statsSqlUtils.selectAll(site, blockType, INSIGHTS, classOfResponse)
     }
 
-    fun hasFreshRequest(site: SiteModel, requestedItems: Int? = null, postId: Long? = null): Boolean {
-        return statsRequestSqlUtils.hasFreshRequest(site, blockType, INSIGHTS, requestedItems, postId = postId)
+    fun hasFreshRequest(
+        site: SiteModel,
+        requestedItems: Int? = null,
+        postId: Long? = null,
+        cacheKey: String? = null
+    ): Boolean {
+        return statsRequestSqlUtils.hasFreshRequest(
+                site,
+                blockType,
+                INSIGHTS,
+                requestedItems,
+                date = cacheKey,
+                postId = postId
+        )
     }
 
     class AllTimeSqlUtils

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStore.kt
@@ -26,7 +26,7 @@ class EmailsStore @Inject constructor(
         sortField: EmailsRestClient.SortField,
         forced: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchEmails") {
-        if (!forced && sqlUtils.hasFreshRequest(siteModel, limitMode.limit)) {
+        if (!forced && sqlUtils.hasFreshRequest(siteModel, limitMode.limit, cacheKey = sortField.sortField)) {
             return@withDefaultContext OnStatsFetched(getEmails(siteModel, limitMode, sortField), cached = true)
         }
 
@@ -34,7 +34,12 @@ class EmailsStore @Inject constructor(
         return@withDefaultContext when {
             response.isError -> OnStatsFetched(response.error)
             response.response != null -> {
-                sqlUtils.insert(siteModel, response.response, requestedItems = limitMode.limit)
+                sqlUtils.insert(
+                    siteModel,
+                    response.response,
+                    requestedItems = limitMode.limit,
+                    cacheKey = sortField.sortField
+                )
                 OnStatsFetched(insightsMapper.map(response.response, limitMode, sortField))
             }
 
@@ -47,6 +52,6 @@ class EmailsStore @Inject constructor(
         cacheMode: LimitMode,
         sortField: EmailsRestClient.SortField
     ) = coroutineEngine.run(STATS, this, "getEmails") {
-        sqlUtils.select(site)?.let { insightsMapper.map(it, cacheMode, sortField) }
+        sqlUtils.select(site, cacheKey = sortField.sortField)?.let { insightsMapper.map(it, cacheMode, sortField) }
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClientTest.kt
@@ -1,0 +1,150 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient.EmailsSummaryResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient.SortField
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+
+@RunWith(MockitoJUnitRunner::class)
+class EmailsRestClientTest {
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+
+    @Mock
+    private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+
+    @Mock
+    private lateinit var site: SiteModel
+
+    @Mock
+    private lateinit var requestQueue: RequestQueue
+
+    @Mock
+    private lateinit var accessToken: AccessToken
+
+    @Mock
+    private lateinit var userAgent: UserAgent
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: EmailsRestClient
+    private val siteId = 12L
+    private val quantity = 30
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = EmailsRestClient(
+            dispatcher,
+            wpComGsonRequestBuilder,
+            null,
+            requestQueue,
+            accessToken, userAgent
+        )
+    }
+
+    @Test
+    fun `sends post_date sort field over the alltime period for POST_DATE sort`() = test {
+        val response = mock<EmailsSummaryResponse>()
+        initEmailsResponse(response)
+
+        val responseModel = restClient.fetchEmailsSummary(site, quantity, SortField.POST_DATE, false)
+
+        assertThat(responseModel.response).isNotNull()
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue)
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/emails/summary/")
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+            mapOf(
+                "period" to "alltime",
+                "quantity" to quantity.toString(),
+                "sort_field" to "post_date",
+                "sort_order" to "desc"
+            )
+        )
+    }
+
+    @Test
+    fun `sends opens sort field for OPENS sort`() = test {
+        val response = mock<EmailsSummaryResponse>()
+        initEmailsResponse(response)
+
+        restClient.fetchEmailsSummary(site, quantity, SortField.OPENS, false)
+
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+            mapOf(
+                "period" to "alltime",
+                "quantity" to quantity.toString(),
+                "sort_field" to "opens",
+                "sort_order" to "desc"
+            )
+        )
+    }
+
+    @Test
+    fun `returns error response`() = test {
+        val errorMessage = "message"
+        initEmailsResponse(
+            error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR, errorMessage, VolleyError(errorMessage)))
+        )
+
+        val responseModel = restClient.fetchEmailsSummary(site, quantity, SortField.POST_DATE, false)
+
+        assertThat(responseModel.error).isNotNull()
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initEmailsResponse(
+        data: EmailsSummaryResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ) = initResponse(EmailsSummaryResponse::class.java, data ?: mock(), error)
+
+    private suspend fun <T> initResponse(
+        clazz: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null,
+        cachingEnabled: Boolean = false
+    ): Response<T> {
+        val response = if (error != null) Response.Error(error) else Success(data)
+        whenever(
+            wpComGsonRequestBuilder.syncGetRequest(
+                eq(restClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(clazz),
+                eq(cachingEnabled),
+                any(),
+                eq(false),
+                customGsonBuilder = anyOrNull()
+            )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStoreTest.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.fluxc.store.stats.subscribers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.model.stats.subscribers.PostsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient.EmailsSummaryResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient.SortField
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+
+@RunWith(MockitoJUnitRunner::class)
+class EmailsStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: EmailsRestClient
+    @Mock lateinit var sqlUtils: EmailsSqlUtils
+    @Mock lateinit var mapper: InsightsMapper
+    private lateinit var store: EmailsStore
+    private val limitMode = LimitMode.Top(10)
+
+    @Before
+    fun setUp() {
+        store = EmailsStore(restClient, sqlUtils, mapper, initCoroutineEngine())
+    }
+
+    @Test
+    fun `caches fetched emails keyed by sort field`() = test {
+        val response = mock<EmailsSummaryResponse>()
+        val model = mock<PostsModel>()
+        whenever(restClient.fetchEmailsSummary(site, limitMode.limit, SortField.POST_DATE, false))
+            .thenReturn(FetchStatsPayload(response))
+        whenever(mapper.map(response, limitMode, SortField.POST_DATE)).thenReturn(model)
+
+        val result = store.fetchEmails(site, limitMode, SortField.POST_DATE, forced = false)
+
+        assertThat(result.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, response, requestedItems = limitMode.limit, cacheKey = "post_date")
+    }
+
+    @Test
+    fun `returns cached emails for the requested sort field without hitting the network`() = test {
+        val response = mock<EmailsSummaryResponse>()
+        val model = mock<PostsModel>()
+        whenever(sqlUtils.hasFreshRequest(site, limitMode.limit, cacheKey = "opens")).thenReturn(true)
+        whenever(sqlUtils.select(site, cacheKey = "opens")).thenReturn(response)
+        whenever(mapper.map(response, limitMode, SortField.OPENS)).thenReturn(model)
+
+        val result = store.fetchEmails(site, limitMode, SortField.OPENS, forced = false)
+
+        assertThat(result.model).isEqualTo(model)
+        assertThat(result.cached).isTrue()
+        verify(restClient, never()).fetchEmailsSummary(site, limitMode.limit, SortField.OPENS, false)
+    }
+
+    @Test
+    fun `reads the cache slot matching the requested sort field`() = test {
+        val response = mock<EmailsSummaryResponse>()
+        val model = mock<PostsModel>()
+        whenever(sqlUtils.select(site, cacheKey = "post_date")).thenReturn(response)
+        whenever(mapper.map(response, limitMode, SortField.POST_DATE)).thenReturn(model)
+
+        val result = store.getEmails(site, limitMode, SortField.POST_DATE)
+
+        assertThat(result).isEqualTo(model)
+    }
+}


### PR DESCRIPTION
## Description

Subscriber **Stats → Subscribers → Emails** did not list recently published/emailed
posts in the app, while the web (Calypso / WP Admin) showed them correctly. The issue was
persistent, survived force-stop / cache-clear / pull-to-refresh, and self-resolved after
~1 week — at which point the post reappeared.

Root cause: the app requested the `stats/emails/summary` endpoint with parameters that
don't match the web, so a freshly emailed post (few/zero opens) was never in the returned
result set:

- **Classic stats (fluxc)** — sent `sort_field=POST_ID` (the enum's `toString()`, an
  invalid value the server ignores) and no `period`, so results came back sorted by the
  server default (opens). Fixed to send `period=alltime` and the valid `sort_field=post_date`.
- **New stats** (`android_new_stats`) — hardcoded `period=MONTH`, `sort_field=opens`, so the
  Subscribers card/detail only showed the current month's top posts by opens. Fixed to
  `period=ALL_TIME` and `sort_field=POST_DATE`.

Both paths now match the web request (`period=alltime`, `sort_field=post_date`,
`sort_order=desc`), so the newest emailed posts appear first.

The new-stats Subscribers **Emails card** now also requests 10 entries (was 5), matching the
web, so more recent posts are visible without opening the detail list.

## Testing instructions

Subscriber email stats show recent posts:

1. Open the Jetpack app on a site with recently emailed posts.
2. Go to Stats → Subscribers → Emails.
- [ ] Verify the most recently emailed post appears in the card and matches the web ordering (newest first).
- [ ] Verify the card shows up to 10 email entries.
3. Tap "View all" to open the Emails detail list.
- [ ] Verify the list is ordered by date (newest first) and includes the latest post.
