### PR TITLE
Keep shared media that providers generate on the fly

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] The experimental block editor now lays out right-to-left when the app language is a right-to-left language.
 * [*] Sharing content to the app now lists self-hosted sites connected with an application password.
 * [**] Images and videos shared to the app from the photo picker now upload instead of being silently dropped.
+* [**] Media shared from apps that generate it on the fly, such as an "Enhanced" photo from Google Photos, now keeps its correct file type instead of always uploading as a JPEG, and sharing several photos at once no longer drops some of them. [https://github.com/wordpress-mobile/WordPress-Android/issues/23047]
 
 26.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -32,6 +32,7 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.fluxc.utils.MediaUtils.getExtension;
 import static org.wordpress.android.fluxc.utils.MediaUtils.isSupportedImageMimeType;
 import static org.wordpress.android.fluxc.utils.MediaUtils.isSupportedVideoMimeType;
 
@@ -148,8 +150,49 @@ public class ShareIntentReceiverActivity extends BaseAppCompatActivity implement
             AppLog.e(T.MEDIA, "ShareIntentReceiver failed to download media " + uri);
             return false;
         }
-        mLocalMediaUris.add(localUri);
+        mLocalMediaUris.add(withFileExtension(localUri, getContentResolver().getType(uri)));
         return true;
+    }
+
+    /**
+     * Renames the cached copy so its name carries a file extension, using the MIME type the provider
+     * reported for the shared URI.
+     *
+     * <p>downloadExternalMedia() names the copy after the provider's display name, falling back to a
+     * MIME type parsed out of the URI string - which a content:// URI never carries. A provider that
+     * reports no display name, or one without an extension, therefore leaves the copy with no
+     * extension at all. Every MIME check downstream reads the file name, so the media ends up
+     * uploaded as image/jpeg no matter what was actually shared.
+     *
+     * @return the renamed URI, or the original one when there is nothing to repair or the rename
+     * fails. This only ever improves on what we already have, so it must not introduce a failure.
+     */
+    @NonNull
+    private Uri withFileExtension(@NonNull Uri localUri, @Nullable String mimeType) {
+        String path = localUri.getPath();
+        if (path == null || mimeType == null) {
+            return localUri;
+        }
+
+        File localFile = new File(path);
+        if (getExtension(localFile.getName()) != null) {
+            return localUri;
+        }
+
+        String extension = MediaUtils.getExtensionForMimeType(mimeType);
+        if (TextUtils.isEmpty(extension)) {
+            return localUri;
+        }
+
+        // an extension-less name still ends in a dot when downloadExternalMedia() had none to append
+        String renamedPath = (path.endsWith(".") ? path.substring(0, path.length() - 1) : path) + "." + extension;
+        // renameTo() overwrites, and an earlier share may still be uploading from that name
+        File renamedFile = new File(renamedPath);
+        if (renamedFile.exists() || !localFile.renameTo(renamedFile)) {
+            AppLog.w(T.MEDIA, "ShareIntentReceiver could not rename " + path + " to " + renamedPath);
+            return localUri;
+        }
+        return Uri.fromFile(renamedFile);
     }
 
     private boolean isAllowedMediaType(@NonNull Uri uri) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -179,8 +180,14 @@ public class ShareIntentReceiverActivity extends BaseAppCompatActivity implement
             return localUri;
         }
 
+        // getExtensionForMimeType() never fails: when the MIME type is unknown to MimeTypeMap it
+        // returns the subtype, so "application/octet-stream" would name the file ".octet-stream".
+        // That reads as a real extension downstream and suppresses the image/jpeg fallback in
+        // FluxCUtils.mediaModelFromLocalUri() that would otherwise have made the upload work, so
+        // only rename when the extension maps back to a MIME type.
         String extension = MediaUtils.getExtensionForMimeType(mimeType);
