### PR TITLE
Route release notifications to #wpmobile-team and cc release managers

### DIFF
--- a/.buildkite/promote-beta.yml
+++ b/.buildkite/promote-beta.yml
@@ -16,5 +16,5 @@ steps:
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
 # message.
 notify:
-  - slack: "#build-and-ship"
+  - slack: "#wpmobile-team"
     if: build.state == "failed"

--- a/.buildkite/promote-production.yml
+++ b/.buildkite/promote-production.yml
@@ -17,5 +17,5 @@ steps:
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
 # message.
 notify:
-  - slack: "#build-and-ship"
+  - slack: "#wpmobile-team"
     if: build.state == "failed"

--- a/.buildkite/schedules/advance-production-rollout.yml
+++ b/.buildkite/schedules/advance-production-rollout.yml
@@ -19,5 +19,5 @@ steps:
 # (gems/secrets) and can't self-report; on a lane failure it may also accompany the lane's own
 # message.
 notify:
-  - slack: "#build-and-ship"
+  - slack: "#wpmobile-team"
     if: build.state == "failed"

--- a/.buildkite/schedules/download-translations.yml
+++ b/.buildkite/schedules/download-translations.yml
@@ -17,12 +17,11 @@ steps:
     plugins: [$CI_TOOLKIT]
 
 # Slack backstop for a failed sync — its unique value is failures that abort before the lane runs
-# (gems/secrets) and can't self-report. Channel intentionally stays the test channel while this flow
-# is validated (mirrors promote-beta.yml + the Fastfile `send_slack_message` default); moves to
-# #wpmobile once it ships to real use.
+# (gems/secrets) and can't self-report. This is a translations PR rather than part of the release
+# flow, so it reports to #build-and-ship instead of the release channel.
 notify:
   - slack:
       channels:
-        - "#test-wpmobile-slack-integration"
+        - "#build-and-ship"
       message: "Failed to sync translations from GlotPress."
     if: build.state == "failed"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,6 +73,11 @@ GITHUB_REPO = 'wordpress-mobile/WordPress-Android'
 DEFAULT_BRANCH = 'trunk'
 REPOSITORY_NAME = 'WordPress-Android'
 
+# Slug (no org prefix) of the GitHub team asked to review the pull requests the automated flows open
+# (translation sync, version bump). The team's "Code review assignments" setting picks a single
+# member, so the request lands on one person rather than the whole team.
+MOBILE_REVIEWER_TEAM = 'wpmobile-team'
+
 # Used by Fastlane to work around the Google API random failures
 ENV['SUPPLY_UPLOAD_MAX_RETRIES'] = '5'
 
@@ -173,8 +178,12 @@ end
 # Slack helpers
 #####################################################################################
 
+# Slack handles cc'd on messages that need someone to act on them — the beta and production
+# confirmations, and any failure. A list so the roster can grow.
+RELEASE_MANAGERS = ['@oguzkocer'].freeze
+
 # Sends a Slack message to the given channel via the incoming webhook.
-def send_slack_message(message:, channel: '#build-and-ship')
+def send_slack_message(message:, channel: '#wpmobile-team')
   slack(
     username: 'WordPress Release Bot',
     icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
@@ -185,11 +194,18 @@ def send_slack_message(message:, channel: '#build-and-ship')
   )
 end
 
-# Posts to Slack without letting a webhook hiccup abort the caller.
-def notify_slack(message)
+# Posts to Slack without letting a webhook hiccup abort the caller. Pass `cc_release_managers: true`
+# for a message someone has to act on — it appends the release-manager cc line.
+def notify_slack(message, cc_release_managers: false)
+  message = "#{message.rstrip}\n\n#{release_managers_footer}" if cc_release_managers
   send_slack_message(message: message)
 rescue StandardError => e
   UI.important("Slack notification failed (#{e.message}); continuing without it.")
+end
+
+# The cc line appended to Slack messages that need someone to act on them.
+def release_managers_footer
+  "cc Release Managers: #{RELEASE_MANAGERS.join(', ')}"
 end
 
 ########################################################################

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -432,11 +432,6 @@ platform :android do
 
   TRANSLATIONS_SYNC_BRANCH = 'translations/daily-update'
 
