### PR TITLE
Migrate the domain registration form's fetches to wordpress-rs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DomainRegistrationDetailsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.SupportedDomainCountry
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.ADDRESS_1
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.ADDRESS_2
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.CITY
@@ -201,7 +200,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
         viewModel.showCountryPickerDialog.observe(viewLifecycleOwner,
             {
                 if (it != null && it.isNotEmpty()) {
-                    showCountryPicker(it)
+                    showCountryPicker()
                 }
             })
 
@@ -384,12 +383,8 @@ class DomainRegistrationDetailsFragment : Fragment() {
         dialogFragment.show(childFragmentManager, StatePickerDialogFragment.TAG)
     }
 
-    private fun showCountryPicker(countries: List<SupportedDomainCountry>) {
-        val dialogFragment = CountryPickerDialogFragment.newInstance(
-            countries.toCollection(
-                ArrayList()
-            )
-        )
+    private fun showCountryPicker() {
+        val dialogFragment = CountryPickerDialogFragment()
         dialogFragment.show(childFragmentManager, CountryPickerDialogFragment.TAG)
     }
 
@@ -488,35 +483,19 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
     @AndroidEntryPoint
     class CountryPickerDialogFragment : DialogFragment() {
-        private lateinit var countries: ArrayList<SupportedDomainCountry>
-
         @Inject
         lateinit var viewModelFactory: ViewModelProvider.Factory
         private lateinit var viewModel: DomainRegistrationDetailsViewModel
 
         companion object {
-            private const val EXTRA_COUNTRIES = "EXTRA_COUNTRIES"
             const val TAG = "COUNTRY_PICKER_DIALOG_FRAGMENT"
-
-            fun newInstance(countries: ArrayList<SupportedDomainCountry>): CountryPickerDialogFragment {
-                val fragment = CountryPickerDialogFragment()
-                val bundle = Bundle()
-                bundle.putParcelableArrayList(EXTRA_COUNTRIES, countries)
-                fragment.arguments = bundle
-                return fragment
-            }
-        }
-
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            countries = arguments?.getParcelableArrayList<SupportedDomainCountry>(EXTRA_COUNTRIES)
-                    as ArrayList<SupportedDomainCountry>
         }
 
         @Suppress("UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             viewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
+            val countries = viewModel.countriesForPicker
             val builder = MaterialAlertDialogBuilder(requireContext())
             builder.setTitle(R.string.domain_registration_country_picker_dialog_title)
             builder.setItems(countries.map { it.name }.toTypedArray()) { _, which ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DomainRegistrationDetailsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.ADDRESS_1
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.ADDRESS_2
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.CITY
@@ -207,7 +206,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
         viewModel.showStatePickerDialog.observe(viewLifecycleOwner,
             {
                 if (it != null && it.isNotEmpty()) {
-                    showStatePicker(it)
+                    showStatePicker()
                 }
             })
 
@@ -378,8 +377,8 @@ class DomainRegistrationDetailsFragment : Fragment() {
         )
     }
 
-    private fun showStatePicker(states: List<SupportedStateResponse>) {
-        val dialogFragment = StatePickerDialogFragment.newInstance(states.toCollection(ArrayList()))
+    private fun showStatePicker() {
+        val dialogFragment = StatePickerDialogFragment()
         dialogFragment.show(childFragmentManager, StatePickerDialogFragment.TAG)
     }
 
@@ -438,35 +437,19 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
     @AndroidEntryPoint
     class StatePickerDialogFragment : DialogFragment() {
-        private lateinit var states: ArrayList<SupportedStateResponse>
-
         @Inject
         lateinit var viewModelFactory: ViewModelProvider.Factory
         private lateinit var viewModel: DomainRegistrationDetailsViewModel
 
         companion object {
-            private const val EXTRA_STATES = "EXTRA_STATES"
             const val TAG = "STATE_PICKER_DIALOG_FRAGMENT"
-
-            fun newInstance(states: ArrayList<SupportedStateResponse>): StatePickerDialogFragment {
-                val fragment = StatePickerDialogFragment()
-                val bundle = Bundle()
-                bundle.putParcelableArrayList(EXTRA_STATES, states)
-                fragment.arguments = bundle
-                return fragment
-            }
-        }
-
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            states = requireArguments().getParcelableArrayList<SupportedStateResponse>(EXTRA_STATES)
-                    as ArrayList<SupportedStateResponse>
         }
 
         @Suppress("UseCheckOrError")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             viewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
+            val states = viewModel.statesForPicker
             val builder = MaterialAlertDialogBuilder(requireContext())
             builder.setTitle(R.string.domain_registration_state_picker_dialog_title)
             builder.setItems(states.map { it.name }.toTypedArray()) { _, which ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -9,13 +9,11 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.TransactionActionBuilder
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
-import org.wordpress.android.fluxc.store.AccountStore.OnDomainContactFetched
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetched
@@ -27,6 +25,8 @@ import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartRedeeme
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.domains.usecases.DomainContactResult
+import org.wordpress.android.ui.domains.usecases.FetchDomainContactUseCase
 import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
 import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
 import org.wordpress.android.util.AppLog
@@ -35,6 +35,7 @@ import org.wordpress.android.util.DomainPhoneNumberUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
 import javax.inject.Inject
 import javax.inject.Named
@@ -48,6 +49,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     private val siteStore: SiteStore,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase,
+    private val fetchDomainContactUseCase: FetchDomainContactUseCase,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     private lateinit var site: SiteModel
@@ -147,44 +149,47 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
             }
             is SupportedCountriesResult.Success -> {
                 supportedCountries = result.countries
-                dispatcher.dispatch(AccountActionBuilder.newFetchDomainContactAction())
+                fetchDomainContact()
             }
         }
     }
 
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDomainContactFetched(event: OnDomainContactFetched) {
-        if (event.isError) {
-            _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
-            _showErrorMessage.value = event.error.message
-            AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching domain contact details")
-        } else {
-            _domainContactForm.value = DomainContactFormModel.fromDomainContactModel(event.contactModel)
-            _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
+    private suspend fun fetchDomainContact() {
+        when (val result = fetchDomainContactUseCase.execute()) {
+            is DomainContactResult.Error -> {
+                _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
+                result.message?.let { _showErrorMessage.value = it }
+                AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching domain contact details")
+            }
+            is DomainContactResult.Success -> {
+                val contact = result.contact
+                _domainContactForm.value = DomainContactFormModel.fromDomainContactInformation(contact)
+                _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
 
-            val countryCode = event.contactModel?.countryCode
+                val countryCode = contact.countryCode
 
-            if (event.contactModel != null && !TextUtils.isEmpty(countryCode)) {
-                _uiState.value =
-                    uiState.value?.copy(
-                        selectedCountry = supportedCountries?.firstOrNull {
-                            it.code == event.contactModel?.countryCode
-                        },
-                        isStateProgressIndicatorVisible = true,
-                        isDomainRegistrationButtonEnabled = false
-                    )
+                if (!TextUtils.isEmpty(countryCode)) {
+                    _uiState.value =
+                        uiState.value?.copy(
+                            selectedCountry = supportedCountries?.firstOrNull {
+                                it.code == countryCode
+                            },
+                            isStateProgressIndicatorVisible = true,
+                            isDomainRegistrationButtonEnabled = false
+                        )
 
-                // if customer does not have a phone number we will try to prefill a country code
-                if (TextUtils.isEmpty(event.contactModel?.phone)) {
-                    val countryCodePrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(countryCode!!)
-                    _domainContactForm.value = _domainContactForm.value?.copy(
-                        phoneNumberPrefix = countryCodePrefix
+                    // if customer does not have a phone number we will try to prefill a country code
+                    if (TextUtils.isEmpty(contact.phone)) {
+                        val countryCodePrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(countryCode!!)
+                        _domainContactForm.value = _domainContactForm.value?.copy(
+                            phoneNumberPrefix = countryCodePrefix
+                        )
+                    }
+
+                    dispatcher.dispatch(
+                        SiteActionBuilder.newFetchDomainSupportedStatesAction(countryCode)
                     )
                 }
-
-                dispatcher.dispatch(
-                    SiteActionBuilder.newFetchDomainSupportedStatesAction(event.contactModel?.countryCode)
-                )
             }
         }
     }
@@ -427,28 +432,22 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
                 )
             }
 
-            fun fromDomainContactModel(domainContactModel: DomainContactModel?): DomainContactFormModel? {
-                if (domainContactModel == null) {
-                    return null
-                }
-
-                return DomainContactFormModel(
-                    firstName = domainContactModel.firstName,
-                    lastName = domainContactModel.lastName,
-                    organization = domainContactModel.organization,
-                    addressLine1 = domainContactModel.addressLine1,
-                    addressLine2 = domainContactModel.addressLine2,
-                    postalCode = domainContactModel.postalCode,
-                    city = domainContactModel.city,
-                    state = domainContactModel.state,
-                    countryCode = domainContactModel.countryCode,
-                    email = domainContactModel.email,
-                    phoneNumberPrefix = DomainPhoneNumberUtils.getPhoneNumberPrefixFromFullPhoneNumber(
-                        domainContactModel.phone
-                    ),
-                    phoneNumber = DomainPhoneNumberUtils.getPhoneNumberWithoutPrefix(domainContactModel.phone)
-                )
-            }
+            fun fromDomainContactInformation(contact: DomainContactInformation) = DomainContactFormModel(
+                firstName = contact.firstName,
+                lastName = contact.lastName,
+                organization = contact.organization,
+                addressLine1 = contact.address1,
+                addressLine2 = contact.address2,
+                postalCode = contact.postalCode,
+                city = contact.city,
+                state = contact.state,
+                countryCode = contact.countryCode,
+                email = contact.email,
+                phoneNumberPrefix = DomainPhoneNumberUtils.getPhoneNumberPrefixFromFullPhoneNumber(
+                    contact.phone
+                ),
+                phoneNumber = DomainPhoneNumberUtils.getPhoneNumberWithoutPrefix(contact.phone)
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -334,7 +334,9 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     }
 
     fun onCountrySelectorClicked() {
-        _showCountryPickerDialog.value = supportedCountries!!
+        // The field is tappable while the countries load and after that load fails,
+        // so there is not always a list to show.
+        supportedCountries?.let { _showCountryPickerDialog.value = it }
     }
 
     fun onStateSelectorClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -9,14 +9,12 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.TransactionAction.FETCH_SUPPORTED_COUNTRIES
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.TransactionActionBuilder
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.SupportedDomainCountry
 import org.wordpress.android.fluxc.store.AccountStore.OnDomainContactFetched
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload
@@ -26,16 +24,18 @@ import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.TransactionsStore
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartRedeemed
-import org.wordpress.android.fluxc.store.TransactionsStore.OnSupportedCountriesFetched
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
+import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DomainPhoneNumberUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import uniffi.wp_api.SupportedCountry
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -47,6 +47,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     @Suppress("unused") private val transactionsStore: TransactionsStore, // needed for events to work
     private val siteStore: SiteStore,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     private lateinit var site: SiteModel
@@ -56,7 +57,18 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
 
     private var siteCheckTries = 0
 
-    private var supportedCountries: List<SupportedDomainCountry>? = null
+    private var supportedCountries: List<SupportedCountry>? = null
+
+    /**
+     * Read by the country picker, which shares this ViewModel with the form.
+     *
+     * The picker used to be handed the list through its fragment arguments.
+     * [SupportedCountry] is a uniffi record and not `Parcelable`, and the
+     * picker already holds this ViewModel to report the selection back, so it
+     * reads the list from here instead of being given a copy of it.
+     */
+    val countriesForPicker: List<SupportedCountry>
+        get() = supportedCountries.orEmpty()
     private val _supportedStates = MutableLiveData<List<SupportedStateResponse>?>()
 
     private val _uiState = MutableLiveData<DomainRegistrationDetailsUiState>()
@@ -71,8 +83,8 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     val formError: LiveData<RedeemShoppingCartError>
         get() = _formError
 
-    private val _showCountryPickerDialog = SingleLiveEvent<List<SupportedDomainCountry>>()
-    val showCountryPickerDialog: LiveData<List<SupportedDomainCountry>>
+    private val _showCountryPickerDialog = SingleLiveEvent<List<SupportedCountry>>()
+    val showCountryPickerDialog: LiveData<List<SupportedCountry>>
         get() = _showCountryPickerDialog
 
     private val _showStatePickerDialog = SingleLiveEvent<List<SupportedStateResponse>>()
@@ -98,7 +110,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         val isDomainRegistrationButtonEnabled: Boolean = false,
         val isPrivacyProtectionEnabled: Boolean = true,
         val selectedState: SupportedStateResponse? = null,
-        val selectedCountry: SupportedDomainCountry? = null,
+        val selectedCountry: SupportedCountry? = null,
         val isStateInputEnabled: Boolean = false
     )
 
@@ -125,20 +137,18 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         isStarted = true
     }
 
-    private fun fetchSupportedCountries() {
+    private fun fetchSupportedCountries() = launch {
         _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = true)
-        dispatcher.dispatch(TransactionActionBuilder.generateNoPayloadAction(FETCH_SUPPORTED_COUNTRIES))
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSupportedCountriesFetched(event: OnSupportedCountriesFetched) {
-        if (event.isError) {
-            _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
-            _showErrorMessage.value = event.error.message
-            AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported countries")
-        } else {
-            supportedCountries = event.countries?.toCollection(ArrayList())
-            dispatcher.dispatch(AccountActionBuilder.newFetchDomainContactAction())
+        when (val result = fetchSupportedCountriesUseCase.execute()) {
+            is SupportedCountriesResult.Error -> {
+                _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
+                result.message?.let { _showErrorMessage.value = it }
+                AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported countries")
+            }
+            is SupportedCountriesResult.Success -> {
+                supportedCountries = result.countries
+                dispatcher.dispatch(AccountActionBuilder.newFetchDomainContactAction())
+            }
         }
     }
 
@@ -336,7 +346,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         )
     }
 
-    fun onCountrySelected(country: SupportedDomainCountry) {
+    fun onCountrySelected(country: SupportedCountry) {
         if (country != uiState.value?.selectedCountry) {
             _supportedStates.value = null
             _uiState.value =

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -13,10 +13,8 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.TransactionActionBuilder
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload
-import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetched
 import org.wordpress.android.fluxc.store.SiteStore.OnPrimaryDomainDesignated
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.TransactionsStore
@@ -28,7 +26,9 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.usecases.DomainContactResult
 import org.wordpress.android.ui.domains.usecases.FetchDomainContactUseCase
 import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
+import org.wordpress.android.ui.domains.usecases.FetchSupportedStatesUseCase
 import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
+import org.wordpress.android.ui.domains.usecases.SupportedStatesResult
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DomainPhoneNumberUtils
@@ -37,6 +37,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
+import uniffi.wp_api.SupportedState
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -50,6 +51,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase,
     private val fetchDomainContactUseCase: FetchDomainContactUseCase,
+    private val fetchSupportedStatesUseCase: FetchSupportedStatesUseCase,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     private lateinit var site: SiteModel
@@ -71,7 +73,13 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
      */
     val countriesForPicker: List<SupportedCountry>
         get() = supportedCountries.orEmpty()
-    private val _supportedStates = MutableLiveData<List<SupportedStateResponse>?>()
+    private val _supportedStates = MutableLiveData<List<SupportedState>?>()
+
+    /**
+     * Read by the state picker, for the same reason [countriesForPicker] is.
+     */
+    val statesForPicker: List<SupportedState>
+        get() = _supportedStates.value.orEmpty()
 
     private val _uiState = MutableLiveData<DomainRegistrationDetailsUiState>()
     val uiState: LiveData<DomainRegistrationDetailsUiState>
@@ -89,8 +97,8 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     val showCountryPickerDialog: LiveData<List<SupportedCountry>>
         get() = _showCountryPickerDialog
 
-    private val _showStatePickerDialog = SingleLiveEvent<List<SupportedStateResponse>>()
-    val showStatePickerDialog: LiveData<List<SupportedStateResponse>>
+    private val _showStatePickerDialog = SingleLiveEvent<List<SupportedState>>()
+    val showStatePickerDialog: LiveData<List<SupportedState>>
         get() = _showStatePickerDialog
 
     private val _domainContactForm = MutableLiveData<DomainContactFormModel>()
@@ -111,7 +119,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         val isRegistrationProgressIndicatorVisible: Boolean = false,
         val isDomainRegistrationButtonEnabled: Boolean = false,
         val isPrivacyProtectionEnabled: Boolean = true,
-        val selectedState: SupportedStateResponse? = null,
+        val selectedState: SupportedState? = null,
         val selectedCountry: SupportedCountry? = null,
         val isStateInputEnabled: Boolean = false
     )
@@ -168,7 +176,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
 
                 val countryCode = contact.countryCode
 
-                if (!TextUtils.isEmpty(countryCode)) {
+                if (!countryCode.isNullOrEmpty()) {
                     _uiState.value =
                         uiState.value?.copy(
                             selectedCountry = supportedCountries?.firstOrNull {
@@ -180,38 +188,38 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
 
                     // if customer does not have a phone number we will try to prefill a country code
                     if (TextUtils.isEmpty(contact.phone)) {
-                        val countryCodePrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(countryCode!!)
+                        val countryCodePrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(countryCode)
                         _domainContactForm.value = _domainContactForm.value?.copy(
                             phoneNumberPrefix = countryCodePrefix
                         )
                     }
 
-                    dispatcher.dispatch(
-                        SiteActionBuilder.newFetchDomainSupportedStatesAction(countryCode)
-                    )
+                    fetchSupportedStates(countryCode)
                 }
             }
         }
     }
 
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDomainSupportedStatesFetched(event: OnDomainSupportedStatesFetched) {
-        if (event.isError) {
-            _uiState.value =
-                uiState.value?.copy(
+    private suspend fun fetchSupportedStates(countryCode: String) {
+        when (val result = fetchSupportedStatesUseCase.execute(countryCode)) {
+            is SupportedStatesResult.Error -> {
+                _uiState.value =
+                    uiState.value?.copy(
+                        isStateProgressIndicatorVisible = false,
+                        isDomainRegistrationButtonEnabled = true
+                    )
+                result.message?.let { _showErrorMessage.value = it }
+                AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported states")
+            }
+            is SupportedStatesResult.Success -> {
+                _uiState.value = uiState.value?.copy(
+                    selectedState = result.states.firstOrNull { it.code == domainContactForm.value?.state },
                     isStateProgressIndicatorVisible = false,
-                    isDomainRegistrationButtonEnabled = true
+                    isDomainRegistrationButtonEnabled = true,
+                    isStateInputEnabled = result.states.isNotEmpty()
                 )
-            event.error?.message?.let { _showErrorMessage.value = it }
-            AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported countries")
-        } else {
-            _uiState.value = uiState.value?.copy(
-                selectedState = event.supportedStates?.firstOrNull { it.code == domainContactForm.value?.state },
-                isStateProgressIndicatorVisible = false,
-                isDomainRegistrationButtonEnabled = true,
-                isStateInputEnabled = !event.supportedStates.isNullOrEmpty()
-            )
-            _supportedStates.value = event.supportedStates
+                _supportedStates.value = result.states
+            }
         }
     }
 
@@ -368,11 +376,11 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
                 state = null,
                 phoneNumberPrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(country.code)
             )
-            dispatcher.dispatch(SiteActionBuilder.newFetchDomainSupportedStatesAction(country.code))
+            launch { fetchSupportedStates(country.code) }
         }
     }
 
-    fun onStateSelected(state: SupportedStateResponse) {
+    fun onStateSelected(state: SupportedState) {
         _uiState.value = uiState.value?.copy(selectedState = state)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
@@ -34,6 +35,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DomainPhoneNumberUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
+import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
@@ -52,6 +54,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     private val fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase,
     private val fetchDomainContactUseCase: FetchDomainContactUseCase,
     private val fetchSupportedStatesUseCase: FetchSupportedStatesUseCase,
+    private val resourceProvider: ResourceProvider,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     private lateinit var site: SiteModel
@@ -136,12 +139,20 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         isStarted = true
     }
 
+    private fun showFetchError(message: String?, isDeviceOffline: Boolean) {
+        when {
+            isDeviceOffline -> _showErrorMessage.value =
+                resourceProvider.getString(R.string.error_network_connection)
+            message != null -> _showErrorMessage.value = message
+        }
+    }
+
     private fun fetchSupportedCountries() = launch {
         _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = true)
         when (val result = fetchSupportedCountriesUseCase.execute()) {
             is SupportedCountriesResult.Error -> {
                 _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
-                result.message?.let { _showErrorMessage.value = it }
+                showFetchError(result.message, result.isDeviceOffline)
                 AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported countries")
             }
             is SupportedCountriesResult.Success -> {
@@ -155,7 +166,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         when (val result = fetchDomainContactUseCase.execute()) {
             is DomainContactResult.Error -> {
                 _uiState.value = _uiState.value?.copy(isFormProgressIndicatorVisible = false)
-                result.message?.let { _showErrorMessage.value = it }
+                showFetchError(result.message, result.isDeviceOffline)
                 AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching domain contact details")
             }
             is DomainContactResult.Success -> {
@@ -197,7 +208,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
                         isStateProgressIndicatorVisible = false,
                         isDomainRegistrationButtonEnabled = true
                     )
-                result.message?.let { _showErrorMessage.value = it }
+                showFetchError(result.message, result.isDeviceOffline)
                 AppLog.e(T.DOMAIN_REGISTRATION, "An error occurred while fetching supported states")
             }
             is SupportedStatesResult.Success -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -63,6 +64,8 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     private var isStarted = false
 
     private var siteCheckTries = 0
+
+    private var supportedStatesJob: Job? = null
 
     private var supportedCountries: List<SupportedCountry>? = null
 
@@ -200,7 +203,17 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchSupportedStates(countryCode: String) {
+    /**
+     * Cancels a states request still in flight, so that picking a country
+     * while the one before it is still loading cannot leave the earlier
+     * country's states standing against the later country.
+     */
+    private fun fetchSupportedStates(countryCode: String) {
+        supportedStatesJob?.cancel()
+        supportedStatesJob = launch { loadSupportedStates(countryCode) }
+    }
+
+    private suspend fun loadSupportedStates(countryCode: String) {
         when (val result = fetchSupportedStatesUseCase.execute(countryCode)) {
             is SupportedStatesResult.Error -> {
                 _uiState.value =
@@ -378,7 +391,7 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
                 state = null,
                 phoneNumberPrefix = DomainPhoneNumberUtils.getPhoneNumberPrefix(country.code)
             )
-            launch { fetchSupportedStates(country.code) }
+            fetchSupportedStates(country.code)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -140,10 +140,10 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     }
 
     private fun showFetchError(message: String?, isDeviceOffline: Boolean) {
-        when {
-            isDeviceOffline -> _showErrorMessage.value =
-                resourceProvider.getString(R.string.error_network_connection)
-            message != null -> _showErrorMessage.value = message
+        _showErrorMessage.value = when {
+            isDeviceOffline -> resourceProvider.getString(R.string.error_network_connection)
+            !message.isNullOrBlank() -> message
+            else -> resourceProvider.getString(R.string.request_failed_message)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -63,21 +63,10 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
 
     private var supportedCountries: List<SupportedCountry>? = null
 
-    /**
-     * Read by the country picker, which shares this ViewModel with the form.
-     *
-     * The picker used to be handed the list through its fragment arguments.
-     * [SupportedCountry] is a uniffi record and not `Parcelable`, and the
-     * picker already holds this ViewModel to report the selection back, so it
-     * reads the list from here instead of being given a copy of it.
-     */
     val countriesForPicker: List<SupportedCountry>
         get() = supportedCountries.orEmpty()
     private val _supportedStates = MutableLiveData<List<SupportedState>?>()
 
-    /**
-     * Read by the state picker, for the same reason [countriesForPicker] is.
-     */
     val statesForPicker: List<SupportedState>
         get() = _supportedStates.value.orEmpty()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/ApiErrorMessage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/ApiErrorMessage.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.domains.usecases
+
+import rs.wordpress.api.kotlin.WpRequestResult
+
+/**
+ * The message WordPress.com sent with a refusal, for the screens that put it in
+ * front of the user.
+ *
+ * Null for a failure that never reached the API, such as an offline device or a
+ * response that did not parse. `WpRequestErrorLogger` records those.
+ */
+internal fun WpRequestResult<*>.apiErrorMessage(): String? =
+    (this as? WpRequestResult.WpError)?.errorMessage

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchDomainContactUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchDomainContactUseCase.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.DomainContactInformation
+import javax.inject.Inject
+
+class FetchDomainContactUseCase @Inject constructor(
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
+) {
+    private var wpComApiClient: WpComApiClient? = null
+
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
+    }
+
+    /**
+     * Fetches the WHOIS contact details the account registers domains with,
+     * which prefill the registration form.
+     */
+    suspend fun execute(): DomainContactResult {
+        val client = getOrCreateClient() ?: run {
+            AppLog.e(
+                AppLog.T.API,
+                "Cannot fetch domain contact details without a WP.com access token"
+            )
+            return DomainContactResult.Error()
+        }
+        val result = client
+            .request { it.me().domainContactInformation().data }
+        return when (result) {
+            is WpRequestResult.Success -> DomainContactResult.Success(result.response)
+            else -> {
+                AppLog.e(
+                    AppLog.T.API,
+                    "An error occurred while fetching domain contact details"
+                )
+                DomainContactResult.Error(result.apiErrorMessage())
+            }
+        }
+    }
+}
+
+sealed interface DomainContactResult {
+    data class Success(
+        val contact: DomainContactInformation,
+    ) : DomainContactResult
+
+    data class Error(val message: String? = null) : DomainContactResult
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchDomainContactUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchDomainContactUseCase.kt
@@ -50,7 +50,7 @@ class FetchDomainContactUseCase @Inject constructor(
                     AppLog.T.API,
                     "An error occurred while fetching domain contact details"
                 )
-                DomainContactResult.Error(result.apiErrorMessage())
+                DomainContactResult.Error(result.apiErrorMessage(), result.isDeviceOffline())
             }
         }
     }
@@ -61,5 +61,8 @@ sealed interface DomainContactResult {
         val contact: DomainContactInformation,
     ) : DomainContactResult
 
-    data class Error(val message: String? = null) : DomainContactResult
+    data class Error(
+        val message: String? = null,
+        val isDeviceOffline: Boolean = false,
+    ) : DomainContactResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
@@ -50,7 +50,7 @@ class FetchSupportedCountriesUseCase @Inject constructor(
                     AppLog.T.API,
                     "An error occurred while fetching supported countries"
                 )
-                SupportedCountriesResult.Error(result.apiErrorMessage())
+                SupportedCountriesResult.Error(result.apiErrorMessage(), result.isDeviceOffline())
             }
         }
     }
@@ -76,5 +76,8 @@ sealed interface SupportedCountriesResult {
         val countries: List<SupportedCountry>,
     ) : SupportedCountriesResult
 
-    data class Error(val message: String? = null) : SupportedCountriesResult
+    data class Error(
+        val message: String? = null,
+        val isDeviceOffline: Boolean = false,
+    ) : SupportedCountriesResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.SupportedCountries
+import uniffi.wp_api.SupportedCountry
+import javax.inject.Inject
+
+class FetchSupportedCountriesUseCase @Inject constructor(
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
+) {
+    private var wpComApiClient: WpComApiClient? = null
+
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
+    }
+
+    /**
+     * Fetches the countries a domain purchase can be billed to.
+     */
+    suspend fun execute(): SupportedCountriesResult {
+        val client = getOrCreateClient() ?: run {
+            AppLog.e(
+                AppLog.T.API,
+                "Cannot fetch supported countries without a WP.com access token"
+            )
+            return SupportedCountriesResult.Error()
+        }
+        val result = client
+            .request { it.me().transactionsSupportedCountries().data }
+        return when (result) {
+            is WpRequestResult.Success -> SupportedCountriesResult.Success(result.response.asPickerList())
+            else -> {
+                AppLog.e(
+                    AppLog.T.API,
+                    "An error occurred while fetching supported countries"
+                )
+                SupportedCountriesResult.Error(result.apiErrorMessage())
+            }
+        }
+    }
+}
+
+/**
+ * The countries in the order the picker lists them.
+ *
+ * The API sends one flat array in three groups, separated by entries whose code
+ * and name are empty: the account's own country, then a block of common ones,
+ * then every country alphabetically. wordpress-rs reads those separators and
+ * splits at the first of them, so [SupportedCountries.featured] holds the
+ * account's country and [SupportedCountries.all] holds the rest. Concatenating
+ * them restores the array the API sent, minus the separators.
+ *
+ * A country therefore appears more than once, which is what the picker has
+ * always shown: the account's country and the common ones sit at the top, and
+ * the alphabetical run below repeats them.
+ */
+private fun SupportedCountries.asPickerList(): List<SupportedCountry> = featured + all
+
+sealed interface SupportedCountriesResult {
+    data class Success(
+        val countries: List<SupportedCountry>,
+    ) : SupportedCountriesResult
+
+    data class Error(val message: String? = null) : SupportedCountriesResult
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedCountriesUseCase.kt
@@ -66,9 +66,8 @@ class FetchSupportedCountriesUseCase @Inject constructor(
  * account's country and [SupportedCountries.all] holds the rest. Concatenating
  * them restores the array the API sent, minus the separators.
  *
- * A country therefore appears more than once, which is what the picker has
- * always shown: the account's country and the common ones sit at the top, and
- * the alphabetical run below repeats them.
+ * A country therefore appears more than once: the account's country and the
+ * common ones sit at the top, and the alphabetical run below repeats them.
  */
 private fun SupportedCountries.asPickerList(): List<SupportedCountry> = featured + all
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedStatesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedStatesUseCase.kt
@@ -51,7 +51,7 @@ class FetchSupportedStatesUseCase @Inject constructor(
                     AppLog.T.API,
                     "An error occurred while fetching supported states"
                 )
-                SupportedStatesResult.Error(result.apiErrorMessage())
+                SupportedStatesResult.Error(result.apiErrorMessage(), result.isDeviceOffline())
             }
         }
     }
@@ -62,5 +62,8 @@ sealed interface SupportedStatesResult {
         val states: List<SupportedState>,
     ) : SupportedStatesResult
 
-    data class Error(val message: String? = null) : SupportedStatesResult
+    data class Error(
+        val message: String? = null,
+        val isDeviceOffline: Boolean = false,
+    ) : SupportedStatesResult
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedStatesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchSupportedStatesUseCase.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.util.AppLog
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.SupportedState
+import javax.inject.Inject
+
+class FetchSupportedStatesUseCase @Inject constructor(
+    private val wpComApiClientProvider: WpComApiClientProvider,
+    private val accountStore: AccountStore,
+) {
+    private var wpComApiClient: WpComApiClient? = null
+
+    /**
+     * Null when there is no WordPress.com account to make the request as.
+     *
+     * `AccountStore.accessToken` is typed nullable but reads `""` when signed
+     * out, and is only null between an in-process sign out and the next
+     * launch, so both have to be treated as no token.
+     */
+    @Synchronized
+    private fun getOrCreateClient(): WpComApiClient? {
+        val token = accountStore.accessToken?.takeIf { it.isNotEmpty() } ?: return null
+        return wpComApiClient
+            ?: wpComApiClientProvider.getWpComApiClient(token)
+                .also { wpComApiClient = it }
+    }
+
+    /**
+     * Fetches the subdivisions a country registers domains against. Empty for
+     * the countries that have none, which is what leaves the state field
+     * disabled.
+     */
+    suspend fun execute(countryCode: String): SupportedStatesResult {
+        val client = getOrCreateClient() ?: run {
+            AppLog.e(
+                AppLog.T.API,
+                "Cannot fetch supported states without a WP.com access token"
+            )
+            return SupportedStatesResult.Error()
+        }
+        val result = client
+            .request { it.domains().supportedStates(countryCode).data }
+        return when (result) {
+            is WpRequestResult.Success -> SupportedStatesResult.Success(result.response)
+            else -> {
+                AppLog.e(
+                    AppLog.T.API,
+                    "An error occurred while fetching supported states"
+                )
+                SupportedStatesResult.Error(result.apiErrorMessage())
+            }
+        }
+    }
+}
+
+sealed interface SupportedStatesResult {
+    data class Success(
+        val states: List<SupportedState>,
+    ) : SupportedStatesResult
+
+    data class Error(val message: String? = null) : SupportedStatesResult
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/WpRequestResultExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/WpRequestResultExtensions.kt
@@ -1,13 +1,15 @@
 package org.wordpress.android.ui.domains.usecases
 
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.RequestExecutionErrorReason
 
 /**
  * The message WordPress.com sent with a refusal, for the screens that put it in
  * front of the user.
- *
- * Null for a failure that never reached the API, such as an offline device or a
- * response that did not parse. `WpRequestErrorLogger` records those.
  */
 internal fun WpRequestResult<*>.apiErrorMessage(): String? =
     (this as? WpRequestResult.WpError)?.errorMessage
+
+internal fun WpRequestResult<*>.isDeviceOffline(): Boolean =
+    this is WpRequestResult.RequestExecutionFailed &&
+            reason is RequestExecutionErrorReason.DeviceIsOfflineError

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.SiteAction
@@ -51,6 +52,7 @@ import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
 import org.wordpress.android.ui.domains.usecases.FetchSupportedStatesUseCase
 import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
 import org.wordpress.android.ui.domains.usecases.SupportedStatesResult
+import org.wordpress.android.viewmodel.ResourceProvider
 import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
 import uniffi.wp_api.SupportedState
@@ -80,6 +82,9 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var fetchSupportedStatesUseCase: FetchSupportedStatesUseCase
+
+    @Mock
+    private lateinit var resourceProvider: ResourceProvider
     private var site: SiteModel = SiteModel()
 
     @Mock
@@ -178,6 +183,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     private val domainContactInformationFetchErrorMessage = "Error fetching domain contact information"
     private val domainSupportedStatesFetchErrorMessage = "Error fetching domain supported states"
     private val fetchSupportedCountriesErrorMessage = "Error fetching countries"
+    private val offlineMessage = "Check your network connection and try again"
 
     private val createShoppingCartResponse = CreateShoppingCartResponse(
         siteId.toInt(),
@@ -202,6 +208,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
             fetchSupportedCountriesUseCase,
             fetchDomainContactUseCase,
             fetchSupportedStatesUseCase,
+            resourceProvider,
             NoDelayCoroutineDispatcher()
         )
         // Setting up chain of actions
@@ -322,6 +329,28 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         assertThat(domainContactModelWithPrefilledPhonePrefix).isNotNull()
         assertThat(domainContactModelWithPrefilledPhonePrefix?.phoneNumberPrefix).isNull()
+    }
+
+    @Test
+    fun offlineFetchingCountriesDuringPreload() = test {
+        whenever(resourceProvider.getString(R.string.error_network_connection)).thenReturn(offlineMessage)
+        whenever(fetchSupportedCountriesUseCase.execute())
+            .thenReturn(SupportedCountriesResult.Error(message = null, isDeviceOffline = true))
+
+        viewModel.start(site, domainProductDetails)
+
+        verify(errorMessageObserver).onChanged(offlineMessage)
+    }
+
+    @Test
+    fun offlineFetchingStates() = test {
+        whenever(resourceProvider.getString(R.string.error_network_connection)).thenReturn(offlineMessage)
+        whenever(fetchSupportedStatesUseCase.execute(any()))
+            .thenReturn(SupportedStatesResult.Error(message = null, isDeviceOffline = true))
+
+        viewModel.start(site, domainProductDetails)
+
+        verify(errorMessageObserver).onChanged(offlineMessage)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -184,6 +184,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     private val domainSupportedStatesFetchErrorMessage = "Error fetching domain supported states"
     private val fetchSupportedCountriesErrorMessage = "Error fetching countries"
     private val offlineMessage = "Check your network connection and try again"
+    private val requestFailedMessage = "There was a problem handling the request. Please try again later."
 
     private val createShoppingCartResponse = CreateShoppingCartResponse(
         siteId.toInt(),
@@ -351,6 +352,28 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.start(site, domainProductDetails)
 
         verify(errorMessageObserver).onChanged(offlineMessage)
+    }
+
+    @Test
+    fun failureWithNoMessageFetchingCountriesDuringPreload() = test {
+        whenever(resourceProvider.getString(R.string.request_failed_message)).thenReturn(requestFailedMessage)
+        whenever(fetchSupportedCountriesUseCase.execute())
+            .thenReturn(SupportedCountriesResult.Error(message = null, isDeviceOffline = false))
+
+        viewModel.start(site, domainProductDetails)
+
+        verify(errorMessageObserver).onChanged(requestFailedMessage)
+    }
+
+    @Test
+    fun failureWithBlankMessageFetchingCountriesDuringPreload() = test {
+        whenever(resourceProvider.getString(R.string.request_failed_message)).thenReturn(requestFailedMessage)
+        whenever(fetchSupportedCountriesUseCase.execute())
+            .thenReturn(SupportedCountriesResult.Error(message = "", isDeviceOffline = false))
+
+        viewModel.start(site, domainProductDetails)
+
+        verify(errorMessageObserver).onChanged(requestFailedMessage)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -20,12 +21,10 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.action.TransactionAction
-import org.wordpress.android.fluxc.action.TransactionAction.FETCH_SUPPORTED_COUNTRIES
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.transactions.SupportedDomainCountry
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Extra
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Product
@@ -47,16 +46,16 @@ import org.wordpress.android.fluxc.store.TransactionsStore
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateCartErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartWithDomainAndPlanPayload
-import org.wordpress.android.fluxc.store.TransactionsStore.FetchSupportedCountriesError
-import org.wordpress.android.fluxc.store.TransactionsStore.FetchSupportedCountriesErrorType
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartRedeemed
-import org.wordpress.android.fluxc.store.TransactionsStore.OnSupportedCountriesFetched
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.PHONE
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainContactFormModel
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainRegistrationDetailsUiState
+import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
+import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
+import uniffi.wp_api.SupportedCountry
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -74,13 +73,16 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    @Mock
+    private lateinit var fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase
     private var site: SiteModel = SiteModel()
 
     @Mock
     private lateinit var domainContactDetailsObserver: Observer<DomainContactFormModel>
 
     @Mock
-    private lateinit var countryPickerDialogObserver: Observer<List<SupportedDomainCountry>>
+    private lateinit var countryPickerDialogObserver: Observer<List<SupportedCountry>>
 
     @Mock
     private lateinit var statePickerDialogObserver: Observer<List<SupportedStateResponse>>
@@ -98,8 +100,8 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: DomainRegistrationDetailsViewModel
 
-    private val primaryCountry = SupportedDomainCountry("US", "United States")
-    private val secondaryCountry = SupportedDomainCountry("AU", "Australia")
+    private val primaryCountry = testSupportedCountry("US", "United States")
+    private val secondaryCountry = testSupportedCountry("AU", "Australia")
     private val countries = listOf(primaryCountry, secondaryCountry)
 
     private val primaryState = SupportedStateResponse("CA", "California")
@@ -161,10 +163,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         DomainSupportedStatesErrorType.GENERIC_ERROR,
         "Error fetching domain supported states"
     )
-    private val fetchSupportedCountriesError = FetchSupportedCountriesError(
-        FetchSupportedCountriesErrorType.GENERIC_ERROR,
-        "Error fetching countries"
-    )
+    private val fetchSupportedCountriesErrorMessage = "Error fetching countries"
 
     private val createShoppingCartResponse = CreateShoppingCartResponse(
         siteId.toInt(),
@@ -186,10 +185,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
             transactionsStore,
             siteStore,
             analyticsTracker,
+            fetchSupportedCountriesUseCase,
             NoDelayCoroutineDispatcher()
         )
         // Setting up chain of actions
-        setupFetchSupportedCountriesDispatcher(false)
+        test { setupFetchSupportedCountries(false) }
         setupFetchDomainContactInformationDispatcher(false)
         setupFetchStatesDispatcher(false)
         setupCreateShoppingCartDispatcher(false)
@@ -213,12 +213,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         // Verifying that correct actions with expected payloads were dispatched
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchSupportedCountriesAction(actionsDispatched[0])
-        validateFetchDomainContactAction(actionsDispatched[1])
-        validateFetchStatesAction(actionsDispatched[2], primaryCountry.code)
+        validateFetchDomainContactAction(actionsDispatched[0])
+        validateFetchStatesAction(actionsDispatched[1], primaryCountry.code)
 
         assertThat(uiStateResults.size).isEqualTo(5)
 
@@ -314,16 +313,12 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Test
     fun errorFetchingCountriesDuringPreload() = test {
-        setupFetchSupportedCountriesDispatcher(true)
+        setupFetchSupportedCountries(true)
 
         viewModel.start(site, domainProductDetails)
 
-        // Verifying that correct actions with expected payloads were dispatched
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher).dispatch(captor.capture())
-
-        val actionsDispatched = captor.allValues
-        validateFetchSupportedCountriesAction(actionsDispatched[0])
+        // The chain stops here, so nothing is dispatched
+        verify(dispatcher, never()).dispatch(any())
 
         assertThat(uiStateResults.size).isEqualTo(3)
 
@@ -337,7 +332,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(errorFetchingCountriesState.selectedState).isNull()
         assertThat(errorFetchingCountriesState.selectedCountry).isNull()
 
-        verify(errorMessageObserver).onChanged(fetchSupportedCountriesError.message)
+        verify(errorMessageObserver).onChanged(fetchSupportedCountriesErrorMessage)
     }
 
     @Test
@@ -348,11 +343,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         // Verifying that correct actions with expected payloads were dispatched
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchSupportedCountriesAction(actionsDispatched[0])
-        validateFetchDomainContactAction(actionsDispatched[1])
+        validateFetchDomainContactAction(actionsDispatched[0])
 
         verify(errorMessageObserver).onChanged(domainContactInformationFetchError.message ?: "")
 
@@ -381,12 +375,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         // Verifying that correct actions with expected payloads were dispatched
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchSupportedCountriesAction(actionsDispatched[0])
-        validateFetchDomainContactAction(actionsDispatched[1])
-        validateFetchStatesAction(actionsDispatched[2], primaryCountry.code)
+        validateFetchDomainContactAction(actionsDispatched[0])
+        validateFetchStatesAction(actionsDispatched[1], primaryCountry.code)
 
         verify(errorMessageObserver).onChanged(domainSupportedStatesFetchError.message ?: "")
 
@@ -430,10 +423,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onCountrySelected(secondaryCountry)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(4)).dispatch(captor.capture())
+        verify(dispatcher, times(3)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchStatesAction(actionsDispatched[3], secondaryCountry.code)
+        validateFetchStatesAction(actionsDispatched[2], secondaryCountry.code)
 
         assertThat(viewModel.domainContactForm.value?.countryCode).isEqualTo("AU")
         assertThat(viewModel.domainContactForm.value?.state).isNull()
@@ -473,7 +466,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onCountrySelected(primaryCountry)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)
         assertThat(uiStateResults.size).isEqualTo(0)
@@ -504,14 +497,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.domainContactForm.value?.state).isEqualTo(primaryState.code)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(7)).dispatch(captor.capture())
+        verify(dispatcher, times(6)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[3])
-        validateRedeemCartAction(actionsDispatched[4])
-        validateDesignatePrimaryDomainActions(actionsDispatched[5])
-        validateFetchSiteAction(actionsDispatched[6])
+        validateCreateCartAction(actionsDispatched[2])
+        validateRedeemCartAction(actionsDispatched[3])
+        validateDesignatePrimaryDomainActions(actionsDispatched[4])
+        validateFetchSiteAction(actionsDispatched[5])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -534,10 +527,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(4)).dispatch(captor.capture())
+        verify(dispatcher, times(3)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[3])
+        validateCreateCartAction(actionsDispatched[2])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -560,11 +553,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(5)).dispatch(captor.capture())
+        verify(dispatcher, times(4)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[3])
-        validateRedeemCartAction(actionsDispatched[4])
+        validateCreateCartAction(actionsDispatched[2])
+        validateRedeemCartAction(actionsDispatched[3])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -588,14 +581,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(7)).dispatch(captor.capture())
+        verify(dispatcher, times(6)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[3])
-        validateRedeemCartAction(actionsDispatched[4])
-        validateDesignatePrimaryDomainActions(actionsDispatched[5])
-        validateFetchSiteAction(actionsDispatched[6])
+        validateCreateCartAction(actionsDispatched[2])
+        validateRedeemCartAction(actionsDispatched[3])
+        validateDesignatePrimaryDomainActions(actionsDispatched[4])
+        validateFetchSiteAction(actionsDispatched[5])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -657,15 +650,13 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(convertedDomainContactFormModel).isEqualTo(domainContactFormModel)
     }
 
