### PR TITLE
Migrate the Domain Suggestions Screen to `wordpress-rs`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -97,9 +97,10 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             }
 
             if (listState is ListState.Error<*>) {
-                val errorMessage = listState.errorMessage.orEmpty().ifEmpty {
-                    getString(R.string.domain_suggestions_fetch_error)
-                }
+                val errorMessage = listState.errorMessageResId?.let { getString(it) }
+                    ?: listState.errorMessage.orEmpty().ifEmpty {
+                        getString(R.string.domain_suggestions_fetch_error)
+                    }
                 ToastUtils.showToast(context, errorMessage)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -87,7 +87,9 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.suggestionsLiveData.observe(viewLifecycleOwner) { listState ->
             val isLoading = listState is ListState.Loading<*>
 
-            domainSuggestionsContainer.isInvisible = isLoading
+            // Nothing has been searched for in the `Init` state, so the list
+            // and its empty view have nothing to say either way.
+            domainSuggestionsContainer.isInvisible = isLoading || listState is ListState.Init<*>
             suggestionSearchIcon.isVisible = !isLoading
             suggestionProgressBar.isVisible = isLoading
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -97,16 +97,33 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             }
 
             if (listState is ListState.Error<*>) {
-                val errorMessage = listState.errorMessageResId?.let { getString(it) }
-                    ?: listState.errorMessage.orEmpty().ifEmpty {
-                        getString(R.string.domain_suggestions_fetch_error)
-                    }
-                ToastUtils.showToast(context, errorMessage)
+                reportSuggestionsError(listState)
+            } else {
+                actionableEmptyView.title.setText(R.string.domains_suggestions_empty_list)
+                actionableEmptyView.subtitle.isVisible = false
             }
         }
         viewModel.selectDomainButtonEnabledState.observe(viewLifecycleOwner) { selectDomainButton.isEnabled = it }
         viewModel.onDomainSelected.observeEvent(viewLifecycleOwner, mainViewModel::selectDomain)
         viewModel.onFreeDomainSelected.observeEvent(viewLifecycleOwner, mainViewModel::selectDomain)
+    }
+
+    /**
+     * An empty list already puts the empty view on screen, so the failure goes
+     * there rather than into a toast that would contradict it. With results
+     * still showing there is nowhere to put it but a toast.
+     */
+    private fun DomainSuggestionsFragmentBinding.reportSuggestionsError(state: ListState.Error<*>) {
+        val detail = state.errorMessageResId?.let { getString(it) }
+            ?: state.errorMessage.orEmpty().ifEmpty { null }
+
+        if (state.data.isEmpty()) {
+            actionableEmptyView.title.setText(R.string.domain_suggestions_fetch_error)
+            actionableEmptyView.subtitle.text = detail
+            actionableEmptyView.subtitle.isVisible = detail != null
+        } else {
+            ToastUtils.showToast(context, detail ?: getString(R.string.domain_suggestions_fetch_error))
+        }
     }
 
     override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -97,7 +96,11 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
             }
 
             if (listState is ListState.Error<*>) {
-                reportSuggestionsError(listState)
+                val detail = listState.errorMessageResId?.let { getString(it) }
+                    ?: listState.errorMessage?.ifEmpty { null }
+                actionableEmptyView.title.setText(R.string.domain_suggestions_fetch_error)
+                actionableEmptyView.subtitle.text = detail
+                actionableEmptyView.subtitle.isVisible = detail != null
             } else {
                 actionableEmptyView.title.setText(R.string.domains_suggestions_empty_list)
                 actionableEmptyView.subtitle.isVisible = false
@@ -106,24 +109,6 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         viewModel.selectDomainButtonEnabledState.observe(viewLifecycleOwner) { selectDomainButton.isEnabled = it }
         viewModel.onDomainSelected.observeEvent(viewLifecycleOwner, mainViewModel::selectDomain)
         viewModel.onFreeDomainSelected.observeEvent(viewLifecycleOwner, mainViewModel::selectDomain)
-    }
-
-    /**
-     * An empty list already puts the empty view on screen, so the failure goes
-     * there rather than into a toast that would contradict it. With results
-     * still showing there is nowhere to put it but a toast.
-     */
-    private fun DomainSuggestionsFragmentBinding.reportSuggestionsError(state: ListState.Error<*>) {
-        val detail = state.errorMessageResId?.let { getString(it) }
-            ?: state.errorMessage.orEmpty().ifEmpty { null }
-
-        if (state.data.isEmpty()) {
-            actionableEmptyView.title.setText(R.string.domain_suggestions_fetch_error)
-            actionableEmptyView.subtitle.text = detail
-            actionableEmptyView.subtitle.isVisible = detail != null
-        } else {
-            ToastUtils.showToast(context, detail ?: getString(R.string.domain_suggestions_fetch_error))
-        }
     }
 
     override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