-  # Slug (no org prefix) of the GitHub team asked to review the translations PR. The team's
-  # "Code review assignments" setting picks a single member, so the request lands on one person
-  # rather than the whole team.
-  TRANSLATIONS_REVIEWER_TEAM = 'wpmobile-team'
-
   #####################################################################################
   # update_translations
   # -----------------------------------------------------------------------------------
@@ -507,7 +502,7 @@ platform :android do
       head: TRANSLATIONS_SYNC_BRANCH,
       base: DEFAULT_BRANCH,
       labels: ['Localization'],
-      team_reviewers: [TRANSLATIONS_REVIEWER_TEAM]
+      team_reviewers: [MOBILE_REVIEWER_TEAM]
     )
     UI.success("Translations PR: #{pr_url}")
   end

--- a/fastlane/lanes/promote.rb
+++ b/fastlane/lanes/promote.rb
@@ -111,7 +111,7 @@ platform :android do
 
     UI.success("Prepared #{candidates.count} promotion candidate(s) and opened the block step.")
   rescue StandardError => e
-    notify_slack(":x: *Beta promotion* failed before the picker could open — #{e.message}")
+    notify_slack(":x: *Beta promotion* failed before the picker could open — #{e.message}", cc_release_managers: true)
     raise
   end
 
@@ -145,7 +145,7 @@ platform :android do
 
     UI.success("Promoted #{version_code} to beta for: #{results.keys.join(', ')}")
   rescue StandardError => e
-    notify_slack(":x: *Beta promotion* failed — #{e.message}") unless result_posted
+    notify_slack(":x: *Beta promotion* failed — #{e.message}", cc_release_managers: true) unless result_posted
     raise
   end
 
@@ -176,7 +176,10 @@ platform :android do
 
     UI.success("Prepared production release candidate #{version_code} and opened the block step.")
   rescue StandardError => e
-    notify_slack(":x: *Production release* failed before the confirmation could open — #{e.message}")
+    notify_slack(
+      ":x: *Production release* failed before the confirmation could open — #{e.message}",
+      cc_release_managers: true
+    )
     raise
   end
 
@@ -208,7 +211,7 @@ platform :android do
 
     UI.success("Promoted #{version_code} to production for: #{results.keys.join(', ')}")
   rescue StandardError => e
-    notify_slack(":x: *Production release* failed — #{e.message}") unless result_posted
+    notify_slack(":x: *Production release* failed — #{e.message}", cc_release_managers: true) unless result_posted
     raise
   end
 
@@ -247,7 +250,7 @@ platform :android do
     # Only failures notify (the rescue below) — anything else would just be noise.
     UI.success("Finalized #{released_version}: release #{release_url}; version bump #{bump_url || 'skipped'}")
   rescue StandardError => e
-    notify_slack(":x: *Promoted-release finalize* failed — #{e.message}")
+    notify_slack(":x: *Promoted-release finalize* failed — #{e.message}", cc_release_managers: true)
     raise
   end
 
@@ -312,7 +315,7 @@ platform :android do
 
     UI.success("Advanced production rollout #{state[:version_code]} to #{rollout_target_label(target)}")
   rescue StandardError => e
-    notify_slack(":x: *Production rollout* failed — #{e.message}") unless result_posted
+    notify_slack(":x: *Production rollout* failed — #{e.message}", cc_release_managers: true) unless result_posted
     raise
   end
 
@@ -727,11 +730,12 @@ platform :android do
       end
 
     notify_slack(
-      <<~MSG
+      <<~MSG,
         #{header} — `#{version_code}`
 
         #{status_lines.join("\n")}
       MSG
+      cc_release_managers: !all_ok
     )
   end
 
@@ -853,7 +857,8 @@ platform :android do
       body: "Advances the marketing version on `#{DEFAULT_BRANCH}` to `#{next_version}`, following the `#{released_version}` production release.",
       head: branch,
       base: DEFAULT_BRANCH,
