### PR TITLE
Make the .aiexclude extension patterns actually match

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -5,11 +5,11 @@
 fastlane/
 
 # Key-related files
-.jks
-.keystore
+*.jks
+*.keystore
 
 # Backup files
-.bak
+*.bak
 
 # Generated files
 bin/
@@ -18,12 +18,12 @@ build/
 build.log
 
 # Built application files
-.apk
-.ap_
-.aab
+*.apk
+*.ap_
+*.aab
 
 # Dex VM files
-.dex
+*.dex
 
 # Configuration files
 .configure


### PR DESCRIPTION
## Description

Noticed that `.aiexclude` had rules such as `.jks` where they should have been `*.jks`. This PR fixes it.
<details>
<summary>AI-generated details</summary>

`.aiexclude` follows gitignore syntax, where a pattern with no wildcard matches a path component named *exactly* that. Seven of its entries are bare extensions, so they match nothing: `.jks` only ever matched a file literally called `.jks`, never `WordPress/upload.jks`.

The upshot is that the signing key the file exists to hide has been reaching Gemini since `.aiexclude` was added, along with the debug keystore and any `.apk`/`.aab`/`.ap_` produced outside `build/`.

The seven affected entries are the ones copied over from `.gitignore`, which spells the same patterns `*.apk`, `*.dex`, `*.bak` — the asterisks were lost in the transfer. Entries that are genuine filenames or directories (`.DS_Store`, `fastlane/`, `google-services.json`, the two `.configure` ones) were always correct and are untouched.

Found while scoping the move of Android release keystores out of the working tree, under [Update secrets management in repos](https://linear.app/a8c/project/update-secrets-management-in-repos-595be06733bc). It is independent of that work and needs no vault changes.


</details>

## Testing instructions

This is a simple config change. Look at the diff. If something were not to work, it would more likely be a bug in the tool that reads `.aiexclude`.

<details>
<summary>AI-generated test steps (these run on my machine)</summary>

There is no build-visible behaviour here, so verify with `git check-ignore`. Run it against an **empty** repo — inside this one, the repo's own `.gitignore` already covers `WordPress/*.jks` and `*.apk` and will mask the result:

1. `mkdir /tmp/aiexclude-check && git -C /tmp/aiexclude-check init`
2. `git -C <this-worktree> show trunk:.aiexclude > /tmp/before && cp <this-worktree>/.aiexclude /tmp/after`
3. For each path below, compare:
   `git -C /tmp/aiexclude-check -c core.excludesFile=/tmp/before check-ignore --no-index -v <path>`
   against the same command with `/tmp/after`.

- [ ] `WordPress/upload.jks` — no match before, matches `*.jks` after
- [ ] `WordPress/debug.keystore` — no match before, matches `*.keystore` after
- [ ] `dist/wp.apk` — no match before, matches `*.apk` after
- [ ] `README.md` — no match either way (control)
- [ ] `.DS_Store`, `fastlane/Fastfile`, `google-services.json` — match both before and after (untouched entries still work)


</details>