### PR TITLE
CMM-2297: Send support login straight to WordPress.com OAuth

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.chuckerteam.chucker.api.Chucker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -132,11 +131,11 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
     }
 
     private fun navigateToLogin() {
-        if (BuildConfig.IS_JETPACK_APP) {
-            ActivityLauncher.showSignInForResultJetpackOnly(this)
-        } else {
-            ActivityLauncher.showSignInForResultWpComOnly(this)
-        }
+        // Support chat (Odie) requires WordPress.com authentication. Go straight to the WP.com
+        // OAuth screen instead of the login prologue: the prologue's "Enter your existing site
+        // address" option authenticates via application password, which does not grant the WP.com
+        // token support needs, so it's a dead-end here. See CMM-2297.
+        ActivityLauncher.showSignInForResultWpComOnly(this)
     }
 
     private fun navigateToHelpCenter() {

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
@@ -36,6 +37,14 @@ class SupportActivity : AppCompatActivity() {
     private val viewModel by viewModels<SupportViewModel>()
 
     private lateinit var composeView: ComposeView
+
+    private val loginLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            viewModel.refreshLoginState()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -134,8 +143,9 @@ private fun getRetentionPeriodStringRes(period: NetworkRequestsRetentionPeriod):
         // Support chat (Odie) requires WordPress.com authentication. Go straight to the WP.com
         // OAuth screen instead of the login prologue: the prologue's "Enter your existing site
         // address" option authenticates via application password, which does not grant the WP.com
-        // token support needs, so it's a dead-end here. See CMM-2297.
-        ActivityLauncher.showSignInForResultWpComOnly(this)
+        // token support needs, so it's a dead-end here. The login finishes back to this screen so
+        // the user can carry on to support chat once authenticated. See CMM-2297.
+        loginLauncher.launch(ActivityLauncher.createWpComSignInForSupportIntent(this))
     }
 
     private fun navigateToHelpCenter() {

--- a/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/main/ui/SupportViewModel.kt
@@ -73,6 +73,15 @@ class SupportViewModel @Inject constructor(
     val networkTrackingState: StateFlow<NetworkTrackingState> = _networkTrackingState.asStateFlow()
 
     fun init() {
+        refreshLoginState()
+        initNetworkTrackingState()
+    }
+
+    /**
+     * Re-reads the account state so the screen reflects a login that happened after it was created
+     * (e.g. the user returning from the support login flow). See CMM-2297.
+     */
+    fun refreshLoginState() {
         val hasAccessToken = accountStore.hasAccessToken()
         _isLoggedIn.value = hasAccessToken
 
@@ -86,8 +95,6 @@ class SupportViewModel @Inject constructor(
         _optionsVisibility.value = SupportOptionsVisibility(
             showUnifiedSupport = hasAccessToken && BuildConfig.IS_JETPACK_APP,
         )
-
-        initNetworkTrackingState()
     }
 
     private fun initNetworkTrackingState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -155,6 +155,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_EDIT_IMAGE_DATA;
 import static org.wordpress.android.ui.accounts.LoginFlow.PROLOGUE;
 import static org.wordpress.android.ui.accounts.LoginFlow.JETPACK_REST_CONNECT;
+import static org.wordpress.android.ui.accounts.LoginFlow.SUPPORT;
 import static org.wordpress.android.ui.accounts.LoginFlow.WPCOM_LOGIN;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 import static org.wordpress.android.ui.WPWebViewActivity.ENCODING_UTF8;
@@ -1498,6 +1499,17 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, LoginActivity.class);
         WPCOM_LOGIN.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
+    }
+
+    /**
+     * Builds the intent for the WordPress.com login required to access support chat (Odie).
+     * Goes straight to WP.com OAuth and, once done, finishes back to the caller (the Support
+     * screen) instead of navigating to the main activity.
+     */
+    public static Intent createWpComSignInForSupportIntent(@NonNull Context context) {
+        Intent intent = new Intent(context, LoginActivity.class);
+        SUPPORT.putInto(intent);
+        return intent;
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginFlow.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginFlow.kt
@@ -56,6 +56,13 @@ enum class LoginFlow(
         completionBehavior = CompletionBehavior.FINISH
     ),
 
+    /** WP.com login required for support chat (Odie); returns to the Support screen when done */
+    SUPPORT(
+        analyticsSource = "support",
+        initialScreen = InitialScreen.WPCOM_OAUTH,
+        completionBehavior = CompletionBehavior.FINISH
+    ),
+
     /** Re-authentication after token expiry */
     WPCOM_REAUTHENTICATE(
         analyticsSource = "reauthentication",


### PR DESCRIPTION
## Description

Fixes [CMM-2297](https://linear.app/a8c/issue/CMM-2297).

When a user taps **"Log into WordPress.com"** on the Support screen, the
Jetpack app launched the login **prologue**, which presents two choices:
"Continue with WordPress.com" and "Enter your existing site address."

The second option authenticates via **application password**, which does not
grant the WordPress.com token that support chat (Odie) requires. For users who
already added their site that way, it's a confusing dead-end.

This change makes the Support login go **straight to the WordPress.com OAuth
screen**, skipping the prologue and its site-address option. The behavior now
matches the WordPress app flavor, which already used
`showSignInForResultWpComOnly`. The prologue and `showSignInForResultJetpackOnly`
remain unchanged for their other callers (main app login, no-sites, and
site-check-error screens), where the site-address option is a valid path.

## Testing instructions

Support login goes directly to WordPress.com OAuth (Jetpack):

1. Use the **Jetpack** app, logged out of WordPress.com (or signed in only
   with a self-hosted / application-password site).
2. Open the Support screen and tap **"Log into WordPress.com"**.
- [ ] Verify you land directly on the WordPress.com login/OAuth screen.
3. Complete WordPress.com login.
- [ ] Verify login succeeds and the AI Assistant / support chat option becomes
      available.

