### PR TITLE
fix: Delete terms by their remote id and surface deletion failures

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,7 +15,7 @@
 * [**] Media shared from apps that generate it on the fly, such as an "Enhanced" photo from Google Photos, now keeps its correct file type instead of always uploading as a JPEG, and sharing several photos at once no longer drops some of them. [https://github.com/wordpress-mobile/WordPress-Android/issues/23047]
 * [**] Self-hosted sites added with an application password now have their Jetpack status detected, so opening Stats in the Jetpack app no longer asks you to install a plugin your site already has.
 * [*] Reworked editor capability detection to be more reliable and prevent a false "Unable to connect to your site" banner on private Atomic sites.
-* [**] Deleting a category now works on sites connected with an application password, and a category that can't be deleted tells you so instead of leaving the screen loading. [https://github.com/wordpress-mobile/WordPress-Android/pull/23294]
+* [**] Deleting a category now works on sites connected with an application password, and a category or tag that can't be deleted tells you so instead of leaving the screen loading. [https://github.com/wordpress-mobile/WordPress-Android/pull/23294]
 
 26.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [**] Media shared from apps that generate it on the fly, such as an "Enhanced" photo from Google Photos, now keeps its correct file type instead of always uploading as a JPEG, and sharing several photos at once no longer drops some of them. [https://github.com/wordpress-mobile/WordPress-Android/issues/23047]
 * [**] Self-hosted sites added with an application password now have their Jetpack status detected, so opening Stats in the Jetpack app no longer asks you to install a plugin your site already has.
 * [*] Reworked editor capability detection to be more reliable and prevent a false "Unable to connect to your site" banner on private Atomic sites.
+* [**] Deleting a category now works on sites connected with an application password, and a category that can't be deleted tells you so instead of leaving the screen loading. [https://github.com/wordpress-mobile/WordPress-Android/pull/23294]
 
 26.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -285,6 +285,14 @@ public class SiteSettingsTagListActivity extends BaseAppCompatActivity
                 }
                 break;
             case REMOVE_TERM:
+                hideProgressDialog();
+                hideDetailFragment();
+                if (event.isError()) {
+                    ToastUtils.showToast(this, R.string.deleting_tag_failed);
+                } else {
+                    loadTags();
+                }
+                break;
             case UPDATE_TERM:
                 hideProgressDialog();
                 hideDetailFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListViewModel.kt
@@ -101,7 +101,7 @@ class CategoriesListViewModel @Inject constructor(
             processFetchCategoriesCallback(event)
         if (event.causeOfChange == TaxonomyAction.UPDATE_TERM)
             launch { fetchCategoriesFromNetwork() }
-        if (event.causeOfChange == TaxonomyAction.REMOVE_TERM)
+        if (event.causeOfChange == TaxonomyAction.REMOVE_TERM && !event.isError)
             launch { fetchCategoriesFromNetwork() }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -783,6 +783,7 @@
     <string name="error_tag_exists">A tag with this name already exists</string>
     <string name="dlg_confirm_delete_tag">Permanently delete \'%s\' tag?</string>
     <string name="dlg_deleting_tag">Deleting</string>
+    <string name="deleting_tag_failed">Deleting tag failed</string>
     <string name="dlg_saving_tag">Saving</string>
 
     <!-- Jetpack settings -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/categories/CategoriesListViewModelTest.kt
@@ -164,6 +164,36 @@ class CategoriesListViewModelTest : BaseUnitTest() {
         assertTrue(uiStates.last() is Content)
     }
 
+    @Test
+    fun `given a deletion succeeds, when the callback arrives, then the list is fetched again`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        viewModel.start(siteModel)
+
+        viewModel.onTaxonomyChanged(OnTaxonomyChanged(1, TaxonomyAction.REMOVE_TERM))
+        advanceUntilIdle()
+
+        verify(getCategoriesUseCase, times(2)).fetchSiteCategories(siteModel)
+    }
+
+    @Test
+    fun `given a deletion fails on no network, when the callback arrives, then the list is left alone`() = test {
+        whenever(getCategoriesUseCase.getSiteCategories(siteModel)).thenReturn(mock())
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true).thenReturn(false)
+        viewModel.start(siteModel)
+
+        viewModel.onTaxonomyChanged(getRemoveTermError())
+        advanceUntilIdle()
+
+        verify(getCategoriesUseCase, times(1)).fetchSiteCategories(siteModel)
+        assertTrue(uiStates.last() is Content)
+    }
+
+    private fun getRemoveTermError(): OnTaxonomyChanged {
+        val taxonomyChanged = OnTaxonomyChanged(0, TaxonomyAction.REMOVE_TERM)
+        taxonomyChanged.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR)
+        return taxonomyChanged
+    }
+
     private fun getGenericTaxonomyError(): OnTaxonomyChanged {
         val taxonomyChanged = OnTaxonomyChanged(0, TaxonomyAction.FETCH_CATEGORIES)
         taxonomyChanged.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -54,7 +54,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
         val termResponse = client.request { requestBuilder ->
             requestBuilder.terms().delete(
                 termEndpointType = termEndpointType,
-                termId = term.id.toLong()
+                termId = term.remoteTermId
             )
         }
         when (termResponse) {
@@ -67,7 +67,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                     val termModel = TermModel(
                         term.id,
                         site.id,
-                        term.id.toLong(),
+                        term.remoteTermId,
                         taxonomyName,
                         term.name,
                         term.slug,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -419,9 +419,11 @@ public class TaxonomyStore extends Store {
 
     private void handleDeleteTermCompleted(@NonNull RemoteTermPayload payload) {
         if (payload.isError()) {
+            // Reported as REMOVE_TERM, the same cause a successful deletion emits, because that is
+            // the cause callers subscribe to.
             OnTaxonomyChanged event = new OnTaxonomyChanged(
                     0,
-                    TaxonomyAction.DELETE_TERM
+                    TaxonomyAction.REMOVE_TERM
             );
             event.error = payload.error;
             emitChange(event);

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.taxonomy
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -17,9 +18,11 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
@@ -37,8 +40,11 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.AnyTermWithEditContext
 import uniffi.wp_api.RequestMethod
 import uniffi.wp_api.TermDeleteResponse
+import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermsRequestCreateResponse
 import uniffi.wp_api.TermsRequestDeleteResponse
+import uniffi.wp_api.TermsRequestExecutor
+import uniffi.wp_api.UniffiWpApiClient
 import uniffi.wp_api.TermsRequestListWithEditContextResponse
 import uniffi.wp_api.TermsRequestUpdateResponse
 import uniffi.wp_api.TaxonomyType
@@ -493,6 +499,38 @@ class TaxonomyRsApiRestClientTest {
     }
 
     @Test
+    fun `deleteTerm category deletes by the remote term id`() = runTest {
+        val deleteResponse = TermsRequestDeleteResponse(
+            createTestCategoryDeleteData(deleted = true),
+            mock<WpNetworkHeaderMap>()
+        )
+        val termsExecutor = mock<TermsRequestExecutor> {
+            onBlocking { delete(any(), any()) } doReturn deleteResponse
+        }
+        val uniffiClient = mock<UniffiWpApiClient> {
+            on { terms() } doReturn termsExecutor
+        }
+
+        // The other delete tests stub the request wholesale, which leaves the id sent to the API
+        // unobservable. Running the request against a stubbed executor exposes it: TermModel
+        // carries both a local row id and a remote one, and only the remote one identifies the
+        // term to the API.
+        whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val executeRequest =
+                invocation.getArgument<Any>(0) as suspend (UniffiWpApiClient) -> TermsRequestDeleteResponse
+            runBlocking { executeRequest(uniffiClient) }
+            WpRequestResult.Success(response = deleteResponse)
+        }
+
+        taxonomyClient.deleteTerm(testSite, testCategoryTermModel)
+
+        verifyBlocking(termsExecutor) {
+            delete(TermEndpointType.Categories, testCategoryTermModel.remoteTermId)
+        }
+    }
+
+    @Test
     fun `deleteTerm category with success response dispatches success action`() = runTest {
         val categoryDeleteData = createTestCategoryDeleteData(deleted = true)
 
@@ -522,7 +560,7 @@ class TaxonomyRsApiRestClientTest {
         // Verify the deleted term has the correct properties
         assertEquals(testCategoryTermModel.id, payload.term.id)
         assertEquals(testSite.id, payload.term.localSiteId)
-        assertEquals(testCategoryTermModel.id.toLong(), payload.term.remoteTermId)
+        assertEquals(testCategoryTermModel.remoteTermId, payload.term.remoteTermId)
         assertEquals(testCategoryTaxonomyName, payload.term.taxonomy)
         assertEquals(testCategoryTermModel.name, payload.term.name)
         assertEquals(testCategoryTermModel.slug, payload.term.slug)
@@ -619,7 +657,7 @@ class TaxonomyRsApiRestClientTest {
         // Verify the deleted term has the correct properties
         assertEquals(testTagTermModel.id, payload.term.id)
         assertEquals(testSite.id, payload.term.localSiteId)
-        assertEquals(testTagTermModel.id.toLong(), payload.term.remoteTermId)
+        assertEquals(testTagTermModel.remoteTermId, payload.term.remoteTermId)
         assertEquals(testTagTaxonomyName, payload.term.taxonomy)
         assertEquals(testTagTermModel.name, payload.term.name)
         assertEquals(testTagTermModel.slug, payload.term.slug)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClientTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpapi.taxonomy
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -19,6 +18,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -500,12 +500,8 @@ class TaxonomyRsApiRestClientTest {
 
     @Test
     fun `deleteTerm category deletes by the remote term id`() = runTest {
-        val deleteResponse = TermsRequestDeleteResponse(
-            createTestCategoryDeleteData(deleted = true),
-            mock<WpNetworkHeaderMap>()
-        )
         val termsExecutor = mock<TermsRequestExecutor> {
-            onBlocking { delete(any(), any()) } doReturn deleteResponse
+            onBlocking { delete(any(), any()) } doReturn createTestDeleteResponse(deleted = true)
         }
         val uniffiClient = mock<UniffiWpApiClient> {
             on { terms() } doReturn termsExecutor
@@ -515,12 +511,10 @@ class TaxonomyRsApiRestClientTest {
         // unobservable. Running the request against a stubbed executor exposes it: TermModel
         // carries both a local row id and a remote one, and only the remote one identifies the
         // term to the API.
-        whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenAnswer { invocation ->
-            @Suppress("UNCHECKED_CAST")
+        whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).doSuspendableAnswer { invocation ->
             val executeRequest =
-                invocation.getArgument<Any>(0) as suspend (UniffiWpApiClient) -> TermsRequestDeleteResponse
-            runBlocking { executeRequest(uniffiClient) }
-            WpRequestResult.Success(response = deleteResponse)
+                invocation.getArgument<suspend (UniffiWpApiClient) -> TermsRequestDeleteResponse>(0)
+            WpRequestResult.Success(response = executeRequest(uniffiClient))
         }
 
         taxonomyClient.deleteTerm(testSite, testCategoryTermModel)
@@ -532,16 +526,8 @@ class TaxonomyRsApiRestClientTest {
 
     @Test
     fun `deleteTerm category with success response dispatches success action`() = runTest {
-        val categoryDeleteData = createTestCategoryDeleteData(deleted = true)
-
-        // Create the correct response structure following the MediaRsApiRestClientTest pattern
-        val categoryResponse = TermsRequestDeleteResponse(
-            categoryDeleteData,
-            mock<WpNetworkHeaderMap>()
-        )
-
         val successResponse: WpRequestResult<TermsRequestDeleteResponse> = WpRequestResult.Success(
-            response = categoryResponse
+            response = createTestDeleteResponse(deleted = true)
         )
 
         whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenReturn(successResponse)
@@ -571,16 +557,8 @@ class TaxonomyRsApiRestClientTest {
 
     @Test
     fun `deleteTerm category with failed deletion response dispatches error action`() = runTest {
-        val categoryDeleteData = createTestCategoryDeleteData(deleted = false)
-
-        // Create the correct response structure with deleted = false
-        val categoryResponse = TermsRequestDeleteResponse(
-            categoryDeleteData,
-            mock<WpNetworkHeaderMap>()
-        )
-
         val successResponse: WpRequestResult<TermsRequestDeleteResponse> = WpRequestResult.Success(
-            response = categoryResponse
+            response = createTestDeleteResponse(deleted = false)
         )
 
         whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenReturn(successResponse)
@@ -629,16 +607,8 @@ class TaxonomyRsApiRestClientTest {
 
     @Test
     fun `deleteTerm tag with success response dispatches success action`() = runTest {
-        val tagDeleteData = createTestTagDeleteData(deleted = true)
-
-        // Create the correct response structure following the MediaRsApiRestClientTest pattern
-        val tagResponse = TermsRequestDeleteResponse(
-            tagDeleteData,
-            mock<WpNetworkHeaderMap>()
-        )
-
         val successResponse: WpRequestResult<TermsRequestDeleteResponse> = WpRequestResult.Success(
-            response = tagResponse
+            response = createTestDeleteResponse(deleted = true)
         )
 
         whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenReturn(successResponse)
@@ -668,16 +638,8 @@ class TaxonomyRsApiRestClientTest {
 
     @Test
     fun `deleteTerm tag with failed deletion response dispatches error action`() = runTest {
-        val tagDeleteData = createTestTagDeleteData(deleted = false)
-
-        // Create the correct response structure with deleted = false
-        val tagResponse = TermsRequestDeleteResponse(
-            tagDeleteData,
-            mock<WpNetworkHeaderMap>()
-        )
-
         val successResponse: WpRequestResult<TermsRequestDeleteResponse> = WpRequestResult.Success(
-            response = tagResponse
+            response = createTestDeleteResponse(deleted = false)
         )
 
         whenever(wpApiClient.request<TermsRequestDeleteResponse>(any())).thenReturn(successResponse)
@@ -889,12 +851,11 @@ class TaxonomyRsApiRestClientTest {
         )
     )
 
-    private fun createTestCategoryDeleteData(deleted: Boolean): TermDeleteResponse {
-        return TermDeleteResponse(deleted, createTestAnyTermWithEditContext())
-    }
-
-    private fun createTestTagDeleteData(deleted: Boolean): TermDeleteResponse {
-        return TermDeleteResponse(deleted, createTestAnyTermWithEditContext())
+    private fun createTestDeleteResponse(deleted: Boolean): TermsRequestDeleteResponse {
+        return TermsRequestDeleteResponse(
+            TermDeleteResponse(deleted, createTestAnyTermWithEditContext()),
+            mock<WpNetworkHeaderMap>()
+        )
     }
 
     private fun createTestAnyTermWithEditContext(): AnyTermWithEditContext {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY;
@@ -77,6 +78,27 @@ public class TaxonomyStoreUnitTest {
             // Callers subscribe to REMOVE_TERM, so both outcomes have to arrive under that cause
             // for the screen that started the deletion to hear about either one.
             assertEquals(TaxonomyAction.REMOVE_TERM, mLastTaxonomyChanged.causeOfChange);
+        } finally {
+            mDispatcher.unregister(this);
+        }
+    }
+
+    @Test
+    public void testSuccessfulDeletionIsReportedAsRemoveTerm() {
+        mDispatcher.register(this);
+        try {
+            TermModel category = TaxonomyTestUtils.generateSampleCategory();
+            TaxonomySqlUtils.insertOrUpdateTerm(category);
+
+            RemoteTermPayload payload = new RemoteTermPayload(category, new SiteModel());
+
+            mTaxonomyStore.onAction(TaxonomyActionBuilder.newDeletedTermAction(payload));
+
+            assertNotNull(mLastTaxonomyChanged);
+            assertFalse(mLastTaxonomyChanged.isError());
+            assertEquals(TaxonomyAction.REMOVE_TERM, mLastTaxonomyChanged.causeOfChange);
+            assertEquals(1, mLastTaxonomyChanged.rowsAffected);
+            assertEquals(0, TaxonomyTestUtils.getTermsCount());
         } finally {
             mDispatcher.unregister(this);
         }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.yarolegovich.wellsql.WellSql;
 
+import org.greenrobot.eventbus.Subscribe;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +13,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests;
+import org.wordpress.android.fluxc.action.TaxonomyAction;
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TaxonomyRestClient;
@@ -20,18 +23,28 @@ import org.wordpress.android.fluxc.network.xmlrpc.taxonomy.TaxonomyXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.TaxonomySqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError;
+import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY;
 import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG;
 
 @RunWith(RobolectricTestRunner.class)
 public class TaxonomyStoreUnitTest {
+    private OnTaxonomyChanged mLastTaxonomyChanged;
+
+    private final Dispatcher mDispatcher = new Dispatcher();
+
     private final TaxonomyStore mTaxonomyStore = new TaxonomyStore(
-            new Dispatcher(),
+            mDispatcher,
             Mockito.mock(TaxonomyRestClient.class),
             Mockito.mock(TaxonomyXMLRPCClient.class),
             Mockito.mock(TaxonomyRsApiRestClient.class),
@@ -45,6 +58,33 @@ public class TaxonomyStoreUnitTest {
         WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, TermModel.class);
         WellSql.init(config);
         config.reset();
+    }
+
+    @Test
+    public void testFailedDeletionIsReportedAsRemoveTerm() {
+        mDispatcher.register(this);
+        try {
+            RemoteTermPayload payload = new RemoteTermPayload(
+                    new TermModel(DEFAULT_TAXONOMY_CATEGORY),
+                    new SiteModel()
+            );
+            payload.error = new TaxonomyError(TaxonomyErrorType.GENERIC_ERROR);
+
+            mTaxonomyStore.onAction(TaxonomyActionBuilder.newDeletedTermAction(payload));
+
+            assertNotNull(mLastTaxonomyChanged);
+            assertTrue(mLastTaxonomyChanged.isError());
+            // Callers subscribe to REMOVE_TERM, so both outcomes have to arrive under that cause
+            // for the screen that started the deletion to hear about either one.
+            assertEquals(TaxonomyAction.REMOVE_TERM, mLastTaxonomyChanged.causeOfChange);
+        } finally {
+            mDispatcher.unregister(this);
+        }
+    }
+
+    @Subscribe
+    public void onTaxonomyChanged(OnTaxonomyChanged event) {
+        mLastTaxonomyChanged = event;
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #23293. Fix CMM-2401.

Deleting a category over the wordpress-rs path failed with a 404 and left the confirmation dialog spinning on "Deleting category" forever. Two independent defects, both from #22252:

**`deleteTerm` identified the term by its local database id.** `TermModel` carries `mId`, the local `@PrimaryKey` row id, and `mRemoteTermId`, the id the API knows. `deleteTerm` sent `term.id`, so the API was asked to delete a term id belonging to something else and answered `404 rest_term_invalid`. Every sibling already uses the remote identity — `TaxonomyXMLRPCClient` sends `getRemoteTermId()`, `TaxonomyRestClient` uses the slug, and `updateTerm` in the same class sends `term.remoteTermId`. Creating works because it needs no id. The success path had the mirror image of the slip, passing the local id as the confirmation model's `remoteTermId`.

**A failed deletion was reported under a cause nothing subscribes to.** A successful deletion emits `OnTaxonomyChanged(causeOfChange = REMOVE_TERM)`; a failed one emitted `DELETE_TERM`. `CategoryDetailViewModel`, `CategoriesListViewModel` and `SiteSettingsTagListActivity` all match on `REMOVE_TERM` only, so the failure reached nobody and the `InProgress` state was never cleared. Both outcomes now emit `REMOVE_TERM`, and `CategoryDetailViewModel` already passes `event.isError` through to the message. This half affects every client — any failed term deletion left the dialog spinning, including on WordPress.com and XML-RPC sites.

Moving failures onto the cause every screen already listens to means the other two subscribers now receive an event they never saw before, so both had to be taught what to do with it:

- **`CategoriesListViewModel`** matched on the cause alone, so a rejected deletion triggered a refetch — the list posted `Loading` and, when the network was unavailable (a likely reason the deletion failed in the first place), replaced itself with the no-connection screen. It now refetches only on success.
- **`SiteSettingsTagListActivity`** shared one `switch` branch between `REMOVE_TERM` and `UPDATE_TERM`, which hides the progress dialog and pops the detail fragment unconditionally. A rejected tag deletion therefore closed the dialog and popped the screen with nothing but an `AppLog` line, indistinguishable from a success while the stale tag stayed in the list. It now shows a "Deleting tag failed" toast, matching the message the categories screen shows.

The existing delete tests stub `WpApiClient.request` wholesale, so the id sent was never observable and two assertions had been written against the wrong value. The new test runs the request against a stubbed executor and asserts the id itself. Every new test here was confirmed to fail without its fix.

## Testing instructions

> [!note]
> The category deletion fix requires a site whose taxonomy requests go through wordpress-rs: added with an application password, with `taxonomies_rest_api_migration` enabled in the dev menu. The failure-reporting fixes apply to every site type.

Deleting a category:

1. Go to Site Settings → Categories and create a category.
2. Open the new category and delete it.
- [x] Verify the category is deleted and disappears from the list
- [x] Verify the `DELETE` request uses the same id the `POST` response returned (on `trunk` it uses a different one and returns 404)

Failed category deletion no longer hangs (regression check, reproducible on any site type):

1. With a proxy, fail `DELETE */categories/*` with a 500.
2. Delete a category.
- [x] Verify the "Deleting category" spinner is replaced by "Failed to delete category" instead of spinning indefinitely
- [x] Verify the category list behind it still shows the categories, rather than flashing a spinner or a "No connection" screen

Failed tag deletion reports the failure:

1. With a proxy, fail `DELETE */tags/*` with a 500.
2. Go to Site Settings → Tags, open a tag and delete it.
- [x] Verify a "Deleting tag failed" toast appears rather than the screen closing silently

Regressions:

1. Create, rename and delete categories on a WordPress.com Simple site.
- [x] Verify all three still work
2. Repeat on a self-hosted site with the feature flag disabled (XML-RPC path).
- [ ] Verify all three still work
3. Create, rename and delete tags.
- [ ] Verify all three still work, and that the list refreshes after each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pj4FNhM3TFx83R5uDSuYh
