### PR TITLE
[DO NOT MERGE] Validate the signing config for #23261

### DIFF
--- a/.buildkite/commands/validate-signing-config.sh
+++ b/.buildkite/commands/validate-signing-config.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# [DO NOT MERGE] Validation-only step, deleted with the branch it lives on.
+
+SECRETS_DIR="$HOME/.configure/wordpress-android/secrets"
+UPLOAD_KEYSTORE="$SECRETS_DIR/upload.keystore"
+DEBUG_KEYSTORE="$SECRETS_DIR/debug.keystore"
+SECRET_PROPERTIES="$SECRETS_DIR/secrets.properties"
+REPORT_DIR="build/signing-validation"
+
+failures=0
+
+pass() {
+  echo "PASS: $*"
+}
+
+fail() {
+  echo "FAIL: $*"
+  failures=$((failures + 1))
+}
+
+# The negative cases run against a throwaway home so the agent's real secrets
+# directory is never mutated. Gradle's own home has to be pinned or it would
+# follow user.home into the throwaway and re-download every dependency.
+signing_report() {
+  local destination=$1
+  shift
+  mkdir -p "$REPORT_DIR"
+  # `signingConfigs {}` is evaluated at configuration time, so a reused configuration
+  # cache entry would let the negative cases pass without re-reading the disk.
+  GRADLE_USER_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}" \
+    ./gradlew :WordPress:signingReport --no-configuration-cache --console=plain "$@" | tee "$destination"
+}
+
+variant_block() {
+  awk -v variant="$1" '$1 == "Variant:" { keep = ($2 == variant) } keep' "$2"
+}
+
+field() {
+  sed -n "s/^$1: *//p" | head -1
+}
+
+# Symlinks rather than copies: no decrypted secret is duplicated anywhere.
+fake_home_with() {
+  local home=$1
+  shift
+  mkdir -p "$home/.configure/wordpress-android/secrets"
+  ln -s "$SECRET_PROPERTIES" "$home/.configure/wordpress-android/secrets/secrets.properties"
+  for keystore in "$@"; do
+    ln -s "$SECRETS_DIR/$keystore" "$home/.configure/wordpress-android/secrets/$keystore"
+  done
+}
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :file_folder: Where configure_apply put the keystores"
+for keystore in "$UPLOAD_KEYSTORE" "$DEBUG_KEYSTORE"; do
+  if [ -f "$keystore" ]; then
+    pass "configure_apply wrote $keystore"
+  else
+    fail "configure_apply did not write $keystore"
+  fi
+done
+
+if [ -e WordPress/upload.jks ]; then
+  echo "WARN: WordPress/upload.jks is present in the checkout — stale from a pre-move configure_apply on a reused agent, or the destination change did not take effect"
+else
+  pass "No upload keystore inside the checkout"
+fi
+
+echo "--- :mag: signingReport with the keystores where the build expects them"
+signing_report "$REPORT_DIR/with-keystores.txt"
+
+for variant in wordpressRelease jetpackRelease; do
+  block=$(variant_block "$variant" "$REPORT_DIR/with-keystores.txt")
+  if [ -z "$block" ]; then
+    fail "$variant is missing from the report"
+    continue
+  fi
+
+  config=$(printf '%s\n' "$block" | field Config)
+  store=$(printf '%s\n' "$block" | field Store)
+  fingerprint=$(printf '%s\n' "$block" | field SHA-256)
+
+  if [ "$config" = "release" ]; then
+    pass "$variant is signed by the release config"
+  else
+    fail "$variant reports 'Config: $config' — the release signing config was not applied"
+  fi
+
+  if [ "$store" = "$UPLOAD_KEYSTORE" ]; then
+    pass "$variant reads the upload keystore from the out-of-repo secrets directory"
+  else
+    fail "$variant reads its keystore from '$store', expected '$UPLOAD_KEYSTORE'"
+  fi
+
+  if [ -n "$fingerprint" ]; then
+    pass "$variant certificate read out of the keystore: SHA-256 $fingerprint"
+  else
+    fail "$variant reported no certificate — the store password or the key alias did not resolve"
+  fi
+done
+
+for variant in wordpressDebug jetpackDebug; do
+  store=$(variant_block "$variant" "$REPORT_DIR/with-keystores.txt" | field Store)
+
+  if [ "$store" = "$DEBUG_KEYSTORE" ]; then
+    pass "$variant reads the shared debug keystore under its new name"
+  else
+    fail "$variant reads its keystore from '$store', expected '$DEBUG_KEYSTORE'"
+  fi
+done
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+echo "--- :test_tube: signingReport with the credentials present but no upload keystore"
+fake_home_with "$scratch/no-upload-keystore" debug.keystore
+signing_report "$REPORT_DIR/without-upload-keystore.txt" -Duser.home="$scratch/no-upload-keystore"
+
+if grep -q "^Variant: wordpressRelease$" "$REPORT_DIR/without-upload-keystore.txt"; then
+  pass "The report still ran, so the assertions below are about the gate rather than about an empty report"
+else
+  fail "The report did not list wordpressRelease at all — this negative case proves nothing"
+fi
+
+for variant in wordpressRelease jetpackRelease; do
+  block=$(variant_block "$variant" "$REPORT_DIR/without-upload-keystore.txt")
+  config=$(printf '%s\n' "$block" | field Config)
+
+  if printf '%s\n' "$block" | grep -q "upload.keystore"; then
+    fail "$variant still points at an upload keystore that is not there"
+  elif [ "$config" = "none" ]; then
+    pass "$variant drops to 'Config: none' with the credentials still readable, so the keystore file is what gates signing"
+  else
+    fail "$variant reports 'Config: $config' without the keystore, expected 'none'"
+  fi
+done
+
+echo "--- :test_tube: signingReport with no shared debug keystore"
+fake_home_with "$scratch/no-debug-keystore"
+signing_report "$REPORT_DIR/without-debug-keystore.txt" -Duser.home="$scratch/no-debug-keystore"
+
+debug_fallback=$(variant_block wordpressDebug "$REPORT_DIR/without-debug-keystore.txt" | field Store)
+if [ "$debug_fallback" = "$DEBUG_KEYSTORE" ]; then
+  fail "wordpressDebug still reports the shared debug keystore when it is not there"
+else
+  pass "wordpressDebug silently falls back to '$debug_fallback', which is why a green prototype build is not on its own evidence that the shared key was used"
+fi
+
+echo "--- :white_check_mark: Result"
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "Every signing-config assertion passed"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,15 @@ steps:
   - wait
 
   #################