-    private fun setupFetchSupportedCountriesDispatcher(isError: Boolean) {
-        val event = if (isError) {
-            OnSupportedCountriesFetched(fetchSupportedCountriesError)
+    private suspend fun setupFetchSupportedCountries(isError: Boolean) {
+        val result = if (isError) {
+            SupportedCountriesResult.Error(fetchSupportedCountriesErrorMessage)
         } else {
-            OnSupportedCountriesFetched(countries)
+            SupportedCountriesResult.Success(countries)
         }
-        whenever(dispatcher.dispatch(argWhere<Action<Void>> { it.type == FETCH_SUPPORTED_COUNTRIES })).then {
-            viewModel.onSupportedCountriesFetched(event)
-        }
+        whenever(fetchSupportedCountriesUseCase.execute()).thenReturn(result)
     }
 
     private fun setupFetchStatesDispatcher(isError: Boolean) {
@@ -741,11 +732,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         })).then {
             viewModel.onPrimaryDomainDesignated(event)
         }
-    }
-
-    private fun validateFetchSupportedCountriesAction(action: Action<*>) {
-        assertThat(action.type).isEqualTo(FETCH_SUPPORTED_COUNTRIES)
-        assertThat(action.payload).isNull()
     }
 
     private fun validateFetchDomainContactAction(action: Action<*>) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -461,6 +461,16 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun onCountrySelectorClickedAfterCountriesFailedToLoad() = test {
+        setupFetchSupportedCountries(true)
+        viewModel.start(site, domainProductDetails)
+
+        viewModel.onCountrySelectorClicked()
+
+        verify(countryPickerDialogObserver, never()).onChanged(any())
+    }
+
+    @Test
     fun onStateSelectorClicked() = test {
         viewModel.start(site, domainProductDetails)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -18,7 +18,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.action.TransactionAction
 import org.wordpress.android.fluxc.annotations.action.Action
@@ -28,9 +27,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateRespons
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Extra
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Product
-import org.wordpress.android.fluxc.store.AccountStore.DomainContactError
-import org.wordpress.android.fluxc.store.AccountStore.DomainContactErrorType
-import org.wordpress.android.fluxc.store.AccountStore.OnDomainContactFetched
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainError
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainErrorType
@@ -53,8 +49,11 @@ import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPay
 import org.wordpress.android.fluxc.store.TransactionsStore.TransactionErrorType.PHONE
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainContactFormModel
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.DomainRegistrationDetailsUiState
+import org.wordpress.android.ui.domains.usecases.DomainContactResult
+import org.wordpress.android.ui.domains.usecases.FetchDomainContactUseCase
 import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
 import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
+import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -76,6 +75,9 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var fetchSupportedCountriesUseCase: FetchSupportedCountriesUseCase
+
+    @Mock
+    private lateinit var fetchDomainContactUseCase: FetchDomainContactUseCase
     private var site: SiteModel = SiteModel()
 
     @Mock
@@ -128,6 +130,22 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         null
     )
 