-      labels: ['Releases']
+      labels: ['Releases'],
+      team_reviewers: [MOBILE_REVIEWER_TEAM]
     )
   end
 
@@ -1009,12 +1014,13 @@ platform :android do
       end
 
     notify_slack(
-      <<~MSG
+      <<~MSG,
         :android: *Beta promotion* — choose a build to release to beta testers (WordPress + Jetpack).#{choose_line}
 
         *Candidates:*
         #{candidate_lines.join("\n")}
       MSG
+      cc_release_managers: true
     )
   end
 
@@ -1030,11 +1036,12 @@ platform :android do
     header = all_ok ? ':rocket: *Promoted to beta*' : ':warning: *Beta promotion finished with errors*'
 
     notify_slack(
-      <<~MSG
+      <<~MSG,
         #{header} — `#{version_code}`
 
         #{status_lines.join("\n")}
       MSG
+      cc_release_managers: !all_ok
     )
   end
 
@@ -1053,29 +1060,46 @@ platform :android do
       end
 
     notify_slack(
-      <<~MSG
+      <<~MSG,
         :android: *Production release* — confirm releasing build `#{version_code}` to production (WordPress + Jetpack).#{confirm_line}
       MSG
+      cc_release_managers: true
     )
   end
 
-  # Posts the per-app outcome of a production release.
+  # Posts the per-app outcome of a production release, including the reminder that a submitted
+  # release still needs a manual Publish click once Play approves it (Managed Publishing).
   def post_production_result_to_slack(version_code:, results:)
+    rollout_label = rollout_target_label(
+      { status: ROLLOUT_STATUS_IN_PROGRESS, user_fraction: PRODUCTION_ROLLOUT_INITIAL_FRACTION.to_f }
+    )
+
     status_lines = results.map do |app, result|
       next "• #{app}: :x: #{result[:error]}" unless result[:ok]
 
-      "• #{app}: :white_check_mark: draft created on production"
+      "• #{app}: :white_check_mark: submitted to production at #{rollout_label}"
     end
 
     all_ok = results.values.all? { |result| result[:ok] }
-    header = all_ok ? ':rocket: *Production draft created*' : ':warning: *Production release finished with errors*'
+    header = all_ok ? ':rocket: *Promoted to production*' : ':warning: *Production release finished with errors*'
+
+    # Only worth saying when something actually landed on the track.
+    publish_note =
+      if results.values.any? { |result| result[:ok] }
+        "\n:warning: Managed Publishing is on, so nobody is being served this yet.\n" \
+          'Once Play approves the release, someone has to click *Publish* in the Play Console to start the rollout.'
+      else
+        ''
+      end
 
     notify_slack(
-      <<~MSG
+      <<~MSG,
         #{header} — `#{version_code}`
 
         #{status_lines.join("\n")}
+        #{publish_note}
       MSG
+      cc_release_managers: true
     )
   end
 


### PR DESCRIPTION
## Description

Release-flow Slack messages move to `#wpmobile-team`, where the people who action the promotion block steps read. Build-shaped traffic stays on `#build-and-ship`: the trunk internal build and the translation sync.

Messages that need someone to act now carry a `cc Release Managers:` footer, and both pull requests the automated flows open request a review from the mobile team.

### Changes

- Default `send_slack_message` to `#wpmobile-team`, which covers every `notify_slack` post from the promote lanes, along with the `notify:` backstops in `promote-beta.yml`, `promote-production.yml` and `advance-production-rollout.yml`.
- Point the translation-sync `notify:` backstop at `#build-and-ship`.
- Add `RELEASE_MANAGERS` and a `cc_release_managers:` option on `notify_slack`, applied to the beta picker prompt, the production confirmation, and every failure notification — including a partial per-app failure in the beta and rollout result posts.
- Add `MOBILE_REVIEWER_TEAM`, replacing `TRANSLATIONS_REVIEWER_TEAM`, and request it via `team_reviewers:` on the version-bump pull request as well as the translations one.
- Report the production promote as a staged rollout at `PRODUCTION_ROLLOUT_INITIAL_FRACTION` rather than as a draft, with a note that Managed Publishing needs a manual **Publish** click once Play approves the release.
