### PR TITLE
CMM-2422: Remove dead account-creation tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -200,19 +200,6 @@ public class AnalyticsUtils {
         return siteStore.getSitesAccessedViaWPComRestCount() - siteStore.getWPComSitesCount() > 0;
     }
 
-    public static void refreshMetadataNewUser(String username, String email) {
-        AnalyticsMetadata metadata = new AnalyticsMetadata();
-        metadata.setUserConnected(true);
-        metadata.setWordPressComUser(true);
-        metadata.setJetpackUser(false);
-        metadata.setNumBlogs(1);
-        metadata.setUsername(username);
-        metadata.setEmail(email);
-        // GB is enabled for new users
-        metadata.setGutenbergEnabled(true);
-        AnalyticsTracker.refreshMetadata(metadata);
-    }
-
     public static int getWordCount(String content) {
         String text = HtmlCompat.fromHtml(
                 content.replaceAll("<img[^>]*>", ""),
@@ -621,19 +608,6 @@ public class AnalyticsUtils {
         if (!isWpcomLogin) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.ADDED_SELF_HOSTED_SITE);
         }
-    }
-
-    /**
-     * Refreshes analytics metadata and bumps the account created stat.
-     *
-     * @param username
-     * @param email
-     */
-    public static void trackAnalyticsAccountCreated(String username, String email, Map<String, Object> properties) {
-        AnalyticsUtils.refreshMetadataNewUser(username, email);
-        // This stat is part of a funnel that provides critical information.  Before
-        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
-        AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_ACCOUNT, properties);
     }
 
     public static void trackLoginProloguePages(int page) {

--- a/WordPress/src/test/java/org/wordpress/android/util/analytics/AnalyticsTrackerNosaraTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/analytics/AnalyticsTrackerNosaraTest.kt
@@ -164,7 +164,6 @@ class AnalyticsTrackerNosaraTest {
         Stat.CREATE_ACCOUNT_EMAIL_EXISTS to "account_create_email_exists",
         Stat.CREATE_ACCOUNT_USERNAME_EXISTS to "account_create_username_exists",
         Stat.CREATE_ACCOUNT_FAILED to "account_create_failed",
-        Stat.CREATED_ACCOUNT to "account_created",
         Stat.SHARED_ITEM_READER to "item_shared_reader",
         Stat.ADDED_SELF_HOSTED_SITE to "self_hosted_blog_added",
         Stat.INSTALL_JETPACK_CANCELLED to "install_jetpack_canceled",

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -408,9 +408,6 @@ public final class AnalyticsTracker {
         CREATE_ACCOUNT_EMAIL_EXISTS("account_create_email_exists"),
         CREATE_ACCOUNT_USERNAME_EXISTS("account_create_username_exists"),
         CREATE_ACCOUNT_FAILED("account_create_failed"),
-        // This stat is part of a funnel that provides critical information.  Before
-        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
-        CREATED_ACCOUNT("account_created"),
         CLOSE_ACCOUNT_FAILED,
         CLOSED_ACCOUNT,
         ACCOUNT_LOGOUT,


### PR DESCRIPTION
## TL;DR

`account_created` has had no callers since the login module was removed. Deletes the unreachable emitter and its `Stat` entry. No behaviour change.

Fixes [CMM-2422](https://linear.app/a8c/issue/CMM-2422), a sub-issue of [CMM-2421](https://linear.app/a8c/issue/CMM-2421).

## Description

`wpandroid_account_created` and the rest of the native signup funnel stopped firing on 2025-01-30. #21414 moved WP.com login/signup into a Custom Chrome Tab, and #22564 ("Remove Login Module") then deleted the last call sites along with `libs/login`. The emitter and its `Stat` enum survived with nothing calling them.

The signups were never lost, they moved — WP.com's `calypso_signup_*` instrumentation records them server-side. Re-instrumenting in the app isn't viable: we hand off to a Chrome tab and never observe completion, so any client-side event would have to *infer* success. The fix belongs in the warehouse transform and on the Calypso side, which is what the two sibling sub-issues cover ([CMM-2423](https://linear.app/a8c/issue/CMM-2423), [CMM-2424](https://linear.app/a8c/issue/CMM-2424)) — both owned by other teams. This PR closes the Android half only.

Removed:

- `AnalyticsUtils.trackAnalyticsAccountCreated()` — zero callers repo-wide
- `AnalyticsUtils.refreshMetadataNewUser()` — unreachable once the above goes; the general `refreshMetadata(...)` path is untouched
- `Stat.CREATED_ACCOUNT("account_created")` and its `p4qSXL-35X-p2` funnel comment
- The matching `specialNames` entry in `AnalyticsTrackerNosaraTest` — mandatory, since the tests partition `Stat.values()` on that map

### ⚠️ Related gaps deliberately left alone

Two things the audit turned up that are **not** fixed here:

1. `signed_in` and `self_hosted_blog_added` are broken the same way — `LoginAnalyticsTracker.trackAnalyticsSignIn()` has zero callers. This is *not* the same story as signup: login still happens in-app, so those events didn't move to WP.com, they just stopped. `LoginActivity.loggedInAndFinish()` is a single funnel for both the OAuth callback and app-password login, so restoring them is close to a one-liner. #23312 flagged this as needing a product decision. `LOGIN_FAILED` and `LOGIN_PROLOGUE_PAGED` are orphaned too. Follow-up issue to come.
2. `CREATE_ACCOUNT_INITIATED` / `_EMAIL_EXISTS` / `_USERNAME_EXISTS` / `_FAILED` also have zero producers, but are outside the scope agreed on CMM-2422 and stay in the enum for now.

## Testing instructions

Nothing to exercise on device — by construction, none of the removed code was reachable. The review is a static one:

1. Confirm the grep comes back empty. Use `git grep` rather than a plain `grep -r` — it only searches files tracked at the current revision, so build output and any sibling worktrees or checkouts nested inside the repo (e.g. `.claude/worktrees/`) can't produce false hits:
```
git grep -n "trackAnalyticsAccountCreated\|CREATED_ACCOUNT\|account_created\|refreshMetadataNewUser" -- '*.java' '*.kt'
```
- [x] No output
2. Run the analytics unit tests:
```
./gradlew :WordPress:testWordPressDebugUnitTest --tests "*AnalyticsTrackerNosaraTest*"
```
- [x] `testEventWithStandardNames` and `testEventWithSpecialNames` both pass
3. Build and launch the app, then sign in and out
- [x] No regression in login or account metadata