+    private val domainContactInformation = DomainContactInformation(
+        firstName = "John",
+        lastName = "Smith",
+        organization = "",
+        address1 = "Street 1",
+        address2 = "Apt 1",
+        postalCode = "10018",
+        city = "First City",
+        state = "CA",
+        countryCode = "US",
+        email = "email@wordpress.org",
+        phone = "+1.3124567890",
+        fax = null,
+        extra = null,
+    )
+
     private val domainContactFormModel = DomainContactFormModel(
         "John",
         "Smith",
@@ -155,10 +173,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         DesignatePrimaryDomainErrorType.GENERIC_ERROR,
         "Error designating primary domain"
     )
-    private val domainContactInformationFetchError = DomainContactError(
-        DomainContactErrorType.GENERIC_ERROR,
-        "Error fetching domain contact information"
-    )
+    private val domainContactInformationFetchErrorMessage = "Error fetching domain contact information"
     private val domainSupportedStatesFetchError = DomainSupportedStatesError(
         DomainSupportedStatesErrorType.GENERIC_ERROR,
         "Error fetching domain supported states"
@@ -186,11 +201,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
             siteStore,
             analyticsTracker,
             fetchSupportedCountriesUseCase,
+            fetchDomainContactUseCase,
             NoDelayCoroutineDispatcher()
         )
         // Setting up chain of actions
