### PR TITLE
Add TL;DR section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+## TL;DR
+<!--
+A short, one or two sentence summary of what this PR does and why it matters.
+⚠️ This section MUST be written by a human.
+-->
+
 ## Description
 <!-- Describe the changes, why they are needed, and how they address the issue -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,12 @@ WordPress/src/main/java/org/wordpress/android/
 - [ ] Did the user respond affirmatively to THIS specific request (not a previous one)?
 - [ ] Are you committing only the changes the user approved?
 
+### Editing PR Descriptions
+**IMPORTANT**: When asked to modify a PR description, always first retrieve the current
+description from the server (e.g. `gh pr view <number> --json body`) and edit that live
+content. Never rewrite the whole description from local knowledge or memory, since it may
+have been changed on the server side and those changes would be lost.
+
 ## Release Notes Compilation Process
 
 ### Overview


### PR DESCRIPTION
## TL;DR
Adds a human-written TL;DR section to the PR template and documents that PR descriptions must be fetched live from the server before being edited.

## Description
Two small repository/tooling changes:

- **PR template**: Adds a `## TL;DR` section at the top of `.github/PULL_REQUEST_TEMPLATE.md` for a quick one/two-sentence summary of each PR. The template note flags that this section must be written by a human.
- **CLAUDE.md**: Adds an "Editing PR Descriptions" guideline instructing the agent to always retrieve the current PR description from the server (e.g. `gh pr view <number> --json body`) before modifying it, to avoid overwriting server-side changes with stale local content.

## Testing instructions

1. Open a new PR on GitHub for this repo.
- [ ] Verify the description pre-fills with a `## TL;DR` section above `## Description`.
- [ ] Verify the TL;DR comment notes the section must be written by a human.
2. Review `CLAUDE.md`.
- [ ] Verify the new "Editing PR Descriptions" section is present and clear.