### PR TITLE
CMM-2343: Align switch with title on tall preference rows

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPSwitchPreference.java
@@ -8,9 +8,11 @@ import android.content.res.TypedArray;
 import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -25,6 +27,7 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
     private ColorStateList mTint;
     private ColorStateList mThumbTint;
     private int mStartOffset = 0;
+    private boolean mAlignSwitchWithTitle = false;
 
     public WPSwitchPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -43,6 +46,8 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
                 mThumbTint = array.getColorStateList(index);
             } else if (index == R.styleable.SummaryEditTextPreference_startOffset) {
                 mStartOffset = array.getDimensionPixelSize(index, 0);
+            } else if (index == R.styleable.SummaryEditTextPreference_alignSwitchWithTitle) {
+                mAlignSwitchWithTitle = array.getBoolean(index, false);
             }
         }
 
@@ -83,6 +88,29 @@ public class WPSwitchPreference extends SwitchPreference implements PreferenceHi
         // Add padding to start of switch.
         ViewCompat.setPaddingRelative(getSwitch((ViewGroup) view),
                 getContext().getResources().getDimensionPixelSize(R.dimen.margin_extra_large), 0, 0, 0);
+
+        alignSwitch(view);
+    }
+
+    /**
+     * Rows whose summary wraps to several lines look broken with the switch stranded in the
+     * vertical centre, so they can opt into having it sit alongside the title instead. Both
+     * branches are applied because preference rows are recycled.
+     */
+    private void alignSwitch(@NonNull View view) {
+        View widgetFrame = view.findViewById(android.R.id.widget_frame);
+        if (!(widgetFrame instanceof LinearLayout)) {
+            return;
+        }
+
+        LinearLayout frame = (LinearLayout) widgetFrame;
+        frame.setGravity(Gravity.END | (mAlignSwitchWithTitle ? Gravity.TOP : Gravity.CENTER_VERTICAL));
+
+        // matches the vertical padding the preference layout gives the title and summary
+        int topPadding = mAlignSwitchWithTitle
+                ? getContext().getResources().getDimensionPixelSize(R.dimen.margin_extra_large) : 0;
+        frame.setPaddingRelative(frame.getPaddingStart(), topPadding, frame.getPaddingEnd(),
+                frame.getPaddingBottom());
     }
 
     private Switch getSwitch(ViewGroup parentView) {

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -54,6 +54,7 @@
         <attr name="iconTint" format="color|reference" />
         <attr name="switchThumbTint" format="integer" />
         <attr name="startOffset" format="dimension|reference" />
+        <attr name="alignSwitchWithTitle" format="boolean" />
     </declare-styleable>
 
     <!-- DetailListPreference attributes -->

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -136,13 +136,15 @@
             android:id="@+id/pref_use_theme_styles"
             android:key="@string/pref_key_use_theme_styles"
             android:summary="@string/site_settings_use_theme_styles_summary"
-            android:title="@string/site_settings_use_theme_styles" />
+            android:title="@string/site_settings_use_theme_styles"
+            app:alignSwitchWithTitle="true" />
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_use_third_party_blocks"
             android:key="@string/pref_key_use_third_party_blocks"
             android:summary="@string/site_settings_use_third_party_blocks_summary"
-            android:title="@string/site_settings_use_third_party_blocks" />
+            android:title="@string/site_settings_use_third_party_blocks"
+            app:alignSwitchWithTitle="true" />
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_gutenberg_kit_enabled"
@@ -237,7 +239,8 @@
             android:id="@+id/pref_toggle_amp"
             android:key="@string/pref_key_site_amp"
             android:summary="@string/site_settings_amp_summary"
-            android:title="@string/site_settings_amp_title" />
+            android:title="@string/site_settings_amp_title"
+            app:alignSwitchWithTitle="true" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
## Description

**TL/DR:** three Site Settings toggles with long summaries had their switch stranded in the vertical middle of the row, far from the title it controls. They now sit alongside the title.

Fixes CMM-2343.

**Before and after shots:**

<img width="400" alt="after" src="https://github.com/user-attachments/assets/d239fa79-5fde-46aa-8d86-8385da645c78" />

---

Site Settings still uses the legacy `android.preference` framework, whose row layout puts the switch in a `match_parent` widget frame with `gravity="end|center_vertical"`. That's fine for the usual one- or two-line row, but *Use Theme Styles* grows to ~7 lines when `SiteSettingsFragment` appends the "your site isn't using a block theme" advisory to the summary, and the centred switch ends up level with the middle of that paragraph instead of the title.

Rather than restyle every switch in the app, `WPSwitchPreference` gains an opt-in `app:alignSwitchWithTitle` attribute (on the styleable it already reads for `iconTint` /`startOffset`). I audited all ~46 `WPSwitchPreference` rows across the four prefs XMLs; only three are ever tall enough to show the problem, and all three are opted in: **Use Theme Styles**, **Use Third-Party Blocks** (same advisory concatenation) and **Accelerated Mobile Pages** (long static summary). Every other row is untouched. The alignment is set on both branches rather than one,
because `PreferenceFragment` recycles rows through a `ListView` and a one-way change would smear onto neighbours.

## Testing instructions

Use Theme Styles:

1. Sign in to a site that is **not** using a block theme.
2. Go to My Site → More → Site Settings → Editor.
- [ ] Verify the *Use Theme Styles* switch sits beside the title, not beside the middle of the
  advisory paragraph below it.