-        test { setupFetchSupportedCountries(false) }
-        setupFetchDomainContactInformationDispatcher(false)
+        test {
+            setupFetchSupportedCountries(false)
+            setupFetchDomainContact(false)
+        }
         setupFetchStatesDispatcher(false)
         setupCreateShoppingCartDispatcher(false)
         setupRedeemShoppingCartDispatcher(false)
@@ -213,11 +231,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         // Verifying that correct actions with expected payloads were dispatched
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchDomainContactAction(actionsDispatched[0])
-        validateFetchStatesAction(actionsDispatched[1], primaryCountry.code)
+        validateFetchStatesAction(actionsDispatched[0], primaryCountry.code)
 
         assertThat(uiStateResults.size).isEqualTo(5)
 
@@ -283,7 +300,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Test
     fun phoneNumberPrefixIsPrefilledDuringPreload() = test {
-        setupFetchDomainContactInformationDispatcher(false, domainContactModel.copy(phone = null))
+        setupFetchDomainContact(false, domainContactInformation.copy(phone = null))
         viewModel.start(site, domainProductDetails)
 
         var domainContactModelWithPrefilledPhonePrefix: DomainContactFormModel? = null
@@ -298,7 +315,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Test
     fun phoneNumberPrefixIsNotPrefiledWhenCountryCodeIsMissingDuringPreload() = test {
-        setupFetchDomainContactInformationDispatcher(false, domainContactModel.copy(phone = null, countryCode = null))
+        setupFetchDomainContact(false, domainContactInformation.copy(phone = null, countryCode = null))
         viewModel.start(site, domainProductDetails)
 
         var domainContactModelWithPrefilledPhonePrefix: DomainContactFormModel? = null
@@ -337,18 +354,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Test
     fun errorFetchingDomainContactInformationDuringPreload() = test {
-        setupFetchDomainContactInformationDispatcher(true)
+        setupFetchDomainContact(true)
 
         viewModel.start(site, domainProductDetails)
 
-        // Verifying that correct actions with expected payloads were dispatched
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
+        // The chain stops here, so nothing is dispatched
+        verify(dispatcher, never()).dispatch(any())
 
-        val actionsDispatched = captor.allValues
-        validateFetchDomainContactAction(actionsDispatched[0])
-
-        verify(errorMessageObserver).onChanged(domainContactInformationFetchError.message ?: "")
+        verify(errorMessageObserver).onChanged(domainContactInformationFetchErrorMessage)
 
         assertThat(uiStateResults.size).isEqualTo(3)
 
@@ -375,11 +388,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         // Verifying that correct actions with expected payloads were dispatched
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchDomainContactAction(actionsDispatched[0])
-        validateFetchStatesAction(actionsDispatched[1], primaryCountry.code)
+        validateFetchStatesAction(actionsDispatched[0], primaryCountry.code)
 
         verify(errorMessageObserver).onChanged(domainSupportedStatesFetchError.message ?: "")
 
@@ -423,10 +435,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onCountrySelected(secondaryCountry)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateFetchStatesAction(actionsDispatched[2], secondaryCountry.code)
+        validateFetchStatesAction(actionsDispatched[1], secondaryCountry.code)
 
         assertThat(viewModel.domainContactForm.value?.countryCode).isEqualTo("AU")
         assertThat(viewModel.domainContactForm.value?.state).isNull()
@@ -466,7 +478,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onCountrySelected(primaryCountry)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)
         assertThat(uiStateResults.size).isEqualTo(0)
@@ -497,14 +509,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.domainContactForm.value?.state).isEqualTo(primaryState.code)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(6)).dispatch(captor.capture())
+        verify(dispatcher, times(5)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[2])
-        validateRedeemCartAction(actionsDispatched[3])
-        validateDesignatePrimaryDomainActions(actionsDispatched[4])
-        validateFetchSiteAction(actionsDispatched[5])
+        validateCreateCartAction(actionsDispatched[1])
+        validateRedeemCartAction(actionsDispatched[2])
+        validateDesignatePrimaryDomainActions(actionsDispatched[3])
+        validateFetchSiteAction(actionsDispatched[4])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -527,10 +539,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[2])
+        validateCreateCartAction(actionsDispatched[1])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -553,11 +565,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(4)).dispatch(captor.capture())
+        verify(dispatcher, times(3)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[2])
-        validateRedeemCartAction(actionsDispatched[3])
+        validateCreateCartAction(actionsDispatched[1])
+        validateRedeemCartAction(actionsDispatched[2])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -581,14 +593,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(6)).dispatch(captor.capture())
+        verify(dispatcher, times(5)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[2])
-        validateRedeemCartAction(actionsDispatched[3])
-        validateDesignatePrimaryDomainActions(actionsDispatched[4])
-        validateFetchSiteAction(actionsDispatched[5])
+        validateCreateCartAction(actionsDispatched[1])
+        validateRedeemCartAction(actionsDispatched[2])
+        validateDesignatePrimaryDomainActions(actionsDispatched[3])
+        validateFetchSiteAction(actionsDispatched[4])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -646,7 +658,8 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         val convertedDomainContactModel = DomainContactFormModel.toDomainContactModel(domainContactFormModel)
         assertThat(convertedDomainContactModel).isEqualTo(domainContactModel)
 
