### PR TITLE
Migrate `CreateCartUseCase` to wordpress-rs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -362,10 +362,7 @@ class DomainSuggestionsViewModel @Inject constructor(
         showLoadingButton(false)
 
         when (result) {
-            is CreateCartResult.Error -> {
-                AppLog.e(T.DOMAIN_REGISTRATION, "Failed cart creation")
-                // TODO Handle failed cart creation
-            }
+            is CreateCartResult.Error -> AppLog.e(T.DOMAIN_REGISTRATION, "Failed cart creation")
             is CreateCartResult.Success -> {
                 AppLog.d(T.DOMAIN_REGISTRATION, "Successful cart creation")
                 if (domainRegistrationPurpose == FREE_DOMAIN_WITH_ANNUAL_PLAN) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.FREE_DOMAIN_WITH_ANNUAL_PLAN
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -126,7 +127,6 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     override fun onCleared() {
         debouncer.shutdown()
-        createCartUseCase.clear()
         super.onCleared()
     }
 
@@ -351,7 +351,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         showLoadingButton(true)
 
-        val event = createCartUseCase.execute(
+        val result = createCartUseCase.execute(
             site,
             selectedSuggestion.productId,
             selectedSuggestion.domainName,
@@ -361,15 +361,18 @@ class DomainSuggestionsViewModel @Inject constructor(
 
         showLoadingButton(false)
 
-        if (event.isError) {
-            AppLog.e(T.DOMAIN_REGISTRATION, "Failed cart creation: ${event.error.message}")
-            // TODO Handle failed cart creation
-        } else {
-            AppLog.d(T.DOMAIN_REGISTRATION, "Successful cart creation: ${event.cartDetails}")
-            if (domainRegistrationPurpose == FREE_DOMAIN_WITH_ANNUAL_PLAN) {
-                openPlans(selectedSuggestion)
-            } else {
-                selectDomain(selectedSuggestion)
+        when (result) {
+            is CreateCartResult.Error -> {
+                AppLog.e(T.DOMAIN_REGISTRATION, "Failed cart creation")
+                // TODO Handle failed cart creation
+            }
+            is CreateCartResult.Success -> {
+                AppLog.d(T.DOMAIN_REGISTRATION, "Successful cart creation")
+                if (domainRegistrationPurpose == FREE_DOMAIN_WITH_ANNUAL_PLAN) {
+                    openPlans(selectedSuggestion)
+                } else {
+                    selectDomain(selectedSuggestion)
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -68,13 +68,22 @@ class PurchaseDomainViewModel @AssistedInject constructor(
         }
     }
 
-    fun onDomainRegistrationComplete(event: DomainRegistrationCompletedEvent?) = event?.also {
+    /**
+     * Called when the checkout web view closes.
+     *
+     * A null [event] means it was dismissed rather than completed. The checkout
+     * reports a completed purchase and nothing else, so there is no failure to
+     * report here; the screen returns to the state it was opened from.
+     */
+    fun onDomainRegistrationComplete(event: DomainRegistrationCompletedEvent?) {
+        if (event == null) {
+            _uiStateFlow.value = UiState.Initial
+            return
+        }
         launch {
             analyticsTracker.track(Stat.DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_COMPLETED)
             _actionEvents.emit(ActionEvent.OpenDomainManagement)
         }
-    } ?: run {
-        _uiStateFlow.value = UiState.ErrorInCheckout
     }
 
     private val SiteModel.shouldOfferPlans
@@ -118,7 +127,6 @@ class PurchaseDomainViewModel @AssistedInject constructor(
         object SubmittingJustDomainCart : UiState
         object SubmittingSiteDomainCart : UiState
         object ErrorSubmittingCart : UiState
-        object ErrorInCheckout : UiState
     }
 
     sealed class ActionEvent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -85,7 +86,7 @@ class PurchaseDomainViewModel @AssistedInject constructor(
     private fun createCart(site: SiteModel?, productId: Int, domainName: String, supportsPrivacy: Boolean) = launch {
         _uiStateFlow.update { if (site == null) UiState.SubmittingJustDomainCart else UiState.SubmittingSiteDomainCart }
 
-        val event = createCartUseCase.execute(
+        val result = createCartUseCase.execute(
             site,
             productId,
             domainName,
@@ -93,21 +94,22 @@ class PurchaseDomainViewModel @AssistedInject constructor(
             false
         )
 
-        if (event.isError) {
-            _uiStateFlow.update { UiState.ErrorSubmittingCart }
-        } else {
-            launch {
-                delay(loadingStateAnimationResetDelay)
-                _uiStateFlow.update { UiState.Initial }
-            }
-            site?.also {
-                if (it.shouldOfferPlans) {
-                    _actionEvents.emit(ActionEvent.GoToExistingSitePlans(domain = domain, siteModel = site))
-                } else {
-                    _actionEvents.emit(ActionEvent.GoToExistingSiteCheckout(domain = domain, siteModel = site))
+        when (result) {
+            is CreateCartResult.Error -> _uiStateFlow.update { UiState.ErrorSubmittingCart }
+            is CreateCartResult.Success -> {
+                launch {
+                    delay(loadingStateAnimationResetDelay)
+                    _uiStateFlow.update { UiState.Initial }
                 }
-            } ?:
-            _actionEvents.emit(ActionEvent.GoToDomainPurchasing(domain = domain))
+                site?.also {
+                    if (it.shouldOfferPlans) {
+                        _actionEvents.emit(ActionEvent.GoToExistingSitePlans(domain = domain, siteModel = site))
+                    } else {
+                        _actionEvents.emit(ActionEvent.GoToExistingSiteCheckout(domain = domain, siteModel = site))
+                    }
+                } ?:
+                _actionEvents.emit(ActionEvent.GoToDomainPurchasing(domain = domain))
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -71,9 +71,10 @@ class PurchaseDomainViewModel @AssistedInject constructor(
     /**
      * Called when the checkout web view closes.
      *
-     * A null [event] means it was dismissed rather than completed. The checkout
-     * reports a completed purchase and nothing else, so there is no failure to
-     * report here; the screen returns to the state it was opened from.
+     * This screen never asks for the close button, so the only result it can be
+     * handed is a completed purchase. A null [event] therefore means the web
+     * view was dismissed rather than that anything failed, and the screen
+     * returns to the state it was opened from.
      */
     fun onDomainRegistrationComplete(event: DomainRegistrationCompletedEvent?) {
         if (event == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
@@ -66,7 +66,7 @@ fun PurchaseDomainScreen(
             )
         },
         content = {
-            if (uiState == UiState.ErrorSubmittingCart || uiState == UiState.ErrorInCheckout) {
+            if (uiState == UiState.ErrorSubmittingCart) {
                 ErrorScreen(onButtonTapped = onErrorButtonTapped)
             } else {
                 Box(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
@@ -1,34 +1,44 @@
 package org.wordpress.android.ui.domains.usecases
 
-import org.greenrobot.eventbus.Subscribe
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.TransactionActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.TransactionsStore
-import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CartKey
+import uniffi.wp_api.CreateShoppingCartParams
+import uniffi.wp_api.CreateShoppingCartProduct
+import uniffi.wp_api.CreateShoppingCartProductExtra
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
-/**
- * Wraps an [OnShoppingCartCreated] into a coroutine.
- */
 class CreateCartUseCase @Inject constructor(
-    private val dispatcher: Dispatcher,
-    @Suppress("unused") private val transactionsStore: TransactionsStore // needed for events to work
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
 ) {
-    private var continuation: Continuation<OnShoppingCartCreated>? = null
+    private var wpComApiClient: WpComApiClient? = null
 
-    init {
-        dispatcher.register(this)
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
     }
 
-    fun clear() {
-        dispatcher.unregister(this)
-    }
-
-    @Suppress("UseCheckOrError")
+    /**
+     * Creates a shopping cart holding a domain, and optionally a plan to bundle
+     * it with.
+     *
+     * A null [site] carries the purchase for a site that does not exist yet.
+     */
     suspend fun execute(
         site: SiteModel?,
         domainProductId: Int,
@@ -36,27 +46,65 @@ class CreateCartUseCase @Inject constructor(
         isDomainPrivacyEnabled: Boolean,
         isTemporary: Boolean,
         planProductId: Int? = null
-    ): OnShoppingCartCreated {
-        if (continuation != null) {
-            throw IllegalStateException("Cart creation is already in progress!")
-        }
-        return suspendCoroutine {
-            continuation = it
-            val payload = TransactionsStore.CreateShoppingCartWithDomainAndPlanPayload(
-                site,
-                domainProductId,
-                domainName,
-                isDomainPrivacyEnabled,
-                planProductId,
-                isTemporary
+    ): CreateCartResult {
+        val client = getOrCreateClient() ?: run {
+            AppLog.e(
+                AppLog.T.API,
+                "Cannot create a shopping cart without a WP.com access token"
             )
-            dispatcher.dispatch(TransactionActionBuilder.newCreateShoppingCartWithDomainAndPlanAction(payload))
+            return CreateCartResult.Error
+        }
+        val cartKey = site?.let { CartKey.Site(it.siteId.toULong()) } ?: CartKey.NoSite
+        val params = createShoppingCartParams(
+            domainProductId = domainProductId,
+            domainName = domainName,
+            isDomainPrivacyEnabled = isDomainPrivacyEnabled,
+            isTemporary = isTemporary,
+            planProductId = planProductId
+        )
+        val result = client.request { it.shoppingCart().create(cartKey, params).data }
+        return when (result) {
+            is WpRequestResult.Success -> CreateCartResult.Success
+            else -> {
+                AppLog.e(
+                    AppLog.T.API,
+                    "An error occurred while creating a shopping cart"
+                )
+                CreateCartResult.Error
+            }
         }
     }
+}
 
-    @Subscribe
-    fun onShoppingCartCreated(event: OnShoppingCartCreated) {
-        continuation?.resume(event)
-        continuation = null
-    }
+/**
+ * The cart request body: the domain being bought, and the plan it is bundled
+ * with when there is one.
+ *
+ * Only the domain product carries [CreateShoppingCartProduct.meta] and
+ * [CreateShoppingCartProduct.extra]; a plan is identified by its product ID
+ * alone.
+ */
+internal fun createShoppingCartParams(
+    domainProductId: Int,
+    domainName: String,
+    isDomainPrivacyEnabled: Boolean,
+    isTemporary: Boolean,
+    planProductId: Int?
+): CreateShoppingCartParams {
+    val domainProduct = CreateShoppingCartProduct(
+        productId = domainProductId.toULong(),
+        meta = domainName,
+        extra = CreateShoppingCartProductExtra(privacy = isDomainPrivacyEnabled)
+    )
+    val planProduct = planProductId?.let { CreateShoppingCartProduct(productId = it.toULong()) }
+    return CreateShoppingCartParams(
+        temporary = isTemporary,
+        products = listOfNotNull(domainProduct, planProduct)
+    )
+}
+
+sealed interface CreateCartResult {
+    data object Success : CreateCartResult
+
+    data object Error : CreateCartResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/CreateCartUseCase.kt
@@ -54,7 +54,7 @@ class CreateCartUseCase @Inject constructor(
             )
             return CreateCartResult.Error
         }
-        val cartKey = site?.let { CartKey.Site(it.siteId.toULong()) } ?: CartKey.NoSite
+        val cartKey = cartKeyFor(site)
         val params = createShoppingCartParams(
             domainProductId = domainProductId,
             domainName = domainName,
@@ -75,6 +75,16 @@ class CreateCartUseCase @Inject constructor(
         }
     }
 }
+
+/**
+ * Whose cart this is, which decides the endpoint the cart is created against.
+ *
+ * A null [site] means the domain is being bought before the site that will
+ * carry it exists, which the API serves under `no-site`. The identifier is the
+ * WordPress.com site ID, not the local one.
+ */
+internal fun cartKeyFor(site: SiteModel?): CartKey =
+    site?.let { CartKey.Site(it.siteId.toULong()) } ?: CartKey.NoSite
 
 /**
  * The cart request body: the domain being bought, and the plan it is bundled

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
@@ -89,7 +90,6 @@ class SiteCreationProgressViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         loadingAnimationJob?.cancel()
-        createCartUseCase.clear()
     }
 
     fun start(siteCreationState: SiteCreationState) {
@@ -205,7 +205,7 @@ class SiteCreationProgressViewModel @Inject constructor(
     private fun createCart() = launch {
         AppLog.d(T.SITE_CREATION, "Creating cart: $domain")
 
-        val event = createCartUseCase.execute(
+        val result = createCartUseCase.execute(
             site,
             domain.productId,
             domain.domainName,
@@ -214,12 +214,15 @@ class SiteCreationProgressViewModel @Inject constructor(
             planProductId = siteCreationState.plan?.productId
         )
 
-        if (event.isError) {
-            AppLog.e(T.SITE_CREATION, "Failed cart creation: ${event.error.message}")
-            updateUiStateAsync(CartError)
-        } else {
-            AppLog.d(T.SITE_CREATION, "Successful cart creation: ${event.cartDetails}")
-            _onCartCreated.postValue(CheckoutDetails(site, domain.domainName, showCloseButton = true))
+        when (result) {
+            is CreateCartResult.Error -> {
+                AppLog.e(T.SITE_CREATION, "Failed cart creation")
+                updateUiStateAsync(CartError)
+            }
+            is CreateCartResult.Success -> {
+                AppLog.d(T.SITE_CREATION, "Successful cart creation")
+                _onCartCreated.postValue(CheckoutDetails(site, domain.domainName, showCloseButton = true))
+            }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/CreateCartUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/CreateCartUseCaseTest.kt
@@ -1,0 +1,161 @@
+package org.wordpress.android.ui.domains
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
+import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
+import org.wordpress.android.ui.domains.usecases.cartKeyFor
+import org.wordpress.android.ui.domains.usecases.createShoppingCartParams
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CartKey
+import uniffi.wp_api.RequestMethod
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class CreateCartUseCaseTest : BaseUnitTest() {
+    @Mock
+    lateinit var wpComApiClientProvider: WpComApiClientProvider
+
+    @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var wpComApiClient: WpComApiClient
+
+    private lateinit var useCase: CreateCartUseCase
+
+    private val site = SiteModel().apply { siteId = 1234L }
+
+    @Before
+    fun setUp() {
+        whenever(accountStore.accessToken).thenReturn("test-token")
+        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
+            .thenReturn(wpComApiClient)
+        useCase = CreateCartUseCase(wpComApiClientProvider, accountStore)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `given the cart is created, when execute, returns success`() = test {
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(WpRequestResult.Success(Unit) as WpRequestResult<Any>)
+
+        val result = useCase.execute(site, PRODUCT_ID, DOMAIN_NAME, true, false)
+
+        assertThat(result).isEqualTo(CreateCartResult.Success)
+    }
+
+    @Test
+    fun `given cart creation returns error, when execute, returns error`() = test {
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(
+                WpRequestResult.UnknownError<Any>(
+                    500.toUInt(),
+                    "Internal Server Error",
+                    "",
+                    RequestMethod.POST
+                )
+            )
+
+        val result = useCase.execute(site, PRODUCT_ID, DOMAIN_NAME, true, false)
+
+        assertThat(result).isEqualTo(CreateCartResult.Error)
+    }
+
+    @Test
+    fun `given no access token, when execute, returns error`() = test {
+        whenever(accountStore.accessToken).thenReturn(null)
+
+        val result = useCase.execute(site, PRODUCT_ID, DOMAIN_NAME, true, false)
+
+        assertThat(result).isEqualTo(CreateCartResult.Error)
+    }
+
+    @Test
+    fun `given a blank access token, when execute, returns error`() = test {
+        whenever(accountStore.accessToken).thenReturn("")
+
+        val result = useCase.execute(site, PRODUCT_ID, DOMAIN_NAME, true, false)
+
+        assertThat(result).isEqualTo(CreateCartResult.Error)
+    }
+
+    @Test
+    fun `given a site, the cart key is its WordPress-com site ID`() {
+        assertThat(cartKeyFor(site)).isEqualTo(CartKey.Site(1234UL))
+    }
+
+    @Test
+    fun `given no site, the cart key is no-site`() {
+        assertThat(cartKeyFor(null)).isEqualTo(CartKey.NoSite)
+    }
+
+    @Test
+    fun `given no plan, the cart holds the domain alone`() {
+        val params = createShoppingCartParams(
+            domainProductId = PRODUCT_ID,
+            domainName = DOMAIN_NAME,
+            isDomainPrivacyEnabled = true,
+            isTemporary = false,
+            planProductId = null
+        )
+
+        assertThat(params.temporary).isFalse()
+        assertThat(params.products).hasSize(1)
+        with(params.products.first()) {
+            assertThat(productId).isEqualTo(PRODUCT_ID.toULong())
+            assertThat(meta).isEqualTo(DOMAIN_NAME)
+            assertThat(extra?.privacy).isTrue()
+        }
+    }
+
+    @Test
+    fun `given privacy is off, the domain product says so`() {
+        val params = createShoppingCartParams(
+            domainProductId = PRODUCT_ID,
+            domainName = DOMAIN_NAME,
+            isDomainPrivacyEnabled = false,
+            isTemporary = false,
+            planProductId = null
+        )
+
+        assertThat(params.products.first().extra?.privacy).isFalse()
+    }
+
+    @Test
+    fun `given a plan, it follows the domain and carries its product ID alone`() {
+        val params = createShoppingCartParams(
+            domainProductId = PRODUCT_ID,
+            domainName = DOMAIN_NAME,
+            isDomainPrivacyEnabled = true,
+            isTemporary = true,
+            planProductId = PLAN_PRODUCT_ID
+        )
+
+        assertThat(params.temporary).isTrue()
+        assertThat(params.products).hasSize(2)
+        with(params.products[1]) {
+            assertThat(productId).isEqualTo(PLAN_PRODUCT_ID.toULong())
+            assertThat(meta).isNull()
+            assertThat(extra).isNull()
+        }
+    }
+
+    companion object {
+        private const val PRODUCT_ID = 6
+        private const val PLAN_PRODUCT_ID = 1009
+        private const val DOMAIN_NAME = "domainname.com"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -18,14 +18,13 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.models.networkresource.ListState
 import org.wordpress.android.networking.restapi.WpComApiClientProvider
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.helpers.Debouncer
 import rs.wordpress.api.kotlin.WpComApiClient
@@ -511,7 +510,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     fun `clicking select domain button for purchase calls cart creation use case and emits selected domain`() = test {
         mockResponses(productsResponse(), suggestionsResponse())
         whenever(createCartUseCase.execute(site, DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME, true, false))
-            .thenReturn(dummySuccessfulOnShoppingCartCreated)
+            .thenReturn(CreateCartResult.Success)
 
         viewModel.start(site, DOMAIN_PURCHASE)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
@@ -526,14 +525,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     companion object {
         const val DUMMY_PRODUCT_ID = 1
         const val DUMMY_DOMAIN_NAME = "domainname.com"
-
-        val dummySuccessfulOnShoppingCartCreated = OnShoppingCartCreated(
-            CreateShoppingCartResponse(
-                1,
-                "dummy_cart_key",
-                emptyList()
-            )
-        )
 
         val dummySelectedDomainSuggestionItem = DomainSuggestionItem(
             domainName = DUMMY_DOMAIN_NAME,

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomain
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingJustDomainCart
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingSiteDomainCart
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.ErrorSubmittingCart
-import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.ErrorInCheckout
 import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -120,9 +119,26 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN check out fails THEN the ui is set to the ErrorInCheckout state`() = test {
+    fun `WHEN check out is dismissed THEN the ui returns to the Initial state`() = test {
+        mockCartCreation()
+        viewModel.onNewDomainSelected()
+
         viewModel.onDomainRegistrationComplete(null)
-        assertThat(viewModel.uiStateFlow.value).isEqualTo(ErrorInCheckout)
+
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+    }
+
+    @Test
+    fun `WHEN check out is dismissed THEN stay on the screen`() = testWithActionEvents { events ->
+        mockCartCreation()
+        viewModel.onNewDomainSelected()
+        advanceUntilIdle()
+        val eventsBefore = events.size
+
+        viewModel.onDomainRegistrationComplete(null)
+        advanceUntilIdle()
+
+        assertThat(events).hasSize(eventsBefore)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
@@ -120,7 +120,6 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
 
     @Test
     fun `WHEN check out is dismissed THEN the ui returns to the Initial state`() = test {
-        mockCartCreation()
         viewModel.onNewDomainSelected()
 
         viewModel.onDomainRegistrationComplete(null)
@@ -130,7 +129,6 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
 
     @Test
     fun `WHEN check out is dismissed THEN stay on the screen`() = testWithActionEvents { events ->
-        mockCartCreation()
         viewModel.onNewDomainSelected()
         advanceUntilIdle()
         val eventsBefore = events.size

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
@@ -19,10 +19,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_P
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_COMPLETED
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Extra
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Product
-import org.wordpress.android.fluxc.store.TransactionsStore
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoBack
@@ -33,6 +29,7 @@ import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomain
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingSiteDomainCart
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.ErrorSubmittingCart
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.ErrorInCheckout
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -232,11 +229,7 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
                 isTemporary = false,
                 planProductId = null
             )
-        ).thenReturn(
-            TransactionsStore.OnShoppingCartCreated(
-                TransactionsRestClient.CreateShoppingCartResponse(0, cartKey, listOf(testProduct))
-            )
-        )
+        ).thenReturn(CreateCartResult.Success)
         whenever(
             createCartUseCase.execute(
                 testSite, productId, domain,
@@ -244,11 +237,7 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
                 isTemporary = false,
                 planProductId = null
             )
-        ).thenReturn(
-            TransactionsStore.OnShoppingCartCreated(
-                TransactionsRestClient.CreateShoppingCartResponse(siteId.toInt(), cartKey, listOf(testProduct))
-            )
-        )
+        ).thenReturn(CreateCartResult.Success)
         whenever(
             createCartUseCase.execute(
                 testFreeSite, productId, domain,
@@ -256,11 +245,7 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
                 isTemporary = false,
                 planProductId = null
             )
-        ).thenReturn(
-            TransactionsStore.OnShoppingCartCreated(
-                TransactionsRestClient.CreateShoppingCartResponse(siteId.toInt(), cartKey, listOf(testProduct))
-            )
-        )
+        ).thenReturn(CreateCartResult.Success)
     }
 
     private fun mockCartError() = test {
@@ -271,9 +256,7 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
                 isTemporary = false,
                 planProductId = null
             )
-        ).thenReturn(
-            TransactionsStore.OnShoppingCartCreated(shoppingCartCreateError)
-        )
+        ).thenReturn(CreateCartResult.Error)
     }
 
     private fun testWithActionEvents(block: suspend TestScope.(events: List<ActionEvent>) -> Unit) = test {
@@ -288,14 +271,8 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     companion object {
         private const val productId = 8
         private const val domain = "domain.com"
-        private const val cartKey = "cart_key"
         private const val siteId = 5L
         private const val supportsPrivacy = true
         private val testSite = SiteModel().apply { siteId = siteId }
-        private val testProduct = Product(productId, domain, Extra(privacy = true))
-        private val shoppingCartCreateError = TransactionsStore.CreateShoppingCartError(
-            TransactionsStore.CreateCartErrorType.GENERIC_ERROR,
-            "Error Creating Cart"
-        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -2,14 +2,12 @@ package org.wordpress.android.ui.sitecreation
 
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartError
-import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
@@ -54,8 +52,8 @@ val CHECKOUT_EVENT = DomainRegistrationCompletedEvent(URL_CUSTOM, "email@host.co
 val FETCH_SUCCESS = OnSiteChanged(1)
 val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
 
-val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
-val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
+val CART_SUCCESS = CreateCartResult.Success
+val CART_ERROR = CreateCartResult.Error
 
 val RESULT_CREATED = mock<Created>()
 val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_MODEL)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -27,8 +27,8 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
+import org.wordpress.android.ui.domains.usecases.CreateCartResult
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.CART_ERROR
 import org.wordpress.android.ui.sitecreation.CART_SUCCESS
@@ -291,7 +291,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     }
 
     // region Helpers
-    private fun testWith(response: OnShoppingCartCreated, block: suspend CoroutineScope.() -> Unit) = test {
+    private fun testWith(response: CreateCartResult, block: suspend CoroutineScope.() -> Unit) = test {
         whenever(
             createCartUseCase.execute(
                 any(),


### PR DESCRIPTION
## Description

`CreateCartUseCase` calls `WpComApiClient.shoppingCart().create()` instead of wrapping FluxC's `Dispatcher` and `OnShoppingCartCreated` event in a `suspendCoroutine`, so the EventBus registration, `clear()` and the "cart creation is already in progress" guard all go away. `execute` keeps its parameter list and returns a `CreateCartResult`.

Behaviour matches trunk apart from one fix. Backing out of the checkout web view left the Purchase Domain screen, reached from **Me** → **Domains** → **Add Domain**, showing "Something went wrong while adding the domain to the cart". It now returns to its initial state. The two other screens that open checkout never showed an error there.

## Testing instructions

None of these spend money. Every path stops at the checkout web view, and nothing is bought until checkout is completed — so the thing to verify is that checkout opens on the right domain, not that a purchase goes through.

Every case below matches trunk except the last, which is the fix.

Needs an account with: a site on a paid plan without a domain credit, a site on the free plan, and a site with an unclaimed domain credit.

Buying a domain from the dashboard:

1. Open **My Site** → **Domains** for a paid-plan site with no domain credit, and tap the purchase call to action — **Add your domain**, or **Add a domain** when the site already has one.
2. Search for a domain and select one, then tap **Select domain**.
- [x] Verify the checkout web view opens on the domain you picked, at the price the list showed.

A free plan, where the domain is bundled with an annual plan:

1. Open **My Site** → **Domains** for a free-plan site, and tap **Upgrade to a plan**.
2. Search for a domain and select one, then tap **Select domain**.
- [x] Verify the plans screen opens rather than checkout.

Domain credit redemption, which creates no cart:

1. Open **My Site** → **Domains** for a site with an unclaimed credit, and tap **Search for a domain**.
2. Select one of the domains offered free for the first year, then tap **Select domain**.
- [x] Verify the **Register Domain** form opens directly, as on trunk.

The purchase domain screen, which is the only place a cart is created without a site:

1. Open **Me** → **Domains** → **Add Domain**, search for a domain and tap one. The **Purchase Domain** screen opens on **Choose how to use your domain**.
2. Tap **Get Domain** under **Just buy a domain**.
- [x] Verify it moves on to domain purchasing. This is the `no-site` cart, and nothing else in the app creates one.
3. Go back, pick the domain again, tap **Choose Site** and pick a site.
- [x] Verify checkout opens.
4. Turn networking off, then repeat step 2.
- [x] Verify the error screen appears — "Something went wrong while adding the domain to the cart" — and that **OK** returns the screen to its initial state.

Site creation with a paid plan, the only cart carrying two products:

1. Start site creation and choose a paid domain.
2. On **Select a plan**, choose **Personal** rather than **Free**.
- [x] Verify checkout opens once the progress screen finishes, with both the domain and the plan on it.

Site creation with the free plan, which creates no cart:

1. Start site creation, choose the free `.wordpress.com` subdomain, and choose **Free** on the plan step.
- [x] Verify the flow completes into the new site without ever opening checkout.

Dismissing checkout, the one case that differs from trunk:

1. Open **Me** → **Domains** → **Add Domain**, search for a domain, and tap one.
2. On **Choose how to use your domain**, tap **Get Domain**.
3. When checkout opens, press back.
- [x] Verify **Choose how to use your domain** comes back with both cards, ready to tap again. On trunk the screen instead reads "Error — Something went wrong while adding the domain to the cart" with an **OK** button.
4. Press back once more.
- [x] Verify the search screen still holds the query and the results you left it on.
5. Repeat steps 2 and 3 through **Choose Site**, picking a site.
- [x] Verify the same.

## Screenshots

Taken on this branch, one per cart shape the use case builds. Each matches trunk, so only the one set is shown. Cropped above the checkout's contact block.

**A domain against a site, and a domain with no site.** The second is reached through **Me** → **Domains** → **Add Domain** → **Get Domain**, and is the only cart the app creates without one.

<img width="250" alt="Checkout for ozkcr.design against ozkcr.blog, C$75, total C$84.75" src="https://github.com/user-attachments/assets/b82dbaa9-e10d-4da6-b671-6b6302874a4d" /> <img width="250" alt="Checkout for coolsite.blog with no site, C$30 reduced to C$3, total C$3.39" src="https://github.com/user-attachments/assets/317529a0-c926-4104-82b1-bf69e0eb438f" />

**A domain bundled with a plan**, from site creation. The only cart carrying two products.

<img width="250" alt="Checkout for WordPress.com Personal at C$5 a month billed yearly, total C$67.80" src="https://github.com/user-attachments/assets/70e93104-9b09-4ff2-b815-fecc85c69add" />