-        if (TextUtils.isEmpty(extension)) {
+        if (TextUtils.isEmpty(extension)
+                || MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) == null) {
             return localUri;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -42,6 +41,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import static org.wordpress.android.fluxc.utils.MediaUtils.getExtension;
+import static org.wordpress.android.fluxc.utils.MediaUtils.getMimeTypeForExtension;
 import static org.wordpress.android.fluxc.utils.MediaUtils.isSupportedImageMimeType;
 import static org.wordpress.android.fluxc.utils.MediaUtils.isSupportedVideoMimeType;
 
@@ -180,14 +180,15 @@ public class ShareIntentReceiverActivity extends BaseAppCompatActivity implement
             return localUri;
         }
 
-        // getExtensionForMimeType() never fails: when the MIME type is unknown to MimeTypeMap it
-        // returns the subtype, so "application/octet-stream" would name the file ".octet-stream".
-        // That reads as a real extension downstream and suppresses the image/jpeg fallback in
+        // getExtensionForMimeType() never fails: when the MIME type is unknown it returns the
+        // subtype, so "application/octet-stream" would name the file ".octet-stream". That reads as
+        // a real extension downstream and suppresses the image/jpeg fallback in
         // FluxCUtils.mediaModelFromLocalUri() that would otherwise have made the upload work, so
-        // only rename when the extension maps back to a MIME type.
+        // only rename when the extension maps back to a MIME type. Check that against the same
+        // table isAllowedMediaType() accepts from, rather than MimeTypeMap, whose coverage of
+        // heic/heif/ogv/3g2 varies by API level.
         String extension = MediaUtils.getExtensionForMimeType(mimeType);
-        if (TextUtils.isEmpty(extension)
-                || MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) == null) {
+        if (TextUtils.isEmpty(extension) || getMimeTypeForExtension(extension) == null) {
             return localUri;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
@@ -61,6 +61,11 @@ object EditorUnitFunctions {
 
     /**
      * Checks if an intent contains media (image or video) content.
+     *
+     * Falls back to the intent's own type when the URI yields nothing, because
+     * getFileExtensionFromUrl() returns an empty string for names containing a space
+     * ("Screenshot 2026-08-19.jpg") and for names left without an extension by the provider that
+     * shared them. Without the fallback those items are dropped with no feedback at all.
      */
     fun isMediaTypeIntent(intent: Intent, uri: Uri?): Boolean {
         var type: String? = null
@@ -69,7 +74,8 @@ object EditorUnitFunctions {
             if (extension != null) {
                 type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
             }
-        } else {
+        }
+        if (type == null) {
             type = intent.type
         }
         return type != null && (type.startsWith("image") || type.startsWith("video"))

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorUnitFunctionsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorUnitFunctionsTest.kt
@@ -24,6 +24,14 @@ class EditorUnitFunctionsTest {
     }
 
     @Test
+    fun `rejects a uri whose extension is not media even when the intent type is`() {
+        // the URI wins whenever it resolves: the intent type is only a fallback for when it doesn't
+        val intent = Intent().apply { type = "image/jpeg" }
+
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(intent, "file:///cache/notes.pdf".toUri())).isFalse()
+    }
+
+    @Test
     fun `falls back to the intent type when the name contains a space`() {
         // getFileExtensionFromUrl() returns an empty string for names containing a space
         val intent = Intent().apply { type = "image/jpeg" }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorUnitFunctionsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorUnitFunctionsTest.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Intent
+import android.webkit.MimeTypeMap
+import androidx.core.net.toUri
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric tests for [EditorUnitFunctions.isMediaTypeIntent], which needs real URI parsing and a
+ * real [MimeTypeMap].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
+class EditorUnitFunctionsTest {
+    @Test
+    fun `accepts a uri whose name carries a recognized extension`() {
+        val intent = Intent().apply { type = "text/plain" }
+
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(intent, "file:///cache/photo.jpg".toUri())).isTrue()
+    }
+
+    @Test
+    fun `falls back to the intent type when the name contains a space`() {
+        // getFileExtensionFromUrl() returns an empty string for names containing a space
+        val intent = Intent().apply { type = "image/jpeg" }
+
+        assertThat(
+            EditorUnitFunctions.isMediaTypeIntent(intent, "file:///cache/Screenshot 2026-08-19.jpg".toUri())
+        ).isTrue()
+    }
+
+    @Test
+    fun `falls back to the intent type when the shared file has no extension`() {
+        // what a provider that reports no usable display name leaves behind
+        val intent = Intent().apply { type = "image/jpeg" }
+
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(intent, "file:///cache/wp-1755600000000.".toUri())).isTrue()
+    }
+
+    @Test
+    fun `rejects an extension-less uri when the intent type is not media`() {
+        val intent = Intent().apply { type = "text/plain" }
+
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(intent, "file:///cache/wp-1755600000000.".toUri())).isFalse()
+    }
+
+    @Test
+    fun `rejects an extension-less uri when the intent has no type at all`() {
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(Intent(), "file:///cache/wp-1755600000000.".toUri()))
+            .isFalse()
+    }
+
+    @Test
+    fun `uses the intent type when no uri is given`() {
+        val intent = Intent().apply { type = "video/mp4" }
+
+        assertThat(EditorUnitFunctions.isMediaTypeIntent(intent, null)).isTrue()
+    }
+}