-        val convertedDomainContactFormModel = DomainContactFormModel.fromDomainContactModel(domainContactModel)
+        val convertedDomainContactFormModel =
+            DomainContactFormModel.fromDomainContactInformation(domainContactInformation)
         assertThat(convertedDomainContactFormModel).isEqualTo(domainContactFormModel)
     }
 
@@ -672,18 +685,16 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         }
     }
 
-    private fun setupFetchDomainContactInformationDispatcher(
+    private suspend fun setupFetchDomainContact(
         isError: Boolean,
-        returnModel: DomainContactModel = domainContactModel
+        contact: DomainContactInformation = domainContactInformation
     ) {
-        val event = if (isError) {
-            OnDomainContactFetched(null, domainContactInformationFetchError)
+        val result = if (isError) {
+            DomainContactResult.Error(domainContactInformationFetchErrorMessage)
         } else {
-            OnDomainContactFetched(returnModel, null)
+            DomainContactResult.Success(contact)
         }
-        whenever(dispatcher.dispatch(argWhere<Action<Void>> { it.type == AccountAction.FETCH_DOMAIN_CONTACT })).then {
-            viewModel.onDomainContactFetched(event)
-        }
+        whenever(fetchDomainContactUseCase.execute()).thenReturn(result)
     }
 
     private fun setupCreateShoppingCartDispatcher(isError: Boolean) {
@@ -732,11 +743,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         })).then {
             viewModel.onPrimaryDomainDesignated(event)
         }
