### PR TITLE
CMM-2304: Detect Jetpack status on the application-password path

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [*] Sharing content to the app now lists self-hosted sites connected with an application password.
 * [**] Images and videos shared to the app from the photo picker now upload instead of being silently dropped.
 * [**] Media shared from apps that generate it on the fly, such as an "Enhanced" photo from Google Photos, now keeps its correct file type instead of always uploading as a JPEG, and sharing several photos at once no longer drops some of them. [https://github.com/wordpress-mobile/WordPress-Android/issues/23047]
+* [**] Self-hosted sites added with an application password now have their Jetpack status detected, so opening Stats in the Jetpack app no longer asks you to install a plugin your site already has.
 
 26.9
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
@@ -19,12 +19,11 @@ import javax.inject.Singleton
 
 /**
  * A self-hosted site's Jetpack connection to WordPress.com. [wpComSiteId] is the blog ID WordPress.com
- * assigned the site when it connected, and is null whenever [isConnected] is false.
+ * assigned the site when it connected, and is null when it isn't connected.
  */
-data class JetpackConnectionState(
-    val isConnected: Boolean,
-    val wpComSiteId: Long?
-)
+data class JetpackConnectionState(val wpComSiteId: Long?) {
+    val isConnected: Boolean get() = wpComSiteId != null
+}
 
 /**
  * Reads a self-hosted site's Jetpack connection state over wordpress-rs.
@@ -58,22 +57,12 @@ class JetpackConnectionStatusFetcher @Inject constructor(
         password: String
     ): JetpackConnectionState? = try {
         buildClient(apiRootUrl, username, password).use { client ->
-            when (val status = client.status()) {
-                is JetpackConnectionStatus.NotConnected -> JetpackConnectionState(
-                    isConnected = false,
-                    wpComSiteId = null
-                )
-
-                is JetpackConnectionStatus.Site -> JetpackConnectionState(
-                    isConnected = true,
-                    wpComSiteId = status.blogId.toLong()
-                )
-
-                is JetpackConnectionStatus.User -> JetpackConnectionState(
-                    isConnected = true,
-                    wpComSiteId = status.blogId.toLong()
-                )
+            val blogId = when (val status = client.status()) {
+                is JetpackConnectionStatus.NotConnected -> null
+                is JetpackConnectionStatus.Site -> status.blogId
+                is JetpackConnectionStatus.User -> status.blogId
             }
+            JetpackConnectionState(wpComSiteId = blogId?.toLong())
         }
     } catch (e: Exception) {
         appLogWrapper.d(AppLog.T.API, "$TAG: couldn't read the Jetpack connection status: ${e.message}")

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
@@ -1,0 +1,98 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.jetpack
+
+import okhttp3.Interceptor
+import org.wordpress.android.fluxc.module.OkHttpClientQualifiers
+import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpNetworkAvailabilityProvider
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.EmptyAppNotifier
+import rs.wordpress.api.kotlin.WpRequestExecutor
+import uniffi.wp_api.JetpackConnectionClient
+import uniffi.wp_api.JetpackConnectionStatus
+import uniffi.wp_api.ParsedUrl
+import uniffi.wp_api.WpApiClientDelegate
+import uniffi.wp_api.WpApiMiddlewarePipeline
+import uniffi.wp_api.WpAuthenticationProvider
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * A self-hosted site's Jetpack connection to WordPress.com. [wpComSiteId] is the blog ID WordPress.com
+ * assigned the site when it connected, and is null whenever [isConnected] is false.
+ */
+data class JetpackConnectionState(
+    val isConnected: Boolean,
+    val wpComSiteId: Long?
+)
+
+/**
+ * Reads a self-hosted site's Jetpack connection state over wordpress-rs.
+ *
+ * Only the Jetpack plugin knows whether a site is connected to WordPress.com and which blog ID it was
+ * given. Sites added with an application password have no other source for either: the WP.com REST site
+ * payload that populates those fields for Jetpack sites is never fetched for them.
+ */
+@Singleton
+class JetpackConnectionStatusFetcher @Inject constructor(
+    @Named(OkHttpClientQualifiers.INTERCEPTORS) private val interceptors: Set<@JvmSuppressWildcards Interceptor>,
+    private val networkAvailabilityProvider: WpNetworkAvailabilityProvider,
+    private val appLogWrapper: AppLogWrapper
+) {
+    /**
+     * Returns the site's Jetpack connection state, or null when it can't be determined — the site is
+     * unreachable, the endpoint isn't there, or Jetpack is older than 14.2, which is where these
+     * endpoints were added. Callers should read null as "unchanged", not as "not connected".
+     */
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun fetch(
+        apiRootUrl: String,
+        username: String,
+        password: String
+    ): JetpackConnectionState? = try {
+        buildClient(apiRootUrl, username, password).use { client ->
+            when (val status = client.status()) {
+                is JetpackConnectionStatus.NotConnected -> JetpackConnectionState(
+                    isConnected = false,
+                    wpComSiteId = null
+                )
+
+                is JetpackConnectionStatus.Site -> JetpackConnectionState(
+                    isConnected = true,
+                    wpComSiteId = status.blogId.toLong()
+                )
+
+                is JetpackConnectionStatus.User -> JetpackConnectionState(
+                    isConnected = true,
+                    wpComSiteId = status.blogId.toLong()
+                )
+            }
+        }
+    } catch (e: Exception) {
+        appLogWrapper.d(AppLog.T.API, "$TAG: couldn't read the Jetpack connection status: ${e.message}")
+        null
+    }
+
+    private fun buildClient(
+        apiRootUrl: String,
+        username: String,
+        password: String
+    ) = JetpackConnectionClient(
+        apiRootUrl = ParsedUrl.parse(apiRootUrl),
+        delegate = WpApiClientDelegate(
+            authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(username, password),
+            requestExecutor = WpRequestExecutor(
+                interceptors = interceptors.toList(),
+                networkAvailabilityProvider = networkAvailabilityProvider
+            ),
+            middlewarePipeline = WpApiMiddlewarePipeline(emptyList()),
+            // Reading the status is a passive check made during a site refresh, so a rejected
+            // credential shouldn't raise the app-wide "re-authenticate" prompt on its own.
+            appNotifier = EmptyAppNotifier()
+        )
+    )
+
+    companion object {
+        private const val TAG = "JetpackConnectionStatusFetcher"
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionStatusFetcher.kt
@@ -35,10 +35,17 @@ data class JetpackConnectionState(
  */
 @Singleton
 class JetpackConnectionStatusFetcher @Inject constructor(
-    @Named(OkHttpClientQualifiers.INTERCEPTORS) private val interceptors: Set<@JvmSuppressWildcards Interceptor>,
-    private val networkAvailabilityProvider: WpNetworkAvailabilityProvider,
+    @Named(OkHttpClientQualifiers.INTERCEPTORS) interceptors: Set<@JvmSuppressWildcards Interceptor>,
+    networkAvailabilityProvider: WpNetworkAvailabilityProvider,
     private val appLogWrapper: AppLogWrapper
 ) {
+    // One executor for the singleton: each WpRequestExecutor builds its own OkHttpClient (with its own
+    // connection pool), and the executor is site-independent -- auth lives in the per-call delegate.
+    private val requestExecutor = WpRequestExecutor(
+        interceptors = interceptors.toList(),
+        networkAvailabilityProvider = networkAvailabilityProvider
+    )
+
     /**
      * Returns the site's Jetpack connection state, or null when it can't be determined — the site is
      * unreachable, the endpoint isn't there, or Jetpack is older than 14.2, which is where these
@@ -81,10 +88,7 @@ class JetpackConnectionStatusFetcher @Inject constructor(
         apiRootUrl = ParsedUrl.parse(apiRootUrl),
         delegate = WpApiClientDelegate(
             authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(username, password),
-            requestExecutor = WpRequestExecutor(
-                interceptors = interceptors.toList(),
-                networkAvailabilityProvider = networkAvailabilityProvider
-            ),
+            requestExecutor = requestExecutor,
             middlewarePipeline = WpApiMiddlewarePipeline(emptyList()),
             // Reading the status is a passive check made during a site refresh, so a rejected
             // credential shouldn't raise the app-wide "re-authenticate" prompt on its own.

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -79,6 +79,11 @@ class SiteWPAPIRestClient @Inject constructor(
                 val jetpackPlugin = fetchJetpackPluginState(response?.namespaces, discoveredWpApiUrl, payload)
                 val jetpackConnection = fetchJetpackConnectionState(jetpackPlugin, discoveredWpApiUrl, payload)
                 SiteModel().apply {
+                    // Carry the local id so SiteStore.updateSite finds the stored row and preserves the
+                    // editor preferences, and so SiteSqlUtils matches the row by local id rather than by
+                    // SITE_ID + URL -- that match misses, and inserts a duplicate site, as soon as a real
+                    // WP.com blog id is stored.
+                    id = previousSite?.id ?: 0
                     name = response?.name
                     description = response?.description
                     timezone = response?.gmtOffset
@@ -119,7 +124,7 @@ class SiteWPAPIRestClient @Inject constructor(
     suspend fun fetchWPAPISite(
         site: SiteModel
     ): SiteModel {
-        val fetchedSite = fetchWPAPISite(
+        return fetchWPAPISite(
             payload = FetchWPAPISitePayload(
                 url = site.url,
                 username = site.getUserNameProcessed(),
@@ -129,14 +134,6 @@ class SiteWPAPIRestClient @Inject constructor(
             ),
             previousSite = site
         )
-
-        if (!fetchedSite.isError) {
-            // Carry the local id so SiteStore.updateSite finds the stored row and preserves the editor
-            // preferences, and so SiteSqlUtils matches the row by local id rather than by SITE_ID + URL --
-            // that match misses, and inserts a duplicate site, as soon as a real WP.com blog id is stored.
-            fetchedSite.id = site.id
-        }
-        return fetchedSite
     }
 
     /**
@@ -213,20 +210,18 @@ class SiteWPAPIRestClient @Inject constructor(
         apiRootUrl: String,
         payload: FetchWPAPISitePayload
     ): JetpackConnectionState? {
+        // isActive = true is only ever produced by requestJetpackPlugin, which already required the
+        // application-password credentials, so no separate credential check is needed here.
         if (plugin?.isActive != true) return null
-
-        val username = payload.username
-        val password = payload.password
-        return if (payload.isApplicationPassword && !username.isNullOrEmpty() && !password.isNullOrEmpty()) {
-            jetpackConnectionStatusFetcher.fetch(apiRootUrl, username, password)
-        } else {
-            null
-        }
+        val username = payload.username ?: return null
+        val password = payload.password ?: return null
+        return jetpackConnectionStatusFetcher.fetch(apiRootUrl, username, password)
     }
 
     /**
      * A null [plugin] or [connection] means that state couldn't be read on this run, in which case the
-     * stored value is carried forward rather than reset.
+     * stored values are carried forward rather than reset. A non-null result is definitive, including
+     * its null fields -- a disconnected site clears the blog id rather than keeping a stale one.
      *
      * Note that [SiteModel.isJetpackConnected] only says the site is connected to *some* WordPress.com
      * account, not necessarily the one signed in here -- callers that need the stronger claim have to check
@@ -237,10 +232,28 @@ class SiteWPAPIRestClient @Inject constructor(
         connection: JetpackConnectionState?,
         previousSite: SiteModel?
     ) {
-        setIsJetpackInstalled(plugin?.isActive ?: previousSite?.isJetpackInstalled ?: false)
-        jetpackVersion = plugin?.version ?: previousSite?.jetpackVersion
-        setIsJetpackConnected(connection?.isConnected ?: previousSite?.isJetpackConnected ?: false)
-        siteId = connection?.wpComSiteId ?: previousSite?.siteId ?: 0L
+        if (plugin != null) {
+            setIsJetpackInstalled(plugin.isActive)
+            jetpackVersion = plugin.version
+        } else {
+            setIsJetpackInstalled(previousSite?.isJetpackInstalled ?: false)
+            jetpackVersion = previousSite?.jetpackVersion
+        }
+        when {
+            // The plugin is definitively gone, so its WordPress.com connection is too.
+            plugin != null && !plugin.isActive -> {
+                setIsJetpackConnected(false)
+                siteId = 0
+            }
+            connection != null -> {
+                setIsJetpackConnected(connection.isConnected)
+                siteId = connection.wpComSiteId ?: 0L
+            }
+            else -> {
+                setIsJetpackConnected(previousSite?.isJetpackConnected ?: false)
+                siteId = previousSite?.siteId ?: 0L
+            }
+        }
     }
 
     private fun discoverApiEndpoint(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -148,8 +148,9 @@ class SiteWPAPIRestClient @Inject constructor(
      * The `jetpack/` REST namespace is only a first filter: it's registered by the shared
      * `automattic/jetpack-connection` package, which also ships inside Jetpack Boost, Protect, Social and
      * VaultPress Backup, so its presence does *not* mean the Jetpack plugin is installed. What it does give
-     * us for free is a reliable negative -- no namespace, no active Jetpack -- which keeps the plugin lookup
-     * off the refresh path for the sites that have nothing to do with Jetpack.
+     * us for free is a reliable negative -- a namespace list without `jetpack/` means no active Jetpack --
+     * which keeps the plugin lookup off the refresh path for the sites that have nothing to do with Jetpack.
+     * That only holds when the list is present: an absent field is "couldn't read", not "no Jetpack".
      *
      * Reading the plugin list needs credentials and the `activate_plugins` capability, so it returns null for
      * sites without an application password and for users who aren't administrators. Callers must read null
@@ -159,17 +160,14 @@ class SiteWPAPIRestClient @Inject constructor(
         namespaces: List<String>?,
         apiRootUrl: String,
         payload: FetchWPAPISitePayload
-    ): JetpackPluginState? {
-        val hasJetpackNamespace = namespaces?.any { it.startsWith(JETPACK_API_NAMESPACE_PREFIX) } ?: false
-        if (!hasJetpackNamespace) return JetpackPluginState(isActive = false, version = null)
-
-        val username = payload.username
-        val password = payload.password
-        return if (payload.isApplicationPassword && !username.isNullOrEmpty() && !password.isNullOrEmpty()) {
-            requestJetpackPlugin(apiRootUrl, username, password)
-        } else {
-            null
-        }
+    ): JetpackPluginState? = when {
+        namespaces == null -> null
+        namespaces.none { it.startsWith(JETPACK_API_NAMESPACE_PREFIX) } ->
+            JetpackPluginState(isActive = false, version = null)
+        payload.isApplicationPassword &&
+            !payload.username.isNullOrEmpty() && !payload.password.isNullOrEmpty() ->
+            requestJetpackPlugin(apiRootUrl, payload.username.orEmpty(), payload.password.orEmpty())
+        else -> null
     }
 
     private suspend fun requestJetpackPlugin(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -213,9 +213,13 @@ class SiteWPAPIRestClient @Inject constructor(
         // isActive = true is only ever produced by requestJetpackPlugin, which already required the
         // application-password credentials, so no separate credential check is needed here.
         if (plugin?.isActive != true) return null
-        val username = payload.username ?: return null
-        val password = payload.password ?: return null
-        return jetpackConnectionStatusFetcher.fetch(apiRootUrl, username, password)
+        val username = payload.username
+        val password = payload.password
+        return if (username != null && password != null) {
+            jetpackConnectionStatusFetcher.fetch(apiRootUrl, username, password)
+        } else {
+            null
+        }
     }
 
     /**

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.site
 
 import com.android.volley.RequestQueue
+import com.google.gson.reflect.TypeToken
+import okhttp3.Credentials
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
@@ -13,6 +15,9 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIDiscoveryUtils
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionState
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionStatusFetcher
+import org.wordpress.android.fluxc.network.rest.wpapi.plugin.PluginResponseModel
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
 import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
@@ -26,19 +31,33 @@ import javax.inject.Singleton
 class SiteWPAPIRestClient @Inject constructor(
     private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
+    private val jetpackConnectionStatusFetcher: JetpackConnectionStatusFetcher,
     dispatcher: Dispatcher,
     @Named(OkHttpClientQualifiers.CUSTOM_SSL) requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     companion object {
         private const val WOO_API_NAMESPACE_PREFIX = "wc/"
+        private const val JETPACK_API_NAMESPACE_PREFIX = "jetpack/"
         private const val FETCH_API_CALL_FIELDS =
             "name,description,gmt_offset,url,authentication,namespaces"
         private const val APPLICATION_PASSWORDS_URL_SUFFIX = "authorize-application.php"
+        private const val PLUGINS_PATH = "wp/v2/plugins"
+        private const val PLUGINS_FIELDS = "plugin,status,version"
+        private const val JETPACK_PLUGIN_SEARCH = "jetpack"
+        private const val JETPACK_PLUGIN_ID = "jetpack/jetpack"
+        private const val PLUGIN_STATUS_ACTIVE = "active"
+        private const val PLUGIN_STATUS_NETWORK_ACTIVE = "network-active"
     }
 
+    /**
+     * @param previousSite the site this fetch is refreshing, when there is one. The model returned here
+     * replaces the stored row wholesale, so fields this fetch can't determine are carried forward from it
+     * rather than reset.
+     */
     suspend fun fetchWPAPISite(
-        payload: FetchWPAPISitePayload
+        payload: FetchWPAPISitePayload,
+        previousSite: SiteModel? = null
     ): SiteModel {
         val cleanedUrl = UrlUtils.addUrlSchemeIfNeeded(payload.url, false).let { urlWithScheme ->
             DiscoveryUtils.stripKnownPaths(urlWithScheme)
@@ -57,6 +76,8 @@ class SiteWPAPIRestClient @Inject constructor(
         return when (result) {
             is Success -> {
                 val response = result.data
+                val jetpackPlugin = fetchJetpackPluginState(response?.namespaces, discoveredWpApiUrl, payload)
+                val jetpackConnection = fetchJetpackConnectionState(jetpackPlugin, discoveredWpApiUrl, payload)
                 SiteModel().apply {
                     name = response?.name
                     description = response?.description
@@ -65,6 +86,7 @@ class SiteWPAPIRestClient @Inject constructor(
                     hasWooCommerce = response?.namespaces?.any {
                         it.startsWith(WOO_API_NAMESPACE_PREFIX)
                     } ?: false
+                    applyJetpackState(jetpackPlugin, jetpackConnection, previousSite)
 
                     applicationPasswordsAuthorizeUrl = response?.authentication?.applicationPasswords
                         ?.endpoints?.authorization
@@ -97,15 +119,128 @@ class SiteWPAPIRestClient @Inject constructor(
     suspend fun fetchWPAPISite(
         site: SiteModel
     ): SiteModel {
-        return fetchWPAPISite(
+        val fetchedSite = fetchWPAPISite(
             payload = FetchWPAPISitePayload(
                 url = site.url,
                 username = site.getUserNameProcessed(),
                 password = site.getPasswordProcessed(),
                 isApplicationPassword =
                     site.hasApplicationPassword(),
-            )
+            ),
+            previousSite = site
         )
+
+        if (!fetchedSite.isError) {
+            // Carry the local id so SiteStore.updateSite finds the stored row and preserves the editor
+            // preferences, and so SiteSqlUtils matches the row by local id rather than by SITE_ID + URL --
+            // that match misses, and inserts a duplicate site, as soon as a real WP.com blog id is stored.
+            fetchedSite.id = site.id
+        }
+        return fetchedSite
+    }
+
+    /**
+     * The Jetpack plugin, as reported by the site itself. [isActive] is what
+     * [SiteModel.isJetpackInstalled] documents -- installed *and* activated.
+     */
+    private data class JetpackPluginState(val isActive: Boolean, val version: String?)
+
+    /**
+     * Determines whether the site is running the Jetpack plugin, or null when it can't be determined.
+     *
+     * The `jetpack/` REST namespace is only a first filter: it's registered by the shared
+     * `automattic/jetpack-connection` package, which also ships inside Jetpack Boost, Protect, Social and
+     * VaultPress Backup, so its presence does *not* mean the Jetpack plugin is installed. What it does give
+     * us for free is a reliable negative -- no namespace, no active Jetpack -- which keeps the plugin lookup
+     * off the refresh path for the sites that have nothing to do with Jetpack.
+     *
+     * Reading the plugin list needs credentials and the `activate_plugins` capability, so it returns null for
+     * sites without an application password and for users who aren't administrators. Callers must read null
+     * as "unchanged", not as "not installed".
+     */
+    private suspend fun fetchJetpackPluginState(
+        namespaces: List<String>?,
+        apiRootUrl: String,
+        payload: FetchWPAPISitePayload
+    ): JetpackPluginState? {
+        val hasJetpackNamespace = namespaces?.any { it.startsWith(JETPACK_API_NAMESPACE_PREFIX) } ?: false
+        if (!hasJetpackNamespace) return JetpackPluginState(isActive = false, version = null)
+
+        val username = payload.username
+        val password = payload.password
+        return if (payload.isApplicationPassword && !username.isNullOrEmpty() && !password.isNullOrEmpty()) {
+            requestJetpackPlugin(apiRootUrl, username, password)
+        } else {
+            null
+        }
+    }
+
+    private suspend fun requestJetpackPlugin(
+        apiRootUrl: String,
+        username: String,
+        password: String
+    ): JetpackPluginState? {
+        val result = wpapiGsonRequestBuilder.syncGetRequest<List<PluginResponseModel>>(
+            restClient = this,
+            url = apiRootUrl.trimEnd('/') + "/" + PLUGINS_PATH,
+            params = mapOf("search" to JETPACK_PLUGIN_SEARCH, "_fields" to PLUGINS_FIELDS),
+            type = object : TypeToken<List<PluginResponseModel>>() {}.type,
+            headers = mapOf("Authorization" to Credentials.basic(username, password))
+        )
+
+        return when (result) {
+            is Success -> {
+                val jetpack = result.data?.firstOrNull { it.plugin == JETPACK_PLUGIN_ID }
+                JetpackPluginState(
+                    isActive = jetpack?.status == PLUGIN_STATUS_ACTIVE ||
+                            jetpack?.status == PLUGIN_STATUS_NETWORK_ACTIVE,
+                    version = jetpack?.version
+                )
+            }
+
+            is Error -> null
+        }
+    }
+
+    /**
+     * Reads the site's Jetpack connection to WordPress.com, or null when it can't be determined. Only the
+     * Jetpack plugin knows the blog ID WordPress.com assigned the site, and without it the row keeps
+     * SITE_ID = 0 -- which is what makes a later /me/sites sync insert a duplicate site instead of matching
+     * and upgrading this one. Skipped entirely when the plugin isn't there to ask.
+     */
+    private suspend fun fetchJetpackConnectionState(
+        plugin: JetpackPluginState?,
+        apiRootUrl: String,
+        payload: FetchWPAPISitePayload
+    ): JetpackConnectionState? {
+        if (plugin?.isActive != true) return null
+
+        val username = payload.username
+        val password = payload.password
+        return if (payload.isApplicationPassword && !username.isNullOrEmpty() && !password.isNullOrEmpty()) {
+            jetpackConnectionStatusFetcher.fetch(apiRootUrl, username, password)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * A null [plugin] or [connection] means that state couldn't be read on this run, in which case the
+     * stored value is carried forward rather than reset.
+     *
+     * Note that [SiteModel.isJetpackConnected] only says the site is connected to *some* WordPress.com
+     * account, not necessarily the one signed in here -- callers that need the stronger claim have to check
+     * account access separately. See CMM-2344.
+     */
+    private fun SiteModel.applyJetpackState(
+        plugin: JetpackPluginState?,
+        connection: JetpackConnectionState?,
+        previousSite: SiteModel?
+    ) {
+        setIsJetpackInstalled(plugin?.isActive ?: previousSite?.isJetpackInstalled ?: false)
+        jetpackVersion = plugin?.version ?: previousSite?.jetpackVersion
+        setIsJetpackConnected(connection?.isConnected ?: previousSite?.isJetpackConnected ?: false)
+        siteId = connection?.wpComSiteId ?: previousSite?.siteId ?: 0L
     }
 
     private fun discoverApiEndpoint(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -429,14 +429,7 @@ class SiteSqlUtils
                 .asModel
                 .firstOrNull()
 
-    private fun wpApiSiteLocalIdByUrl(siteUrl: String): Int? =
-        WellSql.select(SiteModel::class.java)
-                .where().beginGroup()
-                .equals(SiteModelTable.URL, siteUrl)
-                .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_WPAPI)
-                .endGroup().endWhere()
-                .asModel
-                .firstOrNull()?.id
+    private fun wpApiSiteLocalIdByUrl(siteUrl: String): Int? = getWPAPISiteByUrl(siteUrl)?.id
 
     val wPComSites: SelectQuery<SiteModel>
         get() = WellSql.select(SiteModel::class.java)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -415,6 +415,20 @@ class SiteSqlUtils
         return updateXmlRpcUrl(localId, xmlRpcUrl)
     }
 
+    /**
+     * The stored ORIGIN_WPAPI row for [siteUrl], for fetches that build a fresh model with no local id and
+     * need the identity and the columns the response can't carry. Keyed by URL for the same reason as
+     * [updateWpApiRestUrlForWPAPISite].
+     */
+    fun getWPAPISiteByUrl(siteUrl: String): SiteModel? =
+        WellSql.select(SiteModel::class.java)
+                .where().beginGroup()
+                .equals(SiteModelTable.URL, siteUrl)
+                .equals(SiteModelTable.ORIGIN, SiteModel.ORIGIN_WPAPI)
+                .endGroup().endWhere()
+                .asModel
+                .firstOrNull()
+
     private fun wpApiSiteLocalIdByUrl(siteUrl: String): Int? =
         WellSql.select(SiteModel::class.java)
                 .where().beginGroup()

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1382,7 +1382,12 @@ open class SiteStore @Inject constructor(
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch site") {
             val updatedSite = when (site.origin) {
                 SiteModel.ORIGIN_WPCOM_REST -> siteRestClient.fetchSite(site)
-                SiteModel.ORIGIN_WPAPI -> siteWPAPIRestClient.fetchWPAPISite(site)
+                // Refresh from the stored row rather than the caller's copy. The fetch carries the
+                // WordPress.com connection and blog id forward from what it's given, and an in-memory
+                // SiteModel can predate the connection flow's write -- carrying those stale zeroes back
+                // would undo it, and then /me/sites no longer matches this row and inserts a duplicate.
+                SiteModel.ORIGIN_WPAPI ->
+                    siteWPAPIRestClient.fetchWPAPISite(getSiteByLocalId(site.id) ?: site)
                 else -> siteXMLRPCClient.fetchSite(site)
             }
 
@@ -1455,6 +1460,19 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    /**
+     * This fetch builds a brand-new model, so it carries neither the local id nor the WordPress.com identity
+     * of the row it is refreshing. Without the local id, [SiteSqlUtils.insertOrUpdateSiteReturningId] has to
+     * fall back to matching on SITE_ID + URL, which stops matching the moment a real blog id is stored by the
+     * Jetpack connection flow -- and then inserts a duplicate site instead of updating the existing one.
+     */
+    private fun carryForwardStoredWPAPIFields(fetchedSite: SiteModel) {
+        val storedSite = siteSqlUtils.getWPAPISiteByUrl(fetchedSite.url) ?: return
+        fetchedSite.id = storedSite.id
+        fetchedSite.siteId = storedSite.siteId
+        fetchedSite.setIsJetpackConnected(storedSite.isJetpackConnected)
+    }
+
     suspend fun fetchWPAPISite(payload: FetchWPAPISitePayload): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.MAIN, this, "Fetch WPAPI Site") {
             updateSite(siteWPAPIRestClient.fetchWPAPISite(payload))
@@ -1481,6 +1499,7 @@ open class SiteStore @Inject constructor(
                 )
                 if (!siteModel.isError) {
                     siteModel.wpApiRestUrl = payload.apiRootUrl
+                    carryForwardStoredWPAPIFields(siteModel)
                 }
                 val result = updateSite(siteModel)
                 // updateSite's full-row write skips WP_API_REST_URL and the credential columns, and this fresh
@@ -1544,8 +1563,27 @@ open class SiteStore @Inject constructor(
                 }
                 OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteModel))
             } catch (e: DuplicateSiteException) {
-                OnSiteChanged(SiteError(DUPLICATE_SITE))
+                retryWithoutBlogId(siteModel) ?: OnSiteChanged(SiteError(DUPLICATE_SITE))
             }
+        }
+    }
+
+    /**
+     * An application-password row can discover a WordPress.com blog id that a /me/sites copy of the same
+     * site already owns, and (SITE_ID, URL) is unique -- so the write is rejected. Losing the whole update
+     * would also lose the Jetpack state, the name and everything else the fetch just learned, so retry
+     * without the blog id and leave the WordPress.com copy owning it.
+     *
+     * @return the result of the retry, or null when this isn't that case (or the retry also fails).
+     */
+    @Suppress("SwallowedException")
+    private fun retryWithoutBlogId(siteModel: SiteModel): OnSiteChanged? {
+        if (siteModel.origin != SiteModel.ORIGIN_WPAPI || siteModel.siteId == 0L) return null
+        siteModel.siteId = 0
+        return try {
+            OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteModel))
+        } catch (retryFailure: DuplicateSiteException) {
+            null
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1469,11 +1469,9 @@ open class SiteStore @Inject constructor(
      */
     private fun storedWPAPISite(url: String?): SiteModel? {
         if (url.isNullOrEmpty()) return null
-        return if (url.contains("://")) {
-            siteSqlUtils.getWPAPISiteByUrl(url)
-        } else {
-            siteSqlUtils.getWPAPISiteByUrl("http://$url") ?: siteSqlUtils.getWPAPISiteByUrl("https://$url")
-        }
+        val bareUrl = url.substringAfter("://")
+        return siteSqlUtils.getWPAPISiteByUrl("https://$bareUrl")
+            ?: siteSqlUtils.getWPAPISiteByUrl("http://$bareUrl")
     }
 
     suspend fun fetchWPAPISite(payload: FetchWPAPISitePayload): OnSiteChanged {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -128,6 +128,7 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.SiteErrorUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.UrlUtils
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
@@ -1380,15 +1381,15 @@ open class SiteStore @Inject constructor(
 
     suspend fun fetchSite(site: SiteModel): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch site") {
-            val updatedSite = when (site.origin) {
-                SiteModel.ORIGIN_WPCOM_REST -> siteRestClient.fetchSite(site)
-                // Refresh from the stored row rather than the caller's copy. The fetch carries the
-                // WordPress.com connection and blog id forward from what it's given, and an in-memory
-                // SiteModel can predate the connection flow's write -- carrying those stale zeroes back
-                // would undo it, and then /me/sites no longer matches this row and inserts a duplicate.
-                SiteModel.ORIGIN_WPAPI ->
-                    siteWPAPIRestClient.fetchWPAPISite(getSiteByLocalId(site.id) ?: site)
-                else -> siteXMLRPCClient.fetchSite(site)
+            // Refresh from the stored row rather than the caller's copy. An in-memory SiteModel can
+            // predate later writes -- carrying stale identity or connection state back would undo
+            // them -- and its origin can predate an upgrade of the row (e.g. WPAPI -> WPCOM_REST by
+            // /me/sites), which would re-fetch through the wrong client and downgrade the row again.
+            val storedSite = getSiteByLocalId(site.id) ?: site
+            val updatedSite = when (storedSite.origin) {
+                SiteModel.ORIGIN_WPCOM_REST -> siteRestClient.fetchSite(storedSite)
+                SiteModel.ORIGIN_WPAPI -> siteWPAPIRestClient.fetchWPAPISite(storedSite)
+                else -> siteXMLRPCClient.fetchSite(storedSite)
             }
 
             updateSite(updatedSite)
@@ -1461,21 +1462,21 @@ open class SiteStore @Inject constructor(
     }
 
     /**
-     * This fetch builds a brand-new model, so it carries neither the local id nor the WordPress.com identity
-     * of the row it is refreshing. Without the local id, [SiteSqlUtils.insertOrUpdateSiteReturningId] has to
-     * fall back to matching on SITE_ID + URL, which stops matching the moment a real blog id is stored by the
-     * Jetpack connection flow -- and then inserts a duplicate site instead of updating the existing one.
+     * The stored row a WPAPI fetch is refreshing, when there is one. Passed to the fetch as its
+     * `previousSite` so the fields the fetch can't determine -- and the local id, which keeps
+     * [SiteSqlUtils.insertOrUpdateSiteReturningId] matching the row once it stores a real blog id --
+     * carry forward instead of resetting. The lookup tries both schemes because the stored URL
+     * carries the scheme discovery resolved, not necessarily the one the caller supplied.
      */
-    private fun carryForwardStoredWPAPIFields(fetchedSite: SiteModel) {
-        val storedSite = siteSqlUtils.getWPAPISiteByUrl(fetchedSite.url) ?: return
-        fetchedSite.id = storedSite.id
-        fetchedSite.siteId = storedSite.siteId
-        fetchedSite.setIsJetpackConnected(storedSite.isJetpackConnected)
+    private fun storedWPAPISite(url: String?): SiteModel? {
+        if (url.isNullOrEmpty()) return null
+        return siteSqlUtils.getWPAPISiteByUrl(UrlUtils.addUrlSchemeIfNeeded(url, false))
+            ?: siteSqlUtils.getWPAPISiteByUrl(UrlUtils.addUrlSchemeIfNeeded(url, true))
     }
 
     suspend fun fetchWPAPISite(payload: FetchWPAPISitePayload): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.MAIN, this, "Fetch WPAPI Site") {
-            updateSite(siteWPAPIRestClient.fetchWPAPISite(payload))
+            updateSite(siteWPAPIRestClient.fetchWPAPISite(payload, storedWPAPISite(payload.url)))
         }
     }
 
@@ -1495,11 +1496,11 @@ open class SiteStore @Inject constructor(
                         username = payload.username,
                         password = payload.password,
                         isApplicationPassword = true,
-                    )
+                    ),
+                    previousSite = storedWPAPISite(payload.url)
                 )
                 if (!siteModel.isError) {
                     siteModel.wpApiRestUrl = payload.apiRootUrl
-                    carryForwardStoredWPAPIFields(siteModel)
                 }
                 val result = updateSite(siteModel)
                 // updateSite's full-row write skips WP_API_REST_URL and the credential columns, and this fresh
@@ -1561,29 +1562,25 @@ open class SiteStore @Inject constructor(
                     siteModel.mobileEditor = freshSiteFromDB.mobileEditor
                     siteModel.webEditor = freshSiteFromDB.webEditor
                 }
+                yieldBlogIdIfOwnedElsewhere(siteModel)
                 OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteModel))
             } catch (e: DuplicateSiteException) {
-                retryWithoutBlogId(siteModel) ?: OnSiteChanged(SiteError(DUPLICATE_SITE))
+                OnSiteChanged(SiteError(DUPLICATE_SITE))
             }
         }
     }
 
     /**
-     * An application-password row can discover a WordPress.com blog id that a /me/sites copy of the same
-     * site already owns, and (SITE_ID, URL) is unique -- so the write is rejected. Losing the whole update
-     * would also lose the Jetpack state, the name and everything else the fetch just learned, so retry
-     * without the blog id and leave the WordPress.com copy owning it.
-     *
-     * @return the result of the retry, or null when this isn't that case (or the retry also fails).
+     * An application-password site can discover the WordPress.com blog id of a site that another row --
+     * typically a /me/sites copy of the same site -- already owns. Persisting it would either trip the
+     * UNIQUE (SITE_ID, URL) constraint (discarding the whole update) or, when the URLs differ, make
+     * [SiteSqlUtils.insertOrUpdateSiteReturningId]'s bare-SITE_ID match target the other row and
+     * overwrite it. Leave the blog id with the row that already owns it.
      */
-    @Suppress("SwallowedException")
-    private fun retryWithoutBlogId(siteModel: SiteModel): OnSiteChanged? {
-        if (siteModel.origin != SiteModel.ORIGIN_WPAPI || siteModel.siteId == 0L) return null
-        siteModel.siteId = 0
-        return try {
-            OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteModel))
-        } catch (retryFailure: DuplicateSiteException) {
-            null
+    private fun yieldBlogIdIfOwnedElsewhere(siteModel: SiteModel) {
+        if (siteModel.origin != SiteModel.ORIGIN_WPAPI || siteModel.siteId == 0L) return
+        if (siteSqlUtils.getSitesWithRemoteId(siteModel.siteId).any { it.id != siteModel.id }) {
+            siteModel.siteId = 0
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -128,7 +128,6 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.SiteErrorUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.UrlUtils
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
@@ -1470,8 +1469,11 @@ open class SiteStore @Inject constructor(
      */
     private fun storedWPAPISite(url: String?): SiteModel? {
         if (url.isNullOrEmpty()) return null
-        return siteSqlUtils.getWPAPISiteByUrl(UrlUtils.addUrlSchemeIfNeeded(url, false))
-            ?: siteSqlUtils.getWPAPISiteByUrl(UrlUtils.addUrlSchemeIfNeeded(url, true))
+        return if (url.contains("://")) {
+            siteSqlUtils.getWPAPISiteByUrl(url)
+        } else {
+            siteSqlUtils.getWPAPISiteByUrl("http://$url") ?: siteSqlUtils.getWPAPISiteByUrl("https://$url")
+        }
     }
 
     suspend fun fetchWPAPISite(payload: FetchWPAPISitePayload): OnSiteChanged {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -494,7 +495,7 @@ class SiteStoreTest {
                 apiRestUsernamePlain = "appUser"
                 apiRestPasswordPlain = "appPass"
             }
-            whenever(siteWPAPIClient.fetchWPAPISite(any<SiteStore.FetchWPAPISitePayload>()))
+            whenever(siteWPAPIClient.fetchWPAPISite(any<SiteStore.FetchWPAPISitePayload>(), anyOrNull()))
                 .thenReturn(fetchedSite)
             whenever(siteSqlUtils.insertOrUpdateSite(fetchedSite))
                 .thenReturn(1)
@@ -557,7 +558,7 @@ class SiteStoreTest {
                     origin = SiteModel.ORIGIN_WPAPI
                     url = "https://example.com"
                 }
-                whenever(siteWPAPIClient.fetchWPAPISite(any<SiteStore.FetchWPAPISitePayload>()))
+                whenever(siteWPAPIClient.fetchWPAPISite(any<SiteStore.FetchWPAPISitePayload>(), anyOrNull()))
                     .thenReturn(fetchedSite)
                 whenever(siteSqlUtils.insertOrUpdateSite(fetchedSite)).thenReturn(1)
 

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -144,7 +144,9 @@ class SiteStoreTest {
 
         assertThat(onSiteChanged.rowsAffected).isEqualTo(0)
         assertThat(onSiteChanged.error).isEqualTo(SiteError(GENERIC_ERROR, null))
-        verifyNoInteractions(siteSqlUtils)
+        // fetchSite reads the stored row to decide which client refreshes it, but an errored
+        // fetch must write nothing.
+        verify(siteSqlUtils, never()).insertOrUpdateSite(any())
     }
 
     private suspend fun assertSiteFetched(


### PR DESCRIPTION
## Description

**TL/DR:** Sites added with an application password never get their Jetpack flags detected, so the Jetpack app shows "Install Jetpack" when tapping Stats on a site that already has it. This PR adds detection to the WPAPI fetch path in fluxc.

---

During the site fetch, the `jetpack/` REST namespace is used as a cheap negative filter, then `wp/v2/plugins` confirms the actual Jetpack plugin (the namespace alone also comes from Boost/Protect/Social), and `jetpack/v4/connection` (via wordpress-rs) supplies the connection state and WP.com blog id. Anything that can't be determined — e.g. a non-admin application password can't list plugins — is carried forward from the stored row, never flipped. `SiteStore` also stops discarding the whole update when the discovered blog id collides with an existing WP.com copy of the same site, and refreshes from the stored row so a stale in-memory model can't undo previous writes.

No app-module changes: once the flags are real, the existing stats gate routes correctly. The WordPress app's Jetpack-removal overlay false positive (Bug 2 in the Linear issue) is a separate follow-up PR.

Fixes Bug 1 of https://linear.app/a8c/issue/CMM-2304/

## Testing instructions

Jetpack app, site with Jetpack connected:

1. Add a self-hosted site with Jetpack installed and connected via site address + application password (admin user, not signed into WP.com).
2. Cold-start the app, then tap Stats from My Site (tap it more than once).
- [x] Signed out: a WP.com login prompt appears instead of the "Install Jetpack" screen.
- [x] Signed in with the connected account: Stats opens.

Site without Jetpack:

1. Add a self-hosted site with no Jetpack plugin via application password.
2. Cold-start and tap Stats.
- [x] The Connect Jetpack screen still appears (unchanged behavior).