### PR TITLE
Move the upload keystore out of the checkout

### DIFF
--- a/.configure
+++ b/.configure
@@ -25,7 +25,7 @@
     },
     {
       "file": "android/automattic_upload.jks",
-      "destination": "~/.configure/wordpress-android/secrets/upload.keystore",
+      "destination": "~/.configure/wordpress-android/secrets/upload.jks",
       "encrypt": true
     },
     {

--- a/.configure
+++ b/.configure
@@ -15,7 +15,7 @@
     },
     {
       "file": "android/debug.keystore",
-      "destination": "~/.configure/wordpress-android/secrets/debug_a8c.keystore",
+      "destination": "~/.configure/wordpress-android/secrets/debug.keystore",
       "encrypt": true
     },
     {
@@ -25,7 +25,7 @@
     },
     {
       "file": "android/automattic_upload.jks",
-      "destination": "WordPress/upload.jks",
+      "destination": "~/.configure/wordpress-android/secrets/upload.keystore",
       "encrypt": true
     },
     {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -280,10 +280,12 @@ android {
     }
 
     signingConfigs {
-        if (["uploadStoreFile", "uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"].count { !gradle.ext.secretProperties.containsKey(it) } == 0) {
-            logger.info("App signing properties found in secrets.properties, configuring signing for release builds.")
+        def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.keystore")
+        def uploadCredentials = ["uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"]
+        if (uploadKeystore.exists() && uploadCredentials.every { gradle.ext.secretProperties.containsKey(it) }) {
+            logger.info("Upload keystore found, configuring signing for release builds.")
             release {
-                storeFile = rootProject.file(gradle.ext.secretProperties.get("uploadStoreFile"))
+                storeFile = uploadKeystore
                 storePassword = gradle.ext.secretProperties.get("uploadStorePassword")
                 keyAlias = gradle.ext.secretProperties.get("uploadKeyAlias")
                 keyPassword = gradle.ext.secretProperties.get("uploadKeyPassword")
@@ -291,13 +293,11 @@ android {
             android.buildTypes.release.signingConfig = android.signingConfigs.release
         }
 
-        if (gradle.ext.secretProperties.containsKey("debugStoreFile")) {
-            logger.info("Debug signing properties found in secrets.properties, configuring signing for debug builds.")
-            def sharedDebugStore = file(gradle.ext.secretProperties.get("debugStoreFile").replaceFirst("^~", System.getProperty("user.home")))
-            if (sharedDebugStore.exists()) {
-                debug {
-                    storeFile sharedDebugStore
-                }
+        def debugKeystore = new File(gradle.ext.decryptedSecretsDir, "debug.keystore")
+        if (debugKeystore.exists()) {
+            logger.info("Shared debug keystore found, configuring signing for debug builds.")
+            debug {
+                storeFile debugKeystore
             }
         }
     }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -274,7 +274,7 @@ android {
     }
 
     signingConfigs {
-        def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.keystore")
+        def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.jks")
         def uploadCredentials = ["uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"]
         if (uploadKeystore.exists() && uploadCredentials.every { gradle.ext.secretProperties.containsKey(it) }) {
             logger.info("Upload keystore found, configuring signing for release builds.")

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -111,6 +111,10 @@ base {
     archivesName = "org.wordpress.android"
 }
 
+def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.jks")
+def uploadCredentials = ["uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"]
+def uploadKeyAvailable = uploadKeystore.exists() && uploadCredentials.every { gradle.ext.secretProperties.containsKey(it) }
+
 android {
     useLibrary 'android.test.runner'
 
@@ -274,9 +278,7 @@ android {
     }
 
     signingConfigs {
-        def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.jks")
-        def uploadCredentials = ["uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"]
-        if (uploadKeystore.exists() && uploadCredentials.every { gradle.ext.secretProperties.containsKey(it) }) {
+        if (uploadKeyAvailable) {
             logger.info("Upload keystore found, configuring signing for release builds.")
             release {
                 storeFile = uploadKeystore
@@ -328,6 +330,22 @@ android {
         buildConfig true
         viewBinding true
         compose true
+    }
+}
+
+// Without the upload key a release build still succeeds, producing an unsigned artifact that only
+// fails once something tries to upload it. AGP creates `validateSigning*` only for variants that
+// are already signed, so the guard hangs off the packaging tasks — always present, and reached
+// before the artifact is written. Checked at execution time so contributors without the secrets
+// keep their debug builds.
+tasks.matching { it.name.startsWith("package") && it.name.contains("Release") }.configureEach {
+    doFirst {
+        if (!uploadKeyAvailable) {
+            throw new GradleException(
+                "The upload keystore is missing, so this release build would not be signed. " +
+                    "Please run `bundle exec fastlane run configure_apply` to apply secrets."
+            )
+        }
     }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -274,10 +274,12 @@ android {
     }
 
     signingConfigs {
-        if (["uploadStoreFile", "uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"].count { !gradle.ext.secretProperties.containsKey(it) } == 0) {
-            logger.info("App signing properties found in secrets.properties, configuring signing for release builds.")
+        def uploadKeystore = new File(gradle.ext.decryptedSecretsDir, "upload.keystore")
+        def uploadCredentials = ["uploadStorePassword", "uploadKeyAlias", "uploadKeyPassword"]
+        if (uploadKeystore.exists() && uploadCredentials.every { gradle.ext.secretProperties.containsKey(it) }) {
+            logger.info("Upload keystore found, configuring signing for release builds.")
             release {
-                storeFile = rootProject.file(gradle.ext.secretProperties.get("uploadStoreFile"))
+                storeFile = uploadKeystore
                 storePassword = gradle.ext.secretProperties.get("uploadStorePassword")
                 keyAlias = gradle.ext.secretProperties.get("uploadKeyAlias")
                 keyPassword = gradle.ext.secretProperties.get("uploadKeyPassword")
@@ -285,13 +287,11 @@ android {
             android.buildTypes.release.signingConfig = android.signingConfigs.release
         }
 
-        if (gradle.ext.secretProperties.containsKey("debugStoreFile")) {
-            logger.info("Debug signing properties found in secrets.properties, configuring signing for debug builds.")
-            def sharedDebugStore = file(gradle.ext.secretProperties.get("debugStoreFile").replaceFirst("^~", System.getProperty("user.home")))
-            if (sharedDebugStore.exists()) {
-                debug {
-                    storeFile sharedDebugStore
-                }
+        def debugKeystore = new File(gradle.ext.decryptedSecretsDir, "debug.keystore")
+        if (debugKeystore.exists()) {
+            logger.info("Shared debug keystore found, configuring signing for debug builds.")
+            debug {
+                storeFile debugKeystore
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,8 @@ plugins {
 gradle.ext {
     isCi = System.getenv('CI')?.toBoolean() ?: false
 
-    secretPath = "${System.getProperty("user.home")}/.configure/wordpress-android/secrets/secrets.properties"
+    decryptedSecretsDir = file("${System.getProperty("user.home")}/.configure/wordpress-android/secrets")
+    secretPath = new File(decryptedSecretsDir, "secrets.properties").path
     secretProperties = loadSecrets(
             logger,
             file("${rootDir}/defaults.properties"),


### PR DESCRIPTION
## Description

Closes [AINFRA-2968](https://linear.app/a8c/issue/AINFRA-2968).

The upload keystore now decrypts next to `secrets.properties`, outside of the checkout, as described internally in paaHJt-akR-p2.

`.gitignore` still ignores `WordPress/*.jks` because pre-change checkouts still have `WordPress/upload.jks` on disk.

`uploadStoreFile` and `debugStoreFile` are unused after this. Dropping them from `mobile-secrets` is a separate follow-up, so this PR stays revertible on its own.

**After merging, run `bundle exec fastlane run configure_apply` and delete the stale `WordPress/upload.jks`.**

## Testing instructions

Signing is not in the unit suite.
Compare `./gradlew :WordPress:signingReport`.

Without secrets:

- [x] `wordpressRelease` / `jetpackRelease` → `Config: none`
- [x] `wordpressDebug` → `~/.android/debug.keystore`

After `bundle exec fastlane run configure_apply`:

- [x] release configs → `Config: release`, `Store:` in the out-of-repo configure directory, not the repo
- [x] `Alias:` matches `uploadKeyAlias`
- [x] `wordpressDebug` → shared `debug.keystore` from that directory

For the record: I run all the check on my end.

PR CI does not exercise release signing.
Prototype builds on this PR did pick up the renamed debug keystore.


<details>
<summary>Also verified on a CI agent</summary>

Because no PR job exercises release signing, the same checks were run on a Buildkite agent from a throwaway stacked PR (#23267, now closed): [build #28383, job "🔐 Validate signing config"](https://buildkite.com/automattic/wordpress-android/builds/28383#01a040aa-8ccf-4ba6-87cf-6bbe973c37dd).

After `configure_apply` on the agent:

```
Variant: wordpressRelease
Config: release
Store: /var/lib/buildkite-agent/.configure/wordpress-android/secrets/upload.jks
SHA-256: 14:F0:…:9F:A6   (same certificate as the local report)
```

Two negative cases ran against a throwaway `user.home` symlinked to the real credentials, so the agent's secrets directory was never touched:

- Credentials readable, no upload keystore → both release variants drop to `Config: none`. The keystore file, not `secrets.properties`, is what gates signing.
- No shared `debug.keystore` → debug variants fall back to `~/.android/debug.keystore` with `Error: Missing keystore`. This is why a green prototype build was never on its own evidence that the shared key was read.

Still unproven until the scheduled trunk-internal build: that `bundleRelease` signs and uploads with this keystore. `signingReport` shows the config resolves, not that the artifact ships.

*Section added by Claude (Opus 5) on behalf of @mokagio with approval. Re-run after the branch kept the `.jks` extension; the earlier run was #23266 / build #28371.*


</details>