@@ -42,7 +44,8 @@ class DomainSuggestionsViewModel @Inject constructor(
     private val domainsRegistrationTracker: DomainsRegistrationTracker,
     private val debouncer: Debouncer,
     private val createCartUseCase: CreateCartUseCase,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
     lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
@@ -172,7 +175,12 @@ class DomainSuggestionsViewModel @Inject constructor(
         launch {
             val result = getOrCreateClient()
                 .request { it.domains().suggestions(params).data }
-            onDomainSuggestionsFetched(query, result)
+            // `suggestions` is read and written from the search field, the
+            // debouncer and here. Handling the response on the main thread
+            // keeps those writes on one thread, so a response that lands
+            // while `fetchSuggestions` is still running cannot be overwritten
+            // by the stale state the other thread is holding.
+            withContext(uiDispatcher) { onDomainSuggestionsFetched(query, result) }
         }
 
         // Reset the selected suggestion, if list is updated

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -193,8 +193,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         launch {
             val result = getOrCreateClient()
                 .request { it.domains().suggestions(params).data }
-            // Applied on the main thread, as FluxC's `ThreadMode.MAIN`
-            // subscription was, so the response shares a thread with the row
+            // Applied on the main thread, so the response shares a thread with the row
             // taps and the search field that read the same state.
             withContext(uiDispatcher) { onDomainSuggestionsFetched(query, result) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -1,21 +1,15 @@
 package org.wordpress.android.ui.domains
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.products.Product
-import org.wordpress.android.fluxc.store.ProductsStore
-import org.wordpress.android.fluxc.store.SiteStore.OnSuggestedDomains
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
@@ -28,22 +22,33 @@ import org.wordpress.android.util.extensions.isOnSale
 import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.api.kotlin.toLogErrorString
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.DomainSuggestionsParams
+import uniffi.wp_api.Product
+import uniffi.wp_api.ProductTypeFilter
+import uniffi.wp_api.ProductsParams
+import uniffi.wp_api.WpErrorCode
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.properties.Delegates
 
 class DomainSuggestionsViewModel @Inject constructor(
-    private val productsStore: ProductsStore,
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
     private val domainsRegistrationTracker: DomainsRegistrationTracker,
-    private val dispatcher: Dispatcher,
     private val debouncer: Debouncer,
     private val createCartUseCase: CreateCartUseCase,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     lateinit var site: SiteModel
     lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
-    var products: List<Product>? = null
+
+    private var wpComApiClient: WpComApiClient? = null
+    private var products: List<Product>? = null
 
     private var isStarted = false
     private var isQueryTrackingCompleted = false
@@ -90,18 +95,22 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_QUERY_DELAY_MS = 250L
-        private const val SUGGESTIONS_REQUEST_COUNT = 20
+        private const val SUGGESTIONS_REQUEST_COUNT = 20u
         private const val BLOG_DOMAIN_TLDS = "blog"
+        private const val ERROR_CODE_EMPTY_RESULTS = "empty_results"
     }
 
-    // Bind Dispatcher to Lifecycle
-
-    init {
-        dispatcher.register(this)
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient {
+        val token = requireNotNull(accountStore.accessToken) {
+            "WP.com access token is required"
+        }
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
     }
 
     override fun onCleared() {
-        dispatcher.unregister(this)
         debouncer.shutdown()
         createCartUseCase.clear()
         super.onCleared()
@@ -132,69 +141,97 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun fetchProducts() {
         launch {
-            val result = productsStore.fetchProducts(TYPE_DOMAINS_PRODUCT)
-            when {
-                result.isError -> {
-                    AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching site domains")
-                    initializeDefaultSuggestions()
-                }
-                else -> {
-                    AppLog.d(T.DOMAIN_REGISTRATION, result.products.toString())
-                    result.products?.let { products = it }
-                    initializeDefaultSuggestions()
-                }
+            val params = ProductsParams(productType = ProductTypeFilter.Domains)
+            val result = getOrCreateClient()
+                .request { it.products().list(params).data }
+            when (result) {
+                is WpRequestResult.Success -> products = result.response.values.toList()
+                else -> AppLog.e(
+                    T.DOMAIN_REGISTRATION,
+                    "An error occurred while fetching domain products: " +
+                        result.toLogErrorString()
+                )
             }
+            initializeDefaultSuggestions()
         }
     }
 
     private fun fetchSuggestions() {
         suggestions = ListState.Loading(suggestions)
 
-        val suggestDomainsPayload = if (SiteUtils.onBloggerPlan(site)) {
-            SuggestDomainsPayload(searchQuery, SUGGESTIONS_REQUEST_COUNT, BLOG_DOMAIN_TLDS)
-        } else {
-            SuggestDomainsPayload(searchQuery, false, false, true, SUGGESTIONS_REQUEST_COUNT)
-        }
+        val query = searchQuery
+        val params = buildSuggestionsParams(query, SiteUtils.onBloggerPlan(site))
 
-        dispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(suggestDomainsPayload))
+        launch {
+            val result = getOrCreateClient()
+                .request { it.domains().suggestions(params).data }
+            onDomainSuggestionsFetched(query, result)
+        }
 
         // Reset the selected suggestion, if list is updated
         onDomainSuggestionSelected(null)
     }
 
+    /**
+     * A site on the Blogger plan can only register a `.blog` domain, so its
+     * search is restricted to that TLD and carries none of the other filters.
+     */
+    @VisibleForTesting
+    internal fun buildSuggestionsParams(query: String, isOnBloggerPlan: Boolean) =
+        if (isOnBloggerPlan) {
+            DomainSuggestionsParams(
+                query = query,
+                quantity = SUGGESTIONS_REQUEST_COUNT,
+                tlds = listOf(BLOG_DOMAIN_TLDS),
+            )
+        } else {
+            DomainSuggestionsParams(
+                query = query,
+                quantity = SUGGESTIONS_REQUEST_COUNT,
+                onlyWordpressdotcom = false, // checkstyle ignore
+                includeWordpressdotcom = false, // checkstyle ignore
+                includeDotblogsubdomain = true,
+            )
+        }
+
     // Network Callback
 
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDomainSuggestionsFetched(event: OnSuggestedDomains) {
-        if (searchQuery != event.query) {
+    private fun onDomainSuggestionsFetched(
+        query: String,
+        result: WpRequestResult<List<DomainSuggestion>>
+    ) {
+        if (searchQuery != query) {
             return
         }
-        if (event.isError) {
-            AppLog.e(
-                T.DOMAIN_REGISTRATION,
-                "An error occurred while fetching the domain suggestions with type: " + event.error.type
-            )
-            suggestions = ListState.Error(suggestions, event.error.message)
-            return
+        when (result) {
+            is WpRequestResult.Success -> showSuggestions(result.response)
+            is WpRequestResult.WpError -> when (result.apiErrorCode()) {
+                // The API rejects a search that matches nothing rather than
+                // returning an empty list. The request itself is fine.
+                ERROR_CODE_EMPTY_RESULTS -> showSuggestions(emptyList())
+                else -> showSuggestionsError(result)
+            }
+            else -> showSuggestionsError(result)
         }
+    }
 
-        event.suggestions
-            .filter { !it.is_free }
-            .map {
-                val product = products?.firstOrNull { product -> product.productId == it.product_id }
+    private fun showSuggestions(fetched: List<DomainSuggestion>) {
+        fetched
+            .filterIsInstance<DomainSuggestion.Paid>()
+            .map { paid ->
+                val product = products?.firstOrNull { it.productId == paid.v1.productId }
                 DomainSuggestionItem(
-                    domainName = it.domain_name,
-                    cost = it.cost,
+                    domainName = paid.v1.domainName,
+                    cost = paid.v1.cost,
                     isOnSale = product.isOnSale(),
                     saleCost = product?.combinedSaleCostDisplay.orEmpty(),
-                    isFree = it.is_free,
-                    supportsPrivacy = it.supports_privacy,
-                    productId = it.product_id,
-                    productSlug = it.product_slug,
-                    vendor = it.vendor,
-                    relevance = it.relevance,
-                    isSelected = _selectedSuggestion.value?.domainName == it.domain_name,
+                    isFree = false,
+                    supportsPrivacy = paid.v1.supportsPrivacy,
+                    productId = paid.v1.productId.toInt(),
+                    productSlug = paid.v1.productSlug,
+                    vendor = paid.v1.vendor,
+                    relevance = paid.v1.relevance.toFloat(),
+                    isSelected = _selectedSuggestion.value?.domainName == paid.v1.domainName,
                     isCostVisible = true,
                     isFreeWithCredits = domainRegistrationPurpose(),
                     isEnabled = true
@@ -205,6 +242,18 @@ class DomainSuggestionsViewModel @Inject constructor(
             .let {
                 suggestions = ListState.Success(it)
             }
+    }
+
+    private fun showSuggestionsError(result: WpRequestResult<*>) {
+        AppLog.e(
+            T.DOMAIN_REGISTRATION,
+            "An error occurred while fetching the domain suggestions: " +
+                result.toLogErrorString()
+        )
+        suggestions = ListState.Error(
+            suggestions,
+            (result as? WpRequestResult.WpError)?.errorMessage
+        )
     }
 
     private fun domainRegistrationPurpose() = domainRegistrationPurpose == CTA_DOMAIN_CREDIT_REDEMPTION ||
@@ -286,3 +335,11 @@ class DomainSuggestionsViewModel @Inject constructor(
         }
     }
 }
+
+/**
+ * The API's own error code, for the codes this endpoint defines. Codes the
+ * WordPress REST API also uses are modelled as [WpErrorCode] variants and
+ * return null.
+ */
+private fun WpRequestResult.WpError<*>.apiErrorCode(): String? =
+    (errorCode as? WpErrorCode.CustomException)?.v1

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.networkresource.ListState
@@ -32,6 +33,7 @@ import uniffi.wp_api.DomainSuggestionsParams
 import uniffi.wp_api.Product
 import uniffi.wp_api.ProductTypeFilter
 import uniffi.wp_api.ProductsParams
+import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.WpErrorCode
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -267,7 +269,8 @@ class DomainSuggestionsViewModel @Inject constructor(
         )
         suggestions = ListState.Error(
             suggestions,
-            (result as? WpRequestResult.WpError)?.errorMessage
+            errorMessage = (result as? WpRequestResult.WpError)?.errorMessage,
+            errorMessageResId = R.string.error_network_connection.takeIf { result.isDeviceOffline() }
         )
     }
 
@@ -358,3 +361,11 @@ class DomainSuggestionsViewModel @Inject constructor(
  */
 private fun WpRequestResult.WpError<*>.apiErrorCode(): String? =
     (errorCode as? WpErrorCode.CustomException)?.v1
+
+/**
+ * True when the request never reached the network because the device has no
+ * connection, which is worth telling the user apart from a server refusal.
+ */
+private fun WpRequestResult<*>.isDeviceOffline(): Boolean =
+    this is WpRequestResult.RequestExecutionFailed &&
+            reason is RequestExecutionErrorReason.DeviceIsOfflineError

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -176,26 +176,28 @@ class DomainSuggestionsViewModel @Inject constructor(
             // rejects a blank query, and reporting that is not useful when the
             // field is showing its placeholder.
             suggestions = ListState.Init()
+            onDomainSuggestionSelected(null)
             return
         }
 
         suggestions = ListState.Loading(suggestions)
+
+        // Reset the selected suggestion, if list is updated. Both writes to
+        // `suggestions` are made before the request is dispatched, so a
+        // response arriving on another thread cannot be overwritten by the
+        // state this one is still holding.
+        onDomainSuggestionSelected(null)
 
         val params = buildSuggestionsParams(query, SiteUtils.onBloggerPlan(site))
 
         launch {
             val result = getOrCreateClient()
                 .request { it.domains().suggestions(params).data }
-            // `suggestions` is read and written from the search field, the
-            // debouncer and here. Handling the response on the main thread
-            // keeps those writes on one thread, so a response that lands
-            // while `fetchSuggestions` is still running cannot be overwritten
-            // by the stale state the other thread is holding.
+            // Applied on the main thread, as FluxC's `ThreadMode.MAIN`
+            // subscription was, so the response shares a thread with the row
+            // taps and the search field that read the same state.
             withContext(uiDispatcher) { onDomainSuggestionsFetched(query, result) }
         }
-
-        // Reset the selected suggestion, if list is updated
-        onDomainSuggestionSelected(null)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -169,9 +169,18 @@ class DomainSuggestionsViewModel @Inject constructor(
     internal fun buildProductsParams() = ProductsParams(productType = ProductTypeFilter.Domains)
 
     private fun fetchSuggestions() {
+        val query = searchQuery
+        if (query.isBlank()) {
+            // A site with no name leaves nothing to search for on open, and
+            // nothing to fall back to when the field is emptied. The API
+            // rejects a blank query, and reporting that is not useful when the
+            // field is showing its placeholder.
+            suggestions = ListState.Init()
+            return
+        }
+
         suggestions = ListState.Loading(suggestions)
 
-        val query = searchQuery
         val params = buildSuggestionsParams(query, SiteUtils.onBloggerPlan(site))
 
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -312,14 +312,15 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         if (query.isNotBlank()) {
             searchQuery = query
-        } else {
-            // Whatever is on screen answers a query that is no longer in the
-            // field, including an error describing how it was written.
+        } else if (searchQuery != site.name) {
+            // What is on screen answers a query that is no longer in the field,
+            // including an error describing how it was written. Leaving the
+            // state alone when the query has not moved keeps the default
+            // suggestions through a configuration change, where the field is
+            // restored empty and reports itself as changed.
             suggestions = ListState.Init()
-            if (searchQuery != site.name) {
-                // Only reinitialize the search query, if it has changed.
-                initializeDefaultSuggestions()
-            }
+            // Only reinitialize the search query, if it has changed.
+            initializeDefaultSuggestions()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -141,7 +141,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun fetchProducts() {
         launch {
-            val params = ProductsParams(productType = ProductTypeFilter.Domains)
+            val params = buildProductsParams()
             val result = getOrCreateClient()
                 .request { it.products().list(params).data }
             when (result) {
@@ -155,6 +155,13 @@ class DomainSuggestionsViewModel @Inject constructor(
             initializeDefaultSuggestions()
         }
     }
+
+    /**
+     * Only the domain products carry the sale pricing the suggestion list
+     * reads, so the request is filtered to them.
+     */
+    @VisibleForTesting
+    internal fun buildProductsParams() = ProductsParams(productType = ProductTypeFilter.Domains)
 
     private fun fetchSuggestions() {
         suggestions = ListState.Loading(suggestions)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -92,8 +92,13 @@ class DomainSuggestionsViewModel @Inject constructor(
                 domainsRegistrationTracker.trackDomainCreditSuggestionQueried()
             }
 
+            // The debouncer runs on its own scheduler thread. The query is read
+            // there, so it is the one the search was scheduled for, and the
+            // rest hops to the main thread, where the row taps and the response
+            // handler already write the same state.
             debouncer.debounce(Void::class.java, {
-                fetchSuggestions()
+                val query = searchQuery
+                launch(uiDispatcher) { fetchSuggestions(query) }
             }, SEARCH_QUERY_DELAY_MS, TimeUnit.MILLISECONDS)
         }
     }
@@ -181,8 +186,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     @VisibleForTesting
     internal fun buildProductsParams() = ProductsParams(productType = ProductTypeFilter.Domains)
 
-    private fun fetchSuggestions() {
-        val query = searchQuery
+    private fun fetchSuggestions(query: String) {
         if (query.isBlank()) {
             // A site with no name leaves nothing to search for on open, and
             // nothing to fall back to when the field is emptied. The API
@@ -206,18 +210,15 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         suggestions = ListState.Loading(suggestions)
 
-        // Reset the selected suggestion, if list is updated. Both writes to
-        // `suggestions` are made before the request is dispatched, so a
-        // response arriving on another thread cannot be overwritten by the
-        // state this one is still holding.
+        // Reset the selected suggestion, if list is updated
         onDomainSuggestionSelected(null)
 
         val params = buildSuggestionsParams(query, SiteUtils.onBloggerPlan(site))
 
         launch {
             val result = client.request { it.domains().suggestions(params).data }
-            // Applied on the main thread, so the response shares a thread with the row
-            // taps and the search field that read the same state.
+            // Back onto the thread the rest of the state is written from, as
+            // FluxC's `ThreadMode.MAIN` subscription did.
             withContext(uiDispatcher) { onDomainSuggestionsFetched(query, result) }
         }
     }
@@ -388,8 +389,8 @@ class DomainSuggestionsViewModel @Inject constructor(
         domainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(site, isSiteCreation = false)
     }
 
-    private fun showLoadingButton(isLoading: Boolean) {
-        _isButtonProgressBarVisible.postValue(isLoading)
+    private suspend fun showLoadingButton(isLoading: Boolean) = withContext(uiDispatcher) {
+        _isButtonProgressBarVisible.value = isLoading
         suggestions = suggestions.transform { list ->
             list.map { it.copy(isEnabled = !isLoading) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -303,9 +303,14 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         if (query.isNotBlank()) {
             searchQuery = query
-        } else if (searchQuery != site.name) {
-            // Only reinitialize the search query, if it has changed.
-            initializeDefaultSuggestions()
+        } else {
+            // Whatever is on screen answers a query that is no longer in the
+            // field, including an error describing how it was written.
+            suggestions = ListState.Init()
+            if (searchQuery != site.name) {
+                // Only reinitialize the search query, if it has changed.
+                initializeDefaultSuggestions()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -105,11 +105,16 @@ class DomainSuggestionsViewModel @Inject constructor(
         private const val ERROR_CODE_EMPTY_RESULTS = "empty_results"
     }
 
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
     @Synchronized
-    private fun getOrCreateClient(): WpComApiClient {
-        val token = requireNotNull(accountStore.accessToken) {
-            "WP.com access token is required"
-        }
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
         return wpComApiClient
             ?: wpComApiClientProvider.getWpComApiClient(token)
                 .also { wpComApiClient = it }
@@ -146,9 +151,17 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private fun fetchProducts() {
         launch {
+            val client = getOrCreateClient()
+            if (client == null) {
+                AppLog.e(
+                    T.DOMAIN_REGISTRATION,
+                    "Cannot fetch domain products without a WP.com access token"
+                )
+                initializeDefaultSuggestions()
+                return@launch
+            }
             val params = buildProductsParams()
-            val result = getOrCreateClient()
-                .request { it.products().list(params).data }
+            val result = client.request { it.products().list(params).data }
             when (result) {
                 is WpRequestResult.Success -> products = result.response.values.toList()
                 else -> AppLog.e(
@@ -180,6 +193,17 @@ class DomainSuggestionsViewModel @Inject constructor(
             return
         }
 
+        val client = getOrCreateClient()
+        if (client == null) {
+            AppLog.e(
+                T.DOMAIN_REGISTRATION,
+                "Cannot fetch domain suggestions without a WP.com access token"
+            )
+            suggestions = ListState.Error(suggestions.transform { emptyList() })
+            onDomainSuggestionSelected(null)
+            return
+        }
+
         suggestions = ListState.Loading(suggestions)
 
         // Reset the selected suggestion, if list is updated. Both writes to
@@ -191,8 +215,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         val params = buildSuggestionsParams(query, SiteUtils.onBloggerPlan(site))
 
         launch {
-            val result = getOrCreateClient()
-                .request { it.domains().suggestions(params).data }
+            val result = client.request { it.domains().suggestions(params).data }
             // Applied on the main thread, so the response shares a thread with the row
             // taps and the search field that read the same state.
             withContext(uiDispatcher) { onDomainSuggestionsFetched(query, result) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -267,8 +267,11 @@ class DomainSuggestionsViewModel @Inject constructor(
             "An error occurred while fetching the domain suggestions: " +
                 result.toLogErrorString()
         )
+        // The list answers the query in the search field. A search that failed
+        // has no results, so carrying the previous ones over would leave the
+        // screen answering a query the user has already replaced.
         suggestions = ListState.Error(
-            suggestions,
+            suggestions.transform { emptyList() },
             errorMessage = (result as? WpRequestResult.WpError)?.errorMessage,
             errorMessageResId = R.string.error_network_connection.takeIf { result.isDeviceOffline() }
         )

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -1,5 +1,10 @@
 package org.wordpress.android.util.extensions
 
-import org.wordpress.android.fluxc.model.products.Product
+import uniffi.wp_api.Product
 
-fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it > 0.0 } == true
+/**
+ * A product is on sale when the API reports a positive sale price. `saleCost`
+ * is a `Decimal2`, which carries the amount in hundredths of the currency
+ * unit, so `700` is `7.00`.
+ */
+fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it > 0L } == true

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -74,20 +74,18 @@
 
             <ImageView
                 android:id="@+id/suggestion_search_icon"
-                android:visibility="gone"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="@dimen/margin_extra_extra_small"
                 android:contentDescription="@null"
                 android:src="@drawable/ic_search_white_24dp"
-                app:tint="?attr/wpColorOnSurfaceMedium"
-                tools:visibility="visible"/>
+                app:tint="?attr/wpColorOnSurfaceMedium" />
 
             <ProgressBar
                 android:id="@+id/suggestion_progress_bar"
                 android:layout_width="@dimen/progress_spinner_small"
                 android:layout_height="@dimen/progress_spinner_small"
-                tools:visibility="gone" />
+                android:visibility="gone" />
         </FrameLayout>
 
         <com.google.android.material.textfield.TextInputEditText

--- a/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_fragment.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:id="@+id/introduction_container"

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -335,6 +335,29 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `emptying the field of a site with no name searches for nothing`() = test {
+        site.name = ""
+        mockResponses(
+            productsResponse(),
+            wpError("invalid_query", "Domain searches must contain a word"),
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+        viewModel.updateSearchQuery("...")
+        advanceUntilIdle()
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Error::class.java)
+
+        viewModel.updateSearchQuery("")
+        advanceUntilIdle()
+
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Init::class.java)
+        // The products request and the one real search, and nothing for the
+        // blank query the emptied field falls back to.
+        verify(wpComApiClient, times(2)).request<Any>(any())
+    }
+
+    @Test
     fun `an offline failure asks the view for the network message`() = test {
         mockResponses(
             productsResponse(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -403,6 +403,29 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `a signed out account reports an error instead of searching`() = test {
+        // What `AccountStore` returns when signed out, despite its nullable type.
+        whenever(accountStore.accessToken).thenReturn("")
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Error::class.java)
+        verifyNoInteractions(wpComApiClient)
+    }
+
+    @Test
+    fun `a null access token reports an error instead of crashing`() = test {
+        whenever(accountStore.accessToken).thenReturn(null)
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Error::class.java)
+        verifyNoInteractions(wpComApiClient)
+    }
+
+    @Test
     fun `an offline failure asks the view for the network message`() = test {
         mockResponses(
             productsResponse(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -94,11 +94,16 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
             dispatcher
         )
 
-        onDomainSelectedEvents = mutableListOf()
-        created.onDomainSelected.observeForever { onDomainSelectedEvents.add(it.peekContent()) }
+        // Each observer appends to the list it was created with rather than
+        // to whichever list the field holds when it fires, so a view model
+        // built later in a test cannot feed an earlier one's sink.
+        val selected = mutableListOf<DomainProductDetails>()
+        onDomainSelectedEvents = selected
+        created.onDomainSelected.observeForever { selected.add(it.peekContent()) }
 
-        suggestionStates = mutableListOf()
-        created.suggestionsLiveData.observeForever { suggestionStates.add(it) }
+        val states = mutableListOf<ListState<DomainSuggestionItem>>()
+        suggestionStates = states
+        created.suggestionsLiveData.observeForever { states.add(it) }
 
         return created
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -334,6 +334,29 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         assertThat(suggestionStates.first()).isInstanceOf(ListState.Init::class.java)
     }
 
+    /**
+     * A configuration change restores the field empty and the restore reports
+     * itself as a text change, so the view model is told the query was cleared
+     * when the user did nothing. The retained suggestions have to survive it.
+     */
+    @Test
+    fun `emptying a field that never moved off the default changes nothing`() = test {
+        mockResponses(
+            productsResponse(),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion("found.com"))),
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+        assertThat(lastSuccess().map { it.domainName }).containsExactly("found.com")
+
+        suggestionStates.clear()
+        viewModel.updateSearchQuery("")
+        advanceUntilIdle()
+
+        assertThat(suggestionStates).isEmpty()
+    }
+
     @Test
     fun `emptying the field of a site with no name searches for nothing`() = test {
         site.name = ""

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.AccountStore
@@ -35,6 +36,7 @@ import uniffi.wp_api.PaidDomainSuggestion
 import uniffi.wp_api.Product
 import uniffi.wp_api.ProductTerm
 import uniffi.wp_api.ProductTypeFilter
+import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.RequestMethod
 import uniffi.wp_api.WpErrorCode
 
@@ -294,6 +296,28 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `an offline failure asks the view for the network message`() = test {
+        mockResponses(
+            productsResponse(),
+            WpRequestResult.RequestExecutionFailed<Any>(
+                null,
+                null,
+                RequestExecutionErrorReason.DeviceIsOfflineError("No internet connection"),
+                "",
+                RequestMethod.GET,
+            )
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        val state = suggestionStates.last()
+        assertThat(state).isInstanceOf(ListState.Error::class.java)
+        assertThat((state as ListState.Error).errorMessageResId)
+            .isEqualTo(R.string.error_network_connection)
+    }
+
+    @Test
     fun `a non api failure carries no message`() = test {
         mockResponses(
             productsResponse(),
@@ -311,6 +335,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         val state = suggestionStates.last()
         assertThat(state).isInstanceOf(ListState.Error::class.java)
         assertThat((state as ListState.Error).errorMessage).isNull()
+        assertThat(state.errorMessageResId).isNull()
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -314,6 +314,27 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `clearing the search field drops the error it was showing`() = test {
+        mockResponses(
+            productsResponse(),
+            suggestionsResponse(),
+            wpError("invalid_query", "Domain searches must contain a word"),
+            suggestionsResponse(),
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+        viewModel.updateSearchQuery("...")
+        advanceUntilIdle()
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Error::class.java)
+
+        suggestionStates.clear()
+        viewModel.updateSearchQuery("")
+
+        assertThat(suggestionStates.first()).isInstanceOf(ListState.Init::class.java)
+    }
+
+    @Test
     fun `an offline failure asks the view for the network message`() = test {
         mockResponses(
             productsResponse(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -358,6 +358,28 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `emptying the field disarms the select button`() = test {
+        site.name = ""
+        mockResponses(
+            productsResponse(),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion("found.com"))),
+        )
+        val selectEnabled = mutableListOf<Boolean>()
+        viewModel.selectDomainButtonEnabledState.observeForever { selectEnabled.add(it) }
+
+        viewModel.start(site, domainRegistrationPurpose)
+        viewModel.updateSearchQuery("coolsite")
+        advanceUntilIdle()
+        viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
+        assertThat(selectEnabled.last()).isTrue()
+
+        viewModel.updateSearchQuery("")
+        advanceUntilIdle()
+
+        assertThat(selectEnabled.last()).isFalse()
+    }
+
+    @Test
     fun `emptying the field of a site with no name searches for nothing`() = test {
         site.name = ""
         mockResponses(

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -91,6 +91,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
             tracker,
             debouncer,
             createCartUseCase,
+            dispatcher,
             dispatcher
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -293,7 +293,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `a non api failure leaves the message empty so the view shows its own`() = test {
+    fun `a non api failure carries no message`() = test {
         mockResponses(
             productsResponse(),
             WpRequestResult.UnknownError<Any>(

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -34,6 +34,7 @@ import uniffi.wp_api.FreeDomainSuggestion
 import uniffi.wp_api.PaidDomainSuggestion
 import uniffi.wp_api.Product
 import uniffi.wp_api.ProductTerm
+import uniffi.wp_api.ProductTypeFilter
 import uniffi.wp_api.RequestMethod
 import uniffi.wp_api.WpErrorCode
 
@@ -158,14 +159,21 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `domain products are fetched only at first start`() = test {
+    fun `only the domain products are requested`() {
+        assertThat(viewModel.buildProductsParams().productType)
+            .isEqualTo(ProductTypeFilter.Domains)
+    }
+
+    @Test
+    fun `starting a second time repeats neither request`() = test {
         mockResponses(productsResponse(), suggestionsResponse())
 
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
 
-        // One products request and one suggestions request, not two of each.
+        // `request` takes an opaque lambda, so the count is all this can pin
+        // down: two requests in total rather than four.
         verify(wpComApiClient, times(2)).request<Any>(any())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -296,6 +296,24 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `a failed search drops the results of the one before it`() = test {
+        mockResponses(
+            productsResponse(),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion("found.com"))),
+            wpError("invalid_query", "Domain searches must contain a word"),
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+        assertThat(lastSuccess().map { it.domainName }).containsExactly("found.com")
+
+        viewModel.updateSearchQuery("...")
+        advanceUntilIdle()
+
+        assertThat(suggestionStates.last().data).isEmpty()
+    }
+
+    @Test
     fun `an offline failure asks the view for the network message`() = test {
         mockResponses(
             productsResponse(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -1,42 +1,52 @@
 package org.wordpress.android.ui.domains
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.Constants.TYPE_DOMAINS_PRODUCT
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.SiteAction
-import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
-import org.wordpress.android.fluxc.store.ProductsStore
-import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import org.wordpress.android.models.networkresource.ListState
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
-import org.wordpress.android.util.PlansConstants
 import org.wordpress.android.util.helpers.Debouncer
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainSuggestion
+import uniffi.wp_api.FreeDomainSuggestion
+import uniffi.wp_api.PaidDomainSuggestion
+import uniffi.wp_api.Product
+import uniffi.wp_api.ProductTerm
+import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.WpErrorCode
 
 @ExperimentalCoroutinesApi
 class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock
-    lateinit var dispatcher: Dispatcher
+    lateinit var wpComApiClientProvider: WpComApiClientProvider
+
+    @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var wpComApiClient: WpComApiClient
 
     @Mock
     lateinit var debouncer: Debouncer
@@ -47,31 +57,62 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var createCartUseCase: CreateCartUseCase
 
-    private val productsStore = mock<ProductsStore> { on { fetchProducts(any()) } doReturn mock() }
     private lateinit var site: SiteModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
     private lateinit var viewModel: DomainSuggestionsViewModel
     private lateinit var onDomainSelectedEvents: MutableList<DomainProductDetails>
+    private lateinit var suggestionStates: MutableList<ListState<DomainSuggestionItem>>
 
     @Before
     fun setUp() {
         site = SiteModel().also { it.name = "Test Site" }
         domainRegistrationPurpose = CTA_DOMAIN_CREDIT_REDEMPTION
-        viewModel = DomainSuggestionsViewModel(
-            productsStore,
-            tracker,
-            dispatcher,
-            debouncer,
-            createCartUseCase,
-            testDispatcher()
-        )
+
+        whenever(accountStore.accessToken).thenReturn("test-token")
+        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
+            .thenReturn(wpComApiClient)
+
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable
             delayedRunnable.run()
         }
+        // Every request has to resolve to something: the view model logs the
+        // result, and an unstubbed mock hands back null for a non-null type.
+        runBlocking { mockResponses(productsResponse(), suggestionsResponse()) }
+
+        viewModel = createViewModel(testDispatcher())
+    }
+
+    private fun createViewModel(dispatcher: CoroutineDispatcher): DomainSuggestionsViewModel {
+        val created = DomainSuggestionsViewModel(
+            wpComApiClientProvider,
+            accountStore,
+            tracker,
+            debouncer,
+            createCartUseCase,
+            dispatcher
+        )
 
         onDomainSelectedEvents = mutableListOf()
-        viewModel.onDomainSelected.observeForever { onDomainSelectedEvents.add(it.peekContent()) }
+        created.onDomainSelected.observeForever { onDomainSelectedEvents.add(it.peekContent()) }
+
+        suggestionStates = mutableListOf()
+        created.suggestionsLiveData.observeForever { suggestionStates.add(it) }
+
+        return created
+    }
+
+    /**
+     * The view model issues the products request first and the suggestions
+     * request second, so responses are stubbed in that order.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun mockResponses(vararg responses: WpRequestResult<*>) {
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(
+                responses.first() as WpRequestResult<Any>,
+                *responses.drop(1).map { it as WpRequestResult<Any> }.toTypedArray()
+            )
     }
 
     @Test
@@ -118,62 +159,176 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `domain products are fetched only at first start`() = test {
+        mockResponses(productsResponse(), suggestionsResponse())
+
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
 
-        verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))
+        // One products request and one suggestions request, not two of each.
+        verify(wpComApiClient, times(2)).request<Any>(any())
     }
 
     @Test
-    fun `site on blogger plan is requesting only dot blog domain suggestions`() = test {
-        site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
-        viewModel.start(site, domainRegistrationPurpose)
-        viewModel.updateSearchQuery("test")
+    fun `site on blogger plan is requesting only dot blog domain suggestions`() {
+        val params = viewModel.buildSuggestionsParams("test", isOnBloggerPlan = true)
 
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
-
-        val lastAction = captor.value
-
-        assertThat(lastAction.type).isEqualTo(SiteAction.SUGGEST_DOMAINS)
-        assertThat(lastAction.payload).isNotNull
-        assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
-
-        val payload = lastAction.payload as SuggestDomainsPayload
-        assertThat(payload.tlds).isNotNull()
-        assertThat(payload.tlds).isEqualTo("blog")
-        assertThat(payload.onlyWordpressCom).isNull()
-        assertThat(payload.includeWordpressCom).isNull()
-        assertThat(payload.includeDotBlogSubdomain).isNull()
-        assertThat(payload.vendor).isNull()
+        assertThat(params.query).isEqualTo("test")
+        assertThat(params.tlds).isEqualTo(listOf("blog"))
+        assertThat(params.onlyWordpressdotcom).isNull() // checkstyle ignore
+        assertThat(params.includeWordpressdotcom).isNull() // checkstyle ignore
+        assertThat(params.includeDotblogsubdomain).isNull()
+        assertThat(params.vendor).isNull()
     }
 
     @Test
-    fun `site on non blogger plan is requesting all possible domain suggestions`() = test {
-        site.planId = PlansConstants.PREMIUM_PLAN_ID
+    fun `site on non blogger plan is requesting all possible domain suggestions`() {
+        val params = viewModel.buildSuggestionsParams("test", isOnBloggerPlan = false)
+
+        assertThat(params.query).isEqualTo("test")
+        assertThat(params.onlyWordpressdotcom).isFalse() // checkstyle ignore
+        assertThat(params.includeWordpressdotcom).isFalse() // checkstyle ignore
+        assertThat(params.includeDotblogsubdomain).isTrue()
+        assertThat(params.vendor).isNull()
+        assertThat(params.tlds).isNull()
+    }
+
+    @Test
+    fun `free suggestions are dropped and paid ones are sorted by relevance`() = test {
+        mockResponses(
+            productsResponse(),
+            suggestionsResponse(
+                DomainSuggestion.Free(
+                    FreeDomainSuggestion("test.wordpress.com", "Free", isFree = true)
+                ),
+                DomainSuggestion.Paid(paidSuggestion("low.com", relevance = 0.2)),
+                DomainSuggestion.Paid(paidSuggestion("high.com", relevance = 0.9)),
+            )
+        )
+
         viewModel.start(site, domainRegistrationPurpose)
-        viewModel.updateSearchQuery("test")
+        advanceUntilIdle()
 
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        assertThat(lastSuccess().map { it.domainName })
+            .containsExactly("high.com", "low.com")
+    }
 
-        val lastAction = captor.value
+    @Test
+    fun `a product on sale is mapped to its server formatted sale cost`() = test {
+        mockResponses(
+            productsResponse(
+                "domain_reg" to testProduct(
+                    productId = 6u,
+                    saleCost = 600L,
+                    combinedSaleCostDisplay = "$6"
+                )
+            ),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion(productId = 6u)))
+        )
 
-        assertThat(lastAction.type).isEqualTo(SiteAction.SUGGEST_DOMAINS)
-        assertThat(lastAction.payload).isNotNull()
-        assertThat(lastAction.payload).isInstanceOf(SuggestDomainsPayload::class.java)
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
 
-        val payload = lastAction.payload as SuggestDomainsPayload
-        assertThat(payload.onlyWordpressCom).isFalse()
-        assertThat(payload.includeWordpressCom).isFalse()
-        assertThat(payload.includeDotBlogSubdomain).isTrue()
-        assertThat(payload.vendor).isNull()
-        assertThat(payload.tlds).isNull()
+        val item = lastSuccess().single()
+        assertThat(item.isOnSale).isTrue()
+        assertThat(item.saleCost).isEqualTo("$6")
+    }
+
+    @Test
+    fun `a product with a zero sale cost is not on sale`() = test {
+        mockResponses(
+            productsResponse(
+                "domain_reg" to testProduct(productId = 6u, saleCost = 0L)
+            ),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion(productId = 6u)))
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        assertThat(lastSuccess().single().isOnSale).isFalse()
+    }
+
+    @Test
+    fun `empty_results is shown as an empty list rather than an error`() = test {
+        mockResponses(
+            productsResponse(),
+            wpError("empty_results", "No available domains for that search.")
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        assertThat(suggestionStates.last()).isInstanceOf(ListState.Success::class.java)
+        assertThat(lastSuccess()).isEmpty()
+    }
+
+    @Test
+    fun `an api error surfaces its message to the view`() = test {
+        mockResponses(
+            productsResponse(),
+            wpError("invalid_query", "Domain searches must contain a word")
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        val state = suggestionStates.last()
+        assertThat(state).isInstanceOf(ListState.Error::class.java)
+        assertThat((state as ListState.Error).errorMessage)
+            .isEqualTo("Domain searches must contain a word")
+    }
+
+    @Test
+    fun `a non api failure leaves the message empty so the view shows its own`() = test {
+        mockResponses(
+            productsResponse(),
+            WpRequestResult.UnknownError<Any>(
+                500.toUInt(),
+                "Internal Server Error",
+                "",
+                RequestMethod.GET,
+            )
+        )
+
+        viewModel.start(site, domainRegistrationPurpose)
+        advanceUntilIdle()
+
+        val state = suggestionStates.last()
+        assertThat(state).isInstanceOf(ListState.Error::class.java)
+        assertThat((state as ListState.Error).errorMessage).isNull()
+    }
+
+    /**
+     * A response that arrives after the search has moved on must not replace
+     * the list. The requests are queued on a [StandardTestDispatcher] so both
+     * are in flight before either resolves, which an unconfined dispatcher
+     * cannot reproduce. `start()` is skipped so the products request does not
+     * reset the query to the site name partway through.
+     */
+    @Test
+    fun `suggestions for a superseded query are discarded`() = test {
+        mockResponses(
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion("stale.com"))),
+            suggestionsResponse(DomainSuggestion.Paid(paidSuggestion("fresh.com"))),
+        )
+        viewModel = createViewModel(StandardTestDispatcher(testDispatcher().scheduler))
+        viewModel.site = site
+        viewModel.domainRegistrationPurpose = domainRegistrationPurpose
+
+        viewModel.updateSearchQuery("stale")
+        viewModel.updateSearchQuery("fresh")
+        advanceUntilIdle()
+
+        val emitted = suggestionStates.filterIsInstance<ListState.Success<DomainSuggestionItem>>()
+        assertThat(emitted).hasSize(1)
+        assertThat(emitted.single().data.map { it.domainName }).containsExactly("fresh.com")
     }
 
     @Test
     fun `clicking select domain button for credit redemption emits selected domain`() = test {
+        mockResponses(productsResponse(), suggestionsResponse())
+
         viewModel.start(site, CTA_DOMAIN_CREDIT_REDEMPTION)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
         viewModel.onSelectDomainButtonClicked()
@@ -185,6 +340,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `clicking select domain button for purchase calls cart creation use case and emits selected domain`() = test {
+        mockResponses(productsResponse(), suggestionsResponse())
         whenever(createCartUseCase.execute(site, DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME, true, false))
             .thenReturn(dummySuccessfulOnShoppingCartCreated)
 
@@ -194,6 +350,9 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
         assertThat(onDomainSelectedEvents.last()).isEqualTo(DomainProductDetails(DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME))
     }
+
+    private fun lastSuccess(): List<DomainSuggestionItem> =
+        suggestionStates.filterIsInstance<ListState.Success<DomainSuggestionItem>>().last().data
 
     companion object {
         const val DUMMY_PRODUCT_ID = 1
@@ -222,6 +381,75 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
             isCostVisible = true,
             isFreeWithCredits = false,
             isEnabled = true
+        )
+
+        private fun productsResponse(vararg products: Pair<String, Product>) =
+            WpRequestResult.Success(products.toMap())
+
+        private fun suggestionsResponse(vararg suggestions: DomainSuggestion) =
+            WpRequestResult.Success(suggestions.toList())
+
+        private fun wpError(code: String, message: String) = WpRequestResult.WpError<Any>(
+            errorCode = WpErrorCode.CustomException(code),
+            errorMessage = message,
+            statusCode = 400.toUInt(),
+            response = "",
+            requestUrl = "",
+            requestMethod = RequestMethod.GET,
+        )
+
+        private fun paidSuggestion(
+            domainName: String = "example.com",
+            relevance: Double = 0.0,
+            productId: ULong = 6u,
+        ) = PaidDomainSuggestion(
+            domainName = domainName,
+            relevance = relevance,
+            supportsPrivacy = true,
+            vendor = "donuts",
+            matchReasons = listOf("tld-common"),
+            maxRegYears = 10u,
+            multiYearRegAllowed = true,
+            productId = productId,
+            productSlug = "domain_reg",
+            cost = "\$18.00",
+            renewCost = "\$18.00",
+            renewRawPrice = 1800L,
+            rawPrice = 1800L,
+            currencyCode = "USD",
+            saleCost = null,
+            hstsRequired = null,
+            policyNotices = emptyList(),
+        )
+
+        private fun testProduct(
+            productId: ULong = 6u,
+            saleCost: Long? = null,
+            combinedSaleCostDisplay: String? = null,
+        ) = Product(
+            productId = productId,
+            productName = "Domain Registration",
+            productSlug = "domain_reg",
+            description = "Register a domain",
+            productType = "domains",
+            available = true,
+            billingProductSlug = "domain_reg",
+            isDomainRegistration = true,
+            costDisplay = "$18.00",
+            combinedCostDisplay = "$18",
+            cost = 1800L,
+            costSmallestUnit = 1800u,
+            currencyCode = "USD",
+            productTerm = ProductTerm.Year,
+            productTermLocalized = "year",
+            priceTierSlug = "",
+            priceTierList = emptyList(),
+            domainInfo = null,
+            costPerMonthDisplay = null,
+            saleCost = saleCost,
+            combinedSaleCostDisplay = combinedSaleCostDisplay,
+            saleCoupon = null,
+            introductoryOffer = null,
         )
     }
 }


### PR DESCRIPTION
## Description

Moves `DomainSuggestionsViewModel` off FluxC. Domain products and suggestions now come from `WpComApiClient.products().list()` and `WpComApiClient.domains().suggestions()` rather than `ProductsStore` and a `newSuggestDomainsAction` dispatch, so the `@Subscribe` handler, the EventBus registration and the `Dispatcher` dependency all go away. `CreateCartUseCase` stays on FluxC; it is shared with `PurchaseDomainViewModel` and `SiteCreationProgressViewModel`, so it moves separately.

Behaviour is meant to match trunk. The pieces worth checking:

- **`empty_results` is not a failure.** The API reports "no domains for that search" as an HTTP error, and `SiteRestClient.suggestDomains` turned it back into a successful empty list. The migration does the same, so the list empties instead of raising a toast.
- **`invalid_query` still carries the API's message**, as on trunk. This screen treats it differently from the site creation search, where FluxC gave it its own empty state.
- **The on-sale check changed units.** FluxC typed `Product.saleCost` as a decimal amount and tested `> 0.0`. wordpress-rs types it as `Decimal2`, which holds hundredths of the currency unit — `700` is `7.00` — so the test is `> 0L`. The two agree, where a null check would not.
- **A superseded response is still discarded.** `searchQuery` is captured before the request rather than read after it, which preserves the check trunk made against `OnSuggestedDomains.query`.

The logging changed along the way. Both failure paths now report through `toLogErrorString`, and the product fetch names products rather than "site domains", which it never fetched. Its success path logged the entire product catalogue through `AppLog.d`; that is gone.

## The failure path, and the layout animation

Several departures from a straight port, all found while testing the failure paths. They were rough enough on this screen to be worth fixing here rather than filing.

**An offline failure says so.** Every failure produced "Domain suggestions couldn't be loaded", including the one the user can do something about — FluxC's no-connection error carried an empty message (`BaseRequest.java:88-92`) and the fragment fell back to that string. wordpress-rs reports `DeviceIsOfflineError` separately, so that case now sets `errorMessageResId` to `error_network_connection`, "Check your network connection and try again".

**A failed search clears the list, and is reported once.** `ListState.Error` is built from the previous state's data, so a rejected query left the previous query's results on screen underneath the new text — searching `...` after a real search showed that search's domains as though they answered it. Results are already hidden while a request is in flight, so this stops a failure restoring them rather than introducing a new behaviour, and it matches `NewDomainSearchViewModel`, whose exclusive `UiState` replaces the list the moment a search starts.

With the list always empty on failure, the empty view carries every error — title, and the reason as its subtitle — and the toast is gone. Previously the two could contradict each other, the empty view reporting no matches while a toast reported a failure, and the toast truncated the longer API messages.

Emptying the field clears the results for the same reason: an error explaining how a query has to be written outlived the query it described. The list returns to `Init`, which the fragment renders as a blank content area rather than an empty list, and the selected domain is dropped so the Select button cannot stay armed over it. This applies only when the query has moved off the site name — restoring the view state after a configuration change reports the emptied field as a change too, and the retained suggestions have to survive that.

**A blank query is not searched for.** `initializeDefaultSuggestions` searches for `site.name`, which runs on open and again whenever the field is emptied. A site with no name made that a blank query, the API rejects a blank query as `invalid_query`, and so emptying the field replaced the error it was meant to clear with an identical one. A blank query now settles on `Init` without a request.

**The screen starts at rest.** The layout declared the search icon `gone` and the progress bar visible — the inverse of the `tools:visibility` on each, which say what the resting state was meant to be. The fragment only corrects them once `suggestions` is first assigned, so a screen that opens without issuing a search sits on a spinner with a blank list behind it. Both defaults now match the not-loading state.

**The implicit layout animation is gone.** Typing the first character hides the intro block and swaps the search icon for a spinner, and `animateLayoutChanges` animated the resulting bounds change, which is what made the screen jump while the first results loaded. The views around the header now snap. #23247 drops the same attribute from the site creation search, where the animation was also taking focus off the search field.

## Testing instructions

Reach the screen: **My Site** → **Domains** → the domain call to action at the bottom (**Claim your free domain**, **Add your domain** or **Get your domain**, depending on the site's plan and credit).

Stop before completing a purchase. Selecting a domain on this screen creates a shopping cart.

Typing is not interrupted:

1. Type a single character into the search field.
- [x] Verify you can keep typing straight away, and that the screen does not jump as the intro block gives way to the results.

A normal search:

1. Type an ordinary word, e.g. `coolsite`.
- [x] Verify paid suggestions appear with prices, and that no free `.wordpress.com` suggestion is among them.
- [x] Verify the most relevant suggestion is at the top.
- [x] Verify tapping one enables the button at the bottom.
- [x] If any suggestion is on sale, verify the struck-through price and the sale price both render.

A query with no matches:

1. Search for a long run of the same letter, e.g. 200 or so `z` characters.
- [x] Verify the empty view says no domains were found, with no error alongside it.

A query the API refuses, after one that worked:

1. Search for something ordinary and let the suggestions load.
2. Replace it with `...`
- [x] Verify the empty view reports the failure, carrying the API's message in full as its subtitle.
- [x] Verify the earlier search's domains are gone rather than sitting under the new text.
3. Delete the whole query.
- [x] Verify the error goes with it and the intro comes back.
- [x] Verify the Select button is disabled again if you had a domain selected.

Rotation:

1. Search for something and let the suggestions load.
2. Rotate the device.
- [x] Verify the suggestions are still on screen.
3. Rotate again without having typed anything.
- [x] Verify they are still there.

No connection:

1. Turn networking off, then search.
- [x] Verify the empty view says the suggestions couldn't be loaded, with "Check your network connection and try again" beneath it, and no toast.
- [x] Verify the spinner stops and the screen settles, rather than sitting on a spinner or flickering.
2. Turn networking back on and search again.
- [x] Verify suggestions load.

Typing quickly:

1. Type a word one character at a time at a normal pace, then keep typing while results are loading.
- [x] Verify the list that settles matches the final query rather than an earlier one.

## Screenshots

| Results | No matches | Invalid query | No connection |
|---|---|---|---|
| <img width="1080" alt="coolsite-search-working-as-expected" src="https://github.com/user-attachments/assets/5a056a0e-0e04-4133-ad70-9f14ce3a8672" /> |  <img width="1080" alt="too-many-zzz-s-leading-to-empty-suggestion-list" src="https://github.com/user-attachments/assets/4bb14ee6-fb61-4ec3-b71f-379b230dc0da" /> | <img width="1080" alt="invalid_query" src="https://github.com/user-attachments/assets/6e9f4e2e-df71-4e68-bf7e-b5f3ec0fbd46" /> | <img width="1080" alt="no-network-while-list-is-empty" src="https://github.com/user-attachments/assets/9e052ab1-83b2-47cb-90de-a09279788ddc" /> |