+  # [DO NOT MERGE] Signing config validation, removed with this branch
+  #################
+  - label: "🔐 Validate signing config"
+    command: .buildkite/commands/validate-signing-config.sh
+    plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - "build/signing-validation/*.txt"
+
+  #################
   # Linters
   #################
   - group: "🕵️‍♂️ Linters"


### PR DESCRIPTION
**Validation only — do not merge.** Stacked on `ainfra-2968-adopt-the-out-of-repo-keystore-convention-in-wordpress` (#23261) so the step runs against exactly the code under review. It is closed once it has answered.

### Why the PR pipeline can't answer this

#23261 changes where the release signing config finds its keystore, and nothing on a PR exercises that path:

- Prototype builds are the only jobs that assemble an app, and `PROTOTYPE_BUILD_TYPE = 'Debug'`.
- Lint and the merged-manifest diffs never sign anything.
- `release-builds.yml` and `beta-builds.yml` are API-triggered from release automation and `checkout_release_branch`, so they never see a PR's code.

The first run that would notice is the scheduled trunk-internal build — after merge.

The debug side is worse than uncovered. When the shared keystore is missing, AGP falls back to `~/.android/debug.keystore` and the build stays green, so a passing prototype build has never been evidence that the renamed `debug.keystore` was read.

### What to read

One job: **🔐 Validate signing config**. Every step is expected to **pass**; there is no intentional failure here. It fails the build on any unmet assertion, and the three `signingReport` outputs are attached as artifacts.

### What each assertion proves

1. `configure_apply` on a Buildkite agent writes both keystores into the out-of-repo secrets directory under their new names.
2. `wordpressRelease` and `jetpackRelease` report `Config: release` with `Store:` pointing at that directory, and print a certificate — so path, store password and key alias all resolve on CI.
3. `wordpressDebug` and `jetpackDebug` read the renamed `debug.keystore` rather than falling back.
4. With the credentials still readable but no upload keystore, both release variants drop to `Config: none` — the keystore file is what gates signing, so assertion 2 could have gone red.
5. With no shared debug keystore, the debug variants silently fall back to `~/.android/debug.keystore` — the failure mode assertion 3 exists to catch.

Both negative cases run against a throwaway `user.home` holding symlinks to the real credentials, so the agent's secrets directory is never mutated and no decrypted secret is copied anywhere. Each `signingReport` runs with `--no-configuration-cache`, since `signingConfigs {}` is evaluated at configuration time and a reused cache entry would let the negative cases pass without re-reading the disk.

### What this still doesn't answer

That AGP can sign and upload a real bundle with this keystore — `signingReport` proves the config resolves, not that `bundleRelease` ships. That first happens on the trunk-internal build, which notifies `#build-and-ship`.

---

*Opened by Claude (Opus 5) on behalf of @mokagio with approval.*
