### PR TITLE
Skip the translations PR when the prune undoes the download

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -481,6 +481,16 @@ platform :android do
     )
     Fastlane::Helper::GitHelper.commit(message: 'Prune orphaned translations', files: :all)
 
+    # The prune can remove exactly what the download added, when the only translations GlotPress has
+    # for us are for keys that no longer exist in the source strings. That leaves two commits whose
+    # combined diff against `trunk` is empty, so there is nothing to push or review. Compare trees
+    # rather than commit SHAs: HEAD is two commits ahead of `trunk` here even when the content matches.
+    trunk_tree, head_tree = [DEFAULT_BRANCH, 'HEAD'].map { |ref| sh('git', 'rev-parse', "#{ref}^{tree}").strip }
+    if trunk_tree == head_tree
+      UI.important('Every translation downloaded today was pruned as orphaned; nothing to sync.')
+      next
+    end
+
     push_to_git_remote(remote_branch: TRANSLATIONS_SYNC_BRANCH, tags: false, force: true, set_upstream: true)
 
     # `find_or_create_pull_request` resolves the GitHub token the standard way (GITHUB_TOKEN) and only


### PR DESCRIPTION
GlotPress still serves translations for keys that are gone from the source strings. On days when those are the only updates, the prune removes exactly what the download added and the branch ends up with two commits and an empty diff against `trunk`, which opened a no-op PR (#23217).

The existing guard compares commit SHAs before the prune, so it cannot see this; after the prune HEAD is two commits ahead of `trunk` with identical content.

Changes:
- Compare `trunk` and HEAD tree SHAs after the prune commit
- Skip the push and the PR when the trees match