-    }
-
-    private fun validateFetchDomainContactAction(action: Action<*>) {
-        assertThat(action.type).isEqualTo(AccountAction.FETCH_DOMAIN_CONTACT)
-        assertThat(action.payload).isNull()
     }
 
     private fun validateFetchStatesAction(action: Action<*>, targetCountryCode: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.action.TransactionAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.DomainContactModel
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Extra
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse.Product
@@ -31,9 +30,6 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainError
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainErrorType
 import org.wordpress.android.fluxc.store.SiteStore.DesignatePrimaryDomainPayload
-import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError
-import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType
-import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetched
 import org.wordpress.android.fluxc.store.SiteStore.OnPrimaryDomainDesignated
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
@@ -52,9 +48,12 @@ import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.Domai
 import org.wordpress.android.ui.domains.usecases.DomainContactResult
 import org.wordpress.android.ui.domains.usecases.FetchDomainContactUseCase
 import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
+import org.wordpress.android.ui.domains.usecases.FetchSupportedStatesUseCase
 import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
+import org.wordpress.android.ui.domains.usecases.SupportedStatesResult
 import uniffi.wp_api.DomainContactInformation
 import uniffi.wp_api.SupportedCountry
+import uniffi.wp_api.SupportedState
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -78,6 +77,9 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var fetchDomainContactUseCase: FetchDomainContactUseCase
+
+    @Mock
+    private lateinit var fetchSupportedStatesUseCase: FetchSupportedStatesUseCase
     private var site: SiteModel = SiteModel()
 
     @Mock
@@ -87,7 +89,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     private lateinit var countryPickerDialogObserver: Observer<List<SupportedCountry>>
 
     @Mock
-    private lateinit var statePickerDialogObserver: Observer<List<SupportedStateResponse>>
+    private lateinit var statePickerDialogObserver: Observer<List<SupportedState>>
 
     @Mock
     private lateinit var tosLinkObserver: Observer<Unit?>
@@ -106,8 +108,8 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     private val secondaryCountry = testSupportedCountry("AU", "Australia")
     private val countries = listOf(primaryCountry, secondaryCountry)
 
-    private val primaryState = SupportedStateResponse("CA", "California")
-    private val secondaryState = SupportedStateResponse("NSW", "New South Wales")
+    private val primaryState = SupportedState("CA", "California")
+    private val secondaryState = SupportedState("NSW", "New South Wales")
     private val states = listOf(primaryState, secondaryState)
 
     private val siteId = 1234L
@@ -174,10 +176,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         "Error designating primary domain"
     )
     private val domainContactInformationFetchErrorMessage = "Error fetching domain contact information"
