### PR TITLE
Make New Stats navigation tests date-independent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/newstats/repository/StatsRepository.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.newstats.StatsPeriod
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import org.wordpress.android.ui.newstats.datasource.StatsErrorType
 import org.wordpress.android.util.AppLog
 import java.time.LocalDate
@@ -954,7 +955,8 @@ class StatsRepository @Inject constructor(
      * Note: [calculatePeriodDates] handles the hourly cases (Today and single-day Custom) separately
      * before reaching here, so those build their own window ending at "<day> 23:00:00".
      */
-    private fun currentPeriodWindow(period: StatsPeriod): Pair<LocalDate, LocalDate> {
+    @VisibleForTesting
+    internal fun currentPeriodWindow(period: StatsPeriod): Pair<LocalDate, LocalDate> {
         val today = LocalDate.now()
         return when (period) {
             is StatsPeriod.Today -> today to today

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
@@ -1328,19 +1328,27 @@ class StatsRepositoryTest : BaseUnitTest() {
 
         val result = repository.nextPeriod(previousWeek)
 
-        assertThat(result).isEqualTo(StatsPeriod.Last7Days)
+        // On the last day of the week that source range is itself a full calendar week, so the step is
+        // a calendar step and the landing window is both Last 7 Days and This Week — snapToPreset then
+        // prefers the source's own calendar unit.
+        val weekStart = today.with(
+            TemporalAdjusters.previousOrSame(WeekFields.of(Locale.getDefault()).firstDayOfWeek)
+        )
+        val expected = if (today == weekStart.plusDays(6)) StatsPeriod.ThisWeek else StatsPeriod.Last7Days
+        assertThat(result).isEqualTo(expected)
     }
 
     @Test
     fun `nextPeriod clamps so the window never ends after today`() {
         val today = LocalDate.now()
-        // A ten-day range ending today (no preset has this span, so it stays Custom): forward would
-        // overshoot into the future and must be clamped back to end on today.
+        // A ten-day range ending today: forward would overshoot into the future and must be clamped
+        // back to end on today. The clamped window may or may not coincide with a preset (on the 10th
+        // of the month it is exactly month-to-date), so assert the window rather than the subtype.
         val endingToday = StatsPeriod.Custom(today.minusDays(9), today)
 
-        val result = repository.nextPeriod(endingToday) as StatsPeriod.Custom
+        val result = repository.nextPeriod(endingToday)
 
-        assertThat(result.endDate).isEqualTo(today)
+        assertThat(repository.currentPeriodWindow(result).second).isEqualTo(today)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/newstats/repository/StatsRepositoryTest.kt
@@ -1296,16 +1296,15 @@ class StatsRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `nextPeriod from the previous full month returns to the current month to date`() {
-        val today = LocalDate.now()
-        val monthStart = today.withDayOfMonth(1)
         val previous = repository.previousPeriod(StatsPeriod.ThisMonth)
 
         val result = repository.nextPeriod(previous)
 
-        // Forward from the whole previous month lands on the current month up to today; on the 1st that
-        // window is a single day and snaps to Today, otherwise it restores the ThisMonth preset.
-        val expected = if (today == monthStart) StatsPeriod.Today else StatsPeriod.ThisMonth
-        assertThat(result).isEqualTo(expected)
+        // Forward from the whole previous month lands on the current month up to today and restores the
+        // ThisMonth preset. On the 1st that window collapses to a single day, so Today's window matches
+        // it too, but snapToPreset prefers the source's own calendar unit (MONTH) and still returns
+        // ThisMonth.
+        assertThat(result).isEqualTo(StatsPeriod.ThisMonth)
     }
 
     @Test
@@ -1348,7 +1347,7 @@ class StatsRepositoryTest : BaseUnitTest() {
 
         val result = repository.nextPeriod(endingToday)
 
-        assertThat(repository.currentPeriodWindow(result).second).isEqualTo(today)
+        assertThat(repository.currentPeriodWindow(result)).isEqualTo(today.minusDays(9) to today)
     }
 
     @Test


### PR DESCRIPTION
## TL;DR

This PR fixes some `StatsRepositoryTest` navigation tests that were failing on `trunk`.

## Description

**Failure 1 — every 10th of the month (trunk is red today).** `nextPeriod clamps so the window never ends after today` builds `Custom(today-9, today)` and casts the forward step to `Custom`. `nextPeriod` clamps the overshooting window back to `(today-span, today)` and then runs `snapToPreset`. On the 10th that clamped window is `(Sep 1, Sep 10)` — exactly `ThisMonth`'s window — so a preset comes back and the cast throws `ClassCastException`. No fixed span dodges this: `ThisMonth`'s span is day-of-month−1 and `ThisYear`'s is day-of-year−1, so any span under ~366 days collides on some date.

**Failure 2 — every Saturday under `Locale.US` (latent).** `nextPeriod onto a preset's own window snaps back to that preset` uses `Custom(today-13, today-7)` as its source. When today is the last day of the week that range *is* a full calendar week, so `stepPeriod` takes the `calendarShift` path; the landing window matches both `Last7Days` and `ThisWeek`, and `snapToPreset` deliberately prefers the preset whose calendar unit matches the source, returning `ThisWeek`.

**Failure 3 — every 1st of the month (latent).** `nextPeriod from the previous full month returns to the current month to date` expects `Today` on the 1st. But on the 1st the source is a full calendar month, so `sourceUnit` is MONTH and the landing window `(today, today)` matches both `Today` and `ThisMonth` — `snapToPreset` prefers the source's unit and returns `ThisMonth`. That branch was never reachable; trunk would have gone red on Oct 1.

In all three cases `StatsRepository` behaves correctly — the test expectations were just over-specific. The fix asserts the invariant each test name states:

- `StatsRepository.currentPeriodWindow` widened from `private` to `@VisibleForTesting internal`. It is already the single place that resolves any `StatsPeriod` (preset or `Custom`) to concrete dates. No behaviour change.
- The clamp test now asserts the whole `currentPeriodWindow(result)` pair equals `(today-9, today)` instead of casting to `Custom`. That holds on the 10th too, where the result snaps to `ThisMonth`, and unlike an end-date-only check it still pins the clamped start.
- The snap test picks its expected preset explicitly for the week-boundary day, since both outcomes are genuinely correct depending on the date.
- The previous-full-month test now expects `ThisMonth` unconditionally.

## Testing instructions

Clean CI should be all that's necessary to approve.
