### PR TITLE
CMM-2353: Drop the month from the block editor deadline notice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
@@ -29,6 +29,9 @@ class GutenbergKitAnnouncementController @Inject constructor(
         // The per-site override/deferral prefs are keyed by URL, so a site without one would
         // loop the announcement on every resume (writes would no-op via TextUtils.isEmpty).
         if (site.url.isNullOrEmpty()) return false
+        // TEMP LOCAL TESTING ONLY - REVERT BEFORE COMMITTING (CMM-2353)
+        @Suppress("KotlinConstantConditions")
+        if (true) return true
         if (!gutenbergKitFeatureChecker.isGutenbergKitRemoteFeatureEnabled()) return false
         if (!siteSettingsProvider.isBlockEditorDefault(site)) return false
         if (appPrefsWrapper.getGutenbergKitSiteOverride(site.url) != null) return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementController.kt
@@ -29,9 +29,6 @@ class GutenbergKitAnnouncementController @Inject constructor(
         // The per-site override/deferral prefs are keyed by URL, so a site without one would
         // loop the announcement on every resume (writes would no-op via TextUtils.isEmpty).
         if (site.url.isNullOrEmpty()) return false
-        // TEMP LOCAL TESTING ONLY - REVERT BEFORE COMMITTING (CMM-2353)
-        @Suppress("KotlinConstantConditions")
-        if (true) return true
         if (!gutenbergKitFeatureChecker.isGutenbergKitRemoteFeatureEnabled()) return false
         if (!siteSettingsProvider.isBlockEditorDefault(site)) return false
         if (appPrefsWrapper.getGutenbergKitSiteOverride(site.url) != null) return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitAnnouncementScreen.kt
@@ -99,7 +99,7 @@ fun GutenbergKitAnnouncementScreen(
 @Composable
 private fun buildDeadlineWithLearnMore(onLearnMore: () -> Unit) = buildAnnotatedString {
     val learnMoreText = stringResource(R.string.gutenberg_kit_announcement_learn_more)
-    val body = stringResource(R.string.gutenberg_kit_announcement_body_deadline, learnMoreText)
+    val body = stringResource(R.string.gutenberg_kit_announcement_body_deadline_v2, learnMoreText)
     val linkStart = body.indexOf(learnMoreText)
     val link = LinkAnnotation.Clickable(
         tag = "learn_more",

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -89,7 +89,6 @@ Language: ar
     <string name="site_settings_gutenberg_kit_enabled_unsupported">انتقل أولاً إلى محرر المكوّنات لتجربة المحرر الجديد.</string>
     <string name="gutenberg_kit_announcement_title">نسخة أفضل من محرر المكوّنات قادمة قريبًا</string>
     <string name="gutenberg_kit_announcement_body_intro">أصبح محرر المكوّنات من الجيل الجديد جاهزًا، ويأتي مع المزيد من الميزات الجديدة.</string>
-    <string name="gutenberg_kit_announcement_body_deadline">وسيصبح المحرر الافتراضي للجميع بحلول نهاية يونيو 2026. %1$s</string>
     <string name="gutenberg_kit_announcement_activate">تفعيل</string>
     <string name="gutenberg_kit_announcement_maybe_later">ربما لاحقًا</string>
     <string name="gutenberg_kit_announcement_learn_more">معرفة المزيد</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -93,7 +93,6 @@ Language: cs_CZ
     <string name="gutenberg_kit_announcement_learn_more">Další informace</string>
     <string name="gutenberg_kit_announcement_maybe_later">Možná později</string>
     <string name="gutenberg_kit_announcement_activate">Aktivovat</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Do konce června 2026 se stane výchozím editorem pro všechny. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Blokový editor nové generace je připraven a přináší řadu nových funkcí.</string>
     <string name="gutenberg_kit_announcement_title">Připravuje se vylepšený blokový editor</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Nejprve přepněte do blokového editoru, abyste si nový editor vyzkoušeli.</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -93,7 +93,6 @@ Language: de
     <string name="gutenberg_kit_announcement_learn_more">Mehr erfahren</string>
     <string name="gutenberg_kit_announcement_maybe_later">Vielleicht später</string>
     <string name="gutenberg_kit_announcement_activate">Aktivieren</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Bis Ende Juni 2026 wird er für alle zum Standard-Editor. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Der Block-Editor der nächsten Generation ist verfügbar und bietet zahlreiche neue Funktionen.</string>
     <string name="gutenberg_kit_announcement_title">Ein besserer Block-Editor ist in Vorbereitung</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Wechsle zunächst zum Block-Editor, um den neuen Editor auszuprobieren.</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -93,7 +93,6 @@ Language: en_GB
     <string name="gutenberg_kit_announcement_learn_more">Learn more</string>
     <string name="gutenberg_kit_announcement_maybe_later">Maybe later</string>
     <string name="gutenberg_kit_announcement_activate">Activate</string>
-    <string name="gutenberg_kit_announcement_body_deadline">By the end of June 2026, it will become the default editor for everyone. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">The next-generation block editor is ready, and it brings more new features.</string>
     <string name="gutenberg_kit_announcement_title">A better block editor is coming</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Switch to the block editor first to try the new editor.</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -93,7 +93,6 @@ Language: es_CO
     <string name="gutenberg_kit_announcement_learn_more">Más información</string>
     <string name="gutenberg_kit_announcement_maybe_later">Quizás más tarde</string>
     <string name="gutenberg_kit_announcement_activate">Activar</string>
-    <string name="gutenberg_kit_announcement_body_deadline">A finales de junio de 2026, se convertirá en el editor predeterminado para todos. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">El editor de bloques de última generación ya está listo y trae consigo más funciones nuevas.</string>
     <string name="gutenberg_kit_announcement_title">Pronto tendremos un editor de bloques mejorado</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Cambia primero al editor de bloques para probar el nuevo editor.</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -93,7 +93,6 @@ Language: es
     <string name="gutenberg_kit_announcement_learn_more">Más información</string>
     <string name="gutenberg_kit_announcement_maybe_later">Quizás más tarde</string>
     <string name="gutenberg_kit_announcement_activate">Activar</string>
-    <string name="gutenberg_kit_announcement_body_deadline">A finales de junio de 2026, se convertirá en el editor predeterminado para todos. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">El editor de bloques de última generación ya está listo y trae consigo más funciones nuevas.</string>
     <string name="gutenberg_kit_announcement_title">Pronto tendremos un editor de bloques mejorado</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Cambia primero al editor de bloques para probar el nuevo editor.</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -89,7 +89,6 @@ Language: fr
     <string name="gutenberg_kit_announcement_learn_more">En savoir plus</string>
     <string name="gutenberg_kit_announcement_maybe_later">Peut-être plus tard</string>
     <string name="gutenberg_kit_announcement_activate">Activer</string>
-    <string name="gutenberg_kit_announcement_body_deadline">D’ici la fin du mois de juin 2026, il deviendra l’éditeur par défaut pour tous. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">L’éditeur de blocs de nouvelle génération est prêt et offre de nouvelles fonctionnalités.</string>
     <string name="gutenberg_kit_announcement_title">Un meilleur éditeur de blocs arrive</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Commencez par passer à l’éditeur de blocs pour essayer le nouvel éditeur.</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -89,7 +89,6 @@ Language: fr
     <string name="gutenberg_kit_announcement_learn_more">En savoir plus</string>
     <string name="gutenberg_kit_announcement_maybe_later">Peut-être plus tard</string>
     <string name="gutenberg_kit_announcement_activate">Activer</string>
-    <string name="gutenberg_kit_announcement_body_deadline">D’ici la fin du mois de juin 2026, il deviendra l’éditeur par défaut pour tous. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">L’éditeur de blocs de nouvelle génération est prêt et offre de nouvelles fonctionnalités.</string>
     <string name="gutenberg_kit_announcement_title">Un meilleur éditeur de blocs arrive</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Commencez par passer à l’éditeur de blocs pour essayer le nouvel éditeur.</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -91,7 +91,6 @@ Language: he_IL
     <string name="gutenberg_kit_announcement_learn_more">למידע נוסף</string>
     <string name="gutenberg_kit_announcement_maybe_later">אולי מאוחר יותר</string>
     <string name="gutenberg_kit_announcement_activate">הפעלה</string>
-    <string name="gutenberg_kit_announcement_body_deadline">עד סוף יוני 2026, הוא יהפוך לעורך ברירת המחדל עבור כולם. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">עורך הבלוקים מהדור הבא מוכן, והוא מביא איתו תכונות חדשות.</string>
     <string name="gutenberg_kit_announcement_title">עורך בלוקים משופר בדרך</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">יש לעבור לעורך הבלוקים כדי לנסות את העורך החדש.</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -90,7 +90,6 @@ Language: id
     <string name="gutenberg_kit_announcement_learn_more">Baca selengkapnya</string>
     <string name="gutenberg_kit_announcement_maybe_later">Mungkin nanti</string>
     <string name="gutenberg_kit_announcement_activate">Aktifkan</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Pada akhir Juni 2026, editor ini akan menjadi editor default untuk semua pengguna. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Editor blok generasi baru telah siap dan menghadirkan lebih banyak fitur baru.</string>
     <string name="gutenberg_kit_announcement_title">Editor blok yang lebih baik akan segera hadir</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Beralih ke editor blok terlebih dahulu untuk mencoba editor baru.</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -93,7 +93,6 @@ Language: it
     <string name="gutenberg_kit_announcement_learn_more">Scopri di più</string>
     <string name="gutenberg_kit_announcement_maybe_later">Forse dopo</string>
     <string name="gutenberg_kit_announcement_activate">Attiva</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Entro la fine di giugno 2026 diventerà l\'editor predefinito per tutti. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">L\'editor a blocchi di nuova generazione è pronto e offre nuove funzionalità.</string>
     <string name="gutenberg_kit_announcement_title">Sta arrivando un editor a blocchi migliore</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Per provare il nuovo editor, passa prima all\'editor a blocchi.</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -92,7 +92,6 @@ Language: ja_JP
     <string name="gutenberg_kit_announcement_learn_more">さらに詳しく</string>
     <string name="gutenberg_kit_announcement_maybe_later">後で確認する</string>
     <string name="gutenberg_kit_announcement_activate">有効化</string>
-    <string name="gutenberg_kit_announcement_body_deadline">2026年6月末までに、全ユーザーにとってデフォルトのエディターとなります。 %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">次世代ブロックエディターの準備ができました。たくさんの新機能があります。</string>
     <string name="gutenberg_kit_announcement_title">より高性能のブロックエディターが登場します</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">まずブロックエディターに切り替えてから、新しいエディターをお試しください。</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -90,7 +90,6 @@ Language: ko_KR
     <string name="gutenberg_kit_announcement_learn_more">더 알아보기</string>
     <string name="gutenberg_kit_announcement_maybe_later">나중에</string>
     <string name="gutenberg_kit_announcement_activate">활성화</string>
-    <string name="gutenberg_kit_announcement_body_deadline">2026년 6월 말까지 모든 사람의 기본 편집기가 될 것입니다. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">차세대 블록 편집기가 준비되었으며, 추가 새 기능이 제공됩니다.</string>
     <string name="gutenberg_kit_announcement_title">더 나은 블록 편집기 공개 예정</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">새 편집기를 사용해 보려면 먼저 블록 편집기로 전환하세요.</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -93,7 +93,6 @@ Language: nl
     <string name="gutenberg_kit_announcement_learn_more">Lees verder</string>
     <string name="gutenberg_kit_announcement_maybe_later">Misschien later</string>
     <string name="gutenberg_kit_announcement_activate">Activeren</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Tegen het einde van juni 2026 wordt het de standaard-editor voor iedereen. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">De volgende generatie blok-editor is klaar en brengt meer nieuwe functies.</string>
     <string name="gutenberg_kit_announcement_title">Een betere blok-editor komt eraan</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Schakel eerst over naar de blok-editor om de nieuwe editor te proberen.</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -93,7 +93,6 @@ Language: pl
     <string name="gutenberg_kit_announcement_learn_more">Dowiedz się więcej</string>
     <string name="gutenberg_kit_announcement_maybe_later">Może później</string>
     <string name="gutenberg_kit_announcement_activate">Włącz</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Do końca czerwca 2026 roku stanie się domyślnym edytorem dla wszystkich. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Edytor blokowy nowej generacji jest gotowy i oferuje więcej nowych funkcji.</string>
     <string name="gutenberg_kit_announcement_title">Nadchodzi lepszy edytor blokowy</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Aby przetestować nowy edytor, najpierw przełącz się na edytor blokowy.</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -93,7 +93,6 @@ Language: ro
     <string name="gutenberg_kit_announcement_learn_more">Află mai multe</string>
     <string name="gutenberg_kit_announcement_maybe_later">Poate mai târziu</string>
     <string name="gutenberg_kit_announcement_activate">Activează</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Până la sfârșitul lunii iunie 2026, va deveni editorul implicit pentru toți. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Noul editor de blocuri modern este pregătit și aduce mai multe funcționalități noi.</string>
     <string name="gutenberg_kit_announcement_title">În curând, un editor de blocuri mai bun</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Pentru a încerca noul editor, comută mai întâi la editorul de blocuri.</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -93,7 +93,6 @@ Language: ru
     <string name="gutenberg_kit_announcement_learn_more">Узнать больше</string>
     <string name="gutenberg_kit_announcement_maybe_later">Возможно позже</string>
     <string name="gutenberg_kit_announcement_activate">Активировать</string>
-    <string name="gutenberg_kit_announcement_body_deadline">К концу июня 2026 года он станет редактором по умолчанию. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Редактор блоков нового поколения готов к работе, и вас ждёт множество новых функций.</string>
     <string name="gutenberg_kit_announcement_title">Совсем скоро: улучшенный редактор блоков</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Переключитесь на новый блочный редактор одним из первых.</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -93,7 +93,6 @@ Language: sv_SE
     <string name="gutenberg_kit_announcement_learn_more">Lär dig mer</string>
     <string name="gutenberg_kit_announcement_maybe_later">Kanske senare</string>
     <string name="gutenberg_kit_announcement_activate">Aktivera</string>
-    <string name="gutenberg_kit_announcement_body_deadline">I slutet av juni 2026 kommer det att bli standardredigeraren för alla. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Nästa generations blockredigerare är redo och ger fler nya funktioner.</string>
     <string name="gutenberg_kit_announcement_title">En bättre blockredigerare är på väg</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Byt till blockredigeraren först för att testa den nya redigeraren.</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -93,7 +93,6 @@ Language: tr
     <string name="gutenberg_kit_announcement_learn_more">Daha fazla bilgi edinin</string>
     <string name="gutenberg_kit_announcement_maybe_later">Belki daha sonra</string>
     <string name="gutenberg_kit_announcement_activate">Etkinleştir</string>
-    <string name="gutenberg_kit_announcement_body_deadline">Haziran 2026\'nın sonuna kadar herkes için varsayılan düzenleyici olacak. %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">Yeni nesil blok düzenleyici hazır, daha fazla yeni özellik getiriyor.</string>
     <string name="gutenberg_kit_announcement_title">Daha iyi bir blok düzenleyici geliyor</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">Yeni düzenleyiciyi denemek için önce blok düzenleyiciye geçin.</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -92,7 +92,6 @@ Language: zh_CN
     <string name="gutenberg_kit_announcement_learn_more">了解更多</string>
     <string name="gutenberg_kit_announcement_maybe_later">稍后再说</string>
     <string name="gutenberg_kit_announcement_activate">激活</string>
-    <string name="gutenberg_kit_announcement_body_deadline">到 2026 年 6 月底，它将成为所有用户的默认编辑器。 %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">新一代区块编辑器已准备就绪，并带来了更多新功能。</string>
     <string name="gutenberg_kit_announcement_title">更出色的区块编辑器即将上线</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">请先切换到区块编辑器，试用新的编辑器。</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -93,7 +93,6 @@ Language: zh_TW
     <string name="gutenberg_kit_announcement_learn_more">深入了解</string>
     <string name="gutenberg_kit_announcement_maybe_later">稍後再說</string>
     <string name="gutenberg_kit_announcement_activate">啟用</string>
-    <string name="gutenberg_kit_announcement_body_deadline">2026 年 6 月底，此編輯器將成為所有使用者的預設編輯器。 %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">新一代區塊編輯器已準備就緒，且提供更多新功能。</string>
     <string name="gutenberg_kit_announcement_title">更完善的區塊編輯器即將推出</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">請先切換至區塊編輯器，以嘗試使用新的編輯器。</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -93,7 +93,6 @@ Language: zh_TW
     <string name="gutenberg_kit_announcement_learn_more">深入了解</string>
     <string name="gutenberg_kit_announcement_maybe_later">稍後再說</string>
     <string name="gutenberg_kit_announcement_activate">啟用</string>
-    <string name="gutenberg_kit_announcement_body_deadline">2026 年 6 月底，此編輯器將成為所有使用者的預設編輯器。 %1$s</string>
     <string name="gutenberg_kit_announcement_body_intro">新一代區塊編輯器已準備就緒，且提供更多新功能。</string>
     <string name="gutenberg_kit_announcement_title">更完善的區塊編輯器即將推出</string>
     <string name="site_settings_gutenberg_kit_enabled_unsupported">請先切換至區塊編輯器，以嘗試使用新的編輯器。</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -713,7 +713,7 @@
     <!-- GutenbergKit announcement -->
     <string name="gutenberg_kit_announcement_title">A better block editor is coming</string>
     <string name="gutenberg_kit_announcement_body_intro">The next-generation block editor is ready, and it brings more new features.</string>
-    <string name="gutenberg_kit_announcement_body_deadline">By the end of June 2026, it will become the default editor for everyone. %1$s</string>
+    <string name="gutenberg_kit_announcement_body_deadline_v2">By the end of 2026, it will become the default editor for everyone. %1$s</string>
     <string name="gutenberg_kit_announcement_activate">Activate</string>
     <string name="gutenberg_kit_announcement_maybe_later">Maybe later</string>
     <string name="gutenberg_kit_announcement_learn_more">Learn more</string>


### PR DESCRIPTION
## Description

**TL/DR:** The GutenbergKit announcement said "By the end of **June** 2026" — that date has passed. Now reads "By the end of 2026."

~~Note that this PR is marked "Do Not Merge" because it currently forces the announcement to appear to make testing easier. This will be removed before merging. This is also why CI is failing.~~

---

The copy lives in one string, used by the announcement bottom sheet shown from My Site (`GutenbergKitAnnouncementScreen`). Rather than editing the existing value, this adds a new key (`gutenberg_kit_announcement_body_deadline_v2`) and deletes the old one from `values/` and all 25 locale files. Every translation spelled out the month literally (fr: *"la fin du mois de juin 2026"*), so keeping the key would have shipped a date we just decided is wrong in 25 languages. With a new key they fall back to the corrected English until GlotPress catches up. Deleting the old key from the locale files is also required to avoid tripping the `ExtraTranslation` lint.

Fixes CMM-2353.

## Testing instructions

Simply start the app and notice the updated wording on the GBK announcement.

<img width="356" height="792" alt="Screenshot_1787684125" src="https://github.com/user-attachments/assets/6a6ee903-1c61-4202-81d9-0400eb396f2b" />

