### PR TITLE
Mark the RS lists with a debug-only "(RS)" title suffix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/screens/CommentsRsListScreen.kt
@@ -65,6 +65,7 @@ import org.wordpress.android.ui.commentsrs.CommentsTabUiState
 import org.wordpress.android.ui.commentsrs.PendingConfirmation
 import org.wordpress.android.ui.commentsrs.batchActions
 import org.wordpress.android.ui.commentsrs.isEnabledFor
+import org.wordpress.android.ui.compose.utils.rsDebugTitle
 import org.wordpress.android.ui.postsrs.SnackbarMessage
 
 // Material's disabled-content alpha, used to dim batch-action icons that can't apply to the
@@ -208,7 +209,7 @@ fun CommentsRsListScreen(
                         }
                     }
                     TopBarMode.NORMAL -> TopAppBar(
-                        title = { Text(text = stringResource(R.string.comments)) },
+                        title = { Text(text = rsDebugTitle(R.string.comments)) },
                         navigationIcon = {
                             IconButton(onClick = onNavigateBack) {
                                 Icon(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/RsDebugTitle.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/RsDebugTitle.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.compose.utils
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import org.wordpress.android.BuildConfig
+
+private const val RS_DEBUG_SUFFIX = "(RS)"
+
+/**
+ * Title for a wordpress-rs screen. Debug builds append an "(RS)" suffix so these screens can be
+ * told apart at a glance from their FluxC-backed counterparts, which are reachable from other
+ * entry points on the same site. Release builds get the unmodified title.
+ */
+@Composable
+fun rsDebugTitle(@StringRes titleResId: Int): String {
+    val title = stringResource(titleResId)
+    return if (BuildConfig.DEBUG) "$title $RS_DEBUG_SUFFIX" else title
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/screens/PagesRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pagesrs/screens/PagesRsListScreen.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.utils.rsDebugTitle
 import org.wordpress.android.ui.pagesrs.PageRsConfirmationDialogState
 import org.wordpress.android.ui.pagesrs.PageRsListConfirmation
 import org.wordpress.android.ui.pagesrs.PageRsListTab
@@ -197,7 +198,7 @@ internal fun PagesRsListScreen(
                             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester)
                         )
                     } else {
-                        Text(text = stringResource(R.string.my_site_btn_site_pages))
+                        Text(text = rsDebugTitle(R.string.my_site_btn_site_pages))
                     }
                 },
                 navigationIcon = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/screens/PostRsListScreen.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.utils.rsDebugTitle
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.postsrs.ConfirmationDialogState
 import org.wordpress.android.ui.postsrs.PendingConfirmation
@@ -171,7 +172,7 @@ fun PostRsListScreen(
                             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester)
                         )
                     } else {
-                        Text(text = stringResource(R.string.my_site_btn_blog_posts))
+                        Text(text = rsDebugTitle(R.string.my_site_btn_blog_posts))
                     }
                 },
                 navigationIcon = {


### PR DESCRIPTION
## Description

Posts, Pages, and Comments each have two implementations: legacy FluxC and WordPress-RS. They look close enough that it's hard to tell which one is on screen, which is a problem for us when testing.

This PR resolves this by adding `(RS)` to the screen titles **in debug builds only**.

<img width="432" height="180" alt="rs" src="https://github.com/user-attachments/assets/ca7f4603-0fce-4454-bfe6-627e1c9a80b7" />

## Testing instructions

**RS screens show the suffix (debug build)**

1. Install a debug build and sign in to a site that authenticates with an **application password**.
2. My Site → Posts.
- [x] Title reads "Blog Posts (RS)"
3. Back, then My Site → Pages.
- [x] Title reads "Site Pages (RS)"
4. Back, then My Site → Comments.
- [x] Title reads "Comments (RS)"

**FluxC screens have no suffix**

1. On the same site, go to My Site and tap the drafts or scheduled posts card.
- [x] The legacy list opens with title "Blog Posts" — no suffix
2. Sign in to a WordPress.com site that has no application password, then open Posts, Pages, and Comments.
- [x] All three open the legacy screens with no suffix