### PR TITLE
CMM-2389: Fix Posts/Pages 404 on Atomic sites (doubled /wp/v2/)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem.QuickLinkItem
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.postsrs.data.WpServiceProvider
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
@@ -40,6 +41,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
     private val siteXMLRPCClient: SiteXMLRPCClient,
     private val siteApiRestUrlRecoverer: SiteApiRestUrlRecoverer,
     private val credentialsChangedNotifier: CredentialsChangedNotifier,
+    private val wpServiceProvider: WpServiceProvider,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
 ) {
     lateinit var scope: CoroutineScope
@@ -145,6 +147,9 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
         siteApiRestUrlRecoverer.discoverApiRootUrl(site.url)?.let { apiRootUrl ->
             site.wpApiRestUrl = apiRootUrl
             siteApiRestUrlRecoverer.persistApiRootUrl(site.id, apiRootUrl)
+            // Drop the cached RS service — it was built with the stale (proxy/missing) apiRoot and
+            // would keep producing the doubled /wp/v2/ 404 until process restart otherwise.
+            wpServiceProvider.clearService(site.id)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -83,7 +83,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 when (applicationPasswordValidator.validate(storedSite)) {
                     ApplicationPasswordValidator.Outcome.Valid -> {
                         // Heal in the background so the card hides immediately on a slow network.
-                        scope.launch { healApiRestUrlIfMissing(storedSite) }
+                        scope.launch { healApiRestUrlIfNeeded(storedSite) }
                         handleValidAuth(storedSite)
                         return@launch
                     }
@@ -115,7 +115,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 // The mint goes through the Jetpack tunnel and never runs discovery — without this
                 // step, freshly minted Atomic sites end up with working creds but a NULL
                 // wpApiRestUrl in the local DB. Run in the background so the card hides immediately.
-                scope.launch { healApiRestUrlIfMissing(storedSite) }
+                scope.launch { healApiRestUrlIfNeeded(storedSite) }
                 handleValidAuth(storedSite)
                 return@launch
             }
@@ -135,13 +135,22 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
         }
     }
 
