### PR TITLE
Migrate the Site Creation Domain Search to `wordpress-rs`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -185,7 +185,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
 
     private fun onDomainsFetched(query: DomainSuggestionsQuery, result: FetchDomainsResult) {
         when (result) {
-            is FetchDomainsResult.Error -> {
+            FetchDomainsResult.Error -> {
                 tracker.trackErrorShown(ERROR_CONTEXT, "GENERIC_ERROR", null)
                 updateUiStateToContent(
                     query,
@@ -195,7 +195,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
                     )
                 )
             }
-            is FetchDomainsResult.InvalidQuery -> {
+            FetchDomainsResult.InvalidQuery -> {
                 val emptyListMessage = UiStringRes(
                     R.string.new_site_creation_empty_domain_list_message_invalid_query
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -480,10 +480,6 @@ private fun createSearchInputUiState(
                         UiStringRes(R.string.site_creation_domain_tag_best_alternative),
                     )
 
-                    object Sale : Tag(
-                        R.color.yellow_50,
-                        UiStringRes(R.string.site_creation_domain_tag_sale)
-                    )
                 }
 
                 sealed class Cost(val title: UiString) {
@@ -496,12 +492,6 @@ private fun createSearchInputUiState(
                         val subtitle = UiStringRes(R.string.site_creation_domain_free_with_annual_plan)
                     }
 
-                    data class OnSale(private val titleCost: String, private val strikeoutTitleCost: String) : Cost(
-                        UiStringText(titleCost)
-                    ) {
-                        val strikeoutTitle = UiStringText(strikeoutTitleCost)
-                        val subtitle = UiStringRes(R.string.site_creation_domain_cost_sale)
-                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -15,14 +15,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.networking.restapi.WpComApiClientProvider
-import rs.wordpress.api.kotlin.WpComApiClient
-import rs.wordpress.api.kotlin.WpRequestResult
-import rs.wordpress.api.kotlin.toLogErrorString
-import uniffi.wp_api.DomainSuggestion
-import uniffi.wp_api.Product
-import uniffi.wp_api.ProductTypeFilter
-import uniffi.wp_api.ProductsParams
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.models.networkresource.ListState.Error
 import org.wordpress.android.models.networkresource.ListState.Loading
@@ -30,6 +22,7 @@ import org.wordpress.android.models.networkresource.ListState.Ready
 import org.wordpress.android.models.networkresource.ListState.Success
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainSuggestionsQuery.UserQuery
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.CreateSiteButtonState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
@@ -52,6 +45,13 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.api.kotlin.toLogErrorString
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.Product
+import uniffi.wp_api.ProductTypeFilter
+import uniffi.wp_api.ProductsParams
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import rs.wordpress.api.kotlin.WpComApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.api.kotlin.toLogErrorString
 import uniffi.wp_api.DomainSuggestion
 import uniffi.wp_api.Product
 import uniffi.wp_api.ProductTypeFilter
@@ -129,7 +130,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
             } else {
                 AppLog.e(
                     AppLog.T.DOMAIN_REGISTRATION,
-                    "Error while fetching domain products"
+                    "Error while fetching domain products: ${result.toLogErrorString()}"
                 )
             }
         }
@@ -185,8 +186,8 @@ class SiteCreationDomainsViewModel @Inject constructor(
 
     private fun onDomainsFetched(query: DomainSuggestionsQuery, result: FetchDomainsResult) {
         when (result) {
-            FetchDomainsResult.Error -> {
-                tracker.trackErrorShown(ERROR_CONTEXT, "GENERIC_ERROR", null)
+            is FetchDomainsResult.Error -> {
+                tracker.trackErrorShown(ERROR_CONTEXT, result.type, result.message)
                 updateUiStateToContent(
                     query,
                     Error(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.models.networkresource.ListState.Error
 import org.wordpress.android.models.networkresource.ListState.Loading
@@ -22,7 +21,6 @@ import org.wordpress.android.models.networkresource.ListState.Ready
 import org.wordpress.android.models.networkresource.ListState.Success
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainSuggestionsQuery.UserQuery
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.CreateSiteButtonState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
@@ -41,17 +39,10 @@ import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
 import org.wordpress.android.viewmodel.SingleLiveEvent
-import rs.wordpress.api.kotlin.WpComApiClient
-import rs.wordpress.api.kotlin.WpRequestResult
-import rs.wordpress.api.kotlin.toLogErrorString
 import uniffi.wp_api.DomainSuggestion
-import uniffi.wp_api.Product
-import uniffi.wp_api.ProductTypeFilter
-import uniffi.wp_api.ProductsParams
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -65,8 +56,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val networkUtils: NetworkUtilsWrapper,
     private val domainSanitizer: SiteCreationDomainSanitizer,
     private val fetchDomainsUseCase: FetchDomainsUseCase,
-    private val wpComApiClientProvider: WpComApiClientProvider,
-    private val accountStore: AccountStore,
     private val plansInSiteCreationFeatureConfig: PlansInSiteCreationFeatureConfig,
     private val tracker: SiteCreationTracker,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -81,8 +70,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val _uiState: MutableLiveData<DomainsUiState> = MutableLiveData()
     val uiState: LiveData<DomainsUiState> = _uiState
 
-    private var wpComApiClient: WpComApiClient? = null
-    private var products: List<Product>? = null
     private var currentQuery: DomainSuggestionsQuery? = null
     private var listState: ListState<DomainModel> = ListState.Init()
     private var selectedDomain by Delegates.observable<DomainModel?>(null) { _, old, new ->
@@ -100,40 +87,11 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val _onHelpClicked = SingleLiveEvent<Unit?>()
     val onHelpClicked: LiveData<Unit?> = _onHelpClicked
 
-    @Synchronized
-    private fun getOrCreateClient(): WpComApiClient {
-        val token = requireNotNull(accountStore.accessToken) {
-            "WP.com access token is required"
-        }
-        return wpComApiClient
-            ?: wpComApiClientProvider.getWpComApiClient(token)
-                .also { wpComApiClient = it }
-    }
-
     fun start() {
         if (isStarted) return
         isStarted = true
         tracker.trackDomainsAccessed()
         resetUiState()
-        if (plansInSiteCreationFeatureConfig.isEnabled()) fetchAndCacheProducts()
-    }
-
-    private fun fetchAndCacheProducts() {
-        launch {
-            val params = ProductsParams(
-                productType = ProductTypeFilter.Domains
-            )
-            val result = getOrCreateClient()
-                .request { it.products().list(params).data }
-            if (result is WpRequestResult.Success) {
-                products = result.response.values.toList()
-            } else {
-                AppLog.e(
-                    AppLog.T.DOMAIN_REGISTRATION,
-                    "Error while fetching domain products: ${result.toLogErrorString()}"
-                )
-            }
-        }
     }
 
     fun onCreateSiteBtnClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -479,7 +479,6 @@ private fun createSearchInputUiState(
                         R.color.purple_50,
                         UiStringRes(R.string.site_creation_domain_tag_best_alternative),
                     )
-
                 }
 
                 sealed class Cost(val title: UiString) {
@@ -491,7 +490,6 @@ private fun createSearchInputUiState(
                         val strikeoutTitle = UiStringText(titleCost)
                         val subtitle = UiStringRes(R.string.site_creation_domain_free_with_annual_plan)
                     }
-
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -13,14 +13,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.products.Product
-import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
-import org.wordpress.android.fluxc.store.ProductsStore
-import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainErrorType
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.Product
+import uniffi.wp_api.ProductTypeFilter
+import uniffi.wp_api.ProductsParams
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.models.networkresource.ListState.Error
 import org.wordpress.android.models.networkresource.ListState.Loading
@@ -41,6 +42,7 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationSearchInputUiState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.usecases.FETCH_DOMAINS_VENDOR_DOT
 import org.wordpress.android.ui.sitecreation.usecases.FETCH_DOMAINS_VENDOR_MOBILE
+import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsResult
 import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -60,10 +62,10 @@ private const val ERROR_CONTEXT = "domains"
 @HiltViewModel
 class SiteCreationDomainsViewModel @Inject constructor(
     private val networkUtils: NetworkUtilsWrapper,
-    private val dispatcher: Dispatcher,
     private val domainSanitizer: SiteCreationDomainSanitizer,
     private val fetchDomainsUseCase: FetchDomainsUseCase,
-    private val productsStore: ProductsStore,
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
     private val plansInSiteCreationFeatureConfig: PlansInSiteCreationFeatureConfig,
     private val tracker: SiteCreationTracker,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -78,7 +80,8 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val _uiState: MutableLiveData<DomainsUiState> = MutableLiveData()
     val uiState: LiveData<DomainsUiState> = _uiState
 
-    private var products: Map<Int?, Product> = mapOf()
+    private var wpComApiClient: WpComApiClient? = null
+    private var products: List<Product>? = null
     private var currentQuery: DomainSuggestionsQuery? = null
     private var listState: ListState<DomainModel> = ListState.Init()
     private var selectedDomain by Delegates.observable<DomainModel?>(null) { _, old, new ->
@@ -96,13 +99,14 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val _onHelpClicked = SingleLiveEvent<Unit?>()
     val onHelpClicked: LiveData<Unit?> = _onHelpClicked
 
-    init {
-        dispatcher.register(fetchDomainsUseCase)
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        dispatcher.unregister(fetchDomainsUseCase)
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient {
+        val token = requireNotNull(accountStore.accessToken) {
+            "WP.com access token is required"
+        }
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
     }
 
     fun start() {
@@ -115,15 +119,18 @@ class SiteCreationDomainsViewModel @Inject constructor(
 
     private fun fetchAndCacheProducts() {
         launch {
-            val result = productsStore.fetchProducts(TYPE_DOMAINS_PRODUCT)
-            when {
-                result.isError -> {
-                    AppLog.e(AppLog.T.DOMAIN_REGISTRATION, "Error while fetching domain products: ${result.error}")
-                }
-
-                else -> {
-                    products = result.products.orEmpty().associateBy { it.productId }
-                }
+            val params = ProductsParams(
+                productType = ProductTypeFilter.Domains
+            )
+            val result = getOrCreateClient()
+                .request { it.products().list(params).data }
+            if (result is WpRequestResult.Success) {
+                products = result.response.values.toList()
+            } else {
+                AppLog.e(
+                    AppLog.T.DOMAIN_REGISTRATION,
+                    "Error while fetching domain products"
+                )
             }
         }
     }
@@ -159,10 +166,12 @@ class SiteCreationDomainsViewModel @Inject constructor(
             updateUiStateToContent(query, Loading(Ready(emptyList()), false))
             fetchDomainsJob = launch {
                 delay(THROTTLE_DELAY)
-                val onSuggestedDomains: OnSuggestedDomains = fetchDomainsByPurchasingFeatureConfig(query.value)
+                val onlyWordpressCom = !plansInSiteCreationFeatureConfig.isEnabled()
+                val vendor = if (onlyWordpressCom) FETCH_DOMAINS_VENDOR_DOT else FETCH_DOMAINS_VENDOR_MOBILE
+                val result = fetchDomainsUseCase.fetchDomains(query.value, vendor, onlyWordpressCom)
 
                 withContext(mainDispatcher) {
-                    onDomainsFetched(query, onSuggestedDomains)
+                    onDomainsFetched(query, result)
                 }
             }
         } else {
@@ -174,55 +183,52 @@ class SiteCreationDomainsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchDomainsByPurchasingFeatureConfig(query: String): OnSuggestedDomains {
-        val onlyWordpressCom = !plansInSiteCreationFeatureConfig.isEnabled()
-        val vendor = if (onlyWordpressCom) FETCH_DOMAINS_VENDOR_DOT else FETCH_DOMAINS_VENDOR_MOBILE
-
-        return fetchDomainsUseCase.fetchDomains(query, vendor, onlyWordpressCom)
-    }
-
-    private fun onDomainsFetched(query: DomainSuggestionsQuery, event: OnSuggestedDomains) {
-        // We want to treat `INVALID_QUERY` as if it's an empty result, so we'll ignore it
-        if (event.isError && event.error.type != SuggestDomainErrorType.INVALID_QUERY) {
-            tracker.trackErrorShown(
-                ERROR_CONTEXT,
-                event.error.type.toString(),
-                event.error.message
-            )
-            updateUiStateToContent(
-                query,
-                Error(
-                    listState,
-                    errorMessageResId = R.string.site_creation_fetch_suggestions_error_unknown
+    private fun onDomainsFetched(query: DomainSuggestionsQuery, result: FetchDomainsResult) {
+        when (result) {
+            is FetchDomainsResult.Error -> {
+                tracker.trackErrorShown(ERROR_CONTEXT, "GENERIC_ERROR", null)
+                updateUiStateToContent(
+                    query,
+                    Error(
+                        listState,
+                        errorMessageResId = R.string.site_creation_fetch_suggestions_error_unknown
+                    )
                 )
-            )
-        } else {
-            /**
-             * We would like to show the domains that matches the current query at the top. For this, we split the
-             * domains into two, one part for the domain names that start with the current query plus `.` and the
-             * other part for the others. We then combine them back again into a single list.
-             */
-            val domains = event.suggestions.map(::parseSuggestion)
-                .partition { it.domainName.startsWith("${query.value}.") }
-                .toList().flatten()
+            }
+            is FetchDomainsResult.InvalidQuery -> {
+                val emptyListMessage = UiStringRes(
+                    R.string.new_site_creation_empty_domain_list_message_invalid_query
+                )
+                updateUiStateToContent(query, Success(emptyList()), emptyListMessage)
+            }
+            is FetchDomainsResult.Success -> {
+                val domains = result.suggestions.map(::parseSuggestion)
+                    .partition { it.domainName.startsWith("${query.value}.") }
+                    .toList().flatten()
 
-            val isInvalidQuery = event.isError && event.error.type == SuggestDomainErrorType.INVALID_QUERY
-            val emptyListMessage = UiStringRes(
-                if (isInvalidQuery) R.string.new_site_creation_empty_domain_list_message_invalid_query
-                else R.string.new_site_creation_empty_domain_list_message
-            )
+                val emptyListMessage = UiStringRes(
+                    R.string.new_site_creation_empty_domain_list_message
+                )
 
-            updateUiStateToContent(query, Success(domains), emptyListMessage)
+                updateUiStateToContent(query, Success(domains), emptyListMessage)
+            }
         }
     }
 
-    private fun parseSuggestion(response: DomainSuggestionResponse): DomainModel = with(response) {
-        DomainModel(
-            domainName = domain_name,
-            isFree = is_free,
-            cost = cost.orEmpty(),
-            productId = product_id,
-            supportsPrivacy = supports_privacy,
+    private fun parseSuggestion(suggestion: DomainSuggestion): DomainModel = when (suggestion) {
+        is DomainSuggestion.Free -> DomainModel(
+            domainName = suggestion.v1.domainName,
+            isFree = true,
+            cost = suggestion.v1.cost,
+            productId = 0,
+            supportsPrivacy = false,
+        )
+        is DomainSuggestion.Paid -> DomainModel(
+            domainName = suggestion.v1.domainName,
+            isFree = false,
+            cost = suggestion.v1.cost,
+            productId = suggestion.v1.productId.toInt(),
+            supportsPrivacy = suggestion.v1.supportsPrivacy,
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -40,7 +40,6 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewMode
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState.Cost
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState.Tag.BestAlternative
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState.Tag.Recommended
-import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState.Tag.Sale
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState.Tag.Unavailable
 
 private val HighlightBgColor @Composable get() = colorScheme.primary.copy(0.1f)
@@ -107,14 +106,7 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                 }
             }
             if (tags.none { it is Unavailable }) {
-                if (cost is Cost.OnSale) {
-                    SalePrice(
-                        cost.strikeoutTitle.asString() to cost.title.asString(),
-                        cost.subtitle.asString(),
-                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                    )
-                }
-                else if (cost is Cost.Paid) {
+                if (cost is Cost.Paid) {
                     Plan(
                         cost.strikeoutTitle.asString() to cost.title.asString(),
                         modifier = Modifier.padding(start = Margin.ExtraLarge.value)
@@ -152,36 +144,6 @@ private fun Price(text: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun SalePrice(title: Pair<String, String>, subtitle: String, modifier: Modifier = Modifier) {
-    Column(
-        modifier,
-        horizontalAlignment = Alignment.End,
-    ) {
-        title.let { (strikethroughText, normalText) ->
-            Row(verticalAlignment = Alignment.Bottom) {
-                Text(
-                    strikethroughText,
-                    color = SecondaryTextColor,
-                    fontSize = SecondaryFontSize,
-                    textDecoration = TextDecoration.LineThrough,
-                    modifier = Modifier.padding(end = 4.dp)
-                )
-                Text(
-                    normalText,
-                    color = colorScheme.primary,
-                    fontSize = PrimaryFontSize,
-                )
-            }
-        }
-        Text(
-            subtitle,
-            color = colorScheme.primary,
-            fontSize = SecondaryFontSize,
-        )
-    }
-}
-
-@Composable
 private fun Plan(title: Pair<String, String>, modifier: Modifier = Modifier) {
     Column(
         modifier,
@@ -213,7 +175,6 @@ private fun DomainItemPreview() {
             },
             cost = when {
                 it % 3 == 0 -> Cost.Paid("$${it * 5}")
-                it in 1..2 -> Cost.OnSale("$${it * 2}", "$${it * 3}")
                 else -> Cost.Free
             },
             tags = listOfNotNull(
@@ -223,7 +184,6 @@ private fun DomainItemPreview() {
                     2 -> BestAlternative
                     else -> null
                 },
-                if (it in 1..2) Sale else null,
             ),
             isSelected = it == 5,
             onClick = {}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -13,6 +13,8 @@ const val FETCH_DOMAINS_VENDOR_DOT = "dot"
 const val FETCH_DOMAINS_VENDOR_MOBILE = "mobile"
 private const val FETCH_DOMAINS_SIZE = 20u
 private const val ERROR_CODE_INVALID_QUERY = "invalid_query"
+private const val ERROR_CODE_EMPTY_RESULTS = "empty_results"
+private const val ERROR_TYPE_GENERIC = "GENERIC_ERROR"
 
 class FetchDomainsUseCase @Inject constructor(
     private val wpComApiClientProvider: WpComApiClientProvider,
@@ -50,21 +52,28 @@ class FetchDomainsUseCase @Inject constructor(
             is WpRequestResult.Success ->
                 FetchDomainsResult.Success(result.response)
             is WpRequestResult.WpError ->
-                if (result.isInvalidQuery()) {
-                    FetchDomainsResult.InvalidQuery
-                } else {
-                    FetchDomainsResult.Error
+                when (val code = result.apiErrorCode()) {
+                    ERROR_CODE_INVALID_QUERY -> FetchDomainsResult.InvalidQuery
+                    // The API reports "no domains for that search" as an error,
+                    // but there is nothing wrong with the request.
+                    ERROR_CODE_EMPTY_RESULTS -> FetchDomainsResult.Success(emptyList())
+                    else -> FetchDomainsResult.Error(
+                        type = code ?: ERROR_TYPE_GENERIC,
+                        message = result.errorMessage,
+                    )
                 }
-            else -> FetchDomainsResult.Error
+            else -> FetchDomainsResult.Error(type = ERROR_TYPE_GENERIC, message = null)
         }
     }
 }
 
-private fun WpRequestResult.WpError<*>.isInvalidQuery(): Boolean {
-    val code = errorCode
-    return code is WpErrorCode.CustomException &&
-        code.v1 == ERROR_CODE_INVALID_QUERY
-}
+/**
+ * The API's own error code, for the codes this endpoint defines. Codes the
+ * WordPress REST API also uses are modelled as [WpErrorCode] variants and
+ * return null.
+ */
+private fun WpRequestResult.WpError<*>.apiErrorCode(): String? =
+    (errorCode as? WpErrorCode.CustomException)?.v1
 
 sealed interface FetchDomainsResult {
     data class Success(
@@ -73,5 +82,8 @@ sealed interface FetchDomainsResult {
 
     data object InvalidQuery : FetchDomainsResult
 
-    data object Error : FetchDomainsResult
+    data class Error(
+        val type: String,
+        val message: String?,
+    ) : FetchDomainsResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -48,14 +48,14 @@ class FetchDomainsUseCase @Inject constructor(
                 .request { it.domains().suggestions(params).data }
         ) {
             is WpRequestResult.Success ->
-                FetchDomainsResult.Success(query, result.response)
+                FetchDomainsResult.Success(result.response)
             is WpRequestResult.WpError ->
                 if (result.isInvalidQuery()) {
-                    FetchDomainsResult.InvalidQuery(query)
+                    FetchDomainsResult.InvalidQuery
                 } else {
-                    FetchDomainsResult.Error(query)
+                    FetchDomainsResult.Error
                 }
-            else -> FetchDomainsResult.Error(query)
+            else -> FetchDomainsResult.Error
         }
     }
 }
@@ -67,18 +67,11 @@ private fun WpRequestResult.WpError<*>.isInvalidQuery(): Boolean {
 }
 
 sealed interface FetchDomainsResult {
-    val query: String
-
     data class Success(
-        override val query: String,
         val suggestions: List<DomainSuggestion>,
     ) : FetchDomainsResult
 
-    data class InvalidQuery(
-        override val query: String,
-    ) : FetchDomainsResult
+    data object InvalidQuery : FetchDomainsResult
 
-    data class Error(
-        override val query: String,
-    ) : FetchDomainsResult
+    data object Error : FetchDomainsResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -1,66 +1,85 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
-import kotlinx.coroutines.suspendCancellableCoroutine
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
-import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.DomainSuggestionsParams
+import uniffi.wp_api.WpErrorCode
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.resume
 
 const val FETCH_DOMAINS_VENDOR_DOT = "dot"
 const val FETCH_DOMAINS_VENDOR_MOBILE = "mobile"
-private const val FETCH_DOMAINS_SIZE = 20
+private const val FETCH_DOMAINS_SIZE = 20u
+private const val ERROR_CODE_INVALID_QUERY = "invalid_query"
 
-/**
- * Transforms newSuggestDomainsAction EventBus event to a coroutine.
- *
- * The client may dispatch multiple requests, but we want to accept only the latest one and ignore all others.
- * We can't rely just on job.cancel() as the OnSuggestedDomains may have already been dispatched and FluxC will
- * return a result.
- */
 class FetchDomainsUseCase @Inject constructor(
-    val dispatcher: Dispatcher,
-    @Suppress("unused") val siteStore: SiteStore
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
 ) {
-    /**
-     * Query - Continuation pair
-     */
-    private var pair: Pair<String, Continuation<OnSuggestedDomains>>? = null
+    private var wpComApiClient: WpComApiClient? = null
+
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient {
+        val token = requireNotNull(accountStore.accessToken) {
+            "WP.com access token is required"
+        }
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
+    }
 
     suspend fun fetchDomains(
         query: String,
         vendor: String,
         onlyWordpressCom: Boolean,
-        size: Int = FETCH_DOMAINS_SIZE
-    ): OnSuggestedDomains {
-        val payload = SuggestDomainsPayload(
-            query,
-            size,
-            vendor,
-            onlyWordpressCom,
-            includeWordpressCom = true,
-            includeDotBlogSubdomain = false
+        @Suppress("UNUSED_PARAMETER") size: Int = FETCH_DOMAINS_SIZE.toInt()
+    ): FetchDomainsResult {
+        val params = DomainSuggestionsParams(
+            query = query,
+            quantity = FETCH_DOMAINS_SIZE,
+            vendor = vendor,
+            onlyWordpressdotcom = onlyWordpressCom, // checkstyle ignore
+            includeWordpressdotcom = true, // checkstyle ignore
+            includeDotblogsubdomain = false,
         )
-
-        return suspendCancellableCoroutine { cont ->
-            pair = Pair(payload.query, cont)
-            dispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(payload))
+        return when (
+            val result = getOrCreateClient()
+                .request { it.domains().suggestions(params).data }
+        ) {
+            is WpRequestResult.Success ->
+                FetchDomainsResult.Success(query, result.response)
+            is WpRequestResult.WpError ->
+                if (result.isInvalidQuery()) {
+                    FetchDomainsResult.InvalidQuery(query)
+                } else {
+                    FetchDomainsResult.Error(query)
+                }
+            else -> FetchDomainsResult.Error(query)
         }
     }
+}
 
-    @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    @Suppress("unused")
-    fun onSuggestedDomains(event: OnSuggestedDomains) {
-        pair?.let {
-            if (event.query == it.first) {
-                it.second.resume(event)
-                pair = null
-            }
-        }
-    }
+private fun WpRequestResult.WpError<*>.isInvalidQuery(): Boolean {
+    val code = errorCode
+    return code is WpErrorCode.CustomException &&
+        code.v1 == ERROR_CODE_INVALID_QUERY
+}
+
+sealed interface FetchDomainsResult {
+    val query: String
+
+    data class Success(
+        override val query: String,
+        val suggestions: List<DomainSuggestion>,
+    ) : FetchDomainsResult
+
+    data class InvalidQuery(
+        override val query: String,
+    ) : FetchDomainsResult
+
+    data class Error(
+        override val query: String,
+    ) : FetchDomainsResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -34,7 +34,6 @@ class FetchDomainsUseCase @Inject constructor(
         query: String,
         vendor: String,
         onlyWordpressCom: Boolean,
-        @Suppress("UNUSED_PARAMETER") size: Int = FETCH_DOMAINS_SIZE.toInt()
     ): FetchDomainsResult {
         val params = DomainSuggestionsParams(
             query = query,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.usecases
 
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpComApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.DomainSuggestion
@@ -15,6 +16,7 @@ private const val FETCH_DOMAINS_SIZE = 20u
 private const val ERROR_CODE_INVALID_QUERY = "invalid_query"
 private const val ERROR_CODE_EMPTY_RESULTS = "empty_results"
 private const val ERROR_TYPE_GENERIC = "GENERIC_ERROR"
+private const val ERROR_TYPE_NO_ACCESS_TOKEN = "NO_ACCESS_TOKEN"
 
 class FetchDomainsUseCase @Inject constructor(
     private val wpComApiClientProvider: WpComApiClientProvider,
@@ -22,11 +24,16 @@ class FetchDomainsUseCase @Inject constructor(
 ) {
     private var wpComApiClient: WpComApiClient? = null
 
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
     @Synchronized
-    private fun getOrCreateClient(): WpComApiClient {
-        val token = requireNotNull(accountStore.accessToken) {
-            "WP.com access token is required"
-        }
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
         return wpComApiClient
             ?: wpComApiClientProvider.getWpComApiClient(token)
                 .also { wpComApiClient = it }
@@ -37,6 +44,13 @@ class FetchDomainsUseCase @Inject constructor(
         vendor: String,
         onlyWordpressCom: Boolean,
     ): FetchDomainsResult {
+        val client = getOrCreateClient() ?: run {
+            AppLog.e(
+                AppLog.T.DOMAIN_REGISTRATION,
+                "Cannot fetch domain suggestions without a WP.com access token"
+            )
+            return FetchDomainsResult.Error(type = ERROR_TYPE_NO_ACCESS_TOKEN, message = null)
+        }
         val params = DomainSuggestionsParams(
             query = query,
             quantity = FETCH_DOMAINS_SIZE,
@@ -46,7 +60,7 @@ class FetchDomainsUseCase @Inject constructor(
             includeDotblogsubdomain = false,
         )
         return when (
-            val result = getOrCreateClient()
+            val result = client
                 .request { it.domains().suggestions(params).data }
         ) {
             is WpRequestResult.Success ->

--- a/WordPress/src/main/res/layout/site_creation_domains_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_domains_screen.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/content_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:layout_height="match_parent">
 
     <include
         android:id="@+id/site_creation_header_item"

--- a/WordPress/src/main/res/layout/site_creation_search_input_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_search_input_item.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:animateLayoutChanges="true"
     android:gravity="center_vertical"
     android:orientation="vertical">
 

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -925,7 +925,6 @@ Language: ar
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">البحث باستخدام الكلمات المفتاحية</string>
     <string name="site_creation_domain_header_subtitle">ابحث عن نطاق قصير لا يُنسى لمساعدة الأشخاص على العثور على موقعك وزيارته.</string>
-    <string name="site_creation_domain_cost_sale">للعام الأول</string>
     <string name="site_creation_error_cart_subtitle">تم إنشاء موقعك على الويب بنجاح، لكننا واجهنا مشكلة في أثناء إعداد نطاقك المخصص للسداد. يرجى المحاولة مجددًا أو الاتصال بالدعم للحصول على المساعدة.</string>
     <string name="new_site_creation_preview_caption_paid">قد يستغرق الأمر ما يصل إلى 30 دقيقة لكي يبدأ نطاقك المخصص بالعمل.</string>
     <string name="new_site_creation_preview_subtitle_paid">لقد أرسلنا إليك الإيصال الخاص بك في رسالة عبر البريد الإلكتروني. %s</string>
@@ -989,7 +988,6 @@ Language: ar
     <string name="blaze_promotional_text">جذب مزيد من حركة المرور إلى موقعك باستخدام Blaze</string>
     <string name="blaze_activity_title">التوهج</string>
     <string name="site_creation_domain_tag_unavailable">هذا النطاق مسجّل بالفعل</string>
-    <string name="site_creation_domain_tag_sale">تخفيض</string>
     <string name="site_creation_domain_tag_recommended">موصى به</string>
     <string name="site_creation_domain_tag_best_alternative">أفضل بديل</string>
     <string name="support_faq_caption">ارجع إلى قسم الأسئلة المتداولة لدينا للحصول على إجابات عن الأسئلة الشائعة التي قد تطرحها.</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -949,7 +949,6 @@ Language: cs_CZ
     <string name="site_creation_search_domain_example_title">NazevVasehoWebu.cz</string>
     <string name="site_creation_domain_search_input_hint">Hledat pomocí klíčových slov</string>
     <string name="site_creation_domain_header_subtitle">Hledejte krátkou a zapamatovatelnou doménu, která pomůže lidem najít a navštívit váš web.</string>
-    <string name="site_creation_domain_cost_sale">za první rok</string>
     <string name="site_creation_error_cart_subtitle">Váš web byl úspěšně vytvořen, ale při přípravě vaší vlastní domény k pokladně jsme narazili na problém. Zkuste to prosím znovu nebo kontaktujte podporu.</string>
     <string name="new_site_creation_preview_caption_paid">Správné fungování vaší vlastní domény může trvat až 30 minut.</string>
     <string name="new_site_creation_preview_subtitle_paid">Zaslali jsme vám e-mailem účtenku. %s</string>
@@ -1013,7 +1012,6 @@ Language: cs_CZ
     <string name="blaze_promotional_text">Přiveďte na svůj web větší návštěvnost se zvýrazněním</string>
     <string name="blaze_activity_title">Zvýraznění</string>
     <string name="site_creation_domain_tag_unavailable">Tato doména je již registrována</string>
-    <string name="site_creation_domain_tag_sale">Prodej</string>
     <string name="site_creation_domain_tag_recommended">Doporučeno</string>
     <string name="site_creation_domain_tag_best_alternative">Nejlepší alternativa</string>
     <string name="support_faq_caption">Odpovědi na běžné otázky, které můžete mít, najdete v našich FAQ.</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -949,7 +949,6 @@ Language: de
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Mit Stichwörtern suchen</string>
     <string name="site_creation_domain_header_subtitle">Suche nach einer kurzen und einprägsamen Domain, damit Personen deine Website leicht finden und besuchen können.</string>
-    <string name="site_creation_domain_cost_sale">für das erste Jahr</string>
     <string name="site_creation_error_cart_subtitle">Deine Website wurde erfolgreich erstellt. Wir haben jedoch ein Problem festgestellt, als wir deine individuelle Domain für den Bezahlvorgang vorbereitet haben. Bitte versuche es erneut oder kontaktiere den Support, um Hilfe zu erhalten.</string>
     <string name="new_site_creation_preview_caption_paid">Es kann bis zu 30 Minuten dauern, bis deine individuelle Domain vollständig erreichbar ist.</string>
     <string name="new_site_creation_preview_subtitle_paid">Wir haben dir deinen Beleg per E-Mail gesendet. %s</string>
@@ -1013,7 +1012,6 @@ Language: de
     <string name="blaze_promotional_text">Leite mit Blaze mehr Traffic auf deine Website</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Diese Domain ist bereits registriert</string>
-    <string name="site_creation_domain_tag_sale">Angebot</string>
     <string name="site_creation_domain_tag_recommended">Empfohlen</string>
     <string name="site_creation_domain_tag_best_alternative">Beste Alternative</string>
     <string name="support_faq_caption">In unseren FAQ findest du Antworten auf häufig gestellte Fragen.</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -6,7 +6,6 @@ Generator: GlotPress/4.1.0
 Language: el_GR
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="site_creation_domain_tag_sale">Προσφορά</string>
     <string name="site_creation_domain_tag_recommended">Προτεινόμενο</string>
     <string name="site_creation_domain_tag_best_alternative">Καλύτερη Εναλλακτική</string>
     <string name="help_buttons_screen_title">Βοήθεια</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -573,7 +573,6 @@ Language: en_CA
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Search with keywords</string>
     <string name="site_creation_domain_header_subtitle">Search for a short and memorable domain to help people find and visit your site.</string>
-    <string name="site_creation_domain_cost_sale">for the first year</string>
     <string name="site_creation_error_cart_subtitle">Your website has been created successfully, but we encountered an issue while preparing your custom domain for checkout. Please try again or contact support for assistance.</string>
     <string name="new_site_creation_preview_caption_paid">It may take up to 30 minutes for your custom domain to start working.</string>
     <string name="new_site_creation_preview_subtitle_paid">We’ve emailed your receipt. %s</string>
@@ -635,7 +634,6 @@ Language: en_CA
     <string name="help_buttons_screen_title">Help</string>
     <string name="free">Free</string>
     <string name="logs_button">Logs</string>
-    <string name="site_creation_domain_tag_sale">Sale</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="tickets">Tickets</string>
     <string name="site_creation_domain_tag_recommended">Recommended</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -949,7 +949,6 @@ Language: en_GB
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Search with keywords</string>
     <string name="site_creation_domain_header_subtitle">Search for a short and memorable domain to help people find and visit your site.</string>
-    <string name="site_creation_domain_cost_sale">for the first year</string>
     <string name="site_creation_error_cart_subtitle">Your website has been created successfully, but we encountered an issue while preparing your custom domain for checkout. Please try again or contact support for assistance.</string>
     <string name="new_site_creation_preview_caption_paid">It may take up to 30 minutes for your custom domain to start working.</string>
     <string name="new_site_creation_preview_subtitle_paid">We’ve emailed your receipt. %s</string>
@@ -1013,7 +1012,6 @@ Language: en_GB
     <string name="blaze_promotional_text">Drive more traffic to your site with Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">This domain is already registered</string>
-    <string name="site_creation_domain_tag_sale">Sale</string>
     <string name="site_creation_domain_tag_recommended">Recommended</string>
     <string name="site_creation_domain_tag_best_alternative">Best Alternative</string>
     <string name="support_faq_caption">See our FAQ for answers to common questions you may have.</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -468,7 +468,6 @@ Language: es_CL
     <string name="site_creation_search_domain_example_title">Elnombredetuweb.com</string>
     <string name="new_site_creation_preview_caption_paid">Puede tardar hasta 30 minutos en que tu dominio personalizado empiece a funcionar.</string>
     <string name="new_site_creation_preview_subtitle_paid">Te hemos mandado tu recibo por correo electrónico. %s</string>
-    <string name="site_creation_domain_cost_sale">el primer año</string>
     <string name="site_creation_domain_header_subtitle">Busca una dominio corto y memorable para ayudar a la gente a encontrar y visitar tu sitio.</string>
     <string name="site_creation_domain_search_input_hint">Buscar con palabras clave</string>
     <string name="site_creation_error_cart_subtitle">Tu web ha sido creada con éxito, pero hemos encontrado un problema al preparar tu dominio personalizado al finalizar la compra. Por favor, inténtalo otra vez o contacta con nuestro soporte para obtener ayuda.</string>
@@ -536,7 +535,6 @@ Language: es_CL
     <string name="logs_button">Registros</string>
     <string name="site_creation_domain_tag_best_alternative">Mejor alternativa</string>
     <string name="site_creation_domain_tag_recommended">Recomendado</string>
-    <string name="site_creation_domain_tag_sale">Oferta</string>
     <string name="site_creation_domain_tag_unavailable">Este dominio ya está registrado</string>
     <string name="support_faq_caption">Con nuestras preguntas frecuentes podrás resolver algunas de tus dudas.</string>
     <string name="support_faq_title">¡Gracias por cambiar a la aplicación Jetpack!</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -949,7 +949,6 @@ Language: es_CO
     <string name="site_creation_search_domain_example_title">Elnombredetuweb.com</string>
     <string name="site_creation_domain_search_input_hint">Buscar con palabras clave</string>
     <string name="site_creation_domain_header_subtitle">Busca una dominio corto y memorable para ayudar a la gente a encontrar y visitar tu sitio.</string>
-    <string name="site_creation_domain_cost_sale">el primer año</string>
     <string name="site_creation_error_cart_subtitle">Tu web ha sido creada con éxito, pero hemos encontrado un problema al preparar tu dominio personalizado al finalizar la compra. Por favor, inténtalo otra vez o contacta con nuestro soporte para obtener ayuda.</string>
     <string name="new_site_creation_preview_caption_paid">Puede tardar hasta 30 minutos en que tu dominio personalizado empiece a funcionar.</string>
     <string name="new_site_creation_preview_subtitle_paid">Te hemos mandado tu recibo por correo electrónico. %s</string>
@@ -1013,7 +1012,6 @@ Language: es_CO
     <string name="blaze_promotional_text">Genera más tráfico hacia tu sitio con Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Este dominio ya está registrado</string>
-    <string name="site_creation_domain_tag_sale">Oferta</string>
     <string name="site_creation_domain_tag_recommended">Recomendado</string>
     <string name="site_creation_domain_tag_best_alternative">Mejor alternativa</string>
     <string name="support_faq_caption">Con nuestras preguntas frecuentes podrás resolver algunas de tus dudas.</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -949,7 +949,6 @@ Language: es
     <string name="site_creation_search_domain_example_title">Elnombredetuweb.com</string>
     <string name="site_creation_domain_search_input_hint">Buscar con palabras clave</string>
     <string name="site_creation_domain_header_subtitle">Busca una dominio corto y memorable para ayudar a la gente a encontrar y visitar tu sitio.</string>
-    <string name="site_creation_domain_cost_sale">el primer año</string>
     <string name="site_creation_error_cart_subtitle">Tu web ha sido creada con éxito, pero hemos encontrado un problema al preparar tu dominio personalizado al finalizar la compra. Por favor, inténtalo otra vez o contacta con nuestro soporte para obtener ayuda.</string>
     <string name="new_site_creation_preview_caption_paid">Puede tardar hasta 30 minutos en que tu dominio personalizado empiece a funcionar.</string>
     <string name="new_site_creation_preview_subtitle_paid">Te hemos mandado tu recibo por correo electrónico. %s</string>
@@ -1013,7 +1012,6 @@ Language: es
     <string name="blaze_promotional_text">Genera más tráfico hacia tu sitio con Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Este dominio ya está registrado</string>
-    <string name="site_creation_domain_tag_sale">Oferta</string>
     <string name="site_creation_domain_tag_recommended">Recomendado</string>
     <string name="site_creation_domain_tag_best_alternative">Mejor alternativa</string>
     <string name="support_faq_caption">Con nuestras preguntas frecuentes podrás resolver algunas de tus dudas.</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -923,7 +923,6 @@ Language: fr
     <string name="site_creation_search_domain_example_title">NomDeVotreSite.com</string>
     <string name="site_creation_domain_search_input_hint">Effectuer une recherche à l’aide de mots-clés</string>
     <string name="site_creation_domain_header_subtitle">Recherchez un domaine court et facile à retenir pour aider les internautes à trouver et visiter votre site.</string>
-    <string name="site_creation_domain_cost_sale">la première année</string>
     <string name="site_creation_error_cart_subtitle">Votre site Web a été créé, mais nous avons rencontré un problème lors de la préparation de votre domaine personnalisé pour la validation de la commande. Réessayez ou contactez l’assistance pour obtenir de l’aide.</string>
     <string name="new_site_creation_preview_caption_paid">Un délai de 30 minutes peut être nécessaire pour que votre domaine personnalisé soit opérationnel.</string>
     <string name="new_site_creation_preview_subtitle_paid">Nous vous avons envoyé le reçu par e-mail. %s</string>
@@ -987,7 +986,6 @@ Language: fr
     <string name="blaze_promotional_text">Améliorer le trafic sur votre site avec Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Ce nom de domaine est déjà enregistré.</string>
-    <string name="site_creation_domain_tag_sale">Promo</string>
     <string name="site_creation_domain_tag_recommended">Recommandé</string>
     <string name="site_creation_domain_tag_best_alternative">Meilleure alternative</string>
     <string name="support_faq_caption">Notre FAQ comporte les réponses aux questions fréquentes que vous vous posez peut-être.</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -923,7 +923,6 @@ Language: fr
     <string name="site_creation_search_domain_example_title">NomDeVotreSite.com</string>
     <string name="site_creation_domain_search_input_hint">Effectuer une recherche à l’aide de mots-clés</string>
     <string name="site_creation_domain_header_subtitle">Recherchez un domaine court et facile à retenir pour aider les internautes à trouver et visiter votre site.</string>
-    <string name="site_creation_domain_cost_sale">la première année</string>
     <string name="site_creation_error_cart_subtitle">Votre site Web a été créé, mais nous avons rencontré un problème lors de la préparation de votre domaine personnalisé pour la validation de la commande. Réessayez ou contactez l’assistance pour obtenir de l’aide.</string>
     <string name="new_site_creation_preview_caption_paid">Un délai de 30 minutes peut être nécessaire pour que votre domaine personnalisé soit opérationnel.</string>
     <string name="new_site_creation_preview_subtitle_paid">Nous vous avons envoyé le reçu par e-mail. %s</string>
@@ -987,7 +986,6 @@ Language: fr
     <string name="blaze_promotional_text">Améliorer le trafic sur votre site avec Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Ce nom de domaine est déjà enregistré.</string>
-    <string name="site_creation_domain_tag_sale">Promo</string>
     <string name="site_creation_domain_tag_recommended">Recommandé</string>
     <string name="site_creation_domain_tag_best_alternative">Meilleure alternative</string>
     <string name="support_faq_caption">Notre FAQ comporte les réponses aux questions fréquentes que vous vous posez peut-être.</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -603,7 +603,6 @@ Language: gl_ES
     <string name="site_creation_search_domain_example_title">ONomeDaTuaWeb.com</string>
     <string name="gutenberg_native_unlabeled_color_s" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Cor sen etiquetar. %s</string>
     <string name="site_creation_search_domain_example_body">Como no exemplo superior, un dominio permítelle á xente encontrar e visitar o teu sitio desde o seu navegador.</string>
-    <string name="site_creation_domain_cost_sale">o primeiro ano</string>
     <string name="site_creation_domain_search_input_hint">Buscar con palabras clave</string>
     <string name="new_site_creation_preview_subtitle_paid">Enviámosche o teu recibo por correo electrónico. %s</string>
     <string name="new_site_creation_preview_caption_paid">Pode tardar ata 30 minutos en que o teu dominio personalizado empece a funcionar.</string>
@@ -664,7 +663,6 @@ Language: gl_ES
     <string name="blaze_overlay_site_promotional_button">Promover unha entrada con Blaze agora</string>
     <string name="blaze_overlay_page_promotional_button">Promover esta páxina con Blaze</string>
     <string name="blaze_overlay_post_promotional_button">Promover esta entrada con Blaze</string>
-    <string name="site_creation_domain_tag_sale">Oferta</string>
     <string name="site_creation_domain_tag_recommended">Recomendado</string>
     <string name="site_creation_domain_tag_best_alternative">Mellor alternativa</string>
     <string name="blaze_promotional_subtitle_2">O teu contido aparecerá en millóns de sitios de WordPress e Tumblr.</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -936,7 +936,6 @@ Language: he_IL
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">לחפש באמצעות מילות מפתח</string>
     <string name="site_creation_domain_header_subtitle">כדאי לחפש דומיין קצר וקליט כדי לעזור לאנשים למצוא את האתר שלך ולבקר בו.</string>
-    <string name="site_creation_domain_cost_sale">בשנה הראשונה</string>
     <string name="site_creation_error_cart_subtitle">האתר שלך נוצר בהצלחה, אבל נתקלנו בבעיה במהלך ההכנה של הדומיין האישי שלך לתשלום בקופה. יש לנסות שוב או לפנות לתמיכה לעזרה.</string>
     <string name="new_site_creation_preview_caption_paid">יידרשו עד 30 דקות להתחלת הפעילות של הדומיין האישי.</string>
     <string name="new_site_creation_preview_subtitle_paid">שלחנו את הקבלה שלך באימייל. %s</string>
@@ -1000,7 +999,6 @@ Language: he_IL
     <string name="blaze_promotional_text">לקבל תעבודה גדולה יותר לאתר שלך בעזרת Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">הדומיין הזה כבר רשום.</string>
-    <string name="site_creation_domain_tag_sale">מבצע</string>
     <string name="site_creation_domain_tag_recommended">מומלץ</string>
     <string name="site_creation_domain_tag_best_alternative">החלופה הטובה ביותר</string>
     <string name="support_faq_caption">כדאי לעיין בשאלות הנפוצות שלנו כדי למצוא מענה על כמה מהשאלות הרגילות שאולי יהיו לך.</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -938,7 +938,6 @@ Language: id
     <string name="site_creation_search_domain_example_title">NamaSitusAnda.com</string>
     <string name="site_creation_domain_search_input_hint">Cari dengan kata kunci</string>
     <string name="site_creation_domain_header_subtitle">Cari domain yang pendek dan mudah diingat agar siapa pun mudah menemukan dan mengunjungi situs Anda.</string>
-    <string name="site_creation_domain_cost_sale">untuk tahun pertama</string>
     <string name="site_creation_error_cart_subtitle">Situs web Anda berhasil dibuat, namun kami menemukan kendala saat menyiapkan domain khusus Anda selama checkout. Mohon coba lagi atau hubungi bantuan jika diperlukan.</string>
     <string name="new_site_creation_preview_caption_paid">Diperlukan 30 menit agar domain khusus Anda dapat berfungsi.</string>
     <string name="new_site_creation_preview_subtitle_paid">Kami telah mengirim e-mail resi Anda. %s</string>
@@ -1002,7 +1001,6 @@ Language: id
     <string name="blaze_promotional_text">Tingkatkan jumlah pengunjung situs Anda dengan Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Domain ini sudah terdaftar</string>
-    <string name="site_creation_domain_tag_sale">Obral</string>
     <string name="site_creation_domain_tag_recommended">Disarankan</string>
     <string name="site_creation_domain_tag_best_alternative">Alternatif Terbaik</string>
     <string name="support_faq_caption">Tanya Jawab Umum akan menjawab berbagai pertanyaan yang umum diajukan.</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -949,7 +949,6 @@ Language: it
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Cerca con le parole chiave</string>
     <string name="site_creation_domain_header_subtitle">Cerca un dominio breve e facile da ricordare per aiutare gli utenti a trovare e visitare il tuo sito.</string>
-    <string name="site_creation_domain_cost_sale">per il primo anno</string>
     <string name="site_creation_error_cart_subtitle">Il tuo sito web è stato creato correttamente, ma abbiamo riscontrato un problema durante la preparazione del dominio personalizzato per il pagamento. Prova di nuovo o contatta il supporto per ricevere assistenza.</string>
     <string name="new_site_creation_preview_caption_paid">Potrebbero essere necessari fino a 30 minuti prima che il tuo dominio personalizzato inizi a funzionare.</string>
     <string name="new_site_creation_preview_subtitle_paid">Ti abbiamo inviato la ricevuta tramite email. %s</string>
@@ -1013,7 +1012,6 @@ Language: it
     <string name="blaze_promotional_text">Attira più traffico sul tuo sito con Blaze</string>
     <string name="blaze_activity_title">Diffondi</string>
     <string name="site_creation_domain_tag_unavailable">Questo dominio è già registrato</string>
-    <string name="site_creation_domain_tag_sale">Offerta</string>
     <string name="site_creation_domain_tag_recommended">Consigliato</string>
     <string name="site_creation_domain_tag_best_alternative">Alternativa migliore</string>
     <string name="support_faq_caption">Consulta le domande frequenti per ricevere risposte ai dubbi più comuni che potresti avere.</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -929,7 +929,6 @@ Language: ja_JP
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">キーワードで検索</string>
     <string name="site_creation_domain_header_subtitle">ユーザーがあなたのサイトを探してアクセスしやすくなる、短く覚えやすいドメインを検索します。</string>
-    <string name="site_creation_domain_cost_sale">最初の年</string>
     <string name="site_creation_error_cart_subtitle">サイトは正常に作成されましたが、カスタムドメインの購入手続きの準備中に問題が発生しました。 もう一度お試しいただくか、ヘルプが必要な場合はサポートにご連絡ください。</string>
     <string name="new_site_creation_preview_caption_paid">カスタムドメインが使用可能になるまでに最長30分かかる場合があります。</string>
     <string name="new_site_creation_preview_subtitle_paid">領収書をメールで送信しました。 %s</string>
@@ -993,7 +992,6 @@ Language: ja_JP
     <string name="blaze_promotional_text">Blaze でサイトのトラフィックを増やす</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">このドメインはすでに登録されています</string>
-    <string name="site_creation_domain_tag_sale">セール</string>
     <string name="site_creation_domain_tag_recommended">おすすめ</string>
     <string name="site_creation_domain_tag_best_alternative">こちらもおすすめ</string>
     <string name="support_faq_caption">FAQ でよくある質問に対する回答をご確認ください。</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -940,7 +940,6 @@ Language: ko_KR
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">키워드로 검색</string>
     <string name="site_creation_domain_header_subtitle">사용자가 사이트를 찾고 방문하는 데 도움이 되는 짧고 기억하기 쉬운 도메인을 검색하세요.</string>
-    <string name="site_creation_domain_cost_sale">첫해 동안</string>
     <string name="site_creation_error_cart_subtitle">웹사이트가 생성되었지만, 체크아웃용 사용자 정의 도메인을 준비하는 동안 문제가 발생했습니다. 다시 시도하거나 지원팀에 도움을 문의하세요.</string>
     <string name="new_site_creation_preview_caption_paid">사용자 정의 도메인이 작동하기 시작하려면 30분 정도 걸릴 수 있습니다.</string>
     <string name="new_site_creation_preview_subtitle_paid">영수증을 이메일로 보내드렸습니다. %s</string>
@@ -1004,7 +1003,6 @@ Language: ko_KR
     <string name="blaze_promotional_text">Blaze를 통해 사이트에 더 많은 트래픽 유도</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">이 도메인은 이미 등록되었습니다.</string>
-    <string name="site_creation_domain_tag_sale">세일</string>
     <string name="site_creation_domain_tag_recommended">권장</string>
     <string name="site_creation_domain_tag_best_alternative">최선의 대안</string>
     <string name="support_faq_caption">궁금할 수도 있는 일반적인 질문에 대한 답변은 FAQ를 참조하세요.</string>

--- a/WordPress/src/main/res/values-lv/strings.xml
+++ b/WordPress/src/main/res/values-lv/strings.xml
@@ -489,7 +489,6 @@ Language: lv
     <string name="new_site_creation_preview_subtitle_paid">Mēs nosūtījām jūsu kvīti pa e-pastu. %s</string>
     <string name="new_site_creation_preview_caption_paid">Var paiet līdz 30 minūtēm, līdz jūsu pielāgotais domēns sāks darboties.</string>
     <string name="site_creation_error_cart_subtitle">Jūsu vietne ir veiksmīgi izveidota, taču, sagatavojot jūsu pielāgoto domēnu norēķiniem, radās problēma. Lūdzu, mēģiniet vēlreiz vai sazinieties ar atbalsta dienestu, lai saņemtu palīdzību.</string>
-    <string name="site_creation_domain_cost_sale">pirmo gadu</string>
     <string name="site_creation_domain_header_subtitle">Meklējiet īsu un neaizmirstamu domēnu, lai palīdzētu cilvēkiem atrast un apmeklēt jūsu vietni.</string>
     <string name="site_creation_domain_search_input_hint">Meklējiet ar atslēgvārdiem</string>
     <string name="notifications_disabled_permission_dialog">Lietotņu paziņojumi ir atspējoti. Pieskarieties šeit, lai tos iespējotu.</string>
@@ -555,7 +554,6 @@ Language: lv
     <string name="support_faq_caption">Atbildes uz bieži uzdotajiem jautājumiem skatiet mūsu BUJ.</string>
     <string name="site_creation_domain_tag_best_alternative">Labākā alternatīva</string>
     <string name="site_creation_domain_tag_recommended">Ieteicams</string>
-    <string name="site_creation_domain_tag_sale">Izpārdošana</string>
     <string name="site_creation_domain_tag_unavailable">Šis domēns jau ir reģistrēts</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="blaze_promotional_text">Palieliniet datplūsmu uz savu vietni, izmantojot Blaze</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -949,7 +949,6 @@ Language: nl
     <string name="site_creation_search_domain_example_title">JeSiteNaam.com</string>
     <string name="site_creation_domain_search_input_hint">Zoeken met keywords</string>
     <string name="site_creation_domain_header_subtitle">Zoek een kort en gedenkwaardig domein om mensen te helpen je site te vinden en te bezoeken.</string>
-    <string name="site_creation_domain_cost_sale">voor het eerste jaar</string>
     <string name="site_creation_error_cart_subtitle">Je site is aangemaakt, maar er is een probleem opgetreden bij het afrekenen van je aangepaste domein. Probeer het nog eens of neem contact met ons op voor hulp.</string>
     <string name="new_site_creation_preview_caption_paid">Het kan tot 30 minuten duren voor je aangepaste domein werkt.</string>
     <string name="new_site_creation_preview_subtitle_paid">We hebben je betalingsbewijs naar je gemaild. %s</string>
@@ -1013,7 +1012,6 @@ Language: nl
     <string name="blaze_promotional_text">Zorg dat meer mensen je site bezoeken met Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Dit domein is al geregistreerd</string>
-    <string name="site_creation_domain_tag_sale">Aanbieding!</string>
     <string name="site_creation_domain_tag_recommended">Aanbevolen</string>
     <string name="site_creation_domain_tag_best_alternative">Beste alternatief</string>
     <string name="support_faq_caption">Bekijk onze FAQ voor antwoorden op veelgestelde vragen die je misschien hebt.</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -949,7 +949,6 @@ Language: pl
     <string name="site_creation_search_domain_example_title">NazwaTwojejDomeny.com</string>
     <string name="site_creation_domain_search_input_hint">Szukaj za pomocą słów kluczowych</string>
     <string name="site_creation_domain_header_subtitle">Szukaj krótkiej i zapadającej w pamięć nazwy domeny, żeby pomóc ludziom znaleźć i przejść na twoją witrynę.</string>
-    <string name="site_creation_domain_cost_sale">za pierwszy rok</string>
     <string name="site_creation_error_cart_subtitle">Twoja witryna internetowa została pomyślnie stworzona, ale napotkaliśmy problem podczas przygotowywania twojej własnej domeny do zakupu. Spróbuj ponownie lub skontaktuj się z pomocą techniczną w celu uzyskania pomocy.</string>
     <string name="new_site_creation_preview_caption_paid">Rozpoczęcie prawidłowego działania domeny może potrwać około 30 minut.</string>
     <string name="new_site_creation_preview_subtitle_paid">Wysłaliśmy tobie wiadomość email z paragonem. %s</string>
@@ -1013,7 +1012,6 @@ Language: pl
     <string name="blaze_promotional_text">Zwiększ ruch na swojej stronie dzięki Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Ta domena jest już zarejestrowana</string>
-    <string name="site_creation_domain_tag_sale">Promocja</string>
     <string name="site_creation_domain_tag_recommended">Polecane</string>
     <string name="site_creation_domain_tag_best_alternative">Najlepsza alternatywa</string>
     <string name="support_faq_caption">Odpowiedzi na najczęstsze pytania znajdziesz w naszej sekcji FAQ.</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -644,7 +644,6 @@ Language: pt_BR
     <string name="site_creation_search_domain_example_title">NomeDoSite.com</string>
     <string name="site_creation_domain_search_input_hint">Pesquise com palavras-chave</string>
     <string name="site_creation_domain_header_subtitle">Pesquise um domínio curto mas marcante para ajudar as pessoas a encontrar e visitar seu site.</string>
-    <string name="site_creation_domain_cost_sale">no primeiro ano</string>
     <string name="site_creation_error_cart_subtitle">Seu site foi criado com sucesso, mas encontramos um problema ao preparar seu domínio personalizado para o checkout. Tente novamente ou entre em contato com o suporte para obter ajuda.</string>
     <string name="new_site_creation_preview_caption_paid">Pode levar até 30 minutos para o domínio personalizado começar a funcionar.</string>
     <string name="new_site_creation_preview_subtitle_paid">Enviamos o recibo por e-mail. %s</string>
@@ -708,7 +707,6 @@ Language: pt_BR
     <string name="blaze_promotional_text">Atraia mais tráfego para seu site com Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Este domínio já está registrado</string>
-    <string name="site_creation_domain_tag_sale">Promoção</string>
     <string name="site_creation_domain_tag_recommended">Recomendado</string>
     <string name="site_creation_domain_tag_best_alternative">Melhor alternativa</string>
     <string name="support_faq_caption">Nossas Perguntas Frequentes podem responder algumas de suas dúvidas.</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -947,7 +947,6 @@ Language: ro
     <string name="site_creation_search_domain_example_body">La fel ca în exemplul de mai sus, un domeniu le permite oamenilor să-ți găsească și să-ți viziteze site-ul din navigatoarele lor web.</string>
     <string name="dashboard_activity_card_title">Activitate recentă</string>
     <string name="gutenberg_native_unlabeled_color_s" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Culoare fără etichetă. %s</string>
-    <string name="site_creation_domain_cost_sale">în primul an</string>
     <string name="new_site_creation_preview_caption_paid">Poate să dureze până la 30 de minute până când domeniul tău personalizat va începe să funcționeze.</string>
     <string name="site_creation_domain_search_input_hint">Caută după cuvinte cheie</string>
     <string name="new_site_creation_preview_subtitle_paid">Ți-am trimis chitanța prin email. %s</string>
@@ -1016,7 +1015,6 @@ Language: ro
     <string name="support_faq_caption">Vezi întrebările frecvente pentru răspunsuri la întrebările pe care le ai.</string>
     <string name="site_creation_domain_tag_best_alternative">Cea mai bună alternativă</string>
     <string name="site_creation_domain_tag_recommended">Recomandat</string>
-    <string name="site_creation_domain_tag_sale">Reducere</string>
     <string name="site_creation_domain_tag_unavailable">Acest domeniu este deja înregistrat</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="blaze_promotional_text">Cu Blaze, aduci mai mult trafic pe site</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -949,7 +949,6 @@ Language: ru
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Поиск по ключевым словам</string>
     <string name="site_creation_domain_header_subtitle">Выберите короткий и запоминающийся домен, который поможет посетителям найти ваш сайт.</string>
-    <string name="site_creation_domain_cost_sale">на первый год</string>
     <string name="site_creation_error_cart_subtitle">Веб-сайт создан, но возникла проблема с подготовкой пользовательского домена для оформления заказа. Повторите попытку или обратитесь в службу поддержки.</string>
     <string name="new_site_creation_preview_caption_paid">Это может занять до 30 минут, после чего пользовательский домен начнёт работать.</string>
     <string name="new_site_creation_preview_subtitle_paid">Чек отправлен вам на почту. %s</string>
@@ -1013,7 +1012,6 @@ Language: ru
     <string name="blaze_promotional_text">Повысьте посещаемость своего сайта с помощью Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Этот домен уже зарегистрирован</string>
-    <string name="site_creation_domain_tag_sale">Распродажа</string>
     <string name="site_creation_domain_tag_recommended">Рекомендуемые</string>
     <string name="site_creation_domain_tag_best_alternative">Лучшая альтернатива</string>
     <string name="support_faq_caption">Ищите ответы на типовые вопросы в разделе \"Часто задаваемые вопросы\".</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -843,7 +843,6 @@ Language: sq_AL
     <string name="site_creation_search_domain_example_title">EmriiSajtitTuaj.com</string>
     <string name="site_creation_domain_search_input_hint">Kërkoni me fjalëkyçe</string>
     <string name="site_creation_domain_header_subtitle">Kërkoni për një përkatësi të shkurtër dhe që mund të mbahet mend, për t’i ndihmuar njerëzit të gjejnë dhe vizitojnë sajtin tuaj.</string>
-    <string name="site_creation_domain_cost_sale">për vitin e parë</string>
     <string name="site_creation_error_cart_subtitle">Sajti juaj është krijuar me sukses, por hasëm një problem, teksa përgatisnim përkatësinë tuaj vetjake për blerje. Ju lutemi, riprovoni, ose lidhuni me asistencën për ndihmë.</string>
     <string name="new_site_creation_preview_caption_paid">Mund të duhen deri në 30 minuta që përkatësia juaj vetjake të fillojë të funksionojë.</string>
     <string name="new_site_creation_preview_subtitle_paid">Ju dërguam faturën tuaj me email. %s</string>
@@ -906,7 +905,6 @@ Language: sq_AL
     <string name="blaze_promotional_subtitle_1">Promovoni çfarëdo postimi ose faqeje, brenda pak minutash, për vetëm pak dollarë në ditë.</string>
     <string name="blaze_promotional_text">Shpini më tepër trafik te sajti juaj, përmes Blaze-it</string>
     <string name="site_creation_domain_tag_unavailable">Kjo përkatësi është e regjistruar tashmë</string>
-    <string name="site_creation_domain_tag_sale">Ulje çmimesh</string>
     <string name="site_creation_domain_tag_recommended">E rekomanduar</string>
     <string name="site_creation_domain_tag_best_alternative">Alternativa Më e Mirë</string>
     <string name="support_faq_caption">Për përgjigje pyetjesh të rëndomta që mund të keni, shihni PBR-të tona.</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -949,7 +949,6 @@ Language: sv_SE
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">Sök med nyckelord</string>
     <string name="site_creation_domain_header_subtitle">Leta efter en kort domän som är lätt att komma ihåg för att hjälpa människor hitta och besöka din webbplats.</string>
-    <string name="site_creation_domain_cost_sale">för första året</string>
     <string name="site_creation_error_cart_subtitle">Din webbplats har skapats, men vi stötte på ett problem när vi skulle förbereda din anpassade domän för betalning. Försök igen eller kontakta supporten för hjälp.</string>
     <string name="new_site_creation_preview_caption_paid">Det kan dröja upp till 30 minuter innan din anpassade domän börjar fungera.</string>
     <string name="new_site_creation_preview_subtitle_paid">Vi har skickat ditt kvitto via e-post. %s</string>
@@ -1013,7 +1012,6 @@ Language: sv_SE
     <string name="blaze_promotional_text">Få mer trafik till din webbplats med Blaze</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Denna domän är redan registrerad</string>
-    <string name="site_creation_domain_tag_sale">Rea</string>
     <string name="site_creation_domain_tag_recommended">Rekommenderat</string>
     <string name="site_creation_domain_tag_best_alternative">Bästa alternativ</string>
     <string name="support_faq_caption">Se våra vanliga frågor för svar på vanliga frågor du kan ha.</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -949,7 +949,6 @@ Language: tr
     <string name="site_creation_search_domain_example_title">SitenizinAdi.com</string>
     <string name="site_creation_domain_search_input_hint">Anahtar sözcük ile arayın</string>
     <string name="site_creation_domain_header_subtitle">Kişilerin sitenizi bulmasına ve ziyaret etmesine yardımcı olacak kısa ve akılda kalıcı bir etki alanı arayın.</string>
-    <string name="site_creation_domain_cost_sale">ilk yıl için</string>
     <string name="site_creation_error_cart_subtitle">Siteniz oluşturuldu, ancak özel etki alanınızın ödemesini hazırlarken bir sorunla karşılaştık. Lütfen yeniden deneyin ya da yardım almak için destek ekibine başvurun.</string>
     <string name="new_site_creation_preview_caption_paid">Özel etki alanınızın çalışmaya başlaması 30 dakika kadar sürebilir.</string>
     <string name="new_site_creation_preview_subtitle_paid">Alındınızı e-posta ile gönderdik. %s</string>
@@ -1013,7 +1012,6 @@ Language: tr
     <string name="blaze_promotional_text">Blaze ile sitenize daha fazla trafik çekin</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">Bu etki alanı zaten kaydedilmiş</string>
-    <string name="site_creation_domain_tag_sale">İndirim</string>
     <string name="site_creation_domain_tag_recommended">Önerilen</string>
     <string name="site_creation_domain_tag_best_alternative">En iyi alternatif</string>
     <string name="support_faq_caption">Sık sorulan soruların yanıtları için SSS bölümümüze bakın.</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -944,7 +944,6 @@ Language: zh_CN
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">使用关键字搜索</string>
     <string name="site_creation_domain_header_subtitle">搜索一个简短易记的域名，以帮助访客找到并访问您的站点。</string>
-    <string name="site_creation_domain_cost_sale">第一年</string>
     <string name="site_creation_error_cart_subtitle">您的网站已成功创建，但我们在准备自定义域名以结账时遇到问题。 请重试或联系支持人员获取帮助。</string>
     <string name="new_site_creation_preview_caption_paid">最多可能需花费 30 分钟时间，您的自定义域名才能开始运行。</string>
     <string name="new_site_creation_preview_subtitle_paid">我们已将您的收据通过电子邮件发送给您。 %s</string>
@@ -1008,7 +1007,6 @@ Language: zh_CN
     <string name="blaze_promotional_text">通过 Blaze 为您的站点吸引更多流量</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">此域名已注册</string>
-    <string name="site_creation_domain_tag_sale">销售</string>
     <string name="site_creation_domain_tag_recommended">推荐</string>
     <string name="site_creation_domain_tag_best_alternative">更好的替代方案</string>
     <string name="support_faq_caption">查看我们的常见问题解答，为您可能遇到的常见问题寻找答案。</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -939,7 +939,6 @@ Language: zh_TW
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">透過關鍵字搜尋</string>
     <string name="site_creation_domain_header_subtitle">搜尋簡短好記的網域，有助於使用者找到並造訪你的網站。</string>
-    <string name="site_creation_domain_cost_sale">第一年</string>
     <string name="site_creation_error_cart_subtitle">你的網站已成功建立，但準備你的自訂網域以結帳時發生問題。 請再試一次，或聯絡支援團隊取得協助。</string>
     <string name="new_site_creation_preview_caption_paid">你的自訂網域最多可能需要 30 分鐘才能開始運作。</string>
     <string name="new_site_creation_preview_subtitle_paid">我們已將收據透過電子郵件傳送給你了。 %s</string>
@@ -1003,7 +1002,6 @@ Language: zh_TW
     <string name="blaze_promotional_text">使用 Blaze 為你的網站吸引更多流量</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">此網域已被註冊</string>
-    <string name="site_creation_domain_tag_sale">特價</string>
     <string name="site_creation_domain_tag_recommended">推薦</string>
     <string name="site_creation_domain_tag_best_alternative">最佳替代選項</string>
     <string name="support_faq_caption">請查看我們的常見問題集，瞭解你可能想知道的一般問題的解答。</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -939,7 +939,6 @@ Language: zh_TW
     <string name="site_creation_search_domain_example_title">YourSiteName.com</string>
     <string name="site_creation_domain_search_input_hint">透過關鍵字搜尋</string>
     <string name="site_creation_domain_header_subtitle">搜尋簡短好記的網域，有助於使用者找到並造訪你的網站。</string>
-    <string name="site_creation_domain_cost_sale">第一年</string>
     <string name="site_creation_error_cart_subtitle">你的網站已成功建立，但準備你的自訂網域以結帳時發生問題。 請再試一次，或聯絡支援團隊取得協助。</string>
     <string name="new_site_creation_preview_caption_paid">你的自訂網域最多可能需要 30 分鐘才能開始運作。</string>
     <string name="new_site_creation_preview_subtitle_paid">我們已將收據透過電子郵件傳送給你了。 %s</string>
@@ -1003,7 +1002,6 @@ Language: zh_TW
     <string name="blaze_promotional_text">使用 Blaze 為你的網站吸引更多流量</string>
     <string name="blaze_activity_title">Blaze</string>
     <string name="site_creation_domain_tag_unavailable">此網域已被註冊</string>
-    <string name="site_creation_domain_tag_sale">特價</string>
     <string name="site_creation_domain_tag_recommended">推薦</string>
     <string name="site_creation_domain_tag_best_alternative">最佳替代選項</string>
     <string name="support_faq_caption">請查看我們的常見問題集，瞭解你可能想知道的一般問題的解答。</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3713,11 +3713,9 @@
     <string name="new_site_creation_site_name_header_subtitle">A good name is short and memorable.\nYou can change it later.</string>
 
     <!-- Site Creation : Domains -->
-    <string name="site_creation_domain_cost_sale">for the first year</string>
     <string name="site_creation_domain_free_with_annual_plan">Free for the first year with annual paid plans</string>
     <string name="site_creation_domain_tag_best_alternative">Best Alternative</string>
     <string name="site_creation_domain_tag_recommended">Recommended</string>
-    <string name="site_creation_domain_tag_sale">Sale</string>
     <string name="site_creation_domain_tag_unavailable">This domain is already registered</string>
     <string name="site_creation_domain_button_purchase_domain">Purchase domain</string>
     <string name="site_creation_domain_button_continue_with_subdomain">Continue with subdomain</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -224,7 +224,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponse() = test {
         val errorQuery = "error_result_query"
         whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any())).thenReturn(
-            FetchDomainsResult.Error
+            FetchDomainsResult.Error(type = "empty_query", message = "Query is empty")
         )
 
         viewModel.start()
@@ -240,6 +240,20 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         )
         assertThat(captor.thirdValue.contentState.items[0])
             .isInstanceOf(Old.ErrorItemUiState::class.java)
+    }
+
+    @Test
+    fun `verify the api error type and message are tracked`() = test {
+        val errorQuery = "error_result_query"
+        whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any())).thenReturn(
+            FetchDomainsResult.Error(type = "empty_query", message = "Query is empty")
+        )
+
+        viewModel.start()
+        viewModel.onQueryChanged(errorQuery)
+        advanceUntilIdle()
+
+        verify(tracker).trackErrorShown("domains", "empty_query", "Query is empty")
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -224,7 +224,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponse() = test {
         val errorQuery = "error_result_query"
         whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any())).thenReturn(
-            FetchDomainsResult.Error(errorQuery)
+            FetchDomainsResult.Error
         )
 
         viewModel.start()
@@ -249,7 +249,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponseOfTypeInvalidQuery() = test {
         val invalidQuery = "empty_result_query_invalid"
         whenever(fetchDomainsUseCase.fetchDomains(eq(invalidQuery), any(), any())).thenReturn(
-            FetchDomainsResult.InvalidQuery(invalidQuery)
+            FetchDomainsResult.InvalidQuery
         )
 
         viewModel.start()
@@ -413,7 +413,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             }
         }
 
-        val result = FetchDomainsResult.Success(query, suggestions)
+        val result = FetchDomainsResult.Success(suggestions)
         whenever(fetchDomainsUseCase.fetchDomains(any(), any(), any()))
             .thenReturn(result)
         block(suggestions)
@@ -631,7 +631,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
                 )
             )
         }
-        return FetchDomainsResult.Success(queryResultSizePair.first, suggestions)
+        return FetchDomainsResult.Success(suggestions)
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -135,7 +135,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             whenever(mSiteCreationDomainSanitizer.sanitizeDomainQuery(any())).thenReturn(
                 createSanitizedDomainResult(isDomainAvailableInSuggestions)
             )
-            whenever(fetchDomainsUseCase.fetchDomains(eq(queryResultSizePair.first), any(), any(), any())).thenReturn(
+            whenever(fetchDomainsUseCase.fetchDomains(eq(queryResultSizePair.first), any(), any())).thenReturn(
                 createSuccessfulFetchResult(queryResultSizePair)
             )
             block()
@@ -223,7 +223,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     @Test
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponse() = test {
         val errorQuery = "error_result_query"
-        whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any(), any())).thenReturn(
+        whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any())).thenReturn(
             FetchDomainsResult.Error(errorQuery)
         )
 
@@ -248,7 +248,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     @Test
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponseOfTypeInvalidQuery() = test {
         val invalidQuery = "empty_result_query_invalid"
-        whenever(fetchDomainsUseCase.fetchDomains(eq(invalidQuery), any(), any(), any())).thenReturn(
+        whenever(fetchDomainsUseCase.fetchDomains(eq(invalidQuery), any(), any())).thenReturn(
             FetchDomainsResult.InvalidQuery(invalidQuery)
         )
 
@@ -346,7 +346,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             eq(MULTI_RESULT_DOMAIN_FETCH_QUERY.first),
             eq(FETCH_DOMAINS_VENDOR_DOT),
             eq(true),
-            eq(MULTI_RESULT_DOMAIN_FETCH_QUERY.second),
         )
     }
 
@@ -415,7 +414,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         }
 
         val result = FetchDomainsResult.Success(query, suggestions)
-        whenever(fetchDomainsUseCase.fetchDomains(any(), any(), any(), any()))
+        whenever(fetchDomainsUseCase.fetchDomains(any(), any(), any()))
             .thenReturn(result)
         block(suggestions)
     }
@@ -424,7 +423,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     @Test
     fun verifyFetchFreeAndPaidDomainsWhenPurchasingFeatureConfigIsEnabled() = testWithSuccessResultNewUi {
-        val (query, size) = MULTI_RESULT_DOMAIN_FETCH_QUERY
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -434,7 +433,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
             eq(query),
             eq(FETCH_DOMAINS_VENDOR_MOBILE),
             eq(false),
-            eq(size),
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
@@ -24,8 +23,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.CreateSiteButtonState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
@@ -42,8 +39,6 @@ import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsUseCase
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
-import rs.wordpress.api.kotlin.WpComApiClient
-import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.DomainSuggestion
 import uniffi.wp_api.FreeDomainSuggestion
 import uniffi.wp_api.PaidDomainSuggestion
@@ -52,22 +47,12 @@ import kotlin.test.assertIs
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = "multi_result_query" to MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
 private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = "empty_result_query" to 0
-private const val SALE_PRODUCTS_COUNT = 1
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var fetchDomainsUseCase: FetchDomainsUseCase
-
-    @Mock
-    private lateinit var wpComApiClientProvider: WpComApiClientProvider
-
-    @Mock
-    private lateinit var accountStore: AccountStore
-
-    @Mock
-    private lateinit var wpComApiClient: WpComApiClient
 
     @Mock
     lateinit var plansInSiteCreationFeatureConfig: PlansInSiteCreationFeatureConfig
@@ -97,15 +82,10 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        whenever(accountStore.accessToken).thenReturn("test-token")
-        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
-            .thenReturn(wpComApiClient)
         viewModel = SiteCreationDomainsViewModel(
             networkUtils = networkUtils,
             domainSanitizer = mSiteCreationDomainSanitizer,
             fetchDomainsUseCase = fetchDomainsUseCase,
-            wpComApiClientProvider = wpComApiClientProvider,
-            accountStore = accountStore,
             plansInSiteCreationFeatureConfig = plansInSiteCreationFeatureConfig,
             tracker = tracker,
             bgDispatcher = testDispatcher(),
@@ -372,14 +352,8 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     // region New UI
 
-    @Suppress("UNCHECKED_CAST")
     private fun testNewUi(block: suspend CoroutineScope.() -> Unit) = test {
         whenever(plansInSiteCreationFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(wpComApiClient.request<Any>(any()))
-            .thenReturn(
-                WpRequestResult.Success(emptyMap<String, Any>())
-                    as WpRequestResult<Any>
-            )
         block()
     }
 
@@ -449,14 +423,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `verify domain products are fetched only at first start`() = testNewUi {
-        viewModel.start()
-        viewModel.start()
-
-        verify(wpComApiClient).request<Any>(any())
-    }
-
-    @Test
     fun `verify create site button text changes when selecting a free domain`() = testNewUi {
         viewModel.start()
 
@@ -507,28 +473,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         assertThat(uiDomains).filteredOn { it.cost is Cost.Paid }.hasSameSizeAs(apiPaidDomains)
-    }
-
-    @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
-    fun `verify cost of sale domain results from api is 'OnSale'`() = testWithSuccessResultNewUi {
-        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
-        viewModel.start()
-
-        viewModel.onQueryChanged(query)
-        advanceUntilIdle()
-
-        assertThat(uiDomains).filteredOn { it.cost is Cost.OnSale }.hasSize(SALE_PRODUCTS_COUNT)
-    }
-
-    @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
-    fun `verify sale domain results from api have tag 'Sale'`() = testWithSuccessResultNewUi {
-        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
-        viewModel.start()
-
-        viewModel.onQueryChanged(query)
-        advanceUntilIdle()
-
-        assertThat(uiDomains.flatMap { it.tags }).filteredOn { it is Tag.Sale }.hasSize(SALE_PRODUCTS_COUNT)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -23,15 +23,15 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.model.products.Product
-import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
-import org.wordpress.android.fluxc.store.ProductsStore
-import org.wordpress.android.fluxc.store.ProductsStore.OnProductsFetched
-import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainError
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.FreeDomainSuggestion
+import uniffi.wp_api.PaidDomainSuggestion
+import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsResult
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.CreateSiteButtonState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
@@ -52,19 +52,24 @@ import kotlin.test.assertIs
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = "multi_result_query" to MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
 private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = "empty_result_query" to 0
-private val SALE_PRODUCTS = listOf(Product(productId = 3, saleCost = 1.0, currencyCode = "EUR"))
+// Sale products test is @Ignore'd — keeping placeholder for future use
+@Suppress("unused")
+private val SALE_PRODUCTS_COUNT = 1
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     @Mock
-    lateinit var dispatcher: Dispatcher
-
-    @Mock
     lateinit var fetchDomainsUseCase: FetchDomainsUseCase
 
     @Mock
-    private lateinit var productsStore: ProductsStore
+    private lateinit var wpComApiClientProvider: WpComApiClientProvider
+
+    @Mock
+    private lateinit var accountStore: AccountStore
+
+    @Mock
+    private lateinit var wpComApiClient: WpComApiClient
 
     @Mock
     lateinit var plansInSiteCreationFeatureConfig: PlansInSiteCreationFeatureConfig
@@ -94,12 +99,15 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        whenever(accountStore.accessToken).thenReturn("test-token")
+        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
+            .thenReturn(wpComApiClient)
         viewModel = SiteCreationDomainsViewModel(
             networkUtils = networkUtils,
             domainSanitizer = mSiteCreationDomainSanitizer,
-            dispatcher = dispatcher,
             fetchDomainsUseCase = fetchDomainsUseCase,
-            productsStore = productsStore,
+            wpComApiClientProvider = wpComApiClientProvider,
+            accountStore = accountStore,
             plansInSiteCreationFeatureConfig = plansInSiteCreationFeatureConfig,
             tracker = tracker,
             bgDispatcher = testDispatcher(),
@@ -128,7 +136,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
                 createSanitizedDomainResult(isDomainAvailableInSuggestions)
             )
             whenever(fetchDomainsUseCase.fetchDomains(eq(queryResultSizePair.first), any(), any(), any())).thenReturn(
-                createSuccessfulOnSuggestedDomains(queryResultSizePair)
+                createSuccessfulFetchResult(queryResultSizePair)
             )
             block()
         }
@@ -214,13 +222,13 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
      */
     @Test
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponse() = test {
-        val queryResultErrorPair = "error_result_query" to "GENERIC_ERROR"
-        whenever(fetchDomainsUseCase.fetchDomains(eq(queryResultErrorPair.first), any(), any(), any())).thenReturn(
-            createFailedOnSuggestedDomains(queryResultErrorPair)
+        val errorQuery = "error_result_query"
+        whenever(fetchDomainsUseCase.fetchDomains(eq(errorQuery), any(), any(), any())).thenReturn(
+            FetchDomainsResult.Error(errorQuery)
         )
 
         viewModel.start()
-        viewModel.onQueryChanged(queryResultErrorPair.first)
+        viewModel.onQueryChanged(errorQuery)
         advanceUntilIdle()
 
         val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
@@ -239,13 +247,13 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
      */
     @Test
     fun verifyNonEmptyUpdateQueryUiStateAfterErrorResponseOfTypeInvalidQuery() = test {
-        val queryResultErrorPair = "empty_result_query_invalid" to "INVALID_QUERY"
-        whenever(fetchDomainsUseCase.fetchDomains(eq(queryResultErrorPair.first), any(), any(), any())).thenReturn(
-            createFailedOnSuggestedDomains(queryResultErrorPair)
+        val invalidQuery = "empty_result_query_invalid"
+        whenever(fetchDomainsUseCase.fetchDomains(eq(invalidQuery), any(), any(), any())).thenReturn(
+            FetchDomainsResult.InvalidQuery(invalidQuery)
         )
 
         viewModel.start()
-        viewModel.onQueryChanged(queryResultErrorPair.first)
+        viewModel.onQueryChanged(invalidQuery)
         advanceUntilIdle()
 
         val captor = ArgumentCaptor.forClass(DomainsUiState::class.java)
@@ -353,31 +361,63 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
     // region New UI
 
+    @Suppress("UNCHECKED_CAST")
     private fun testNewUi(block: suspend CoroutineScope.() -> Unit) = test {
         whenever(plansInSiteCreationFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(
+                WpRequestResult.Success(emptyMap<String, Any>())
+                    as WpRequestResult<Any>
+            )
         block()
     }
 
     private fun <T> testWithSuccessResultNewUi(
         queryToSize: Pair<String, Int> = MULTI_RESULT_DOMAIN_FETCH_QUERY,
-        block: suspend CoroutineScope.(OnSuggestedDomains) -> T
+        block: suspend CoroutineScope.(List<DomainSuggestion>) -> T
     ) = testNewUi {
         val (query, size) = queryToSize
 
         val suggestions = List(size) {
-            DomainSuggestionResponse().apply {
-                domain_name = if (it == 0) query else "$query-$it.com"
-                is_free = it % 2 == 0
-                cost = if (is_free) "Free" else "$$it.00"
-                product_id = it
-                supports_privacy = !is_free
+            val name = if (it == 0) query else "$query-$it.com"
+            val isFree = it % 2 == 0
+            if (isFree) {
+                DomainSuggestion.Free(
+                    FreeDomainSuggestion(
+                        domainName = name,
+                        cost = "Free",
+                        isFree = true,
+                    )
+                )
+            } else {
+                DomainSuggestion.Paid(
+                    PaidDomainSuggestion(
+                        domainName = name,
+                        relevance = 0.0,
+                        supportsPrivacy = true,
+                        vendor = "donuts",
+                        matchReasons = emptyList(),
+                        maxRegYears = 10u,
+                        multiYearRegAllowed = true,
+                        productId = it.toULong(),
+                        productSlug = "domain_reg",
+                        cost = "$$it.00",
+                        renewCost = "$$it.00",
+                        renewRawPrice = (it * 100).toLong(),
+                        rawPrice = (it * 100).toLong(),
+                        currencyCode = "USD",
+                        saleCost = null,
+                        hstsRequired = null,
+                        policyNotices = emptyList(),
+                    )
+                )
             }
         }
 
-        val event = OnSuggestedDomains(query, suggestions)
-        whenever(fetchDomainsUseCase.fetchDomains(any(), any(), any(), any())).thenReturn(event)
-        block(event)
+        val result = FetchDomainsResult.Success(query, suggestions)
+        whenever(fetchDomainsUseCase.fetchDomains(any(), any(), any(), any()))
+            .thenReturn(result)
+        block(suggestions)
     }
 
     private val uiDomains get() = assertIs<List<New.DomainUiState>>(viewModel.uiState.value?.contentState?.items)
@@ -398,12 +438,13 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun `verify domain products are fetched only at first start`() = testNewUi {
         viewModel.start()
         viewModel.start()
 
-        verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))
+        verify(wpComApiClient).request<Any>(any())
     }
 
     @Test
@@ -426,18 +467,20 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
 
     @Test
-    fun `verify all domain results from api are visible`() = testWithSuccessResultNewUi { (query, results) ->
+    fun `verify all domain results from api are visible`() = testWithSuccessResultNewUi { suggestions ->
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
         advanceUntilIdle()
 
-        assertThat(uiDomains).hasSameSizeAs(results)
+        assertThat(uiDomains).hasSameSizeAs(suggestions)
     }
 
     @Test
-    fun `verify cost of free domain results from api is 'Free'`() = testWithSuccessResultNewUi { (query, results) ->
-        val apiFreeDomains = results.filter { it.is_free }
+    fun `verify cost of free domain results from api is 'Free'`() = testWithSuccessResultNewUi { suggestions ->
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
+        val apiFreeDomains = suggestions.filterIsInstance<DomainSuggestion.Free>()
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -447,8 +490,9 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `verify cost of paid domain results from api is 'Paid'`() = testWithSuccessResultNewUi { (query, results) ->
-        val apiPaidDomains = results.filter { !it.is_free }
+    fun `verify cost of paid domain results from api is 'Paid'`() = testWithSuccessResultNewUi { suggestions ->
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
+        val apiPaidDomains = suggestions.filterIsInstance<DomainSuggestion.Paid>()
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -458,31 +502,30 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
-    fun `verify cost of sale domain results from api is 'OnSale'`() = testWithSuccessResultNewUi { (query) ->
-        whenever(productsStore.fetchProducts(any())).thenReturn(OnProductsFetched(SALE_PRODUCTS))
-
+    fun `verify cost of sale domain results from api is 'OnSale'`() = testWithSuccessResultNewUi {
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
         advanceUntilIdle()
 
-        assertThat(uiDomains).filteredOn { it.cost is Cost.OnSale }.hasSameSizeAs(SALE_PRODUCTS)
+        assertThat(uiDomains).filteredOn { it.cost is Cost.OnSale }.hasSize(SALE_PRODUCTS_COUNT)
     }
 
     @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
-    fun `verify sale domain results from api have tag 'Sale'`() = testWithSuccessResultNewUi { (query) ->
-        whenever(productsStore.fetchProducts(any())).thenReturn(OnProductsFetched(SALE_PRODUCTS))
-
+    fun `verify sale domain results from api have tag 'Sale'`() = testWithSuccessResultNewUi {
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
         advanceUntilIdle()
 
-        assertThat(uiDomains.flatMap { it.tags }).filteredOn { it is Tag.Sale }.hasSameSizeAs(SALE_PRODUCTS)
+        assertThat(uiDomains.flatMap { it.tags }).filteredOn { it is Tag.Sale }.hasSize(SALE_PRODUCTS_COUNT)
     }
 
     @Test
-    fun `verify only 1st domain result from api is 'Recommended'`() = testWithSuccessResultNewUi { (query) ->
+    fun `verify only 1st domain result from api is 'Recommended'`() = testWithSuccessResultNewUi {
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -492,7 +535,8 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `verify only 2nd domain result from api is 'BestAlternative'`() = testWithSuccessResultNewUi { (query) ->
+    fun `verify only 2nd domain result from api is 'BestAlternative'`() = testWithSuccessResultNewUi {
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -502,7 +546,8 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `verify selected domain is propagated to UI on click`() = testWithSuccessResultNewUi { (query) ->
+    fun `verify selected domain is propagated to UI on click`() = testWithSuccessResultNewUi {
+        val query = MULTI_RESULT_DOMAIN_FETCH_QUERY.first
         viewModel.start()
 
         viewModel.onQueryChanged(query)
@@ -576,25 +621,19 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     /**
-     * Helper function that creates an [OnSuggestedDomains] event for the given query and number of results pair.
+     * Helper function that creates a [FetchDomainsResult.Success] for the given query and number of results pair.
      */
-    private fun createSuccessfulOnSuggestedDomains(queryResultSizePair: Pair<String, Int>): OnSuggestedDomains {
+    private fun createSuccessfulFetchResult(queryResultSizePair: Pair<String, Int>): FetchDomainsResult.Success {
         val suggestions = (0 until queryResultSizePair.second).map {
-            val response = DomainSuggestionResponse()
-            response.domain_name = "${queryResultSizePair.first}-$it.wordpress.com"
-            response
+            DomainSuggestion.Free(
+                FreeDomainSuggestion(
+                    domainName = "${queryResultSizePair.first}-$it.wordpress.com",
+                    cost = "Free",
+                    isFree = true,
+                )
+            )
         }
-        return OnSuggestedDomains(queryResultSizePair.first, suggestions)
-    }
-
-    /**
-     * Helper function that creates an error [OnSuggestedDomains] event.
-     */
-    private fun createFailedOnSuggestedDomains(queryResultErrorPair: Pair<String, String>): OnSuggestedDomains {
-        return OnSuggestedDomains(queryResultErrorPair.first, emptyList())
-            .apply {
-                error = SuggestDomainError(queryResultErrorPair.second, "test")
-            }
+        return FetchDomainsResult.Success(queryResultSizePair.first, suggestions)
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -26,12 +26,6 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.networking.restapi.WpComApiClientProvider
-import rs.wordpress.api.kotlin.WpComApiClient
-import rs.wordpress.api.kotlin.WpRequestResult
-import uniffi.wp_api.DomainSuggestion
-import uniffi.wp_api.FreeDomainSuggestion
-import uniffi.wp_api.PaidDomainSuggestion
-import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsResult
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.CreateSiteButtonState
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
@@ -43,18 +37,22 @@ import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewMode
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.usecases.FETCH_DOMAINS_VENDOR_DOT
 import org.wordpress.android.ui.sitecreation.usecases.FETCH_DOMAINS_VENDOR_MOBILE
+import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsResult
 import org.wordpress.android.ui.sitecreation.usecases.FetchDomainsUseCase
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.FreeDomainSuggestion
+import uniffi.wp_api.PaidDomainSuggestion
 import kotlin.test.assertIs
 
 private const val MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE = 20
 private val MULTI_RESULT_DOMAIN_FETCH_QUERY = "multi_result_query" to MULTI_RESULT_DOMAIN_FETCH_RESULT_SIZE
 private val EMPTY_RESULT_DOMAIN_FETCH_QUERY = "empty_result_query" to 0
-// Sale products test is @Ignore'd — keeping placeholder for future use
-@Suppress("unused")
-private val SALE_PRODUCTS_COUNT = 1
+private const val SALE_PRODUCTS_COUNT = 1
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -450,7 +448,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         )
     }
 
-    @Suppress("UNCHECKED_CAST")
     @Test
     fun `verify domain products are fetched only at first start`() = testNewUi {
         viewModel.start()
@@ -476,7 +473,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
         assertIs<CreateSiteButtonState.Paid>(viewModel.uiState.value?.createSiteButtonState)
     }
-
 
     @Test
     fun `verify all domain results from api are visible`() = testWithSuccessResultNewUi { suggestions ->

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.store.AccountStore
@@ -136,6 +137,37 @@ class FetchDomainsUseCaseTest : BaseUnitTest() {
             assertThat(result).isEqualTo(
                 FetchDomainsResult.Error(type = "empty_query", message = "Query is empty")
             )
+        }
+
+    @Test
+    fun `given a signed out account, when fetchDomains, then report the missing token`() =
+        test {
+            // What `AccountStore` returns when signed out, despite its nullable type.
+            whenever(accountStore.accessToken).thenReturn("")
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isEqualTo(
+                FetchDomainsResult.Error(type = "NO_ACCESS_TOKEN", message = null)
+            )
+            verifyNoInteractions(wpComApiClient)
+        }
+
+    @Test
+    fun `given a null access token, when fetchDomains, then report it instead of crashing`() =
+        test {
+            whenever(accountStore.accessToken).thenReturn(null)
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isEqualTo(
+                FetchDomainsResult.Error(type = "NO_ACCESS_TOKEN", message = null)
+            )
+            verifyNoInteractions(wpComApiClient)
         }
 
     @Suppress("UNCHECKED_CAST")

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -17,6 +17,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.DomainSuggestion
 import uniffi.wp_api.FreeDomainSuggestion
 import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.WpErrorCode
 
 private const val SEARCH_QUERY = "test"
 
@@ -88,6 +89,62 @@ class FetchDomainsUseCaseTest : BaseUnitTest() {
                 SEARCH_QUERY, "vendor", onlyWordpressCom = false
             )
 
-            assertThat(result).isEqualTo(FetchDomainsResult.Error)
+            assertThat(result).isEqualTo(
+                FetchDomainsResult.Error(type = "GENERIC_ERROR", message = null)
+            )
         }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `given invalid_query error, when fetchDomains, then return InvalidQuery`() =
+        test {
+            whenever(wpComApiClient.request<Any>(any()))
+                .thenReturn(wpError("invalid_query", "Domain searches must contain a word"))
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isEqualTo(FetchDomainsResult.InvalidQuery)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `given empty_results error, when fetchDomains, then return Success with no suggestions`() =
+        test {
+            whenever(wpComApiClient.request<Any>(any()))
+                .thenReturn(wpError("empty_results", "No available domains for that search."))
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isEqualTo(FetchDomainsResult.Success(emptyList()))
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `given another api error, when fetchDomains, then return Error carrying its code`() =
+        test {
+            whenever(wpComApiClient.request<Any>(any()))
+                .thenReturn(wpError("empty_query", "Query is empty"))
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isEqualTo(
+                FetchDomainsResult.Error(type = "empty_query", message = "Query is empty")
+            )
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun wpError(code: String, message: String) = WpRequestResult.WpError<Any>(
+        errorCode = WpErrorCode.CustomException(code),
+        errorMessage = message,
+        statusCode = 400.toUInt(),
+        response = "",
+        requestUrl = "",
+        requestMethod = RequestMethod.GET,
+    ) as WpRequestResult<Any>
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -67,7 +67,6 @@ class FetchDomainsUseCaseTest : BaseUnitTest() {
 
             assertThat(result).isInstanceOf(FetchDomainsResult.Success::class.java)
             val success = result as FetchDomainsResult.Success
-            assertThat(success.query).isEqualTo(SEARCH_QUERY)
             assertThat(success.suggestions).hasSize(1)
         }
 
@@ -89,7 +88,6 @@ class FetchDomainsUseCaseTest : BaseUnitTest() {
                 SEARCH_QUERY, "vendor", onlyWordpressCom = false
             )
 
-            assertThat(result).isInstanceOf(FetchDomainsResult.Error::class.java)
-            assertThat(result.query).isEqualTo(SEARCH_QUERY)
+            assertThat(result).isEqualTo(FetchDomainsResult.Error)
         }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCaseTest.kt
@@ -1,23 +1,22 @@
 package org.wordpress.android.ui.sitecreation.usecases
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.FreeDomainSuggestion
+import uniffi.wp_api.RequestMethod
 
 private const val SEARCH_QUERY = "test"
 
@@ -25,28 +24,72 @@ private const val SEARCH_QUERY = "test"
 @RunWith(MockitoJUnitRunner::class)
 class FetchDomainsUseCaseTest : BaseUnitTest() {
     @Mock
-    lateinit var dispatcher: Dispatcher
+    lateinit var wpComApiClientProvider: WpComApiClientProvider
 
     @Mock
-    lateinit var store: SiteStore
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var wpComApiClient: WpComApiClient
+
     private lateinit var useCase: FetchDomainsUseCase
-    private lateinit var dispatchCaptor: KArgumentCaptor<Action<SuggestDomainsPayload>>
-    private val event = OnSuggestedDomains(SEARCH_QUERY, emptyList())
 
     @Before
     fun setUp() {
-        useCase = FetchDomainsUseCase(dispatcher, store)
-        dispatchCaptor = argumentCaptor()
+        whenever(accountStore.accessToken).thenReturn("test-token")
+        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
+            .thenReturn(wpComApiClient)
+        useCase = FetchDomainsUseCase(wpComApiClientProvider, accountStore)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
-    fun coroutineResumedWhenResultEventDispatched() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onSuggestedDomains(event) }
+    fun `given successful response, when fetchDomains, then return Success with suggestions`() =
+        test {
+            val suggestions = listOf(
+                DomainSuggestion.Free(
+                    FreeDomainSuggestion(
+                        domainName = "$SEARCH_QUERY.wordpress.com",
+                        cost = "Free",
+                        isFree = true,
+                    )
+                )
+            )
+            whenever(wpComApiClient.request<Any>(any()))
+                .thenReturn(
+                    WpRequestResult.Success(suggestions)
+                        as WpRequestResult<Any>
+                )
 
-        val resultEvent = useCase.fetchDomains(SEARCH_QUERY, "vendor", onlyWordpressCom = false)
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
 
-        verify(dispatcher).dispatch(dispatchCaptor.capture())
-        assertEquals(dispatchCaptor.lastValue.payload.query, SEARCH_QUERY)
-        assertEquals(event, resultEvent)
-    }
+            assertThat(result).isInstanceOf(FetchDomainsResult.Success::class.java)
+            val success = result as FetchDomainsResult.Success
+            assertThat(success.query).isEqualTo(SEARCH_QUERY)
+            assertThat(success.suggestions).hasSize(1)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `given error response, when fetchDomains, then return Error`() =
+        test {
+            whenever(wpComApiClient.request<Any>(any()))
+                .thenReturn(
+                    WpRequestResult.UnknownError<Any>(
+                        500.toUInt(),
+                        "Internal Server Error",
+                        "",
+                        RequestMethod.GET,
+                    )
+                )
+
+            val result = useCase.fetchDomains(
+                SEARCH_QUERY, "vendor", onlyWordpressCom = false
+            )
+
+            assertThat(result).isInstanceOf(FetchDomainsResult.Error::class.java)
+            assertThat(result.query).isEqualTo(SEARCH_QUERY)
+        }
 }


### PR DESCRIPTION
## Description

Moves `SiteCreationDomainsViewModel` and `FetchDomainsUseCase` off FluxC and onto wordpress-rs. `FetchDomainsUseCase` calls `WpComApiClient.domains().suggestions()` directly instead of dispatching `newSuggestDomainsAction` and waiting for an `OnSuggestedDomains` event, so the EventBus subscription, the query-to-continuation pairing, and the ViewModel's dispatcher registration all go away.

Behaviour is meant to match trunk. The pieces worth checking:

- **`empty_results` is not a failure.** The API reports "no domains for that search" as an HTTP error, and FluxC turned it back into a successful empty list. The migration does the same, so the screen shows the empty-list message rather than a red error with a retry button.
- **`invalid_query` keeps its own message.** Same as trunk, and it is not tracked as an error.
- **The tracked error type survives.** `FetchDomainsResult.Error` carries the API's error code and message through to `trackErrorShown`. `SuggestDomainErrorType` supplied that value before, derived from the same code, and the tracker lowercases whatever it is given, so the value reported for a known code is unchanged.

Three cleanups came out of reviewing the migration:

- `fetchDomains` had a `size` parameter that was suppressed rather than read, since `quantity` is always `FETCH_DOMAINS_SIZE`. No caller passed it.
- Every `FetchDomainsResult` echoed the `query` back, which the caller already held. That existed to match an EventBus result to its request and a suspend call needs no such thing.
- The screen fetched the domain products list on start and stored it in a field nothing read. `NewDomainsSearchRepository` and `DomainSuggestionsViewModel` are the callers that read a product, both for `combinedSaleCostDisplay`, and neither is affected. The sale UI this screen kept for it — `Cost.OnSale`, `Tag.Sale`, the `SalePrice` composable — was only ever built by `DomainItemPreview`, so it rendered in Android Studio and nowhere else.

## Dropping `animateLayoutChanges` on this screen

On trunk, typing the first character into the domain search stops you typing until that first request finishes — every keystroke in between is lost. The implicit layout animation that runs when the clear button and the spinner appear takes focus off the search field, and nothing gives it back until the results arrive.

Removing `animateLayoutChanges` from this screen's two layouts fixes it. The trade is that the views around the header snap into place rather than sliding. It reads as snappier to me and losing keystrokes was the worse of the two, but it is a visible change.

## Testing instructions

Reach the screen: **My Site** → the site name dropdown → **+** → **Create WordPress.com site** → skip or fill the two steps before **Choose a domain**.

Typing is not interrupted:

1. Type a single character into the search field.
- [x] Verify you can keep typing straight away, without waiting for the spinner to stop or tapping the field again.

A query the API refuses:

1. Search for `.`
- [x] Verify the empty-state message about the search being invalid, not an error with a retry button.

A query with no matches:

1. Search for a long run of the same letter, e.g. 200 or so `z` characters.
- [x] Verify the ordinary empty-state message.

A normal search:

1. Search for anything ordinary, e.g. `coolsite`.
- [x] Verify suggestions appear, the free `.wordpress.com` option among them.
- [x] Verify the first two paid suggestions are tagged Recommended and Best Alternative.
- [x] Verify selecting one enables the button at the bottom and its label matches free vs. paid.

No connection:

1. Turn off networking and search.
- [x] Verify the no-network message with a retry button, and that retry works once networking is back.

## Screenshots

| Invalid query | No matches | Results | No connection |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/638cfc75-6959-4b4e-9a9f-63a66e7be493" width="200" alt="Invalid query" /> | <img src="https://github.com/user-attachments/assets/b499e333-46a9-447b-be61-e8ee68caa9fc" width="200" alt="No matches" /> | <img src="https://github.com/user-attachments/assets/19022bf0-0b43-4ce1-86b4-0f5e35142f55" width="200" alt="Results" /> | <img src="https://github.com/user-attachments/assets/086c5f8e-b2e7-4ad5-9a96-1578a1c7b9da" width="200" alt="No connection" /> |