### PR TITLE
Fix dashboard loading message state reset

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
@@ -191,11 +191,11 @@ class DashboardCardsViewModelSlice @Inject constructor(
 
 
     fun clearValue() {
+        personalizeCardViewModelSlice.clearValue()
         jetpackInstallFullPluginCardViewModelSlice.clearValue()
         blazeCardViewModelSlice.clearValue()
         bloggingPromptCardViewModelSlice.clearValue()
         bloganuaryNudgeCardViewModelSlice.clearValue()
-        personalizeCardViewModelSlice.clearValue()
         quickLinksItemViewModelSlice.clearValue()
         plansCardViewModelSlice.clearValue()
         cardViewModelSlice.clearValue()


### PR DESCRIPTION
## Description

Fixes #20411
Fixes an issue where the dashboard could incorrectly show the "No cards" message while clearing dashboard card states.

The `PersonalizeCardViewModelSlice` state is used to determine whether the dashboard should be displayed. Previously, the personalize card value was cleared after other card states, which could leave the dashboard in an incorrect intermediate state.

This change moves `personalizeCardViewModelSlice.clearValue()` to the beginning of `clearValue()` so all dependent card states are reset in the correct order.



## Testing instructions
Test case title: Verify dashboard loading state reset

1. Open the WordPress app.
2. Navigate to the My Site dashboard.
3. Refresh the dashboard or trigger a dashboard reload.
4. Wait for the dashboard cards to finish loading.
- [x] Verify that the "No cards" message is not displayed incorrectly during loading.
- [x] Verify that dashboard cards appear normally after loading completes.

Test case title: Unit test verification

1. Run:
   `./gradlew :WordPress:testWordPressDebugUnitTest --tests "*DashboardCardsViewModelSliceTest"`
- [x] Verify that the test passes.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->