-    private suspend fun healApiRestUrlIfMissing(site: SiteModel) {
-        if (!site.wpApiRestUrl.isNullOrEmpty()) return
+    private suspend fun healApiRestUrlIfNeeded(site: SiteModel) {
+        // Heal both a missing value and a wrong-but-present WP.com proxy URL. Migrated Atomic /
+        // Jetpack-WPCom-REST sites carry the proxy-form wpApiRestUrl
+        // (…/wp/v2/sites/{id}), which breaks the RS Posts/Pages lists with a doubled /wp/v2/ 404.
+        // Rediscovering against the direct host replaces it with the correct wp-json root.
+        val current = site.wpApiRestUrl
+        if (!current.isNullOrEmpty() && !isWpComProxyApiRestUrl(current)) return
         siteApiRestUrlRecoverer.discoverApiRootUrl(site.url)?.let { apiRootUrl ->
             site.wpApiRestUrl = apiRootUrl
             siteApiRestUrlRecoverer.persistApiRootUrl(site.id, apiRootUrl)
         }
     }
+
+    // The WP.com REST proxy root looks like https://public-api.wordpress.com/wp/v2/sites/{id}; a
+    // genuine self-hosted wp-json root never contains the /wp/v2/ route segment.
+    private fun isWpComProxyApiRestUrl(apiRestUrl: String): Boolean = apiRestUrl.contains("/wp/v2/")
 
     private fun handleValidAuth(site: SiteModel) {
         // Only true self-hosted sites need the XML-RPC fallback path — Atomic and Jetpack-WPCom-REST
@@ -282,7 +291,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
             }
             if (!result.isError) {
                 site.xmlRpcUrl = xmlRpcEndpoint
-                // Persist only the rediscovered column — mirrors healApiRestUrlIfMissing. A full-row
+                // Persist only the rediscovered column — mirrors healApiRestUrlIfNeeded. A full-row
                 // updateSite would rewrite ~80 columns from this in-memory model for a one-field change
                 // (risking clobbering other out-of-band values), so write just xmlRpcUrl.
                 siteStore.persistXmlRpcUrl(site.id, xmlRpcEndpoint)

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
@@ -48,6 +48,16 @@ class WpServiceProvider @Inject constructor(
         services.clear()
     }
 
+    /**
+     * Drops the cached service for a single site so the next [getService] rebuilds it. Call this
+     * after the site's stored [SiteModel.getWpApiRestUrl] changes (e.g. a background heal), otherwise
+     * a service built with the stale `apiRoot` keeps serving requests until the process restarts.
+     */
+    @Synchronized
+    fun clearService(siteId: Int) {
+        services.remove(siteId)
+    }
+
     private fun createService(site: SiteModel): WpService {
         val delegate = createDelegate(site)
         val wpApiCache = getOrCreateCache()
@@ -72,13 +82,22 @@ class WpServiceProvider @Inject constructor(
      * 404 (`rest_no_route`). These sites reach their `wp-admin` directly, so derive the root from the
      * site host instead of trusting the stored proxy URL. Genuine self-hosted sites keep their
      * discovered [SiteModel.getWpApiRestUrl].
+     *
+     * The proxy URL is detected two ways to stay robust: the [SiteModel.isUsingWpComRestApi] flag,
+     * and — for migrated sites that carry the proxy URL without being flagged — the `/wp/v2/` route
+     * segment in the stored value itself. Either match falls back to the direct host root.
      */
     private fun resolveApiRoot(site: SiteModel): String {
-        if (site.isUsingWpComRestApi) {
+        val stored = site.wpApiRestUrl?.takeIf { it.isNotEmpty() }
+        if (site.isUsingWpComRestApi || stored == null || isWpComProxyApiRestUrl(stored)) {
             return "${site.url}/wp-json"
         }
-        return site.wpApiRestUrl?.takeIf { it.isNotEmpty() } ?: "${site.url}/wp-json"
+        return stored
     }
+
+    // The WP.com REST proxy root looks like https://public-api.wordpress.com/wp/v2/sites/{id}; a
+    // genuine self-hosted wp-json root never contains the /wp/v2/ route segment.
+    private fun isWpComProxyApiRestUrl(apiRestUrl: String): Boolean = apiRestUrl.contains("/wp/v2/")
 
     private fun createDelegate(site: SiteModel): WpApiClientDelegate {
         val authProvider = if (site.isWPCom) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/data/WpServiceProvider.kt
@@ -54,14 +54,30 @@ class WpServiceProvider @Inject constructor(
         val siteInfo = if (site.isWPCom) {
             SiteInfo.WordPressCom(siteId = site.siteId.toULong())
         } else {
-            val apiRoot = site.wpApiRestUrl?.takeIf { it.isNotEmpty() }
-                ?: "${site.url}/wp-json"
             SiteInfo.SelfHosted(
                 siteUrl = ParsedUrl.parse(site.url),
-                apiRoot = ParsedUrl.parse(apiRoot),
+                apiRoot = ParsedUrl.parse(resolveApiRoot(site)),
             )
         }
         return WpService(siteInfo, delegate, wpApiCache.cache)
+    }
+
+    /**
+     * Resolves the REST API root for a [SiteInfo.SelfHosted] service.
+     *
+     * Atomic / Jetpack-WPCom-REST app-password sites store the WordPress.com REST *proxy* URL
+     * (`https://public-api.wordpress.com/wp/v2/sites/{id}`) in [SiteModel.getWpApiRestUrl] — the
+     * same value simple `.wordpress.com` sites get. That URL already contains `/wp/v2/`, so letting
+     * wordpress-rs append the standard `/wp/v2/...` route onto it produces a doubled `/wp/v2/` and a
+     * 404 (`rest_no_route`). These sites reach their `wp-admin` directly, so derive the root from the
+     * site host instead of trusting the stored proxy URL. Genuine self-hosted sites keep their
+     * discovered [SiteModel.getWpApiRestUrl].
+     */
+    private fun resolveApiRoot(site: SiteModel): String {
+        if (site.isUsingWpComRestApi) {
+            return "${site.url}/wp-json"
+        }
+        return site.wpApiRestUrl?.takeIf { it.isNotEmpty() } ?: "${site.url}/wp-json"
     }
 
     private fun createDelegate(site: SiteModel): WpApiClientDelegate {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.accounts.login.CredentialsChangedNotifier
 import org.wordpress.android.ui.accounts.login.SiteApiRestUrlRecoverer
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.postsrs.data.WpServiceProvider
 import kotlin.test.assertNotNull
 
 private const val TEST_URL = "https://www.test.com"
@@ -74,6 +75,9 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var credentialsChangedNotifier: CredentialsChangedNotifier
 
+    @Mock
+    lateinit var wpServiceProvider: WpServiceProvider
+
     private lateinit var siteTest: SiteModel
 
     private var applicationPasswordCard: MySiteCardAndItem? = null
@@ -94,6 +98,7 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
             siteXMLRPCClient,
             siteApiRestUrlRecoverer,
             credentialsChangedNotifier,
+            wpServiceProvider,
             testDispatcher()
         ).apply {
             initialize(testScope())
@@ -255,6 +260,8 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
 
         verify(siteApiRestUrlRecoverer).discoverApiRootUrl(TEST_URL)
         verify(siteApiRestUrlRecoverer).persistApiRootUrl(TEST_SITE_ID, "$TEST_URL/wp-json")
+        // The cached RS service was built with the stale proxy apiRoot, so it must be dropped.
+        verify(wpServiceProvider).clearService(TEST_SITE_ID)
     }
 
     @Test
@@ -278,6 +285,7 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
         applicationPasswordViewModelSlice.buildCard(siteTest)
 
         verify(siteApiRestUrlRecoverer, never()).discoverApiRootUrl(any())
+        verify(wpServiceProvider, never()).clearService(any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
@@ -232,6 +232,55 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given valid stored creds with proxy-form apiRestUrl, then heal rediscovers the api root`() = runTest {
+        whenever(applicationPasswordLoginHelper.siteHasBadCredentials(any())).thenReturn(false)
+        whenever(siteStore.sites).thenReturn(
+            listOf(
+                SiteModel().apply {
+                    id = siteTest.id
+                    url = TEST_URL
+                    apiRestUsernamePlain = "user"
+                    apiRestPasswordPlain = "password"
+                    xmlRpcUrl = siteTest.xmlRpcUrl
+                    // Migrated Atomic sites carry the WP.com REST proxy URL, which breaks the RS lists.
+                    wpApiRestUrl = "https://public-api.wordpress.com/wp/v2/sites/256930037"
+                }
+            )
+        )
+        whenever(applicationPasswordValidator.validate(any()))
+            .thenReturn(ApplicationPasswordValidator.Outcome.Valid)
+        whenever(siteApiRestUrlRecoverer.discoverApiRootUrl(any())).thenReturn("$TEST_URL/wp-json")
+
+        applicationPasswordViewModelSlice.buildCard(siteTest)
+
+        verify(siteApiRestUrlRecoverer).discoverApiRootUrl(TEST_URL)
+        verify(siteApiRestUrlRecoverer).persistApiRootUrl(TEST_SITE_ID, "$TEST_URL/wp-json")
+    }
+
+    @Test
+    fun `given valid stored creds with direct-host apiRestUrl, then heal skips rediscovery`() = runTest {
+        whenever(applicationPasswordLoginHelper.siteHasBadCredentials(any())).thenReturn(false)
+        whenever(siteStore.sites).thenReturn(
+            listOf(
+                SiteModel().apply {
+                    id = siteTest.id
+                    url = TEST_URL
+                    apiRestUsernamePlain = "user"
+                    apiRestPasswordPlain = "password"
+                    xmlRpcUrl = siteTest.xmlRpcUrl
+                    wpApiRestUrl = "$TEST_URL/wp-json/"
+                }
+            )
+        )
+        whenever(applicationPasswordValidator.validate(any()))
+            .thenReturn(ApplicationPasswordValidator.Outcome.Valid)
+
+        applicationPasswordViewModelSlice.buildCard(siteTest)
+
+        verify(siteApiRestUrlRecoverer, never()).discoverApiRootUrl(any())
+    }
+
+    @Test
     fun `given headless mint returns NotSupported, then fall back to discovery`() = runTest {
         stubMintFailure(notSupported = true)
         whenever(applicationPasswordLoginHelper.getAuthorizationUrlComplete(eq(TEST_URL)))


### PR DESCRIPTION
## Description

Posts and Pages fail to load on **Atomic sites** (WordPress.com-hosted with a real
wp-admin + application password) on the new `wordpress-rs` lists. The lists show
"An error occurred" and the network request 404s with `rest_no_route` and a
**doubled `/wp/v2/`**:

`https://public-api.wordpress.com/wp/v2/sites/{id}/wp/v2/posts`

### Root cause

`WpServiceProvider.createService()` routes solely on `site.isWPCom`. Atomic sites
have `isWPCom = false`, so they take the `SiteInfo.SelfHosted` branch, which appends
the standard `/wp/v2/...` route onto the stored `wpApiRestUrl`. Migrated installs keep
the **WP.com proxy** form of that URL (`.../wp/v2/sites/{id}`, the same value simple
`.wordpress.com` sites get), which already contains `/wp/v2/` — so a second one is
appended, producing the 404. Clean installs store the direct-host `.../wp-json/` value
and work fine. `healApiRestUrlIfMissing()` only replaced a null/empty value, so the
wrong-but-present proxy URL was never corrected.

This is a long-standing latent defect exposed by the app-password + RS-list rollout,
not a 27.2 regression. Full analysis in CMM-2389.

### Changes

1. **`WpServiceProvider.resolveApiRoot(site)`** (the real fix): for
   `site.isUsingWpComRestApi` sites reaching the SelfHosted branch, derive the API root
   from `${site.url}/wp-json` instead of trusting the stored proxy `wpApiRestUrl`.
   Genuine self-hosted sites keep their discovered value. Fixes already-broken migrated
   installs immediately, no relogin, regardless of the stored value.
2. **`ApplicationPasswordViewModelSlice.healApiRestUrlIfNeeded`** (backstop, renamed
   from `healApiRestUrlIfMissing`): also rediscovers/overwrites a proxy-form
   `wpApiRestUrl` (detected via `contains("/wp/v2/")`), so the persisted DB value
   self-corrects — not just null/empty.
3. Added two `ApplicationPasswordViewModelSlice` unit tests (proxy → heals;
   direct-host → skips).

Fixes CMM-2389.

## Testing instructions

Reproduce the failure on an Atomic site:

1. Log in to WP site
2. Make it Atomic by installing an external plugin using the webapp
3. Go to the app again
4. Enable Application Password if you see the promt card (otherwise the migration was done automatically)
5. Open **Posts** and **Pages** and pull to refresh.
- [ ] Verify Posts and Pages load (no "An error occurred" / 404).

Regression check:

- [ ] Smoke test loging into WP regular site and self-hosted one. Check Posts and Pages load correctly.