### PR TITLE
CMM-2390 Fetch all terms in post editor picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionActivity.kt
@@ -53,8 +53,6 @@ class TermSelectionActivity : BaseAppCompatActivity() {
                         viewModel::onTermToggled,
                     onSearchQueryChanged =
                         viewModel::onSearchQueryChanged,
-                    onLoadMore =
-                        viewModel::onLoadMore,
                     onAddTermClicked =
                         viewModel::onAddTermClicked,
                     onAddDialogDismissed =

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionModels.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionModels.kt
@@ -10,8 +10,6 @@ data class SelectableTerm(
 data class TermSelectionUiState(
     val isLoading: Boolean = true,
     val isSearching: Boolean = false,
-    val isLoadingMore: Boolean = false,
-    val canLoadMore: Boolean = false,
     val error: String? = null,
     val terms: List<SelectableTerm> = emptyList(),
     val searchQuery: String = "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -57,7 +56,6 @@ fun TermSelectionScreen(
     onSaveClicked: () -> Unit,
     onTermToggled: (Long) -> Unit,
     onSearchQueryChanged: (String) -> Unit,
-    onLoadMore: () -> Unit,
     onAddTermClicked: () -> Unit,
     onAddDialogDismissed: () -> Unit,
     onAddTermConfirmed: (String, Long?) -> Unit,
@@ -141,13 +139,9 @@ fun TermSelectionScreen(
                         terms = uiState.terms,
                         searchQuery = uiState.searchQuery,
                         isSearching = uiState.isSearching,
-                        canLoadMore = uiState.canLoadMore,
-                        isLoadingMore =
-                            uiState.isLoadingMore,
                         onSearchQueryChanged =
                             onSearchQueryChanged,
                         onTermToggled = onTermToggled,
-                        onLoadMore = onLoadMore,
                     )
             }
         }
@@ -194,11 +188,8 @@ private fun TermListContent(
     terms: List<SelectableTerm>,
     searchQuery: String,
     isSearching: Boolean,
-    canLoadMore: Boolean,
-    isLoadingMore: Boolean,
     onSearchQueryChanged: (String) -> Unit,
     onTermToggled: (Long) -> Unit,
-    onLoadMore: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         OutlinedTextField(
@@ -268,48 +259,7 @@ private fun TermListContent(
                             }
                         )
                     }
-                    if (canLoadMore) {
-                        item(key = "load_more") {
-                            LoadMoreItem(
-                                isLoading =
-                                    isLoadingMore,
-                                onLoadMore = onLoadMore,
-                            )
-                        }
-                    }
                 }