-    private val domainSupportedStatesFetchError = DomainSupportedStatesError(
-        DomainSupportedStatesErrorType.GENERIC_ERROR,
-        "Error fetching domain supported states"
-    )
+    private val domainSupportedStatesFetchErrorMessage = "Error fetching domain supported states"
     private val fetchSupportedCountriesErrorMessage = "Error fetching countries"
 
     private val createShoppingCartResponse = CreateShoppingCartResponse(
@@ -202,14 +201,15 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
             analyticsTracker,
             fetchSupportedCountriesUseCase,
             fetchDomainContactUseCase,
+            fetchSupportedStatesUseCase,
             NoDelayCoroutineDispatcher()
         )
         // Setting up chain of actions
         test {
             setupFetchSupportedCountries(false)
             setupFetchDomainContact(false)
+            setupFetchStates(false)
         }
-        setupFetchStatesDispatcher(false)
         setupCreateShoppingCartDispatcher(false)
         setupRedeemShoppingCartDispatcher(false)
         setupFetchSiteDispatcher(false)
@@ -229,12 +229,9 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     fun contactDetailsPreload() = test {
         viewModel.start(site, domainProductDetails)
 
-        // Verifying that correct actions with expected payloads were dispatched
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
-
-        val actionsDispatched = captor.allValues
-        validateFetchStatesAction(actionsDispatched[0], primaryCountry.code)
+        // The form's fetches are all migrated, so nothing is dispatched
+        verify(dispatcher, never()).dispatch(any())
+        verify(fetchSupportedStatesUseCase).execute(primaryCountry.code)
 
         assertThat(uiStateResults.size).isEqualTo(5)
 
@@ -382,18 +379,15 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
     @Test
     fun errorFetchingStatesDuringPreload() = test {
-        setupFetchStatesDispatcher(true)
+        setupFetchStates(true)
 
         viewModel.start(site, domainProductDetails)
 
-        // Verifying that correct actions with expected payloads were dispatched
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
+        // The form's fetches are all migrated, so nothing is dispatched
+        verify(dispatcher, never()).dispatch(any())
 
-        val actionsDispatched = captor.allValues
-        validateFetchStatesAction(actionsDispatched[0], primaryCountry.code)
-
-        verify(errorMessageObserver).onChanged(domainSupportedStatesFetchError.message ?: "")
+        verify(fetchSupportedStatesUseCase).execute(primaryCountry.code)
+        verify(errorMessageObserver).onChanged(domainSupportedStatesFetchErrorMessage)
 
         assertThat(uiStateResults.size).isEqualTo(5)
 
@@ -434,11 +428,8 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.onCountrySelected(secondaryCountry)
 
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
-
-        val actionsDispatched = captor.allValues
-        validateFetchStatesAction(actionsDispatched[1], secondaryCountry.code)
+        verify(dispatcher, never()).dispatch(any())
+        verify(fetchSupportedStatesUseCase).execute(secondaryCountry.code)
 
         assertThat(viewModel.domainContactForm.value?.countryCode).isEqualTo("AU")
         assertThat(viewModel.domainContactForm.value?.state).isNull()
@@ -477,8 +468,8 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)
         viewModel.onCountrySelected(primaryCountry)
 
-        val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
+        // Selecting the country already selected refetches nothing
+        verify(fetchSupportedStatesUseCase, times(1)).execute(any())
 
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)
         assertThat(uiStateResults.size).isEqualTo(0)
@@ -509,14 +500,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.domainContactForm.value?.state).isEqualTo(primaryState.code)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(5)).dispatch(captor.capture())
+        verify(dispatcher, times(4)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[1])
-        validateRedeemCartAction(actionsDispatched[2])
-        validateDesignatePrimaryDomainActions(actionsDispatched[3])
-        validateFetchSiteAction(actionsDispatched[4])
+        validateCreateCartAction(actionsDispatched[0])
+        validateRedeemCartAction(actionsDispatched[1])
+        validateDesignatePrimaryDomainActions(actionsDispatched[2])
+        validateFetchSiteAction(actionsDispatched[3])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -539,10 +530,10 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(2)).dispatch(captor.capture())
+        verify(dispatcher, times(1)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[1])
+        validateCreateCartAction(actionsDispatched[0])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -565,11 +556,11 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(3)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
-        validateCreateCartAction(actionsDispatched[1])
-        validateRedeemCartAction(actionsDispatched[2])
+        validateCreateCartAction(actionsDispatched[0])
+        validateRedeemCartAction(actionsDispatched[1])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -593,14 +584,14 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         viewModel.onRegisterDomainButtonClicked()
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(5)).dispatch(captor.capture())
+        verify(dispatcher, times(4)).dispatch(captor.capture())
 
         val actionsDispatched = captor.allValues
 
-        validateCreateCartAction(actionsDispatched[1])
-        validateRedeemCartAction(actionsDispatched[2])
-        validateDesignatePrimaryDomainActions(actionsDispatched[3])
-        validateFetchSiteAction(actionsDispatched[4])
+        validateCreateCartAction(actionsDispatched[0])
+        validateRedeemCartAction(actionsDispatched[1])
+        validateDesignatePrimaryDomainActions(actionsDispatched[2])
+        validateFetchSiteAction(actionsDispatched[3])
 
         assertThat(uiStateResults.size).isEqualTo(2)
 
@@ -672,17 +663,13 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         whenever(fetchSupportedCountriesUseCase.execute()).thenReturn(result)
     }
 