### PR DESCRIPTION
## Description

**TL/DR:** Fixes #23047, where a photo shared from Google Photos opens a blank post. The blank post itself is already fixed on trunk by #23233. This PR closes two follow-on gaps in the same path that still mislabel or silently drop shared media.

---

The "Enhanced" framing in the issue is a red herring. What actually matters is whether the shared `content://` URI resolves to a real file: "Original" arrives as a MediaStore URI with a `_data` column, while "Enhanced" is a stream generated on the fly with no `_data` and no extension anywhere. The photo picker, SAF/Files, Drive and Dropbox all behave the same way.

`MediaUtils.downloadExternalMedia()` names its cached copy after the provider's `DISPLAY_NAME`, falling back to a MIME type parsed out of the URI string — which a `content://` URI never carries. A provider reporting no usable display name leaves a file called `wp-1755600000000.`, and since every MIME check downstream reads the file name, `FluxCUtils.mediaModelFromLocalUri()` runs out of fallbacks and defaults to `image/jpeg`. A shared PNG, HEIC or video was uploaded labelled as a JPEG. `ShareIntentReceiverActivity` now renames the copy using the type the provider reported, which `isAllowedMediaType()` already resolves.

Separately, `EditorUnitFunctions.isMediaTypeIntent()` derived the type from the URI's file extension for `ACTION_SEND_MULTIPLE`. `getFileExtensionFromUrl()` returns an empty string both for those extension-less names and for any name containing a space (`Screenshot 2026-08-19.jpg`), so sharing several photos at once dropped some of them with no toast and no snackbar. It now falls back to `intent.type`, the branch the single-share path already trusts, which covers both `EditPostActivity` and `GutenbergKitActivity`.

Two related problems are **not** addressed here and deserve their own issues: the copy still runs on the main thread (an ANR risk for cloud-only photos, but deliberate per #5818 — some providers revoke access as soon as the requesting context goes away), and `MediaUtils.getDocumentProviderPathKitkatOrHigher()` in wordpress-utils dereferences `downloadExternalMedia(...).getPath()` with no null check.

## Testing instructions

Sharing a generated photo to a post:

1. Open a photo in Google Photos and tap Share.
2. Choose **Enhanced**, then Share, then WordPress.
3. Choose a site and **Post**.
- [x] Verify the image appears in the editor rather than a blank post.
4. Repeat with **Original** instead of Enhanced.
- [x] Verify it still works.

Correct file type on upload (the main payoff of the first commit):

1. Share a **video** through.
- [x] Verify the file that lands in the site's media library keeps its own type and is not renamed to `.jpg`.

Sharing several photos at once:

1. In Google Photos, select 2 or more photos, then Share, then WordPress.
2. Choose a site and **Post**.
- [x] Verify **all** of the selected photos appear in the editor. On trunk today the extension-less ones vanish with no error.

Media Library route:

1. Repeat the single-photo and multi-photo shares, choosing **Media Library** instead of Post.
- [x] Verify the media uploads and appears in the grid.