-        }
-    }
-}
-
-@Composable
-private fun LoadMoreItem(
-    isLoading: Boolean,
-    onLoadMore: () -> Unit,
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(
-                enabled = !isLoading,
-                onClick = onLoadMore
-            )
-            .padding(16.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(24.dp),
-                strokeWidth = 2.dp,
-            )
-        } else {
-            Text(
-                text = stringResource(
-                    R.string.post_rs_settings_load_more
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
@@ -122,7 +122,7 @@ class TermSelectionViewModel @Inject constructor(
     fun onAddTermClicked() {
         val parentOptions = if (isCategories) {
             loadedTerms.map {
-                ParentOption(it.id, displayName(it))
+                ParentOption(it.id, it.name)
             }
         } else {
             emptyList()
@@ -287,7 +287,7 @@ class TermSelectionViewModel @Inject constructor(
         val selectable = terms.map { term ->
             SelectableTerm(
                 id = term.id,
-                name = displayName(term),
+                name = term.name,
                 level = if (
                     isCategories && !hasSearchQuery
                 ) {
@@ -323,7 +323,7 @@ class TermSelectionViewModel @Inject constructor(
             visited.add(term.id)
             result.add(term)
             terms.filter { it.parent == term.id }
-                .sortedBy { displayName(it).lowercase() }
+                .sortedBy { it.name.lowercase() }
                 .forEach { addWithChildren(it) }
         }
 
@@ -332,7 +332,7 @@ class TermSelectionViewModel @Inject constructor(
                 it.parent == null ||
                 termsById[it.parent] == null
         }
-            .sortedBy { displayName(it).lowercase() }
+            .sortedBy { it.name.lowercase() }
             .forEach { addWithChildren(it) }
 
         return result
@@ -351,10 +351,6 @@ class TermSelectionViewModel @Inject constructor(
         }
         return level
     }
-
-    private fun displayName(
-        term: AnyTermWithViewContext,
-    ) = term.name.ifBlank { term.slug }
 
     private fun handleCreateTermError() {
         _events.trySend(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
@@ -122,7 +122,7 @@ class TermSelectionViewModel @Inject constructor(
     fun onAddTermClicked() {
         val parentOptions = if (isCategories) {
             loadedTerms.map {
-                ParentOption(it.id, it.name)
+                ParentOption(it.id, displayName(it))
             }
         } else {
             emptyList()
@@ -287,7 +287,7 @@ class TermSelectionViewModel @Inject constructor(
         val selectable = terms.map { term ->
             SelectableTerm(
                 id = term.id,
-                name = term.name,
+                name = displayName(term),
                 level = if (
                     isCategories && !hasSearchQuery
                 ) {
@@ -323,7 +323,7 @@ class TermSelectionViewModel @Inject constructor(
             visited.add(term.id)
             result.add(term)
             terms.filter { it.parent == term.id }
-                .sortedBy { it.name.lowercase() }
+                .sortedBy { displayName(it).lowercase() }
                 .forEach { addWithChildren(it) }
         }
 
@@ -332,7 +332,7 @@ class TermSelectionViewModel @Inject constructor(
                 it.parent == null ||
                 termsById[it.parent] == null
         }
-            .sortedBy { it.name.lowercase() }
+            .sortedBy { displayName(it).lowercase() }
             .forEach { addWithChildren(it) }
 
         return result
@@ -351,6 +351,10 @@ class TermSelectionViewModel @Inject constructor(
         }
         return level
     }
+
+    private fun displayName(
+        term: AnyTermWithViewContext,
+    ) = term.name.ifBlank { term.slug }
 
     private fun handleCreateTermError() {
         _events.trySend(

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.postsrs.data.PostRsRestClient
 import org.wordpress.android.util.AppLog
@@ -27,6 +28,7 @@ import uniffi.wp_api.AnyTermWithViewContext
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 @Suppress("TooManyFunctions")
@@ -36,6 +38,7 @@ class TermSelectionViewModel @Inject constructor(
     private val restClient: PostRsRestClient,
     private val resourceProvider: ResourceProvider,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val isCategories: Boolean =
         savedStateHandle[EXTRA_IS_CATEGORIES] ?: true
@@ -68,7 +71,6 @@ class TermSelectionViewModel @Inject constructor(
 
     private var loadedTerms =
         mutableListOf<AnyTermWithViewContext>()
-    private var nextPageParams: TermListParams? = null
     private val selectedIds =
         initialSelectedIds.toMutableSet()
     private var searchJob: Job? = null
@@ -117,21 +119,6 @@ class TermSelectionViewModel @Inject constructor(
         }
     }
 
-    fun onLoadMore() {
-        val currentSite = site ?: return
-        val params = nextPageParams ?: return
-        if (!_uiState.value.isLoadingMore) {
-            _uiState.update {
-                it.copy(isLoadingMore = true)
-            }
-            viewModelScope.launch {
-                fetchPage(
-                    currentSite, params, append = true
-                )
-            }
-        }
-    }
-
     fun onAddTermClicked() {
         val parentOptions = if (isCategories) {
             loadedTerms.map {
@@ -166,7 +153,7 @@ class TermSelectionViewModel @Inject constructor(
         }
         viewModelScope.launch {
             try {
-                val newId = withContext(Dispatchers.IO) {
+                val newId = withContext(ioDispatcher) {
                     restClient.createTerm(
                         currentSite,
                         endpointType,
@@ -226,88 +213,64 @@ class TermSelectionViewModel @Inject constructor(
         }
         viewModelScope.launch {
             loadedTerms.clear()
-            nextPageParams = null
             val search = _uiState.value.searchQuery
                 .trim().ifEmpty { null }
-            fetchPage(
-                currentSite,
-                initialParams = null,
-                append = false,
-                search = search,
-            )
+            fetchAllPages(currentSite, search)
         }
     }
 
     @Suppress("TooGenericExceptionCaught", "LongMethod")
-    private suspend fun fetchPage(
+    private suspend fun fetchAllPages(
         site: SiteModel,
-        initialParams: TermListParams?,
-        append: Boolean,
         search: String? = null,
     ) {
-        try {
-            val result = withContext(Dispatchers.IO) {
-                restClient.fetchTermsPage(
-                    site,
-                    endpointType,
-                    search = search,
-                    nextPageParams = initialParams,
-                )
-            }
-            if (append) {
+        var nextPageParams: TermListParams? = null
+        do {
+            try {
+                val result = withContext(ioDispatcher) {
+                    restClient.fetchTermsPage(
+                        site,
+                        endpointType,
+                        search = search,
+                        nextPageParams = nextPageParams,
+                    )
+                }
                 loadedTerms.addAll(result.terms)
-            } else {
-                loadedTerms.clear()
-                loadedTerms.addAll(result.terms)
-            }
-            nextPageParams = result.nextPageParams
-            _uiState.update {
-                it.copy(
-                    isLoading = false,
-                    isSearching = false,
-                    isLoadingMore = false,
-                    isCreating = false,
-                    canLoadMore =
-                        result.nextPageParams != null,
-                    error = null,
+                nextPageParams = result.nextPageParams
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLog.e(
+                    AppLog.T.POSTS,
+                    "Failed to load terms",
+                    e
                 )
+                if (loadedTerms.isEmpty()) {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isSearching = false,
+                            isCreating = false,
+                            error = resourceProvider.getString(
+                                R.string.request_failed_message
+                            )
+                        )
+                    }
+                    return
+                }
+                nextPageParams = null
             }
-            rebuildUi()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            AppLog.e(
-                AppLog.T.POSTS,
-                "Failed to load terms",
-                e
+        } while (nextPageParams != null)
+
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                isSearching = false,
+                isCreating = false,
+                error = null,
             )
-            if (append) {
-                _uiState.update {
-                    it.copy(
-                        isSearching = false,
-                        isLoadingMore = false,
-                    )
-                }
-                _events.trySend(
-                    TermSelectionEvent.ShowSnackbar(
-                        resourceProvider.getString(
-                            R.string.request_failed_message
-                        )
-                    )
-                )
-            } else {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isSearching = false,
-                        isCreating = false,
-                        error = resourceProvider.getString(
-                            R.string.request_failed_message
-                        )
-                    )
-                }
-            }
         }
+        rebuildUi()
     }
 
     private fun rebuildUi() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
@@ -74,6 +74,7 @@ class TermSelectionViewModel @Inject constructor(
     private val selectedIds =
         initialSelectedIds.toMutableSet()
     private var searchJob: Job? = null
+    private var loadJob: Job? = null
 
     init {
         if (site == null) {
@@ -196,6 +197,7 @@ class TermSelectionViewModel @Inject constructor(
         showLoading: Boolean = true,
     ) {
         val currentSite = site ?: return
+        loadJob?.cancel()
         if (showLoading) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 _uiState.value = TermSelectionUiState(
@@ -211,7 +213,7 @@ class TermSelectionViewModel @Inject constructor(
                 it.copy(isLoading = true, error = null)
             }
         }
-        viewModelScope.launch {
+        loadJob = viewModelScope.launch {
             loadedTerms.clear()
             val search = _uiState.value.searchQuery
                 .trim().ifEmpty { null }

--- a/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModel.kt
@@ -260,6 +260,15 @@ class TermSelectionViewModel @Inject constructor(
                     }
                     return
                 }
+                // Keep the pages already fetched, but tell the user the
+                // list is incomplete so they can retry.
+                _events.trySend(
+                    TermSelectionEvent.ShowSnackbar(
+                        resourceProvider.getString(
+                            R.string.request_failed_message
+                        )
+                    )
+                )
                 nextPageParams = null
             }
         } while (nextPageParams != null)

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -125,6 +126,8 @@ class TermSelectionViewModelTest : BaseUnitTest(
         assertThat(viewModel.uiState.value.error).isNull()
         assertThat(viewModel.uiState.value.terms.map { it.id })
             .containsExactly(1L)
+        assertThat(viewModel.events.first())
+            .isEqualTo(TermSelectionEvent.ShowSnackbar("error"))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
@@ -143,6 +143,33 @@ class TermSelectionViewModelTest : BaseUnitTest(
         assertThat(viewModel.uiState.value.terms).isEmpty()
     }
 
+    @Test
+    fun `uses the slug when a term name is empty`() = test {
+        val unnamedTerm = term(
+            id = 1L,
+            name = "",
+            slug = "generated-category",
+        )
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = null,
+            )
+        ).thenReturn(
+            PostRsRestClient.TermsPageResult(
+                listOf(unnamedTerm),
+                null,
+            )
+        )
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.terms.single().name)
+            .isEqualTo("generated-category")
+    }
+
     private fun createViewModel(): TermSelectionViewModel {
         val savedStateHandle = SavedStateHandle(
             mapOf(
@@ -163,10 +190,12 @@ class TermSelectionViewModelTest : BaseUnitTest(
     private fun term(
         id: Long,
         name: String,
+        slug: String = name,
     ): AnyTermWithViewContext {
         val term = org.mockito.kotlin.mock<AnyTermWithViewContext>()
         whenever(term.id).thenReturn(id)
         whenever(term.name).thenReturn(name)
+        whenever(term.slug).thenReturn(slug)
         whenever(term.parent).thenReturn(0L)
         return term
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.postsrs.data.PostRsRestClient
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 import uniffi.wp_api.AnyTermWithViewContext
+import uniffi.wp_api.TaxonomyType
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
 
@@ -143,33 +144,6 @@ class TermSelectionViewModelTest : BaseUnitTest(
         assertThat(viewModel.uiState.value.terms).isEmpty()
     }
 
-    @Test
-    fun `uses the slug when a term name is empty`() = test {
-        val unnamedTerm = term(
-            id = 1L,
-            name = "",
-            slug = "generated-category",
-        )
-        whenever(
-            restClient.fetchTermsPage(
-                site,
-                TermEndpointType.Categories,
-                nextPageParams = null,
-            )
-        ).thenReturn(
-            PostRsRestClient.TermsPageResult(
-                listOf(unnamedTerm),
-                null,
-            )
-        )
-
-        val viewModel = createViewModel()
-        advanceUntilIdle()
-
-        assertThat(viewModel.uiState.value.terms.single().name)
-            .isEqualTo("generated-category")
-    }
-
     private fun createViewModel(): TermSelectionViewModel {
         val savedStateHandle = SavedStateHandle(
             mapOf(
@@ -190,13 +164,14 @@ class TermSelectionViewModelTest : BaseUnitTest(
     private fun term(
         id: Long,
         name: String,
-        slug: String = name,
-    ): AnyTermWithViewContext {
-        val term = org.mockito.kotlin.mock<AnyTermWithViewContext>()
-        whenever(term.id).thenReturn(id)
-        whenever(term.name).thenReturn(name)
-        whenever(term.slug).thenReturn(slug)
-        whenever(term.parent).thenReturn(0L)
-        return term
-    }
+    ) = AnyTermWithViewContext(
+        id = id,
+        count = 0L,
+        description = "",
+        link = "",
+        name = name,
+        slug = name,
+        taxonomy = TaxonomyType.Category,
+        parent = 0L,
+    )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
@@ -1,0 +1,173 @@
+package org.wordpress.android.ui.postsrs.terms
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.postsrs.data.PostRsRestClient
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
+import uniffi.wp_api.AnyTermWithViewContext
+import uniffi.wp_api.TermEndpointType
+import uniffi.wp_api.TermListParams
+
+@ExperimentalCoroutinesApi
+class TermSelectionViewModelTest : BaseUnitTest(
+    StandardTestDispatcher()
+) {
+    @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Mock lateinit var restClient: PostRsRestClient
+    @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    private val site = SiteModel()
+    private var activeViewModel: TermSelectionViewModel? = null
+
+    @Before
+    fun setUp() {
+        whenever(selectedSiteRepository.getSelectedSite())
+            .thenReturn(site)
+        whenever(networkUtilsWrapper.isNetworkAvailable())
+            .thenReturn(true)
+        whenever(resourceProvider.getString(any()))
+            .thenReturn("error")
+    }
+
+    @After
+    fun tearDown() {
+        activeViewModel?.viewModelScope?.cancel()
+        activeViewModel = null
+    }
+
+    @Test
+    fun `loads every page before showing terms`() = test {
+        val secondPageParams = TermListParams(perPage = 100u)
+        val firstTerm = term(id = 1L, name = "First")
+        val secondTerm = term(id = 2L, name = "Second")
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = null,
+            )
+        ).thenReturn(
+            PostRsRestClient.TermsPageResult(
+                listOf(firstTerm),
+                secondPageParams,
+            )
+        )
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = secondPageParams,
+            )
+        ).thenReturn(
+            PostRsRestClient.TermsPageResult(
+                listOf(secondTerm),
+                null,
+            )
+        )
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.isLoading).isFalse()
+        assertThat(viewModel.uiState.value.terms.map { it.id })
+            .containsExactly(1L, 2L)
+    }
+
+    @Test
+    fun `keeps fetched pages when a later page fails`() = test {
+        val secondPageParams = TermListParams(perPage = 100u)
+        val firstTerm = term(id = 1L, name = "First")
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = null,
+            )
+        ).thenReturn(
+            PostRsRestClient.TermsPageResult(
+                listOf(firstTerm),
+                secondPageParams,
+            )
+        )
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = secondPageParams,
+            )
+        ).thenAnswer {
+            throw PostRsRestClient.TermsFetchException("failure")
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.error).isNull()
+        assertThat(viewModel.uiState.value.terms.map { it.id })
+            .containsExactly(1L)
+    }
+
+    @Test
+    fun `shows an error when the first page fails`() = test {
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = null,
+            )
+        ).thenAnswer {
+            throw PostRsRestClient.TermsFetchException("failure")
+        }
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.isLoading).isFalse()
+        assertThat(viewModel.uiState.value.error).isEqualTo("error")
+        assertThat(viewModel.uiState.value.terms).isEmpty()
+    }
+
+    private fun createViewModel(): TermSelectionViewModel {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                TermSelectionViewModel.EXTRA_IS_CATEGORIES to true,
+                TermSelectionViewModel.EXTRA_SELECTED_IDS to longArrayOf(),
+            )
+        )
+        return TermSelectionViewModel(
+            savedStateHandle = savedStateHandle,
+            selectedSiteRepository = selectedSiteRepository,
+            restClient = restClient,
+            resourceProvider = resourceProvider,
+            networkUtilsWrapper = networkUtilsWrapper,
+            ioDispatcher = testDispatcher(),
+        ).also { activeViewModel = it }
+    }
+
+    private fun term(
+        id: Long,
+        name: String,
+    ): AnyTermWithViewContext {
+        val term = org.mockito.kotlin.mock<AnyTermWithViewContext>()
+        whenever(term.id).thenReturn(id)
+        whenever(term.name).thenReturn(name)
+        whenever(term.parent).thenReturn(0L)
+        return term
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/postsrs/terms/TermSelectionViewModelTest.kt
@@ -4,14 +4,17 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
@@ -142,6 +145,44 @@ class TermSelectionViewModelTest : BaseUnitTest(
         assertThat(viewModel.uiState.value.isLoading).isFalse()
         assertThat(viewModel.uiState.value.error).isEqualTo("error")
         assertThat(viewModel.uiState.value.terms).isEmpty()
+    }
+
+    @Test
+    fun `retry cancels an in-flight load`() = test {
+        val staleTerm = term(id = 1L, name = "Stale")
+        val freshTerm = term(id = 2L, name = "Fresh")
+        var requestCount = 0
+        whenever(
+            restClient.fetchTermsPage(
+                site,
+                TermEndpointType.Categories,
+                nextPageParams = null,
+            )
+        ).doSuspendableAnswer {
+            requestCount++
+            if (requestCount == 1) {
+                delay(60_000)
+                PostRsRestClient.TermsPageResult(
+                    listOf(staleTerm),
+                    null,
+                )
+            } else {
+                PostRsRestClient.TermsPageResult(
+                    listOf(freshTerm),
+                    null,
+                )
+            }
+        }
+
+        val viewModel = createViewModel()
+        runCurrent()
+
+        viewModel.retry()
+        advanceUntilIdle()
+
+        assertThat(requestCount).isEqualTo(2)
+        assertThat(viewModel.uiState.value.terms.map { it.id })
+            .containsExactly(2L)
     }
 
     private fun createViewModel(): TermSelectionViewModel {


### PR DESCRIPTION
**Fixes CMM-2390**

## The Problem

The new wordpress-rs Compose term picker loads terms 100 at a time and only advances when the user taps a "Load more" row. On a site with more than 100 categories or tags, the picker shows exactly 100 and looks truncated. 

## The Solution

- Fetches all category/tag pages before displaying terms.
- Preserves successfully fetched pages if a later request fails.
- Shows an error only when the first page fails.
- Removes manual “Load more” UI and state.
- Injects the I/O dispatcher for testability.
- Adds focused tests covering full pagination and failure handling.

## Testing

- Login to the Jurassic Ninja site I DM'd you
- Open the RS post list
- Tap the overflow menu on a post
- Select "Post settings"
- Tap "Categories"

Verify:
- More than 100 categories are present immediately.
- There is no Load more row.
- Scrolling reaches the complete category list.
- Existing category selections remain checked.
- Selecting or clearing categories and saving works normally.