-    private fun setupFetchStatesDispatcher(isError: Boolean) {
-        val event = if (isError) {
-            OnDomainSupportedStatesFetched(null, domainSupportedStatesFetchError)
+    private suspend fun setupFetchStates(isError: Boolean) {
+        val result = if (isError) {
+            SupportedStatesResult.Error(domainSupportedStatesFetchErrorMessage)
         } else {
-            OnDomainSupportedStatesFetched(states, null)
+            SupportedStatesResult.Success(states)
         }
-        whenever(dispatcher.dispatch(argWhere<Action<Void>> {
-            it.type == SiteAction.FETCH_DOMAIN_SUPPORTED_STATES
-        })).then {
-            viewModel.onDomainSupportedStatesFetched(event)
-        }
+        whenever(fetchSupportedStatesUseCase.execute(any())).thenReturn(result)
     }
 
     private suspend fun setupFetchDomainContact(
@@ -743,11 +730,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         })).then {
             viewModel.onPrimaryDomainDesignated(event)
         }
-    }
-
-    private fun validateFetchStatesAction(action: Action<*>, targetCountryCode: String) {
-        assertThat(action.type).isEqualTo(SiteAction.FETCH_DOMAIN_SUPPORTED_STATES)
-        assertThat(action.payload).isEqualTo(targetCountryCode)
     }
 
     private fun validateCreateCartAction(action: Action<*>) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -229,7 +229,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     fun contactDetailsPreload() = test {
         viewModel.start(site, domainProductDetails)
 
-        // The form's fetches are all migrated, so nothing is dispatched
         verify(dispatcher, never()).dispatch(any())
         verify(fetchSupportedStatesUseCase).execute(primaryCountry.code)
 
@@ -331,7 +330,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, domainProductDetails)
 
-        // The chain stops here, so nothing is dispatched
         verify(dispatcher, never()).dispatch(any())
 
         assertThat(uiStateResults.size).isEqualTo(3)
@@ -355,7 +353,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, domainProductDetails)
 
-        // The chain stops here, so nothing is dispatched
         verify(dispatcher, never()).dispatch(any())
 
         verify(errorMessageObserver).onChanged(domainContactInformationFetchErrorMessage)
@@ -383,7 +380,6 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, domainProductDetails)
 
-        // The form's fetches are all migrated, so nothing is dispatched
         verify(dispatcher, never()).dispatch(any())
 
         verify(fetchSupportedStatesUseCase).execute(primaryCountry.code)
@@ -468,7 +464,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)
         viewModel.onCountrySelected(primaryCountry)
 
-        // Selecting the country already selected refetches nothing
+        // The one call is the preload's, so selecting the same country refetched nothing
         verify(fetchSupportedStatesUseCase, times(1)).execute(any())
 
         assertThat(viewModel.uiState.value?.selectedCountry).isEqualTo(primaryCountry)

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/FetchSupportedCountriesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/FetchSupportedCountriesUseCaseTest.kt
@@ -1,0 +1,118 @@
+package org.wordpress.android.ui.domains
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.networking.restapi.WpComApiClientProvider
+import org.wordpress.android.ui.domains.usecases.FetchSupportedCountriesUseCase
+import org.wordpress.android.ui.domains.usecases.SupportedCountriesResult
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.RequestMethod
+import uniffi.wp_api.SupportedCountries
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class FetchSupportedCountriesUseCaseTest : BaseUnitTest() {
+    @Mock
+    lateinit var wpComApiClientProvider: WpComApiClientProvider
+
+    @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var wpComApiClient: WpComApiClient
+
+    private lateinit var useCase: FetchSupportedCountriesUseCase
+
+    @Before
+    fun setUp() {
+        whenever(accountStore.accessToken).thenReturn("test-token")
+        whenever(wpComApiClientProvider.getWpComApiClient("test-token"))
+            .thenReturn(wpComApiClient)
+        useCase = FetchSupportedCountriesUseCase(wpComApiClientProvider, accountStore)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun stubResponse(countries: SupportedCountries) {
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(WpRequestResult.Success(countries) as WpRequestResult<Any>)
+    }
+
+    @Test
+    fun `given featured and all, when execute, the featured countries come first`() = test {
+        stubResponse(
+            SupportedCountries(
+                featured = listOf(testSupportedCountry("CA", "Canada")),
+                all = listOf(
+                    testSupportedCountry("AF", "Afghanistan"),
+                    testSupportedCountry("CA", "Canada"),
+                ),
+            )
+        )
+
+        val result = useCase.execute()
+
+        assertThat(result).isInstanceOf(SupportedCountriesResult.Success::class.java)
+        assertThat((result as SupportedCountriesResult.Success).countries.map { it.code })
+            .containsExactly("CA", "AF", "CA")
+    }
+
+    @Test
+    fun `given no featured countries, when execute, only the full list is returned`() = test {
+        stubResponse(
+            SupportedCountries(
+                featured = emptyList(),
+                all = listOf(testSupportedCountry("AF", "Afghanistan")),
+            )
+        )
+
+        val result = useCase.execute()
+
+        assertThat((result as SupportedCountriesResult.Success).countries.map { it.code })
+            .containsExactly("AF")
+    }
+
+    @Test
+    fun `given the request fails, when execute, returns error carrying no message`() = test {
+        whenever(wpComApiClient.request<Any>(any()))
+            .thenReturn(
+                WpRequestResult.UnknownError<Any>(
+                    500.toUInt(),
+                    "Internal Server Error",
+                    "",
+                    RequestMethod.GET
+                )
+            )
+
+        val result = useCase.execute()
+
+        assertThat(result).isEqualTo(SupportedCountriesResult.Error(null))
+    }
+
+    @Test
+    fun `given no access token, when execute, returns error`() = test {
+        whenever(accountStore.accessToken).thenReturn(null)
+
+        val result = useCase.execute()
+
+        assertThat(result).isEqualTo(SupportedCountriesResult.Error(null))
+    }
+
+    @Test
+    fun `given a blank access token, when execute, returns error`() = test {
+        whenever(accountStore.accessToken).thenReturn("")
+
+        val result = useCase.execute()
+
+        assertThat(result).isEqualTo(SupportedCountriesResult.Error(null))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/TestSupportedCountryFactory.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/TestSupportedCountryFactory.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.domains
+
+import uniffi.wp_api.SupportedCountry
+
+/**
+ * Builds a [SupportedCountry] for tests. Only the code and the name are
+ * exposed, because that is all the registration form reads; the tax and postal
+ * code fields are given false or null.
+ */
+fun testSupportedCountry(
+    code: String,
+    name: String,
+) = SupportedCountry(
+    code = code,
+    name = name,
+    hasPostalCodes = false,
+    vatSupported = false,
+    taxNeedsCity = false,
+    taxNeedsSubdivision = false,
+    taxName = null,
+)


### PR DESCRIPTION
## Description

`DomainRegistrationDetailsViewModel`'s three form fetches — supported countries, domain contact details and supported states — go through `WpComApiClient` instead of dispatching FluxC actions and waiting on `@Subscribe` handlers. The form makes no FluxC calls now. The purchase behind it still creates its cart, redeems it, sets the primary domain and refreshes the site through FluxC, so the `Dispatcher` and its registration stay.

One minor improvement made in its own commit. Opening the form with no connection showed a toast with empty text in trunk which now says "Check your network connection and try again".

## Testing instructions

Nothing here spends a domain credit. Every case stops at the filled-in form, and the credit is only claimed by tapping **Register domain**, which this PR does not touch.

Reaching the screen needs a site holding an unclaimed domain credit: **My Site** → **Domains** → **Search for a domain**, pick one of the domains offered free for the first year, then tap **Select domain**. The **Register Domain** form opens on it.

Every case matches trunk, so it is worth recording trunk first.

The form's prefilled contact details, which is the case worth the most care:

1. Open the **Register Domain** form.
- [x] Verify every field carries the same value it does on trunk — first and last name, organization, both address lines, postal code, city, state, country, email and phone. The two address lines are worth reading closely; they are the pair whose names differ between the two stacks.
- [x] Verify the form stops loading and **Register domain** becomes tappable.

The country picker:

1. Tap the country field.
- [x] Verify the list opens on the same country trunk shows first, followed by the same common countries, then the alphabetical run.
- [x] Verify the countries near the top appear a second time in the alphabetical run, as on trunk, and that no blank rows appear anywhere in the list.

Countries with and without subdivisions:

1. In the country picker, choose a country that has states — **United States** or **Canada**.
- [x] Verify the state field becomes tappable and lists that country's states.
2. Choose a country that has none. (i.e. **France**)
- [x] Verify the state field is emptied and left untappable.
3. Reopen the picker and choose the country that was already selected.
- [x] Verify nothing reloads and the state field keeps what it had.

A failed load:

1. Turn networking off, then open the **Register Domain** form.
- [x] Verify a toast reports the failure, the form stops loading, and **Register domain** stays untappable — the same as trunk.
2. Turn networking back on and reopen the form.
- [x] Verify it loads and prefills.

A failed state fetch:

1. Let the form load, then turn networking off and pick a different country.
- [x] Verify a toast reports the failure, the state spinner stops, and **Register domain** becomes tappable again, as on trunk.

Rotation:

1. Rotate the device with the form open, and again with each picker open.
- [x] Verify the form keeps its values and the pickers still list their contents.

## Screenshots

None. The form is prefilled with real contact details, and every capture worth comparing carries them. Each case above was checked against trunk and matches.
